### PR TITLE
Adds shared examples for the Essence module.

### DIFF
--- a/lib/alchemy/test_support/essence_shared_examples.rb
+++ b/lib/alchemy/test_support/essence_shared_examples.rb
@@ -1,18 +1,24 @@
 require 'spec_helper'
 
 module Alchemy
-  describe "ActsAsEssence" do
+  shared_examples_for "an essence" do
+
     let(:element) { Element.new }
     let(:content) { Content.new(name: 'foo') }
-    let(:essence) { build_stubbed(:essence_text) }
     let(:content_description) { {'name' => 'foo'} }
 
     it "touches the content after update" do
-      content = create(:content)
+      essence.save
+      content.update(essence: essence, essence_type: essence.class.name)
       d = content.updated_at
-      content.essence.update(body: 'Yadada')
+      content.essence.update(essence.ingredient_column.to_sym => ingredient_value)
       content.reload
       content.updated_at.should_not eq(d)
+    end
+
+    it "should have correct partial path" do
+      underscored_essence = essence.class.name.demodulize.underscore
+      expect(essence.to_partial_path).to eq("alchemy/essences/#{underscored_essence}_view")
     end
 
     describe '#description' do
@@ -53,35 +59,13 @@ module Alchemy
 
     describe '#ingredient=' do
       it 'should set the value to ingredient column' do
-        essence.ingredient = 'Hallo'
-        expect(essence.ingredient).to eq('Hallo')
-      end
-    end
-
-    describe '#open_link_in_new_window?' do
-
-      subject { essence.open_link_in_new_window? }
-
-      context 'essence responds to link_taget' do
-        context 'if link_target attribute is set to "blank"' do
-
-          before { essence.link_target = 'blank' }
-
-          it "should return true" do
-            expect(subject).to eq(true)
-          end
-        end
-
-        context 'if link_target attribute is not "blank"' do
-          it "should return false" do
-            expect(subject).to eq(false)
-          end
-        end
+        essence.ingredient = ingredient_value
+        expect(essence.ingredient).to eq ingredient_value
       end
     end
 
     describe '#page' do
-      let(:page) { build_stubbed(:page) }
+      let(:page)    { build_stubbed(:page) }
       let(:element) { build_stubbed(:element, page: page) }
 
       context 'essence has no element' do

--- a/spec/models/essence_boolean_spec.rb
+++ b/spec/models/essence_boolean_spec.rb
@@ -2,14 +2,9 @@ require 'spec_helper'
 
 module Alchemy
   describe EssenceBoolean do
-
-    it "should act as essence" do
-      expect { EssenceBoolean.new.acts_as_essence? }.to_not raise_error
+    it_behaves_like "an essence" do
+      let(:essence)          { EssenceBoolean.new }
+      let(:ingredient_value) { false }
     end
-
-    it "should have correct partial path" do
-      EssenceBoolean.new.to_partial_path.should == 'alchemy/essences/essence_boolean_view'
-    end
-
   end
 end

--- a/spec/models/essence_date_spec.rb
+++ b/spec/models/essence_date_spec.rb
@@ -2,24 +2,28 @@ require 'spec_helper'
 
 module Alchemy
   describe EssenceDate do
-    let(:essence_date) { EssenceDate.new }
+    let(:essence) { EssenceDate.new }
+
+    it_behaves_like "an essence" do
+      let(:essence)          { EssenceDate.new }
+      let(:ingredient_value) { Date.today }
+    end
 
     describe '#preview_text' do
-
       context "if no date set" do
         it "should return an empty string" do
-          expect(essence_date.preview_text).to eq("")
+          expect(essence.preview_text).to eq("")
         end
       end
 
       context "if date set" do
         it "should format the date by i18n" do
-          essence_date.date = Date.today
-          ::I18n.should_receive(:l).with(essence_date.date, format: :date)
-          essence_date.preview_text
+          essence.date = Date.today
+          ::I18n.should_receive(:l).with(essence.date, format: :date)
+          essence.preview_text
         end
       end
