### PR TITLE
Fix bug in page#new overlay when clipboard contains a page.

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.windows.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.windows.js.coffee
@@ -192,6 +192,7 @@ $.extend Alchemy,
                 options.complete($dialog)
               if options.image_loader
                 Alchemy.ImageLoader Alchemy.CurrentWindow, {color: options.image_loader_color}
+              $("#overlay_tabs", $dialog).tabs()
               Alchemy.watchRemoteForms($dialog)
           error: (XMLHttpRequest, textStatus, errorThrown) ->
             Alchemy.AjaxErrorHandler($dialog, XMLHttpRequest.status, textStatus, errorThrown)

--- a/app/views/alchemy/admin/pages/edit.html.erb
+++ b/app/views/alchemy/admin/pages/edit.html.erb
@@ -133,10 +133,7 @@
             Alchemy.openWindow('<%= alchemy.new_admin_element_path(page_id: @page.id) %>', {
               title: '<%= _t("New Element") %>',
               width: 320,
-              height: 120,
-              complete: function($dialog) {
-                $("#overlay_tabs", $dialog).tabs();
-              }
+              height: 120
             });
           }
         },

--- a/app/views/alchemy/admin/pages/new.html.erb
+++ b/app/views/alchemy/admin/pages/new.html.erb
@@ -13,8 +13,10 @@
     <%= alchemy_form_for [:admin, @page] do |f| %>
       <%= f.hidden_field(:parent_id) %>
       <div class="input select">
-        <label for="paste_from_clipboard"><%= _t("Page") %></label>
-        <%= clipboard_select_tag(@clipboard_items) %>
+        <label for="paste_from_clipboard" class="control-label"><%= _t("Page") %></label>
+        <%= select_tag 'paste_from_clipboard',
+          clipboard_select_tag_options(@clipboard_items),
+          class: 'alchemy_selectbox' %>
       </div>
       <%= f.input :name %>
       <%= f.submit _t(:paste) %>

--- a/spec/features/admin/page_creation_feature_spec.rb
+++ b/spec/features/admin/page_creation_feature_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+module Alchemy
+  describe "Page creation" do
+    before { authorize_as_admin }
+
+    describe "overlay GUI" do
+      context "without having a Page in the clipboard" do
+        it "does not contain tabs" do
+          visit new_admin_page_path
+          within('#main_content') { expect(page).to_not have_selector('#overlay_tabs') }
+        end
+      end
+
+      context "when having a Page in the clipboard" do
+        before { Page.stub all_from_clipboard_for_select: [build_stubbed(:page)] }
+
+        it "contains tabs for creating a new page and pasting from clipboard" do
+          visit new_admin_page_path
+          within('#overlay_tabs') { expect(page).to have_selector '#create_page_tab, #paste_page_tab' }
+        end
+
+        context "", js: true do
+          before do
+            visit admin_pages_path
+            page.first(:link, 'Create a new subpage').click
+          end
+
+          it "the create page tab is visible by default" do
+            within('#overlay_tabs') do
+              expect(find '#create_page_tab').to be_visible
+              expect(find '#paste_page_tab').to_not be_visible
+            end
+          end
+
+          context "when clicking on an inactive tab" do
+            it "shows that clicked tab" do
+              within('#overlay_tabs') do
+                click_link('Paste from clipboard')
+                expect(find '#create_page_tab').to_not be_visible
+                expect(find '#paste_page_tab').to be_visible
+              end
+            end
+          end
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Since the select_clipboard_tag helper has been removed, we use the rails select_tag helper instead.

Also added tab initialization when the ajax request for loading overlay content is complete.

(Fixes #451)
