### PR TITLE
Add an amount option for elements

### DIFF
--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -178,18 +178,23 @@ module Alchemy
 			elements_for_layout = []
 			elements_for_layout += all_definitions_for(page_layout['elements'])
 			return [] if elements_for_layout.blank?
-			# all unique elements from this layout
-			unique_elements = elements_for_layout.select{ |m| m["unique"] == true }
+			# all unique and limited elements from this layout
+			limited_elements = elements_for_layout.select{ |m| m["unique"] == true || (m["amount"] > 0 unless m["amount"].nil?) }
 			elements_already_on_the_page = page.elements
-			# delete all elements from the elements that could be placed that are unique and already and the page
-			unique_elements.each do |unique_element|
-				elements_already_on_the_page.each do |already_placed_element|
-					if already_placed_element.name == unique_element["name"]
-						elements_for_layout.delete(unique_element)
-					end
+			# delete all elements from the elements that could be placed that are unique or limited and already and the page
+			elements_counts = Hash.new(0)
+			elements_already_on_the_page.each { |e| elements_counts[e.name] += 1 }
+			limited_elements.each do |limited_element|
+				next if elements_counts[limited_element["name"]] == 0
+				if limited_element["unique"]
+					elements_for_layout.delete(limited_element) if elements_counts[limited_element["name"]] > 0
+					next
+				end
+				unless limited_element["amount"].nil?
+					elements_for_layout.delete(limited_element) if elements_counts[limited_element["name"]] >= limited_element["amount"]
 				end
 			end
-			return elements_for_layout
+			elements_for_layout
 		end
 
 		def self.all_definitions_for(element_names)

--- a/db/migrate/20120402221737_add_amount_to_alchemy_elements.rb
+++ b/db/migrate/20120402221737_add_amount_to_alchemy_elements.rb
@@ -1,0 +1,5 @@
+class AddAmountToAlchemyElements < ActiveRecord::Migration
+  def change
+    add_column :alchemy_elements, :amount, :integer
+  end
+end


### PR DESCRIPTION
This implements an 'amount' option as described in #187. Uniqueness has precedence so it should be backwards compatible.
I'm not sure about the migration. Alchemy complained about a missing column and I added it, although it is a little bit redundant because the amount is read from the `elements.yml` file every time. However, I noticed that there is a `unique` column which is also in the .yml, so I added the `amount`.
