### PR TITLE
Fixes :from_page option of render_navigation helper. Adds specs.

### DIFF
--- a/app/helpers/alchemy/pages_helper.rb
+++ b/app/helpers/alchemy/pages_helper.rb
@@ -122,6 +122,7 @@ module Alchemy
         :reverse_children => false
       }.merge(options)
       page = page_or_find(options[:from_page])
+      return nil if page.blank?
       pages = page.children.visible.with_permissions_to(:show, :context => :alchemy_pages)
       pages = pages.restricted if options.delete(:restricted_only)
       if depth = options[:deepness]

--- a/spec/helpers/base_helper_spec.rb
+++ b/spec/helpers/base_helper_spec.rb
@@ -60,5 +60,31 @@ module Alchemy
       end
     end
 
+    describe '#page_or_find' do
+      let(:page) { FactoryGirl.create(:public_page) }
+
+      context "passing a page_layout string" do
+        context "of a not existing page" do
+          it "should return nil" do
+            expect(helper.page_or_find('contact')).to be_nil
+          end
+        end
+
+        context 'of an existing page' do
+          it "should return the page object" do
+            session[:language_id] = page.language_id
+            expect(helper.page_or_find(page.page_layout)).to eq(page)
+          end
+        end
+      end
+
+      context "passing a page object" do
+        it "should return the given page object" do
+          expect(helper.page_or_find(page)).to eq(page)
+        end
+      end
+
+    end
+
   end
 end

--- a/spec/helpers/pages_helper_spec.rb
+++ b/spec/helpers/pages_helper_spec.rb
@@ -114,6 +114,34 @@ module Alchemy
         end
       end
 
+      context "with options[:from_page] set" do
+        before { level_2_page }
+
+        context "passing a page object" do
+          it "should render the pages underneath the given one" do
+            output = helper.render_navigation(from_page: visible_page)
+            output.should_not have_selector("ul li a[href=\"/#{visible_page.urlname}\"]")
+            output.should have_selector("ul li a[href=\"/#{level_2_page.urlname}\"]")
+          end
+        end
+
+        context "passing a page_layout" do
+          it "should render the pages underneath the page with the given page_layout" do
+            helper.stub(:page_or_find).with('contact').and_return(visible_page)
+            output = helper.render_navigation(from_page: 'contact')
+            output.should_not have_selector("ul li a[href=\"/#{visible_page.urlname}\"]")
+            output.should have_selector("ul li a[href=\"/#{level_2_page.urlname}\"]")
+          end
+        end
+
+        context "passing a page_layout of a not existing page" do
+          it "should render nothing" do
+            expect(helper.render_navigation(from_page: 'news')).to be_nil
+          end
+        end
+
+      end
+
     end
 
     describe '#render_subnavigation' do


### PR DESCRIPTION
- Fixes an error when passing a page_layout name of a not existing page to :from_page option of render_navigation helper.
- Adds specs for the from_page option
- Adds specs the base_helper#page_or_find method.
