### PR TITLE
Removes the creation and dropping of alchemy_users.

### DIFF
--- a/db/migrate/20130827094554_alchemy_two_point_six.rb
+++ b/db/migrate/20130827094554_alchemy_two_point_six.rb
@@ -294,38 +294,6 @@ class AlchemyTwoPointSix < ActiveRecord::Migration
       add_index "alchemy_sites", ["host"], name: "index_alchemy_sites_on_host"
     end
 
-    unless table_exists?('alchemy_users')
-      create_table "alchemy_users" do |t|
-        t.string   "firstname"
-        t.string   "lastname"
-        t.string   "login"
-        t.string   "email"
-        t.string   "gender"
-        t.string   "roles",                  default: "registered"
-        t.string   "language"
-        t.string   "encrypted_password",     limit: 128, default: "",  null: false
-        t.string   "password_salt",          limit: 128, default: "",  null: false
-        t.integer  "sign_in_count",          default: 0,               null: false
-        t.integer  "failed_attempts",        default: 0,               null: false
-        t.datetime "last_request_at"
-        t.datetime "current_sign_in_at"
-        t.datetime "last_sign_in_at"
-        t.string   "current_sign_in_ip"
-        t.string   "last_sign_in_ip"
-        t.datetime "created_at",                                       null: false
-        t.datetime "updated_at",                                       null: false
-        t.integer  "creator_id"
-        t.integer  "updater_id"
-        t.text     "cached_tag_list"
-        t.string   "reset_password_token"
-        t.datetime "reset_password_sent_at"
-      end
-      add_index "alchemy_users", ["email"], name: "index_alchemy_users_on_email", unique: true
-      add_index "alchemy_users", ["login"], name: "index_alchemy_users_on_login", unique: true
-      add_index "alchemy_users", ["reset_password_token"], name: "index_alchemy_users_on_reset_password_token", unique: true
-      add_index "alchemy_users", ["roles"], name: "index_alchemy_users_on_roles"
-    end
-
     unless table_exists?('taggings')
       create_table "taggings" do |t|
         t.integer  "tag_id"

--- a/db/migrate/20131015125201_remove_alchemy_users.rb
+++ b/db/migrate/20131015125201_remove_alchemy_users.rb
@@ -1,5 +1,0 @@
-class RemoveAlchemyUsers < ActiveRecord::Migration
-  def up
-    drop_table :alchemy_users
-  end
-end

--- a/spec/dummy/db/migrate/20131015125201_remove_alchemy_users.rb
+++ b/spec/dummy/db/migrate/20131015125201_remove_alchemy_users.rb
@@ -1,1 +1,0 @@
-../../../../db/migrate/20131015125201_remove_alchemy_users.rb


### PR DESCRIPTION
Dropping an existing alchemy_users table means loosing data.
To prevent this, this commit removed that migration for dropping the alchemy_users table and also removed the creation of it from the merged migration file.

This change means: The alchemy_users table will never been created for new apps, but will not dropped for upgraded apps that still relies on the existing table and its data.
