### PR TITLE
specify partial-path, otherwise MissingPartial error is raised

### DIFF
--- a/app/views/alchemy/admin/attachments/_files_list.html.erb
+++ b/app/views/alchemy/admin/attachments/_files_list.html.erb
@@ -21,7 +21,7 @@
 		<th class="tools"></th>
 	</tr>
 	<%- end -%>
-	<%= render(:partial => @attachments) %>
+	<%= render :partial => 'alchemy/admin/attachments/attachment', :collection => @attachments %>
 </table>
 
 <%= paginate @attachments %>


### PR DESCRIPTION
got this error with rails 3.2 and ruby 1.9.3.

Seems like Rails only looks in app/views/alchemy/attachements since the model is Alchemy::Attachement not Alchemy::Admin::Attachement...
