### PR TITLE
By default, include 'element' css class in element wrapper tags.

### DIFF
--- a/app/helpers/alchemy/elements_block_helper.rb
+++ b/app/helpers/alchemy/elements_block_helper.rb
@@ -110,7 +110,7 @@ module Alchemy
       options = {
         :tag   => :div,
         :id    => element_dom_id(element),
-        :class => element.name,
+        :class => ['element', element.name],
         :tags_formatter => lambda { |tags| tags.join(" ") }
       }.merge(options)
 

--- a/spec/helpers/elements_block_helper_spec.rb
+++ b/spec/helpers/elements_block_helper_spec.rb
@@ -6,7 +6,7 @@ module Alchemy
   describe ElementsBlockHelper do
     let(:page)    { FactoryGirl.create(:public_page) }
     let(:element) { FactoryGirl.create(:element, page: page, tag_list: 'foo, bar') }
-    let(:expected_wrapper_tag) { "div.#{element.name}##{element_dom_id(element)}" }
+    let(:expected_wrapper_tag) { "div.element.#{element.name}##{element_dom_id(element)}" }
 
     describe '#element_view_for' do
       it "should yield an instance of ElementViewHelper" do


### PR DESCRIPTION
This is so we can have element wrapper DOM elements (WTF, we need a better nomenclature) that use semantic CSS classes, simple_form style.

Consider an element named 'teaser'; using the new `element_view_for` helper, the generated wrapping DOM element will now have its CSS classes set to `element teaser`, allowing the developer to style it using `.element.teaser` instead of just `.teaser`, minimizing potential namespace conflicts.

We've previously talked about this, and your side of the argument was to not force semantics on the developer. However, please consider that this change (just like anything else involving the new block level helpers) will only affect new Alchemy projects, and even then the helpers allow you to change the defaults at any time (besides being completely optional, anyway).
