### PR TITLE
Add support for Haml and Slim.

### DIFF
--- a/app/helpers/alchemy/admin/elements_helper.rb
+++ b/app/helpers/alchemy/admin/elements_helper.rb
@@ -3,6 +3,7 @@ module Alchemy
     module ElementsHelper
 
       include Alchemy::ElementsHelper
+      include Alchemy::ElementsBlockHelper
       include Alchemy::Admin::BaseHelper
       include Alchemy::Admin::ContentsHelper
       include Alchemy::Admin::EssencesHelper

--- a/app/helpers/alchemy/elements_block_helper.rb
+++ b/app/helpers/alchemy/elements_block_helper.rb
@@ -1,0 +1,150 @@
+module Alchemy
+  # Provides a collection of block-level helpers, allowing for a much more
+  # concise way of writing element view/editor partials.
+  #
+  module ElementsBlockHelper
+    # Base class for our block-level helpers.
+    #
+    class BlockHelper
+      def initialize(helpers, opts = {})
+        @helpers = helpers
+        @opts = opts
+      end
+
+      def opts
+        @opts
+      end
+
+      def element
+        opts[:element]
+      end
+
+      def helpers
+        @helpers
+      end
+    end
+
+    # Block-level helper class for element views.
+    #
+    class ElementViewHelper < BlockHelper
+      # Renders one of the element's contents.
+      #
+      def render(name, *args)
+        helpers.render_essence_view_by_name(element, name.to_s, *args)
+      end
+
+      # Returns one of the element's contents (ie. essence instances).
+      #
+      def content(name)
+        element.content_by_name(name)
+      end
+
+      # Returns the ingredient of one of the element's contents.
+      #
+      def ingredient(name)
+        element.ingredient(name)
+      end
+    end
+
+    # Block-level helper class for element editors.
+    #
+    class ElementEditorHelper < BlockHelper
+      def edit(name, *args)
+        helpers.render_essence_editor_by_name(element, name.to_s, *args)
+      end
+    end
+
+    # Block-level helper for element views. Constructs a DOM element wrapping
+    # your content element and provides a block helper object you can use for
+    # concise access to Alchemy's various helpers.
+    #
+    # === Example:
+    #
+    #   <%= element_view_for(element) do |el| %>
+    #     <%= el.render :title %>
+    #     <%= el.render :body %>
+    #     <%= link_to "Go!", el.ingredient(:target_url) %>
+    #   <% end %>
+    #
+    # You can override the tag, ID and class used for the generated DOM
+    # element:
+    #
+    #   <%= element_view_for(element, tag: 'span', id: 'my_id', class: 'thing') do |el| %>
+    #      <%- ... %>
+    #   <% end %>
+    #
+    # If you don't want your view to be wrapped into an extra element, simply set
+    # `tag` to `false`:
+    #
+    #   <%= element_view_for(element, tag: false) do |el| %>
+    #      <%- ... %>
+    #   <% end %>
+    #
+    # @param [Alchemy::Element] element
+    #   The element to display.
+    # @param [Hash] options
+    #   Additional options.
+    #
+    # @option options :tag (:div)
+    #   The HTML tag to be used for the wrapping element.
+    # @option options :id (the element's ID)
+    #   The wrapper tag's DOM ID.
+    # @option options :class (the element's essence name)
+    #   The wrapper tag's DOM class.
+    # @option options :tags_formatter
+    #   A lambda used for formatting the element's tags (see Alchemy::ElementsHelper::element_tags_attributes). Set to +false+ to not include tags in the wrapper element.
+    #
+    def element_view_for(element, options = {})
+      options = {
+        :tag   => :div,
+        :id    => element_dom_id(element),
+        :class => element.name,
+        :tags_formatter => lambda { |tags| tags.join(" ") }
+      }.merge(options)
+
+      # capture inner template block
+      output = capture do
+        yield ElementViewHelper.new(self, :element => element) if block_given?
+      end
+
+      # wrap output in a useful DOM element
+      if tag = options.delete(:tag)
+        # add preview attributes
+        options.merge!(element_preview_code_attributes(element))
+
+        # add tags
+        if tags_formatter = options.delete(:tags_formatter)
+          options.merge!(element_tags_attributes(element, formatter: tags_formatter))
+        end
+
+        output = content_tag(tag, output, options)
+      end
+
+      # that's it!
+      output
+    end
+    # Block-level helper for element editors. Provides a block helper object
+    # you can use for concise access to Alchemy's various helpers.
+    #
+    # === Example:
+    #
+    #   <%= element_editor_for(element) do |el| %>
+    #     <%= el.edit :title %>
+    #     <%= el.edit :body %>
+    #     <%= el.edit :target_url %>
+    #   <% end %>
+    #
+    # @param [Alchemy::Element] element
+    #   The element to display.
+    #
+    def element_editor_for(element, options = {})
+      options = {
+        # nothing here yet.
+      }.merge(options)
+
+      capture do
+        yield ElementEditorHelper.new(self, :element => element)
+      end
+    end
+  end
+end

