### PR TITLE
Include #attachment_id in list of white-listed attributes for EssenceFile

### DIFF
--- a/app/models/alchemy/essence_file.rb
+++ b/app/models/alchemy/essence_file.rb
@@ -1,7 +1,7 @@
 module Alchemy
   class EssenceFile < ActiveRecord::Base
 
-    attr_accessible :title, :css_class
+    attr_accessible :title, :css_class, :attachment_id
 
     acts_as_essence(
       :ingredient_column => :attachment,


### PR DESCRIPTION
As discussed. Fixes EssenceFile file attachments, surprisingly.
