### PR TITLE
renamed @current_language to @language

### DIFF
--- a/app/helpers/alchemy/base_helper.rb
+++ b/app/helpers/alchemy/base_helper.rb
@@ -7,10 +7,11 @@ module Alchemy
       text.truncate(:length => length)
     end
 
-    # Returns @current_language set in the action (e.g. Page.show)
+    # Returns @language set in the action (e.g. Page.show)
     def current_language
+      ActiveSupport::Deprecation.warn('This Proxy-method is deprecated. Please use @language directly.')
       if @language.nil?
-        warning('@current_language is not set')
+        warning('@language is not set')
         nil
       else
         @language


### PR DESCRIPTION
There is no other @current_language-variable in alchemy. I guess you renamed it some time ago and forgot this one?
