### PR TITLE
jquery-rails version bumped to 2.0.0 for rails 3.2.1

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<acts_as_list>, ["~> 0.1"])
   s.add_runtime_dependency(%q<magiclabs-userstamp>, ["~> 2.0.2"])
   s.add_runtime_dependency(%q<dynamic_form>, ["~> 1.1"])
-  s.add_runtime_dependency(%q<jquery-rails>, ["~> 1.0.16"])
+  s.add_runtime_dependency(%q<jquery-rails>, ["~> 2.0.0"])
   s.add_runtime_dependency(%q<attachment_magic>, ["~> 0.2.1"])
 
 	s.add_development_dependency(%q<rspec-rails>, ["~> 2.8"])


### PR DESCRIPTION
Added latest jquery-rails gem version to the gemspec for rails 3.2.1
