### PR TITLE
Page#sitemap scope now depends on the current site.

### DIFF
--- a/app/models/alchemy/page/scopes.rb
+++ b/app/models/alchemy/page/scopes.rb
@@ -86,7 +86,7 @@ module Alchemy
 
       # All pages for xml sitemap
       #
-      scope :sitemap, -> { published.contentpages.where(sitemap: true) }
+      scope :sitemap, -> { from_current_site.published.contentpages.where(sitemap: true) }
     end
 
   end


### PR DESCRIPTION
This is necessary because elsewise the sitemap would render all pages from all sites which is not desired.
