### PR TITLE
Reduce build matrix on travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
-  - ree
   - rbx-19mode
 branches:
   only:


### PR DESCRIPTION
It takes over an hour in total and nobody has reported any issues on REE that did not manifest
on 1.8.7.

Also, please consider removing SQLite from the matrix. Thank you.
