### PR TITLE
Adds a Tasks::Helpers module to encapsulate logic from rake and capistrano tasks.

### DIFF
--- a/lib/alchemy/tasks/helpers.rb
+++ b/lib/alchemy/tasks/helpers.rb
@@ -1,0 +1,41 @@
+module Alchemy
+  module Tasks
+    module Helpers
+
+      def mysql_credentials
+        mysql_credentials = []
+        if database_config['username']
+          mysql_credentials << "--user='#{database_config['username']}'"
+        end
+        if database_config['password']
+          mysql_credentials << "--password='#{database_config['password']}'"
+        end
+        if (host = database_config['host']) && (host != 'localhost')
+          mysql_credentials << "--host='#{host}'"
+        end
+        mysql_credentials.join(' ')
+      end
+
+      def database_config
+        raise "Could not find #{database_config_file}!" if !File.exists?(database_config_file)
+        @database_config ||= begin
+          config_file = YAML.load_file(database_config_file)
+          config_file.fetch(environment)
+          rescue KeyError
+            raise "Database configuration for #{environment} not found!"
+        end
+      end
+
+      private
+
+      def database_config_file
+        "./config/database.yml"
+      end
+
+      def environment
+        ENV['RAILS_ENV'] || 'development'
+      end
+
+    end
+  end
+end

--- a/lib/tasks/alchemy/db.rake
+++ b/lib/tasks/alchemy/db.rake
@@ -1,4 +1,6 @@
 require 'alchemy/seeder'
+require 'alchemy/tasks/helpers'
+include Alchemy::Tasks::Helpers
 
 namespace :alchemy do
   namespace :db do
@@ -10,11 +12,9 @@ namespace :alchemy do
 
     desc "Dumps the database to STDOUT (Pass DUMP_FILENAME to store the dump into a file). NOTE: This only works with MySQL yet."
     task :dump => :environment do
-      db_conf = Rails.configuration.database_configuration.fetch(Rails.env)
-      raise "Sorry, but Alchemy only supports MySQL database dumping at the moment." unless db_conf['adapter'] =~ /mysql/
+      raise "Sorry, but Alchemy only supports MySQL database dumping at the moment." unless database_config['adapter'] =~ /mysql/
       dump_store = ENV['DUMP_FILENAME'] ? " > #{ENV['DUMP_FILENAME']}" : ""
-      cmd = "mysqldump --user='#{db_conf['username']}'#{db_conf['password'].present? ? " --password='#{db_conf['password']}'" : nil} #{db_conf['database']}#{dump_store}"
-      system cmd
+      system "mysqldump #{mysql_credentials} #{database_config['database']}#{dump_store}"
     end
 
   end

--- a/spec/tasks/helpers_spec.rb
+++ b/spec/tasks/helpers_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+require 'alchemy/tasks/helpers'
+
+module Alchemy
+
+  class Foo
+    extend Tasks::Helpers
+  end
+
+  describe "Tasks:Helpers" do
+
+    let(:config) do
+      {
+        'test' => {
+          'username' => 'testuser',
+          'password' => '123456',
+          'host'     => 'localhost'
+        }
+      }
+    end
+
+    before do
+      File.stub(exists?: true)
+      YAML.stub(load_file: config)
+    end
+
+    describe "#mysql_credentials" do
+
+      subject { Foo.mysql_credentials }
+
+      after do
+        Foo.instance_variable_set("@database_config", nil) # resets the memoization
+      end
+
+      context "when a username is set in the config file" do
+        it { should include("--user='testuser'") }
+      end
+
+      context "when a password is set in the config file" do
+        it { should include("--password='123456'") }
+      end
+
+      context "when a host is set in the config file" do
+        context "and the host is localhost" do
+          it { should_not include("--host=") }
+        end
+
+        context "and the host is anything but not localhost" do
+          before do
+            YAML.stub(load_file: {'test' => {'host' => 'mydomain.com'}})
+          end
+          it { should include("--host='mydomain.com'") }
+        end
+      end
+
+      context "when config for RAILS_ENV not found" do
+        before { Foo.stub(environment: 'huh?') }
+        it "should raise an error" do
+          expect{Foo.mysql_credentials}.to raise_error(RuntimeError)
+        end
+      end
+    end
+
+    describe "#database_config" do
+      it "should memoize the results" do
+        expect(Foo.database_config).to eq(config['test'])
+        config['username'] = 'newuser'
+        expect(Foo.database_config).to eq(config['test'])
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Because of sharing this helper methods between the db.rake and capistrano.rb the `rake alchemy:db:dump` task can now take the --host option for mysqldump. (Useful for importing sql from an external db server)
