### PR TITLE
Refactoring the language_switcher helper. (Now called language_links)

### DIFF
--- a/app/helpers/alchemy/pages_helper.rb
+++ b/app/helpers/alchemy/pages_helper.rb
@@ -15,82 +15,39 @@ module Alchemy
       content.essence.caption
     end
 
-    # == Helper for rendering language switches
+    # Renders links to language root pages of all published languages.
     #
-    # Renders links to all public language root pages
+    # @option options linkname [String] ('name') Renders name/code of language, or I18n translation for code.
+    # @option options show_title [Boolean] (true) Renders title attributes for the links.
+    # @option options spacer [String] ('') Renders the passed spacer string. You can also overwrite the spacer partial: "alchemy/language_links/_spacer".
+    # @option options reverse [Boolean] (false) Reverses the ordering of the links.
     #
-    # === Options:
-    #
-    #   :linkname => :name,
-    #   :spacer => "",
-    #   :link_to_public_child => configuration(:redirect_to_public_child),
-    #   :link_to_page_with_layout => nil,
-    #   :show_title => true,
-    #   :reverse => false,
-    #   :as_select_box => false,
-    #   :show_flags => false
-    #
-    def language_switcher(options={})
-      default_options = {
-        :linkname => :name,
-        :spacer => "",
-        :link_to_public_child => configuration(:redirect_to_public_child),
-        :link_to_page_with_layout => nil,
-        :show_title => true,
-        :reverse => false,
-        :as_select_box => false,
-        :show_flags => false
-      }
-      options = default_options.merge(options)
-      if multi_language?
-        language_links = []
-        pages = (options[:link_to_public_child] == true) ? Page.from_current_site.language_roots : Page.from_current_site.public_language_roots
-        return nil if (pages.blank? || pages.length == 1)
-        pages.each_with_index do |page, i|
-          if (options[:link_to_page_with_layout] != nil)
-            page_found_by_layout = Page.from_current_site.where(:page_layout => options[:link_to_page_with_layout].to_s, :language_id => page.language_id).first
-          end
-          page = page_found_by_layout || page
-          page = (options[:link_to_public_child] ? (page.first_public_child.blank? ? nil : page.first_public_child) : nil) if !page.public?
-          if !page.blank?
-            active = session[:language_id] == page.language.id
-            linkname = page.language.label(options[:linkname])
-            if options[:as_select_box]
-              language_links << [linkname, show_page_url(:urlname => page.urlname, :lang => page.language.code)]
-            else
-              language_links << link_to(
-                "#{content_tag(:span, '', :class => "flag") if options[:show_flags]}#{ content_tag(:span, linkname)}".html_safe,
-                alchemy.show_page_path(:urlname => page.urlname, :lang => page.language.code),
-                :class => "#{(active ? 'active ' : nil)}#{page.language.code} #{(i == 0) ? 'first' : (i==pages.length-1) ? 'last' : nil}",
-                :title => options[:show_title] ? Alchemy::I18n.t("alchemy.language_links.#{page.language.code}.title", :default => page.language.name) : nil
-              )
-            end
-          end
-          # when last iteration and we have just one language_link,
-          # we dont need to render it.
-          if (i==pages.length-1) && language_links.length == 1
-            return nil
-          end
-        end
-        return nil if language_links.empty? || language_links.length == 1
-        language_links.reverse! if options[:reverse]
-        if options[:as_select_box]
-          return select_tag(
-            'language',
-            options_for_select(
-              language_links,
-              show_page_url(:urlname => @page.urlname, :lang => @page.language.code)
-            ),
-            :onchange => "window.location=this.value"
-          )
-        else
-          raw(language_links.join(options[:spacer]))
-        end
-      else
-        nil
-      end
+    def language_links(options={})
+      options = {
+        linkname: 'name',
+        show_title: true,
+        spacer: '',
+        reverse: false
+      }.merge(options)
+      languages = Language.published.with_language_root.order("name #{options[:reverse] ? 'DESC' : 'ASC'}")
+      return nil if languages.count < 2
+      render(
+        partial: "alchemy/language_links/language",
+        collection: languages,
+        spacer_template: "alchemy/language_links/spacer",
+        locals: {languages: languages, options: options}
+      )
     end
-    alias_method :language_switches, :language_switcher
+
+    def language_switches(options={})
+      ActiveSupport::Deprecation.warn("Used deprecated language_switches helper. Please use language_links instead.")
+      language_links(options)
+    end
+
+    def language_switcher(options={})
+      ActiveSupport::Deprecation.warn("Used deprecated language_switcher helper. Please use language_links instead.")
+      language_links(options)
+    end
 
     # Renders the layout from @page.page_layout. File resists in /app/views/page_layouts/_LAYOUT-NAME.html.erb
     def render_page_layout(options={})

--- a/app/models/alchemy/language.rb
+++ b/app/models/alchemy/language.rb
@@ -31,6 +31,7 @@ module Alchemy
     before_save :remove_old_default, :if => proc { |m| m.default_changed? && m != Language.get_default }
 
     scope :published, where(:public => true)
+    scope :with_language_root, joins(:pages).where("alchemy_pages" => {language_root: true})
 
     # multi-site support
     scope :on_site, lambda { |s| s.present? ? where(site_id: s) : scoped }

--- a/app/views/alchemy/language_links/_language.html.erb
+++ b/app/views/alchemy/language_links/_language.html.erb
@@ -1,0 +1,12 @@
+<% css_classes = [language.code] %>
+<% css_classes << 'active' if session[:language_id] == language.id %>
+<% css_classes << 'first' if languages.first == language %>
+<% css_classes << 'last' if languages.last == language %>
+<% link_title = options[:show_title] ? _t("#{language.code}.title", scope: 'language_links', default: language.name) : nil %>
+
+<%= link_to(
+  content_tag(:span, language.label(options[:linkname])).html_safe,
+  show_alchemy_page_path(language.pages.language_roots.first, lang: language.code),
+  class: css_classes.join(" "),
+  title: link_title
+) %>

--- a/app/views/alchemy/language_links/_spacer.html.erb
+++ b/app/views/alchemy/language_links/_spacer.html.erb
@@ -1,0 +1,1 @@
+<%= options[:spacer].html_safe %>

--- a/lib/rails/generators/alchemy/scaffold/scaffold_generator.rb
+++ b/lib/rails/generators/alchemy/scaffold/scaffold_generator.rb
@@ -3,6 +3,9 @@ require 'rails'
 module Alchemy
   module Generators
     class ScaffoldGenerator < ::Rails::Generators::Base
+
+      ALCHEMY_VIEWS = %w(breadcrumb language_links messages navigation notifications search)
+
       desc "This generator generates the Alchemy scaffold."
       class_option :copy_views, :default => false, :type => :boolean, :desc => "Copy all Alchemy views into your app.", :aliases => '-v'
       source_root File.expand_path('templates', File.dirname(__FILE__))
@@ -37,7 +40,7 @@ module Alchemy
       end
 
       def copy_alchemy_views
-        %w(breadcrumb messages navigation notifications search).each do |dir|
+        ALCHEMY_VIEWS.each do |dir|
           src = File.expand_path("../../../../../app/views/alchemy/#{dir}", File.dirname(__FILE__))
           dest = Rails.root.join('app/views/alchemy', dir)
           directory src, dest


### PR DESCRIPTION
- Removed the following options (link_to_public_child, link_to_page_with_layout, as_select_box, show_flags)
- Renders a partial instead of returning html markup as a string.
