### PR TITLE
Make the current_user configurable

### DIFF
--- a/lib/alchemy/auth_accessors.rb
+++ b/lib/alchemy/auth_accessors.rb
@@ -29,11 +29,12 @@
 #     Alchemy.register_ability MyCustom::Ability
 #
 module Alchemy
-  mattr_accessor :user_class_name, :login_path, :logout_path
+  mattr_accessor :user_class_name, :current_user_method, :login_path, :logout_path
 
   # Defaults
   #
   @@user_class_name = 'User'
+  @@current_user_method = 'current_user'
   @@login_path = '/login'
   @@logout_path = '/logout'
 

--- a/lib/alchemy/controller_actions.rb
+++ b/lib/alchemy/controller_actions.rb
@@ -25,14 +25,16 @@ module Alchemy
     #
     # In order to have Alchemy's authorization work, you have to
     # provide a +current_user+ method in your app's ApplicationController,
-    # that returns the current user.
+    # that returns the current user. To change the method +current_alchemy_user+
+    # will call, set +Alchemy.current_user_method+ to a different method name.
     #
     # If you don't have an App that can provide a +current_user+ object,
     # you can install the `alchemy-devise` gem that provides everything you need.
     #
     def current_alchemy_user
-      raise NoCurrentUserFoundError if !defined?(current_user)
-      current_user
+      current_user_method = Alchemy.current_user_method
+      raise NoCurrentUserFoundError if !respond_to?(current_user_method, true)
+      send current_user_method
     end
 
     # Returns true if a +current_alchemy_user+ is present

--- a/spec/controllers/base_controller_spec.rb
+++ b/spec/controllers/base_controller_spec.rb
@@ -92,5 +92,45 @@ module Alchemy
       end
     end
 
+    describe "#current_alchemy_user" do
+
+      context "with default current_user_method" do
+
+        it "calls current_user by default" do
+          controller.should_receive :current_user
+          controller.send :current_alchemy_user
+        end
+      end
+
+      context "with custom current_user_method" do
+
+        before do
+          Alchemy.current_user_method = 'current_admin'
+        end
+
+        it "calls the custom method" do
+          controller.should_receive :current_admin
+          controller.send :current_alchemy_user
+        end
+      end
+
+      context "with not implemented current_user_method" do
+
+        before do
+          Alchemy.current_user_method = 'not_implemented_method'
+        end
+
+        after do
+          Alchemy.current_user_method = 'current_user'
+        end
+
+        it "raises an error" do
+          expect{
+            controller.send :current_alchemy_user
+          }.to raise_error(NoCurrentUserFoundError)
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Makes the function configurable that is called by `current_alchemy_user`
to get the current user. Set Alchemy.current_user_method to the name
of the custom function.
