### PR TITLE
Memoize elements

### DIFF
--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -80,15 +80,19 @@ module Alchemy
       # your own set of elements
       #
       def descriptions
-        if ::File.exists? "#{::Rails.root}/config/alchemy/elements.yml"
-          ::YAML.load_file("#{::Rails.root}/config/alchemy/elements.yml") || []
-        else
-          raise LoadError, "Could not find elements.yml file! Please run: rails generate alchemy:scaffold"
+        unless @elements_config
+          if ::File.exists? "#{::Rails.root}/config/alchemy/elements.yml"
+            @elements_config = ::YAML.load_file("#{::Rails.root}/config/alchemy/elements.yml") || []
+          else
+            raise LoadError, "Could not find elements.yml file! Please run: rails generate alchemy:scaffold"
+          end
         end
+        @elements_config
       rescue TypeError => e
         warn "Your elements.yml is empty."
         []
       end
+
       alias_method :definitions, :descriptions
 
       # pastes a element from the clipboard in the session to page


### PR DESCRIPTION
This patch memoizes the elements.yml file once per request. 

Previously the elements file was loaded several times per request incurring a lot of unneccesary overhead - in our app we saw ~60 file loads per request, resulting in load times up to 10 seconds. With this patch it dropped to 2 seconds.

I know that this is handled in the forthcoming 3.0 release, but that upgrade will require Rails 4 which will delay the upgrade for us. I hope you will accept this patch for the 2.6 branch so we can continue using your repo as our base.
