### PR TITLE
fixes: reload sitemap after page has been deleted in english version

### DIFF
--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -161,7 +161,7 @@ en:
     "Image size": "Imagesize"
     "Image deleted successfully": "Image deleted successfully."
     "Mandatory": "Mandatory fields"
-    "Page deleted": "Page: '%{name}' deleted."
+    "Page deleted": "Page: %{name} deleted."
     "Page saved": "Page: '%{name}' saved."
     "Password": "Password"
     "Paste from clipboard": "Paste from clipboard"


### PR DESCRIPTION
This was a nasty one: page-name has been in apostrophe in english translation. This in turn lead to an javascript-error so that the page was never reloaded after deleting a page.
