### PR TITLE
Introduce host aliases for sites.

### DIFF
--- a/app/controllers/alchemy/base_controller.rb
+++ b/app/controllers/alchemy/base_controller.rb
@@ -10,7 +10,7 @@ module Alchemy
     before_filter :set_language
     before_filter :mailer_set_url_options
 
-    helper_method :current_server, :t
+    helper_method :current_server, :current_site, :t
 
     # Returns a host string with the domain the app is running on.
     def current_server
@@ -46,9 +46,17 @@ module Alchemy
 
   private
 
-    # Sets the current site.
+    # Returns the current site.
+    #
+    def current_site
+      @current_site ||= Site.find_for_host(request.host)
+    end
+
+    # Sets the current site in a cvar so the Language model
+    # can be scoped against it.
+    #
     def set_current_site
-      Site.current = Site.where(host: request.host).first || Site.default
+      Site.current = current_site
     end
 
     # Sets Alchemy's GUI translation to users preffered language and stores it in the session.

--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -10,6 +10,7 @@ module Alchemy
 
     rescue_from ActionController::RoutingError, :with => :render_404
 
+    before_filter :enforce_primary_host_for_site
     before_filter :render_page_or_redirect, :only => [:show, :sitemap]
     before_filter :perform_search, :only => :show, :if => proc { configuration(:ferret) }
 
@@ -75,6 +76,18 @@ module Alchemy
         # currently active language.
         Page.language_root_for(@language.id)
       end
+    end
+
+    def enforce_primary_host_for_site
+      if needs_redirect_to_primary_host?
+        redirect_to url_for(host: current_site.host)
+      end
+    end
+
+    def needs_redirect_to_primary_host?
+      current_site.redirect_to_primary_host? &&
+        current_site.host != '*' &&
+        current_site.host != request.host
     end
 
     def render_page_or_redirect

--- a/config/locales/alchemy.de.yml
+++ b/config/locales/alchemy.de.yml
@@ -932,6 +932,8 @@ de:
         name: "Bezeichnung"
         host: "Host/Domain"
         public: "veröffentlicht"
+        aliases: "Domain-Aliases"
+        redirect_to_primary_host: "Primären Host erzwingen"
 
     errors:
       <<: *errors

--- a/db/migrate/20121220102223_add_aliases_to_site.rb
+++ b/db/migrate/20121220102223_add_aliases_to_site.rb
@@ -1,0 +1,6 @@
+class AddAliasesToSite < ActiveRecord::Migration
+  def change
+    add_column :alchemy_sites, :aliases, :text
+    add_column :alchemy_sites, :redirect_to_primary_host, :boolean
+  end
+end

--- a/spec/dummy/db/migrate/20121220102223_add_aliases_to_site.rb
+++ b/spec/dummy/db/migrate/20121220102223_add_aliases_to_site.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20121220102223_add_aliases_to_site.rb

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20121211163003) do
+ActiveRecord::Schema.define(:version => 20121220102223) do
 
   create_table "alchemy_attachments", :force => true do |t|
     t.string   "name"
@@ -246,9 +246,11 @@ ActiveRecord::Schema.define(:version => 20121211163003) do
   create_table "alchemy_sites", :force => true do |t|
     t.string   "host"
     t.string   "name"
-    t.datetime "created_at",                    :null => false
-    t.datetime "updated_at",                    :null => false
-    t.boolean  "public",     :default => false
+    t.datetime "created_at",                                  :null => false
+    t.datetime "updated_at",                                  :null => false
+    t.boolean  "public",                   :default => false
+    t.text     "aliases"
+    t.boolean  "redirect_to_primary_host"
   end
 
   add_index "alchemy_sites", ["host", "public"], :name => "alchemy_sites_public_hosts_idx"

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -8,7 +8,7 @@ module Alchemy
     describe 'new instances' do
       subject { FactoryGirl.build(:site) }
 
-      it 'should start out with on languages' do
+      it 'should start out with no languages' do
         subject.languages.should be_empty
       end
 
@@ -32,6 +32,46 @@ module Alchemy
               to_not change(subject, "languages")
           end
         end
+      end
+    end
+
+    describe '.find_for_host' do
+      # No need to create a default site, as it has already been added through the seeds.
+      # But let's add some more:
+      #
+      let(:default_site)    { Site.default }
+      let!(:magiclabs_site) { FactoryGirl.create(:site, host: 'www.magiclabs.de', aliases: 'magiclabs.de magiclabs.com www.magiclabs.com') }
+
+      subject { Site.find_for_host(host) }
+
+      context "when the request doesn't match anything" do
+        let(:host) { 'oogabooga.com' }
+        it { should == default_site }
+      end
+
+      context "when the request matches a site's host field" do
+        let(:host) { 'www.magiclabs.de' }
+        it { should == magiclabs_site }
+      end
+
+      context "when the request matches one of the site's aliases" do
+        let(:host) { 'magiclabs.com' }
+        it { should == magiclabs_site }
+      end
+
+      context "when the request matches the site's first alias" do
+        let(:host) { 'magiclabs.de' }
+        it { should == magiclabs_site }
+      end
+
+      context "when the request matches the site's last alias" do
+        let(:host) { 'www.magiclabs.com' }
+        it { should == magiclabs_site }
+      end
+
+      context "when the request host matches only part of a site's aliases" do
+        let(:host) { 'labs.com' }
+        it { should == default_site }
       end
     end
 


### PR DESCRIPTION
This allows the site admin to optionally enter a list of whitespace-separated alias hosts for sites, making individual sites available to more than a single host.

In addition, each site now has the option to enforce its primary host name as its canonical URL by way of redirection.
