### PR TITLE
Add multisite support.

### DIFF
--- a/app/controllers/alchemy/admin/sites_controller.rb
+++ b/app/controllers/alchemy/admin/sites_controller.rb
@@ -1,0 +1,51 @@
+module Alchemy
+  module Admin
+    class SitesController < BaseController
+
+      def index
+        @sites = Site.all
+      end
+
+      def new
+        @site = Site.new
+        render layout: false
+      end
+
+      def create
+        @site = Site.new(params[:site])
+        @site.save
+
+        render_errors_or_redirect(
+          @site,
+          admin_sites_path,
+          t("Site created", :name => @site.name)
+        )
+      end
+
+      def edit
+        @site = Site.find(params[:id])
+        render layout: false
+      end
+
+      def update
+        @site = Site.find(params[:id])
+        @site.update_attributes(params[:site])
+        render_errors_or_redirect(
+          @site,
+          admin_sites_path,
+          t("Site updated", :name => @site.name)
+        )
+      end
+
+      def destroy
+        @site = Site.find(params[:id])
+        @site.destroy
+
+        flash[:notice] = t("Site deleted", :name => @site.name)
+        @redirect_url = admin_sites_path
+        render :action => :redirect
+      end
+
+    end
+  end
+end

--- a/app/controllers/alchemy/base_controller.rb
+++ b/app/controllers/alchemy/base_controller.rb
@@ -6,6 +6,7 @@ module Alchemy
 
     protect_from_forgery
 
+    before_filter :set_current_site
     before_filter :set_language
     before_filter :mailer_set_url_options
 
@@ -44,6 +45,11 @@ module Alchemy
     end
 
   private
+
+    # Sets the current site.
+    def set_current_site
+      Site.current = Site.where(host: request.host).first || Site.first
+    end
 
     # Sets Alchemy's GUI translation to users preffered language and stores it in the session.
     #

--- a/app/models/alchemy/site.rb
+++ b/app/models/alchemy/site.rb
@@ -1,0 +1,19 @@
+module Alchemy
+  class Site < ActiveRecord::Base
+    cattr_accessor :current
+
+    attr_accessible :host, :name
+
+    # validations
+    validates_presence_of :host
+    validates_uniqueness_of :host
+
+    # associations
+    has_many :languages
+
+    # Returns true if this site is the current site
+    def current?
+      self.class.current == self
+    end
+  end
+end

--- a/app/views/alchemy/admin/sites/_form.html.erb
+++ b/app/views/alchemy/admin/sites/_form.html.erb
@@ -1,0 +1,17 @@
+<%= form_for [:admin, @site], :as => :site, :remote => true do |f| %>
+  <table border="0" cellspacing="4" cellpadding="4" style="width: 100%">
+    <tr>
+      <td class="label"><%= f.label :host %></td>
+      <td class="input"><%= f.text_field :host, :class => "thin_border long" %></td>
+    </tr>
+    <tr>
+      <td class="label"><%= f.label :name %></td>
+      <td class="input"><%= f.text_field :name, :class => "thin_border long" %></td>
+    </tr>
+    <tr>
+      <td class="submit" colspan="2">
+        <%= f.button t('save'), :class => 'button' %>
+      </td>
+    </tr>
+  </table>
+<% end %>

--- a/app/views/alchemy/admin/sites/_site.html.erb
+++ b/app/views/alchemy/admin/sites/_site.html.erb
@@ -1,0 +1,26 @@
+<tr class="<%= cycle('even', 'odd') %>">
+  <td class="icon"><%= render_icon :tag %></td>
+  <td class="host"><%= site.host %></td>
+  <td class="name"><%= site.name %></td>
+  <td class="tools">
+    <%= link_to_overlay_window(
+      "",
+      edit_admin_site_path(site),
+      {
+        :title => t(:edit_site),
+        :size => '360x385'
+      },
+      {
+        :title => t(:edit_site),
+        :class => 'icon site_edit'
+      }
+    ) %>
+    <%= link_to_confirmation_window(
+      '',
+      t(:do_you_really_want_to_delete_this_site?),
+      admin_site_path(site),
+      :title => t(:delete_site),
+      :class => "icon site_delete"
+    ) %>
+  </td>
+</tr>

