### PR TITLE
custom admin-css and page_layout-class in sitemap

### DIFF
--- a/app/assets/stylesheets/alchemy/alchemy.css
+++ b/app/assets/stylesheets/alchemy/alchemy.css
@@ -2,6 +2,7 @@
 * -------------------------------
 *= require alchemy/base
 *= require alchemy/buttons
+*= require alchemy/custom
 *= require alchemy/dashboard
 *= require alchemy/elements
 *= require alchemy/flash

--- a/app/assets/stylesheets/alchemy/alchemy_custom.css.scss
+++ b/app/assets/stylesheets/alchemy/alchemy_custom.css.scss
@@ -1,1 +1,0 @@
-// Here you can put in your styles to customized alchemy's backend.

--- a/app/assets/stylesheets/alchemy/custom.css.scss
+++ b/app/assets/stylesheets/alchemy/custom.css.scss
@@ -1,0 +1,1 @@
+// Overwrite this file in your app to customize alchemy's backend.

--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -5,10 +5,8 @@
     <title><%= render_alchemy_title %></title>
     <%= csrf_meta_tag %>
     <%= stylesheet_link_tag('alchemy/alchemy', :media => 'screen') %>
-    <%= stylesheet_link_tag('alchemy/alchemy_custom', :media => 'screen') %>
     <%= stylesheet_link_tag('alchemy/print', :media => 'print') %>
     <%= yield :stylesheets %>
-    <%= yield :stylesheet_includes %>
     <script type="text/javascript" charset="utf-8">
       var tinyMCEPreInit = {
         base: '<%= Rails.application.config.assets.prefix %>/tiny_mce',


### PR DESCRIPTION
This is a proposal: Firstly I'd like to change alchemy's backend sometimes for several reasons. With a standardized /alchemy/alchemy_custom.css this would be possible.
Moreover I changed :stylesheets to :stylesheet_includes (and left the other one for historical reasons).

And I put the page_layout as class in sitemap's li-item. That way you can customize i.e. the color to see what page is what page-layout.

What do you think? Is this helpful?
