### PR TITLE
Deleted deprecations from rails 3.2.1 update (spec. format and handler in names)

### DIFF
--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -46,7 +46,7 @@ module Alchemy
 				format.html { render }
 				format.rss {
 					if @page.contains_feed?
-						render :action => "show.rss.builder", :layout => false
+						render :action => "show", :layout => false, :handlers => [:builder]
 					else
 						render :xml => { :error => 'Not found' }, :status => 404
 					end
@@ -157,7 +157,7 @@ module Alchemy
 		def redirect_to_public_child
 			@page = find_first_public(@page)
 			if @page.blank?
-				render :file => "#{Rails.root}/public/404.html", :status => 404, :layout => false
+				render :file => "#{Rails.root}/public/404", :status => 404, :layout => false
 			else
 				redirect_page
 			end
@@ -179,7 +179,7 @@ module Alchemy
 		end
 
 		def render_404
-			render(:file => "#{Rails.root}/public/404.html", :status => 404, :layout => false)
+			render(:file => "#{Rails.root}/public/404", :status => 404, :layout => false)
 		end
 
 		def url_levels

--- a/app/views/alchemy/admin/attachments/create.js.erb
+++ b/app/views/alchemy/admin/attachments/create.js.erb
@@ -1,6 +1,6 @@
 (function($) {
 <%- if @while_assigning -%>
-	$('#alchemy_window_body').replaceWith('<%= escape_javascript(render(:partial => "archive_overlay.html.erb")) -%>');
+    $('#alchemy_window_body').replaceWith('<%= escape_javascript(render(:partial => "archive_overlay", :formats => [:html])) -%>');
 <%- else -%>
   $('#archive_all').html('<%= escape_javascript(render(:partial => "files_list")) %>');
   Alchemy.growl('<%= @message %>');

--- a/app/views/alchemy/admin/essence_files/assign.js.erb
+++ b/app/views/alchemy/admin/essence_files/assign.js.erb
@@ -1,6 +1,6 @@
 (function($) {
 	
-	$('#<%= content_dom_id(@content) %>').replaceWith('<%= escape_javascript(render(:partial => "alchemy/essences/essence_file_editor.html.erb", :locals => {:content => @content, :options => @options})) %>');
+  $('#<%= content_dom_id(@content) %>').replaceWith('<%= escape_javascript(render(:partial => "alchemy/essences/essence_file_editor", :formats => [:html], :locals => {:content => @content, :options => @options})) %>');
 	Alchemy.closeCurrentWindow();
 	Alchemy.reloadPreview();
 	Alchemy.setElementDirty('#element_<%= @content.element.id %>');


### PR DESCRIPTION
I took the format and handler specifications out of partial/template names in render calls and pass them by option keys (where needed).
