### PR TITLE
gem update: acts_as_list => 0.1.9

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -46,7 +46,7 @@ POST_INSTALL
   s.add_runtime_dependency %q<dragonfly>,                  ["~> 0.9.12"]
   s.add_runtime_dependency %q<kaminari>,                   ["~> 0.13.0"]
   s.add_runtime_dependency %q<acts_as_ferret>,             ["~> 0.5"]
-  s.add_runtime_dependency %q<acts_as_list>,               ["~> 0.1"]
+  s.add_runtime_dependency %q<acts_as_list>,               ["~> 0.1.9"]
   s.add_runtime_dependency %q<magiclabs-userstamp>,        ["~> 2.0.2"]
   s.add_runtime_dependency %q<dynamic_form>,               ["~> 1.1"]
   s.add_runtime_dependency %q<jquery-rails>,               ["~> 2.1.3"]

--- a/app/models/alchemy/content.rb
+++ b/app/models/alchemy/content.rb
@@ -7,8 +7,7 @@ module Alchemy
       :essence_id,
       :essence_type,
       :ingredient,
-      :name,
-      :position
+      :name
     )
 
     belongs_to :essence, :polymorphic => true, :dependent => :destroy

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -12,7 +12,6 @@ module Alchemy
       :folded,
       :name,
       :page_id,
-      :position,
       :public,
       :tag_list,
       :unique

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -28,7 +28,6 @@ module Alchemy
       :name,
       :page_layout,
       :parent_id,
-      :position,
       :public,
       :restricted,
       :robot_index,


### PR DESCRIPTION
- This update enables us to remove all :position attributes from attribute whitelists. - So we did -
