### PR TITLE
Skip attributes and resource relations

### DIFF
--- a/spec/dummy/app/models/event.rb
+++ b/spec/dummy/app/models/event.rb
@@ -1,4 +1,5 @@
 class Event < ActiveRecord::Base
-  attr_accessible :name, :hidden_name, :starts_at, :ends_at, :description, :published, :entrance_fee, :location_id
+  attr_accessible :name, :hidden_name, :starts_at, :ends_at, :description, :published, :entrance_fee, :location_id, :organizer_id
   validates_presence_of :name
+
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -292,6 +292,7 @@ ActiveRecord::Schema.define(:version => 20120611221734) do
     t.decimal  "entrance_fee", :precision => 6, :scale => 2
     t.boolean  "published"
     t.integer  "location_id"
+    t.integer  "organizer_id"
     t.datetime "created_at",   :null => false
     t.datetime "updated_at",   :null => false
   end

--- a/spec/libraries/resource_spec.rb
+++ b/spec/libraries/resource_spec.rb
@@ -4,6 +4,25 @@ require File.dirname(__FILE__) + '/../../lib/alchemy/resource'
 class Event
 end
 
+module Namespace1
+  module Namespace2
+    class Event
+    end
+  end
+end
+
+module Namespace
+  class Event
+  end
+end
+
+module Engine
+  module Namespace
+    class Event
+    end
+  end
+end
+
 
 describe Alchemy::Resource do
 
@@ -29,7 +48,7 @@ describe Alchemy::Resource do
   end
 
   describe "instance methods" do
-      let(:resource) { Alchemy::Resource.new("admin/events") }
+    let(:resource) { Alchemy::Resource.new("admin/events") }
 
     describe "model" do
       it "returns resource's model-class" do
@@ -71,6 +90,8 @@ describe Alchemy::Resource do
             mock(:column, {:name => 'starts_at', :type => :datetime}),
           ]
           Event.stub(:columns).and_return columns
+          module Config; end
+          Config.stub(:get).and_return {}
         end
 
         it "parses and returns the resource-model's attributes from ActiveRecord::ModelSchema" do
@@ -99,6 +120,7 @@ describe Alchemy::Resource do
     end
 
     describe "namespaced_model_name" do
+
       it "returns model_name with namespace (namespace_event for Namespace::Event), i.e. for use in forms" do
         namespaced_resource = Alchemy::Resource.new("admin/namespace/events")
         namespaced_resource.namespaced_model_name.should == 'namespace_event'

--- a/spec/libraries/resources_helper_spec.rb
+++ b/spec/libraries/resources_helper_spec.rb
@@ -6,6 +6,9 @@ module Namespace
   end
 end
 
+module EngineResource
+end
+
 class ResourcesController
   def resource_handler
     @resource_handler = Alchemy::Resource.new('admin/namespace/my_resources')


### PR DESCRIPTION
I tried to move skip_attributes and resource_relations into the model as discussed.
But I'm not really satisfied with the way things are now. It would be much better to have a small DSL for that, that can be included in the model. Something like:

skip_attributes :id, :location
resource_relation :location_id, 'location_name'
