### PR TITLE
Changes error on Language from base to certain attributes

### DIFF
--- a/app/models/alchemy/language.rb
+++ b/app/models/alchemy/language.rb
@@ -98,7 +98,7 @@ module Alchemy
 
     def presence_of_default_language
       if Language.default == self && self.default_changed?
-        errors.add(:base, I18n.t("We need at least one default."))
+        errors.add(:default, I18n.t("We need at least one default."))
         return false
       else
         return true

--- a/spec/models/language_spec.rb
+++ b/spec/models/language_spec.rb
@@ -112,7 +112,7 @@ module Alchemy
 
           it "should add an error to the object" do
             expect(language.valid?).to eq(false)
-            expect(language.errors.messages).to have_key(:base)
+            expect(language.errors.messages).to have_key(:default)
           end
         end
       end


### PR DESCRIPTION
1) If one tried to unpublish the default language, the error message was not shown in the form. By setting the error object to the public attribute will make the error notice visible for the user.

Fixes #487 

2) If one unchecked the default checkbox of the default language, the page could not be saved, which is absolutely correct. But there was missing a notice for the user. By setting the error object to the default attribute, the notice is now shown for the user in the form.
