### PR TITLE
Adds #element_preview_code_attributes in preparation for Slim and Haml support

### DIFF
--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -160,12 +160,15 @@ module Alchemy
       "#{element.name}_#{element.id}".html_safe
     end
 
-    # Renders the data-alchemy-element HTML attribut used for the preview window hover effect.
+    # Renders the HTML tag attributes required for preview mode.
     def element_preview_code(element)
-      return "" if element.nil?
-      if @preview_mode && element.page == @page
-        tag_options(:data => {'alchemy-element' => element.id})
-      end
+      tag_options(element_preview_code_attributes(element))
+    end
+
+    # Returns a hash containing the HTML tag attributes required for preview mode.
+    def element_preview_code_attributes(element)
+      return {} unless element.present? && @preview_mode && element.page == @page
+      { :'data-alchemy-element' => element.id }
     end
 
     # Returns the full url containing host, page and anchor for the given element

--- a/spec/helpers/elements_helper_spec.rb
+++ b/spec/helpers/elements_helper_spec.rb
@@ -157,21 +157,28 @@ describe Alchemy::ElementsHelper do
     end
   end
 
-  describe '#element_preview_code' do
-
-    context "in preview mode" do
+  context "in preview mode" do
+    describe '#element_preview_code_attributes' do
       it "should return the data-alchemy-element HTML attribute for element" do
         @preview_mode = true
+        helper.element_preview_code_attributes(@element).should == {:'data-alchemy-element' => @element.id}
+      end
+
+      it "should return an empty hash if not in preview_mode" do
+        helper.element_preview_code_attributes(@element).should == {}
+      end
+    end
+
+    describe '#element_preview_code' do
+      it "should return the data-alchemy-element HTML attribute for element" do
+        assign(:preview_mode, true)
         helper.element_preview_code(@element).should == " data-alchemy-element=\"#{@element.id}\""
       end
-    end
 
-    context "not in preview mode" do
-      it "should return nil" do
-        helper.element_preview_code(@element).should be_nil
+      it "should not return the data-alchemy-element HTML attribute if not in preview_mode" do
+        helper.element_preview_code(@element).should_not == " data-alchemy-element=\"#{@element.id}\""
       end
     end
-
   end
 
   describe '#element_tags' do


### PR DESCRIPTION
- #element_preview_code_attributes returns the preview mode attributes as a hash
- #element_preview_code was refactored to use above method and render the attributes as a string
