### PR TITLE
Includes admin base_helper to attachments_helper and adds specs.

### DIFF
--- a/app/helpers/alchemy/admin/attachments_helper.rb
+++ b/app/helpers/alchemy/admin/attachments_helper.rb
@@ -1,6 +1,7 @@
 module Alchemy
   module Admin
     module AttachmentsHelper
+      include Alchemy::Admin::BaseHelper
 
       def mime_to_human(mime)
         I18n.t(mime, scope: 'mime_types', default: _t(:document))

--- a/spec/helpers/admin/attachments_helper_spec.rb
+++ b/spec/helpers/admin/attachments_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Alchemy::Admin::AttachmentsHelper do
+  describe '#mime_to_human' do
+    context 'when given mime type has no translation' do
+      it "should return the default" do
+        expect(helper.mime_to_human('something')).to eq('File')
+      end
+    end
+
+    it "should return the translation for the given mime type" do
+      expect(helper.mime_to_human('text/plain')).to eq('Text-Document')
+    end
+  end
+end


### PR DESCRIPTION
The BaseHelper is now included in the AttachmentsHelper because the used _t method is defined in the BaseHelper.