--- a/app/views/alchemy/admin/sites/edit.html.erb
+++ b/app/views/alchemy/admin/sites/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form' %>

--- a/app/views/alchemy/admin/sites/index.html.erb
+++ b/app/views/alchemy/admin/sites/index.html.erb
@@ -1,0 +1,36 @@
+<% content_for :toolbar do %>
+  <div id="toolbar_buttons">
+    <div class="button_with_label">
+      <%= link_to_overlay_window(
+        content_tag('span', '', :class => 'icon site_add'),
+        new_admin_site_path,
+        {
+          :title => t('New Site'),
+          :size => '360x385'
+        },
+        :title => t('New Site'),
+        :class => 'icon_button'
+      ) %><br />
+      <label><%= t('New Site') %></label>
+    </div>
+  </div>
+  <%= render :partial => 'alchemy/admin/partials/search_form' %>
+<% end %>
+
+<div id="archive_all">
+  <% if @sites.any? %>
+    <table class="list" id="tag_list">
+      <tr class="legend">
+        <th class="icon"></th>
+        <th class="host">Host</th>
+        <th class="name">Name</th>
+        <th class="tools"></th>
+      </tr>
+      <%= render :partial => 'site', :collection => @sites %>
+    </table>
+  <% else %>
+    <%= render_message do %>
+      <h2><%= t('No sites found') %></h2>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/alchemy/admin/sites/new.html.erb
+++ b/app/views/alchemy/admin/sites/new.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form' %>

--- a/config/alchemy/modules.yml
+++ b/config/alchemy/modules.yml
@@ -80,3 +80,15 @@
     - name: 'modules.tags'
       controller: 'alchemy/admin/tags'
       action: index
+
+- name: sites
+  engine_name: alchemy
+  navigation:
+    name: 'modules.sites'
+    controller: 'alchemy/admin/sites'
+    action: index
+    icon: sites
+    sub_navigation:
+    - name: 'modules.sites'
+      controller: 'alchemy/admin/sites'
+      action: index

--- a/config/authorization_rules.rb
+++ b/config/authorization_rules.rb
@@ -61,6 +61,7 @@ authorization do
     has_permission_on :alchemy_admin_users, :to => [:manage, :update_role]
     has_permission_on :alchemy_admin_languages, :to => [:manage]
     has_permission_on :authorization_rules, :to => :read
+    has_permission_on :alchemy_admin_sites, :to => [:manage]
   end
 
 end

--- a/config/locales/alchemy.de.yml
+++ b/config/locales/alchemy.de.yml
@@ -458,6 +458,7 @@ de:
       pages: "Seiten"
       users: "Benutzer"
       tags: "Schlagworte"
+      sites: "Multisite"
     name: "Name"
     names: "Namen"
     navigation_name: "Navigationsname"
@@ -907,6 +908,10 @@ de:
         password_confirmation: "Passwort Bestätigung"
         role: "Benutzerrolle"
         tag_list: Schlagworte
+
+      alchemy/site:
+        name: "Bezeichnung"
+        host: "Host/Domain"
 
     errors:
       <<: *errors

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,6 +140,8 @@ Alchemy::Engine.routes.draw do
       end
     end
 
+    resources :sites
+
   end
 
   match '/:lang' => 'pages#show',

--- a/db/migrate/20121205155004_create_alchemy_sites.rb
+++ b/db/migrate/20121205155004_create_alchemy_sites.rb
@@ -1,0 +1,14 @@
+class CreateAlchemySites < ActiveRecord::Migration
+  def change
+    create_table "alchemy_sites" do |t|
+      t.string :host
+      t.string :name
+      t.timestamps
+    end
+    add_index :alchemy_sites, :host, uniq: true
+
+    # add Language#site_id
+    add_column :alchemy_languages, :site_id, :integer
+    add_index  :alchemy_languages, :site_id
+  end
+end

