### PR TITLE
Simplify support for custom per-request layouts.

### DIFF
--- a/app/controllers/alchemy/base_controller.rb
+++ b/app/controllers/alchemy/base_controller.rb
@@ -125,33 +125,19 @@ module Alchemy
       end
     end
 
-    # Handles the layout rendering
+    # Returns the layout to be used by the current page. This method is being
+    # used in PageController#show's invocation of #render.
     #
-    # Can be used inside the controller´s +layout+ class method
-    #
-    # === Example:
-    #   layout :layout_for_page
-    #
-    # === Usage:
-    # 1. You can pass none or false as url parameter to avoid any layout rendering.
-    # 2. You can pass a layout name of any existing layout file in +app/views/layouts+ folder.
-    #
-    # If no layout name is given, Alchemy tries to render +app/views/layouts/application/+ layout.
-    # If that is not present, Alchemy tries to render +app/views/layouts/alchemy/pages+ layout.
+    # It allows you to request a specific page layout by passing a 'layout' parameter
+    # in a request. If this parameter is set to 'none' or 'false', no layout whatsoever
+    # will be used to render the page; otherwise, a layout by the given name
+    # will be applied.
     #
     def layout_for_page
       if params[:layout] == 'none' || params[:layout] == 'false'
         false
-      elsif !params[:layout].blank?
-        if File.exist?(Rails.root.join('app/views/layouts', "#{params[:layout]}.html.erb"))
-          params[:layout]
-        else
-          raise_not_found_error
-        end
-      elsif File.exist?(Rails.root.join('app/views/layouts', 'application.html.erb'))
-        'application'
       else
-        'alchemy/pages'
+        params[:layout] || 'application'
       end
     end
 
@@ -159,8 +145,7 @@ module Alchemy
       if exception
         logger.info "Rendering 404: #{exception.message}"
       end
-      @page = Page.language_root_for(session[:language_id])
-      render :file => Rails.root.join("public/404.html"), :status => 404, :layout => !@page.nil?
+      render :file => Rails.root.join("public/404.html"), :status => 404, :layout => false
     end
 
     # Enforce ssl for login and all admin modules.

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -58,11 +58,9 @@ describe Alchemy::PagesController do
     end
 
     context "with params layout set to not existing layout" do
-
-      it "should raise ActionController::RoutingError" do
-        expect { get :show, :urlname => :home, :layout => 'lkuiuk' }.to raise_error(ActionController::RoutingError)
+      it "should raise ActionView::MissingTemplate" do
+        expect { get :show, :urlname => :home, :layout => 'lkuiuk' }.to raise_error(ActionView::MissingTemplate)
       end
-
     end
 
     context "with param layout set to a custom layout" do
@@ -84,36 +82,6 @@ describe Alchemy::PagesController do
       end
 
     end
-
-    context "with application layout absent" do
-
-      it "should render pages layout" do
-        get :show, :urlname => :home
-        response.body.should_not have_content('I am the application layout')
-      end
-
-    end
-
-    context "with application layout present" do
-
-      before do
-        @app_layout = Rails.root.join('app/views/layouts', 'application.html.erb')
-        File.open(@app_layout, 'w') do |app_layout|
-          app_layout.puts "<html>I am the application layout</html>"
-        end
-      end
-
-      it "should render application layout" do
-        get :show, :urlname => :home
-        response.body.should have_content('I am the application layout')
-      end
-
-      after do
-        FileUtils.rm(@app_layout)
-      end
-
-    end
-
   end
 
   describe "url nesting" do

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <!-- Your site title-prefix (That is YourSite in "YourSite - CurrentPage" is taken from a layout-page by default.
+    Alternatively you can hardcode it here -->
+  <%= render_meta_data(:title_prefix => sitename_from_header_page, :title_seperator => "-") %>
+  <!-- Paths here are relative to app/assets/stylesheets.
+    alchemy/standard_set, though, is located in Alchemy-source and doesn't have to be present in your app,
+     but you can copy it over and customize it of course. -->
+  <%= stylesheet_link_tag "alchemy/standard_set", :media => :screen %>
+  <%= stylesheet_link_tag "alchemy/standard_set", :media => :print %>
+  <!-- Here is also the place for custom javascripts. Put them in app/assets/javascripts/yourscript.js (or yourscript.js.coffee)
+    and include them like this (remove the \):
+    <\%= javascript_include_tag "yourscript" %> -->
+</head>
+<body>
+<div id="page">
+  <div id="language_select">
+    <!-- Render links with flags for all public languages -->
+    <%= language_switches(:linkname => :code) %>
+  </div>
+  <div id="breadcrump">
+    <!-- Renders a breadcrumb/ariadne-path. For customizing see docs for render_breadcrumb (link?) -->
+    <%= render_breadcrumb :seperator => "<span>&nbsp;<&nbsp;</span>" %>
+  </div>
+  <div id="navigation">
+    <!-- Renders main navigation. For customizing see docs for render_navigation (link?)
+        You can overwrite app/views/navigation/_renderer.html.erb and app/views/navigation/_link.html.erb
+        if you want to roll out your own markup -->
+    <%= render_navigation :all_sub_menues => true %>
+  </div>
+  <!-- Most important call here!
+    This yields (=inserts) all content of the current page.
+    Markup depends on page_layout, elements and essences and can be changed in app/views/alchemy/... -->
+  <%= yield %>
+  <div class="footer">
+    <!-- Renders elements that are called "footnote" (name-attribute in elements.yml)
+      from page_layout "layout_footer" (name-attribute in page_layout.yml) -->
+    <%= render_elements(
+          :from_page => 'layout_footer',
+          :only => ['footnote']
+        ) %>
+  </div>
+</div>
+<!-- This is used in Alchemy's backend to prevent navigating to other pages through the preview window -->
+<%= alchemy_preview_mode_code %>
+<!-- Renders a menu_bar when a user with sufficient rights visits a page -->
+<%= alchemy_menu_bar %>
+</body>
+</html>
+

--- a/spec/integration/pages_controller_spec.rb
+++ b/spec/integration/pages_controller_spec.rb
@@ -309,10 +309,6 @@ module Alchemy
           within("title") { page.should have_content("404") }
         end
 
-        it "should render the layout" do
-          page.should have_selector("#language_select")
-        end
-
       end
 
       it "should render public/404.html when it exists" do


### PR DESCRIPTION
- presence of requested layouts is not checked in the file system. If a layout is missing, Rails will raise ActionView::MissingTemplate as expected (instead of our own error handling.)
- Alchemy apps will not fall back to an 'alchemy/pages' layout any longer. If your Alchemy app doesn't have an application layout (why doesn't it?), you should add one now.
- Due to the previous change, an application.html.erb layout was added to the spec suite's dummy app.