--- a/app/helpers/alchemy/pages_helper.rb
+++ b/app/helpers/alchemy/pages_helper.rb
@@ -3,6 +3,7 @@ module Alchemy
 
     include Alchemy::BaseHelper
     include Alchemy::ElementsHelper
+    include Alchemy::ElementsBlockHelper
     include Alchemy::UrlHelper
 
     def render_classes(classes=[])

--- a/lib/rails/generators/alchemy/base.rb
+++ b/lib/rails/generators/alchemy/base.rb
@@ -1,0 +1,41 @@
+require 'rails'
+
+module Alchemy
+  module Generators
+    class Base < ::Rails::Generators::Base
+      class_option :template_engine, :type => :string, :aliases => '-e', :desc => 'Template engine for the views. Available options are "erb", "haml", and "slim".'
+
+      private
+
+      def conditional_template(source, destination)
+        files = Dir.glob(destination.gsub(/\.([a-z]+)$/, '*'))
+        if files.any?
+          ext = File.extname(files.first)[1..-1]
+
+          # If view already exists using a different template engine, change
+          # source and destination file names to use that engine.
+          if ext != template_engine.to_s
+            say_status :warning, "View uses unexpected template engine '#{ext}'.", :cyan
+            destination.gsub!(/#{template_engine}$/, ext)
+            source.gsub!(/#{template_engine}$/, ext)
+          end
+        end
+
+        template source, destination
+      end
+
+      def template_engine
+        # Rails is clever enough to default this to whatever template
+        # engine is configured through its generator configuration,
+        # but we'll default it to erb anyway, just in case.
+        options[:template_engine] || 'erb'
+      end
+
+      def load_alchemy_yaml(name)
+        YAML.load_file "#{Rails.root}/config/alchemy/#{name}"
+      rescue Errno::ENOENT
+        puts "\nERROR: Could not read config/alchemy/#{name} file. Please run: rails generate alchemy:scaffold"
+      end
+    end
+  end
+end

--- a/lib/rails/generators/alchemy/elements/elements_generator.rb
+++ b/lib/rails/generators/alchemy/elements/elements_generator.rb
@@ -1,8 +1,8 @@
-require 'rails'
+require File.join(__FILE__, '../../base')
 
 module Alchemy
   module Generators
-    class ElementsGenerator < ::Rails::Generators::Base
+    class ElementsGenerator < Base
       desc "This generator generates your elements view partials."
       source_root File.expand_path('templates', File.dirname(__FILE__))
 
@@ -12,7 +12,7 @@ module Alchemy
       end
 
       def create_partials
-        @elements = get_elements_from_yaml
+        @elements = load_alchemy_yaml('elements.yml')
         @elements.each do |element|
           @element = element
           if @element['available_contents']
@@ -22,19 +22,11 @@ module Alchemy
             @contents = (element["contents"] or [])
           end
           @element_name = element["name"].underscore
-          template "editor.html.erb", "#{@elements_dir}/_#{@element_name}_editor.html.erb"
-          template "view.html.erb", "#{@elements_dir}/_#{@element_name}_view.html.erb"
+
+          conditional_template "editor.html.#{template_engine}", "#{@elements_dir}/_#{@element_name}_editor.html.#{template_engine}"
+          conditional_template "view.html.#{template_engine}", "#{@elements_dir}/_#{@element_name}_view.html.#{template_engine}"
         end if @elements
       end
-
-      private
-
-      def get_elements_from_yaml
-        YAML.load_file "#{Rails.root}/config/alchemy/elements.yml"
-      rescue Errno::ENOENT
-        puts "\nERROR: Could not read config/alchemy/elements.yml file. Please run: rails generate alchemy:scaffold"
-      end
-
     end
   end
 end

--- a/lib/rails/generators/alchemy/elements/templates/editor.html.erb
+++ b/lib/rails/generators/alchemy/elements/templates/editor.html.erb
@@ -1,12 +1,14 @@
+<%%= element_editor_for(element) do |el| -%>
 <%- if @element['picture_gallery'] -%>
-<%%= render_picture_gallery_editor(element, :max_images => nil, :crop => true) %>
+  <%%= render_picture_gallery_editor(element, :max_images => nil, :crop => true) %>
 <%- end -%>
 <% @contents.each do |content| -%>
-<%%= render_essence_editor_by_name(element, '<%= content["name"] %>') %>
+  <%%= el.edit :<%= content["name"] %> %>
 <% end -%>
 <%- if @element['available_contents'] -%>
-<%% element.contents.where(:name => ['<%= @available_contents_names.join("', '") %>']).each do |content| %>
-  <%%= render_essence_editor content %>
-<%% end %>
-<p><%%= render_new_content_link(element) %></p>
+  <%% element.contents.where(:name => ['<%= @available_contents_names.join("', '") %>']).each do |content| %>
+    <%%= render_essence_editor content %>
+  <%% end %>
+  <p><%%= render_new_content_link(element) %></p>
 <%- end -%>
+<%%- end -%>

--- a/lib/rails/generators/alchemy/elements/templates/editor.html.haml
+++ b/lib/rails/generators/alchemy/elements/templates/editor.html.haml
@@ -1,0 +1,13 @@
+= element_editor_for(element) do |el|
+<%- if @element['picture_gallery'] -%>
+  = render_picture_gallery_editor(element, :max_images => nil, :crop => true)
+<%- end -%>
+<% @contents.each do |content| -%>
+  = el.edit :<%= content["name"] %>
+<% end -%>
+<%- if @element['available_contents'] -%>
+  - element.contents.where(:name => ['<%= @available_contents_names.join("', '") %>']).each do |content|
+    = render_essence_editor content
+
+  %p= render_new_content_link(element)
+<% end -%>

--- a/lib/rails/generators/alchemy/elements/templates/editor.html.slim
+++ b/lib/rails/generators/alchemy/elements/templates/editor.html.slim
@@ -1,0 +1,13 @@
+= element_editor_for(element) do |el|
+<%- if @element['picture_gallery'] -%>
+  = render_picture_gallery_editor(element, :max_images => nil, :crop => true)
+<%- end -%>
+<% @contents.each do |content| -%>
+  = el.edit :<%= content["name"] %>
+<% end -%>
+<%- if @element['available_contents'] -%>
+  - element.contents.where(:name => ['<%= @available_contents_names.join("', '") %>']).each do |content|
+    = render_essence_editor content
+
+  p= render_new_content_link(element)
+<% end -%>

--- a/lib/rails/generators/alchemy/elements/templates/view.html.erb
+++ b/lib/rails/generators/alchemy/elements/templates/view.html.erb
@@ -1,5 +1,5 @@
-<div class="<%= @element_name %>" id="<%%= element_dom_id(element) %>"<%%= element_preview_code(element) %><%- if @element['taggable'] == true -%><%%= element_tags(element) %><%- end -%>>
-<%- if @element["picture_gallery"] == true -%>
+<%%= element_view_for(element) do |el| -%>
+<%- if @element["picture_gallery"] -%>
   <div class="<%= @element_name %>_images">
     <%%- element.contents.gallery_pictures.each do |image| -%>
     <div class="<%= @element_name %>_image <%%= image.essence.css_class %>">
@@ -11,10 +11,10 @@
 <%- @contents.each do |content| -%>
   <%- if @contents.length > 1 -%>
   <div class="<%= content["name"] %>">
-    <%%= render_essence_view_by_name(element, '<%= content["name"] %>') %>
+    <%%= el.render :<%= content["name"] %> %>
   </div>
   <%- else -%>
-  <%%= render_essence_view_by_name(element, '<%= content["name"] %>') %>
+  <%%= el.render :<%= content["name"] %> %>
   <%- end -%>
 <%- end -%>
-</div>
+<%%- end -%>

--- a/lib/rails/generators/alchemy/elements/templates/view.html.haml
+++ b/lib/rails/generators/alchemy/elements/templates/view.html.haml
@@ -1,0 +1,15 @@
+= element_view_for(element) do |el|
+<%- if @element["picture_gallery"] -%>
+  .<%= @element_name %>_images
+    - element.contents.gallery_pictures.each do |image|
+    .<%= @element_name %>_image<%= image.essence.css_class ? ".#{image.essence.css_class}" : '' %>
+      = render_essence_view(image, :image_size => "160x120")
+<%- end -%>
+<%- @contents.each do |content| -%>
+  <%- if @contents.length > 1 -%>
+  .<%= content["name"] %>
+    = el.render :<%= content["name"] %>
+  <%- else -%>
+  = el.render :<%= content["name"] %>
+  <%- end -%>
+<%- end -%>

--- a/lib/rails/generators/alchemy/elements/templates/view.html.slim
+++ b/lib/rails/generators/alchemy/elements/templates/view.html.slim
@@ -1,0 +1,15 @@
+= element_view_for(element) do |el|
+<%- if @element["picture_gallery"] -%>
+  .<%= @element_name %>_images
+    - element.contents.gallery_pictures.each do |image|
+    .<%= @element_name %>_image<%= image.essence.css_class ? ".#{image.essence.css_class}" : '' %>
+      = render_essence_view(image, :image_size => "160x120")
+<%- end -%>
+<%- @contents.each do |content| -%>
+  <%- if @contents.length > 1 -%>
+  .<%= content["name"] %>
+    = el.render :<%= content["name"] %>
+  <%- else -%>
+  = el.render :<%= content["name"] %>
+  <%- end -%>
+<%- end -%>

--- a/lib/rails/generators/alchemy/page_layouts/page_layouts_generator.rb
+++ b/lib/rails/generators/alchemy/page_layouts/page_layouts_generator.rb
@@ -1,8 +1,8 @@
-require 'rails'
+require File.join(__FILE__, '../../base')
 
 module Alchemy
   module Generators
-    class PageLayoutsGenerator < ::Rails::Generators::Base
+    class PageLayoutsGenerator < Base
       desc "This generator generates your page_layouts view partials."
       source_root File.expand_path('templates', File.dirname(__FILE__))
 
@@ -12,21 +12,12 @@ module Alchemy
       end
 
       def create_partials
-        @page_layouts = get_page_layouts_from_yaml
+        @page_layouts = load_alchemy_yaml('page_layouts.yml')
         @page_layouts.each do |page_layout|
           @page_layout_name = page_layout["name"].underscore
-          template "layout.html.erb", "#{@page_layouts_dir}/_#{@page_layout_name}.html.erb"
+          conditional_template "layout.html.#{template_engine}", "#{@page_layouts_dir}/_#{@page_layout_name}.html.#{template_engine}"
         end if @page_layouts
       end
-
-      private
-
-      def get_page_layouts_from_yaml
-        YAML.load_file "#{Rails.root}/config/alchemy/page_layouts.yml"
-      rescue Errno::ENOENT
-        puts "\nERROR: Could not read config/alchemy/page_layouts.yml file. Please run: rails generate alchemy:scaffold"
-      end
-
     end
   end
 end

--- a/lib/rails/generators/alchemy/page_layouts/templates/layout.html.haml
+++ b/lib/rails/generators/alchemy/page_layouts/templates/layout.html.haml
@@ -1,0 +1,1 @@
+= render_elements

--- a/lib/rails/generators/alchemy/page_layouts/templates/layout.html.slim
+++ b/lib/rails/generators/alchemy/page_layouts/templates/layout.html.slim
@@ -1,0 +1,1 @@
+= render_elements

--- a/spec/helpers/elements_block_helper_spec.rb
+++ b/spec/helpers/elements_block_helper_spec.rb
@@ -1,0 +1,119 @@
+require 'spec_helper'
+
+include Alchemy::ElementsHelper
+
+module Alchemy
+  describe ElementsBlockHelper do
+    let(:page)    { FactoryGirl.create(:public_page) }
+    let(:element) { FactoryGirl.create(:element, page: page, tag_list: 'foo, bar') }
+    let(:expected_wrapper_tag) { "div.#{element.name}##{element_dom_id(element)}" }
+
+    describe '#element_view_for' do
+      it "should yield an instance of ElementViewHelper" do
+        expect { |b| element_view_for(element, &b) }.
+          to yield_with_args(ElementsBlockHelper::ElementViewHelper)
+      end
+
+      it "should wrap its output in a DOM element" do
+        element_view_for(element).
+          should have_css expected_wrapper_tag
+      end
+
+      it "should change the wrapping DOM element according to parameters" do
+        element_view_for(element, tag: 'span', class: 'some_class', id: 'some_id').
+          should have_css 'span.some_class#some_id'
+      end
+
+      it "should include the element's tags in the wrapper DOM element" do
+        element_view_for(element).
+          should have_css "#{expected_wrapper_tag}[data-element-tags='foo bar']"
+      end
+
+      it "should use the provided tags formatter to format tags" do
+        element_view_for(element, tags_formatter: lambda { |tags| tags.join ", " }).
+          should have_css "#{expected_wrapper_tag}[data-element-tags='foo, bar']"
+      end
+
+      it "should include the contents rendered by the block passed to it" do
+        element_view_for(element) do
+          'view'
+        end.should have_content 'view'
+      end
+
+      context "when/if preview mode is not active" do
+        subject { element_view_for(element) }
+        it { should have_css expected_wrapper_tag }
+        it { should_not have_css "#{expected_wrapper_tag}[data-alchemy-element]" }
+      end
+
+      context "when/if preview mode is active" do
+        before do
+          assign(:preview_mode, true)
+          assign(:page, page)
+        end
+
+        subject { helper.element_view_for(element) }
+        it { should have_css "#{expected_wrapper_tag}[data-alchemy-element='#{element.id}']" }
+      end
+    end
+
+    describe '#element_editor_for' do
+      it "should yield an instance of ElementEditorHelper" do
+        expect { |b| element_editor_for(element, &b) }.
+          to yield_with_args(ElementsBlockHelper::ElementEditorHelper)
+      end
+
+      it "should not add any extra elements" do
+        element_editor_for(element) do
+          'view'
+        end.should == 'view'
+      end
+    end
+
+    describe ElementsBlockHelper::ElementViewHelper do
+      let(:scope) { mock }
+      subject { ElementsBlockHelper::ElementViewHelper.new(scope, element: element) }
+
+      it 'should have a reference to the specified element' do
+        subject.element == element
+      end
+
+      describe '#render' do
+        it 'should delegate to the render_essence_view_by_name helper' do
+          scope.should_receive(:render_essence_view_by_name).with(element, "title", foo: 'bar')
+          subject.render :title, foo: 'bar'
+        end
+      end
+
+      describe '#content' do
+        it "should delegate to the element's #content_by_name method" do
+          element.should_receive(:content_by_name).with(:title)
+          subject.content :title
+        end
+      end
+
+      describe '#ingredient' do
+        it "should delegate to the element's #ingredient method" do
+          element.should_receive(:ingredient).with(:title)
+          subject.ingredient :title
+        end
+      end
+    end
+
+    describe ElementsBlockHelper::ElementEditorHelper do
+      let(:scope) { mock }
+      subject { ElementsBlockHelper::ElementEditorHelper.new(scope, element: element) }
+
+      it 'should have a reference to the specified element' do
+        subject.element == element
+      end
+
+      describe '#edit' do
+        it "should delegate to the render_essence_editor_by_name helper" do
+          scope.should_receive(:render_essence_editor_by_name).with(element, "title", foo: 'bar')
+          subject.edit :title, foo: 'bar'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Elements, Page Layouts and Cells now officially support alternative template engines (eg. Haml and Slim.)
- The Elements and Page Layouts generators have been refactored to support alternative template engines. In addition to this, they will automatically use your project's default template engine if no other engine is specified on the command line.
- Introduced new block-level helpers named `element_view_for(element)` and `element_editor_for(element)` (see `Alchemy::ElementsBlockHelper` for details.)
- Haml and Slim templates have been added to the Elements and Page Layouts generators. These new templates also use the new element block helpers.