--- a/lib/alchemy/seeder.rb
+++ b/lib/alchemy/seeder.rb
@@ -8,6 +8,7 @@ module Alchemy
       # This seed builds the necessary page structure for alchemy in your database.
       # Run the alchemy:db:seed rake task to seed your database.
       def seed!
+        create_default_site
         create_default_language
         create_root_page
       end
@@ -74,6 +75,20 @@ module Alchemy
 
     protected
 
+      def create_default_site
+        desc "Creating default site"
+        site = Alchemy::Site.find_or_initialize_by_host(
+          :name => 'Default',
+          :host => 'default'
+        )
+        if site.new_record?
+          site.save!
+          log "Created default site."
+        else
+          log "Default site was already present.", :skip
+        end
+      end
+
       def create_default_language
         desc "Creating default language"
         default_language = Alchemy::Config.get(:default_language)
@@ -83,7 +98,8 @@ module Alchemy
           :frontpage_name => default_language['frontpage_name'],
           :page_layout => default_language['page_layout'],
           :public => true,
-          :default => true
+          :default => true,
+          :site => Site.first
         )
         if lang.new_record?
           if lang.save!

--- a/spec/dummy/db/migrate/20121205155004_create_alchemy_sites.rb
+++ b/spec/dummy/db/migrate/20121205155004_create_alchemy_sites.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20121205155004_create_alchemy_sites.rb

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20121121162313) do
+ActiveRecord::Schema.define(:version => 20121205155004) do
 
   create_table "alchemy_attachments", :force => true do |t|
     t.string   "name"
@@ -187,10 +187,12 @@ ActiveRecord::Schema.define(:version => 20121121162313) do
     t.integer  "updater_id"
     t.boolean  "default",        :default => false
     t.string   "country_code",   :default => "",      :null => false
+    t.integer  "site_id"
   end
 
   add_index "alchemy_languages", ["language_code", "country_code"], :name => "index_alchemy_languages_on_language_code_and_country_code"
   add_index "alchemy_languages", ["language_code"], :name => "index_alchemy_languages_on_language_code"
+  add_index "alchemy_languages", ["site_id"], :name => "index_alchemy_languages_on_site_id"
 
   create_table "alchemy_pages", :force => true do |t|
     t.string   "name"
@@ -240,6 +242,15 @@ ActiveRecord::Schema.define(:version => 20121121162313) do
     t.string   "image_file_uid"
     t.integer  "image_file_size"
   end
+
+  create_table "alchemy_sites", :force => true do |t|
+    t.string   "host"
+    t.string   "name"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
+  add_index "alchemy_sites", ["host"], :name => "index_alchemy_sites_on_host"
 
   create_table "alchemy_users", :force => true do |t|
     t.string   "firstname"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -107,4 +107,8 @@ FactoryGirl.define do
     entrance_fee 12.3
   end
 
+  factory :site, class: 'Alchemy::Site' do
+    name 'A Site'
+    host 'domain.com'
+  end
 end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+module Alchemy
+  describe Site do
+    let(:site) { FactoryGirl.create(:site) }
+    let(:another_site) { FactoryGirl.create(:site, name: 'Another Site', host: 'another.com') }
+
+    describe '.current' do
+      context 'when set to a site' do
+        before { Site.current = site }
+        specify "Language should be scoped to that site"
+      end
+
+      context 'when set to nil' do
+        before { Site.current = nil }
+        specify "Language should not be scoped to a site"
+      end
+    end
+
+    describe '#current?' do
+      subject { site.current? }
+
+      context 'when Site.current is set to the same site' do
+        before { Site.current = site }
+        it { should be_true }
+      end
+
+      context 'when Site.current is set to nil' do
+        before { Site.current = nil }
+        it { should be_false }
+      end
+
+      context 'when Site.current is set to a different site' do
+        before { Site.current = another_site }
+        it { should be_false }
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Introduces a new model `Alchemy::Site`.
- Every request will set a current site, matching the request's host name, or the first site if no site matches.
- Binds and scopes `Alchemy::Language` to sites.
- Sites can be edited through a new web admin module.
