### PR TITLE
Makes picture urls cacheable with CDNs like CloudFront

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,11 +50,12 @@ Alchemy::Engine.routes.draw do
   get '/uploads/files/0000/:id/:name(.:suffix)' => 'attachments#download'
 
   # Picture urls
-  get "/pictures/:id/show(/:size)(/:crop)(/:crop_from/:crop_size)(/:quality)/:name.:format" => 'pictures#show',
-        :as => :show_picture
+  get "/pictures/:id/show(/:size)(/:crop)(/:crop_from/:crop_size)(/:quality)/:sh/:name.:format" => 'pictures#show',
+    :as => :show_picture
+
   get '/pictures/:id/zoom/:name.:format' => 'pictures#zoom',
         :as => :zoom_picture
-  get "/pictures/:id/thumbnails/:size(/:crop)(/:crop_from/:crop_size)/:name.:format" => 'pictures#thumbnail',
+  get "/pictures/:id/thumbnails/:size(/:crop)(/:crop_from/:crop_size)/:sh/:name.:format" => 'pictures#thumbnail',
         :as => :thumbnail, :defaults => {:format => 'png', :name => "thumbnail"}
 
   resources :messages, :only => [:index, :new, :create]


### PR DESCRIPTION
The security token applied to the picture show url will not translate well to CDNs like Amazon CloudFront because they ignore any query strings.

This commit places `param[:sh]` in the path before the file name.

`/pictures/90/show/file.png?sh=aksjdksjkjsj`

becomes

`/pictures/90/show/aksjdksjkjsj/file.png`
