### PR TITLE
Missing cd into appdir

### DIFF
--- a/bin/alchemy
+++ b/bin/alchemy
@@ -37,7 +37,7 @@ class AlchemyInstaller < Thor
 
       create_database_yml if options[:database] == 'mysql'
 
-      system "rake alchemy:mount"
+      system "cd #{@application} && rake alchemy:mount"
 
       with_standard_set = yes?("\nDo you want to copy the files of Alchemy´s Standardset into your App? (y/N)")
 


### PR DESCRIPTION
Bootstrapping of the application fails at rake alchemy:mount cause it´s running outside the appdir.
