### PR TITLE
Protects Element#show from rendering not accessible elements.

### DIFF
--- a/app/controllers/alchemy/elements_controller.rb
+++ b/app/controllers/alchemy/elements_controller.rb
@@ -16,7 +16,11 @@ module Alchemy
   private
 
     def load_element
-      @element = Element.find(params[:id])
+      element = Element.available
+      if !current_user
+        element = element.joins(:page).where("alchemy_pages" => {:restricted => false})
+      end
+      @element = element.find(params[:id])
     end
 
   end

--- a/spec/controllers/elements_controller_spec.rb
+++ b/spec/controllers/elements_controller_spec.rb
@@ -3,29 +3,44 @@ require 'spec_helper'
 module Alchemy
   describe ElementsController do
 
-    let(:page)       { FactoryGirl.create(:public_page, :restricted => true) }
-    let(:element)    { FactoryGirl.create(:element, :page => page, :name => 'download') }
+    let(:page)                { FactoryGirl.create(:public_page) }
+    let(:element)             { FactoryGirl.create(:element, :page => page, :name => 'download') }
+    let(:restricted_page)     { FactoryGirl.create(:public_page, :restricted => true) }
+    let(:restricted_element)  { FactoryGirl.create(:element, :page => restricted_page, :name => 'download') }
 
     describe '#show' do
 
-      it "should not return restricted elements" do
+      it "should render available elements" do
         get :show, :id => element.id
-        response.status.should == 302
-        response.should redirect_to(login_path)
+        response.status.should == 200
+      end
+
+      it "should raise ActiveRecord::RecordNotFound error for trashed elements" do
+        element.trash
+        expect { get(:show, :id => element.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "should raise ActiveRecord::RecordNotFound error for unpublished elements" do
+        element.update_attributes(:public => false)
+        expect { get(:show, :id => element.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      context "for guest user" do
+        it "should raise ActiveRecord::RecordNotFound error for elements of restricted pages" do
+          expect { get(:show, :id => restricted_element.id) }.to raise_error(ActiveRecord::RecordNotFound)
+        end
       end
 
       context "for registered user" do
-
         before do
           activate_authlogic
           UserSession.create(FactoryGirl.create(:registered_user))
         end
 
-        it "should render restricted elements" do
-          get :show, :id => element.id
+        it "should render elements of restricted pages" do
+          get :show, :id => restricted_element.id
           response.status.should == 200
         end
-
       end
 
     end


### PR DESCRIPTION
- Trashed or unpublished elements can not be rendered.
- Restricted elements can not be accessed by guest users anymore.
