### PR TITLE
Performance improvements

### DIFF
--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -80,14 +80,7 @@ module Alchemy
       # your own set of elements
       #
       def descriptions
-        if ::File.exists? "#{::Rails.root}/config/alchemy/elements.yml"
-          ::YAML.load_file("#{::Rails.root}/config/alchemy/elements.yml") || []
-        else
-          raise LoadError, "Could not find elements.yml file! Please run: rails generate alchemy:scaffold"
-        end
-      rescue TypeError => e
-        warn "Your elements.yml is empty."
-        []
+        ElementsDescription.descriptions
       end
       alias_method :definitions, :descriptions
 

--- a/lib/alchemy/elements_description.rb
+++ b/lib/alchemy/elements_description.rb
@@ -1,0 +1,24 @@
+module Alchemy
+  module ElementsDescription
+
+    class << self
+    
+      def descriptions
+        @@descriptions ||= read_file
+      end
+
+      def read_file
+        if ::File.exists? "#{::Rails.root}/config/alchemy/elements.yml"
+          ::YAML.load_file("#{::Rails.root}/config/alchemy/elements.yml") || []
+        else
+          raise LoadError, "Could not find elements.yml file! Please run: rails generate alchemy:scaffold"
+        end
+      rescue TypeError => e
+        warn "Your elements.yml is empty."
+        []
+      end
+
+    end
+
+  end
+end

--- a/lib/alchemy_cms.rb
+++ b/lib/alchemy_cms.rb
@@ -35,6 +35,7 @@ if Rails::VERSION::MAJOR == 3 && Rails::VERSION::MINOR == 2
     'essence',
     'page_layout',
     'modules',
+    'elements_description',
     'tinymce',
     'i18n',
     'scoped_pagination_url_helper',

--- a/spec/libraries/elements_description_spec.rb
+++ b/spec/libraries/elements_description_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+module Alchemy
+
+  describe ElementsDescription do
+
+    context "no description files are found" do
+
+      before do
+        FileUtils.mv(File.join(File.dirname(__FILE__), '../dummy/config/alchemy/elements.yml'), File.join(File.dirname(__FILE__), '../dummy/config/alchemy/elements.yml.bak'))
+      end
+
+      it "should raise an error" do
+        expect { ElementsDescription.read_file }.to raise_error(LoadError)
+      end
+
+      after do
+        FileUtils.mv(File.join(File.dirname(__FILE__), '../dummy/config/alchemy/elements.yml.bak'), File.join(File.dirname(__FILE__), '../dummy/config/alchemy/elements.yml'))
+      end
+
+    end
+
+    context "without any descriptions in elements.yml file" do
+
+      it "should return an empty array" do
+        YAML.stub(:load_file).and_return(false) # Yes, YAML.load_file returns false if an empty file exists.
+        ElementsDescription.read_file.should == []
+      end
+
+    end
+
+  end
+
+end

--- a/spec/models/element_spec.rb
+++ b/spec/models/element_spec.rb
@@ -100,31 +100,6 @@ module Alchemy
 
     end
 
-    context "no description files are found" do
-
-      before do
-        FileUtils.mv(File.join(File.dirname(__FILE__), '../dummy/config/alchemy/elements.yml'), File.join(File.dirname(__FILE__), '../dummy/config/alchemy/elements.yml.bak'))
-      end
-
-      it "should raise an error" do
-        expect { Element.descriptions }.to raise_error(LoadError)
-      end
-
-      after do
-        FileUtils.mv(File.join(File.dirname(__FILE__), '../dummy/config/alchemy/elements.yml.bak'), File.join(File.dirname(__FILE__), '../dummy/config/alchemy/elements.yml'))
-      end
-
-    end
-
-    context "without any descriptions in elements.yml file" do
-
-      it "should return an empty array" do
-        YAML.stub(:load_file).and_return(false) # Yes, YAML.load_file returns false if an empty file exists.
-        Element.descriptions.should == []
-      end
-
-    end
-
     context "retrieving contents, essences and ingredients" do
 
       let(:element) { FactoryGirl.create(:element, :name => 'news', :create_contents_after_create => true) }
@@ -422,5 +397,15 @@ module Alchemy
 
     end
 
+    describe "#descriptions" do
+
+      it "calls ElementsDescription to get descriptions" do
+        ElementsDescription.should_receive(:descriptions)
+        Element.descriptions
+      end
+
+    end
+
   end
+
 end


### PR DESCRIPTION
Before, the configuration file elements.yml was read multiple times when, for example, editing a page. We ran in to some performance issues. Loading the edit page view took > 10 seconds. After this fix, loading the edit page view now takes less than 1 second. 

This commit will read elements.yml once and save it in memory. A module was created that handles the reading of the file, just as in the case for page_layout.yml. 

The obvious drawback with the solution is that a developer has to restart the server every time elements.yml is changed. Apart from that, it'll speed up the application quite a lot.
