### PR TITLE
Gemspec fleximage with path spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@ source "http://rubygems.org"
 
 gemspec
 
-gem 'tvdeyen-fleximage', :path => '../fleximage'
-
 group :test do
 	gem 'rspec-rails'
 	gem 'sqlite3'


### PR DESCRIPTION
I deleted the path specification in your Gemfile since Fleximage now works with Rails 3.2.

Greetz
Markus
