### PR TITLE
Throw 404 if attachment can not be found.

### DIFF
--- a/app/controllers/alchemy/attachments_controller.rb
+++ b/app/controllers/alchemy/attachments_controller.rb
@@ -28,7 +28,7 @@ module Alchemy
   private
 
     def load_attachment
-      @attachment = Attachment.where(:id => params[:id]).first
+      @attachment = Attachment.find(params[:id])
     end
 
   end

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -24,6 +24,10 @@ module Alchemy
       response.should redirect_to(login_path)
     end
 
+    it "should raise ActiveRecord::RecordNotFound for requesting not existing attachments" do
+      expect { get :download, id: 0 }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
     context "as registered user" do
 
       before do


### PR DESCRIPTION
For the 2.7-stable release candidate.