-
     end
+
   end
 end

--- a/spec/models/essence_file_spec.rb
+++ b/spec/models/essence_file_spec.rb
@@ -3,11 +3,16 @@ require 'spec_helper'
 module Alchemy
   describe EssenceFile do
 
+    let(:attachment) { build_stubbed(:attachment) }
+    let(:essence)    { EssenceFile.new(attachment: attachment) }
+
+    it_behaves_like "an essence" do
+      let(:essence)          { EssenceFile.new }
+      let(:ingredient_value) { attachment }
+    end
+
     describe '#attachment_url' do
       subject { essence.attachment_url }
-
-      let(:attachment) { build_stubbed(:attachment) }
-      let(:essence)    { build_stubbed(:essence_file, attachment: attachment) }
 
       it "returns the download attachment url." do
         should match(/\/attachment\/#{attachment.id}\/download\/#{attachment.file_name}/)
@@ -21,16 +26,14 @@ module Alchemy
     end
 
     describe '#preview_text' do
-      let(:attachment) { mock_model(Attachment, name: 'File') }
-      let(:essence) { EssenceFile.new }
 
       it "returns the attachment's name as preview text" do
-        essence.stub(:attachment).and_return(attachment)
-        essence.preview_text.should == 'File'
+        essence.preview_text.should == attachment.name
       end
 
       context "with no attachment assigned" do
         it "returns empty string" do
+          essence.attachment = nil
           essence.preview_text.should == ''
         end
       end

--- a/spec/models/essence_html_spec.rb
+++ b/spec/models/essence_html_spec.rb
@@ -2,11 +2,16 @@ require 'spec_helper'
 
 module Alchemy
   describe EssenceHtml do
-    describe '#preview_text' do
-      let (:essence_html) { EssenceHtml.new(source: '<p>hello!</p>') }
+    let (:essence) { EssenceHtml.new(source: '<p>hello!</p>') }
 
+    it_behaves_like "an essence" do
+      let(:essence)          { EssenceHtml.new }
+      let(:ingredient_value) { '<p>hello!</p>' }
+    end
+
+    describe '#preview_text' do
       it "should return html escaped source code" do
-        expect(essence_html.preview_text).to eq('&lt;p&gt;hello!&lt;/p&gt;')
+        expect(essence.preview_text).to eq('&lt;p&gt;hello!&lt;/p&gt;')
       end
     end
   end

--- a/spec/models/essence_link_spec.rb
+++ b/spec/models/essence_link_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+module Alchemy
+  describe EssenceLink do
+    it_behaves_like "an essence" do
+      let(:essence)          { EssenceLink.new }
+      let(:ingredient_value) { 'http://alchemy-cms.com' }
+    end
+  end
+end

--- a/spec/models/essence_picture_spec.rb
+++ b/spec/models/essence_picture_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 
 module Alchemy
   describe EssencePicture do
+    it_behaves_like "an essence" do
+      let(:essence)          { EssencePicture.new }
+      let(:ingredient_value) { Picture.new }
+    end
 
     it "should not store negative values for crop values" do
       essence = EssencePicture.new(:crop_from => '-1x100', :crop_size => '-20x30')

--- a/spec/models/essence_richtext_spec.rb
+++ b/spec/models/essence_richtext_spec.rb
@@ -2,9 +2,14 @@ require 'spec_helper'
 
 module Alchemy
   describe EssenceRichtext do
+    let(:essence) { EssenceRichtext.new(:body => '<h1>Hello!</h1><p>Welcome to Peters Petshop.</p>') }
+
+    it_behaves_like "an essence" do
+      let(:essence)          { EssenceRichtext.new }
+      let(:ingredient_value) { '<h1>Hello!</h1><p>Welcome to Peters Petshop.</p>' }
+    end
 
     it "should save a HTML tag free version of body column" do
-      essence = EssenceRichtext.new(:body => '<h1>Hello!</h1><p>Welcome to Peters Petshop.</p>')
       essence.save
       essence.stripped_body.should == "Hello!Welcome to Peters Petshop."
     end

--- a/spec/models/essence_select_spec.rb
+++ b/spec/models/essence_select_spec.rb
@@ -2,14 +2,9 @@ require 'spec_helper'
 
 module Alchemy
   describe EssenceSelect do
-
-    it "should act as essence" do
-      expect { EssenceSelect.new.acts_as_essence? }.to_not raise_error
+    it_behaves_like "an essence" do
+      let(:essence)          { EssenceSelect.new }
+      let(:ingredient_value) { 'select value' }
     end
-
-    it "should have correct partial path" do
-      EssenceSelect.new.to_partial_path.should == 'alchemy/essences/essence_select_view'
-    end
-
   end
 end

--- a/spec/models/essence_text_spec.rb
+++ b/spec/models/essence_text_spec.rb
@@ -2,34 +2,62 @@ require 'spec_helper'
 
 module Alchemy
   describe EssenceText do
+    let(:essence) { EssenceText.new }
+    let(:ingredient_value) { 'Lorem ipsum' }
 
-    context "acts_as_essence methods" do
+    it_behaves_like "an essence" do
+      let(:essence)          { EssenceText.new }
+      let(:ingredient_value) { 'Lorem ipsum' }
+    end
 
-      describe '#preview_text' do
-        let(:essence) { EssenceText.new(body: 'Lorem ipsum') }
+    describe '#preview_text' do
+      before do
+        ingredient_column = essence.ingredient_column
+        essence.send("#{ingredient_column}=", ingredient_value)
+      end
 
-        it "should return a preview text" do
-          essence.preview_text.should == 'Lorem ipsum'
-        end
+      it "should return a preview text" do
+        essence.preview_text.should == "#{ingredient_value}"
+      end
 
-        context "with maxlength of 2" do
-          it "should return very short preview text" do
-            essence.preview_text(2).should == 'Lo'
-          end
-        end
-
-        context "with another preview_text_column defined" do
-          before {
-            essence.stub(:title).and_return('Title column')
-            essence.stub(:preview_text_column).and_return(:title)
-          }
-
-          it "should use this column as preview text method" do
-            essence.preview_text.should == 'Title column'
-          end
+      context "with given maxlength" do
+        it "should return as much beginning characters as defined with maxlength" do
+          essence.preview_text(2).should == "#{ingredient_value}"[0..1]
         end
       end
 
+      context "with another preview_text_column defined" do
+        before do
+          essence.stub(:title).and_return('Title column')
+          essence.stub(:preview_text_column).and_return(:title)
+        end
+
+        it "should use this column as preview text method" do
+          essence.preview_text.should == 'Title column'
+        end
+      end
+    end
+
+    describe '#open_link_in_new_window?' do
+      let(:essence) { EssenceText.new }
+      subject { essence.open_link_in_new_window? }
+
+      context 'essence responds to link_taget' do
+        context 'if link_target attribute is set to "blank"' do
+
+          before { essence.link_target = 'blank' }
+
+          it "should return true" do
+            expect(subject).to eq(true)
+          end
+        end
+
+        context 'if link_target attribute is not "blank"' do
+          it "should return false" do
+            expect(subject).to eq(false)
+          end
+        end
+      end
     end
 
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,7 @@ require 'alchemy/test_support/auth_helpers'
 require 'alchemy/test_support/controller_requests'
 require 'alchemy/test_support/integration_helpers'
 require 'alchemy/test_support/factories'
+require 'alchemy/test_support/essence_shared_examples'
 require_relative "support/test_tweaks.rb"
 
 # Temporay fix for mavericks phantomjs bug


### PR DESCRIPTION
These shared examples are used for testing the basic essence behavior of all models that acts as an essence.

Every model that mixes the essence module in, is tested against the basic behavior of an essence. We can now rely on that.

These examples could also be used to test custom essences in a project.
