### PR TITLE
Adds a more helpful installer.

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |gem|
   gem.requirements         << 'ImageMagick (libmagick), v6.6 or greater.'
   gem.required_ruby_version = '>= 1.9.3'
   gem.license               = 'BSD New'
-
   gem.files                 = `git ls-files`.split("\n")
   gem.test_files            = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.executables           = 'alchemy'
@@ -47,4 +46,20 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec-rails'
   gem.add_development_dependency 'capybara'
   gem.add_development_dependency 'factory_girl_rails'
+  
+  gem.post_install_message =<<-MSG
+To complete the installation of Alchemy please run:
+
+$ bin/rake alchemy:install
+
+To upgrade former Alchemy intallations please run:
+
+$ bin/rake alchemy:upgrade
+
+Thanks for installing Alchemy!
+
+Need help?
+Try https://groups.google.com/forum/#!forum/alchemy-cms
+or #alchemy_cms on irc.freenode.net
+MSG
 end

--- a/app/views/alchemy/admin/pages/_create_language_form.html.erb
+++ b/app/views/alchemy/admin/pages/_create_language_form.html.erb
@@ -31,7 +31,7 @@
     <%= form.hidden_field :page_layout, value: @language.page_layout %>
     <%= form.hidden_field :language_root, value: true %>
     <%= form.hidden_field :parent_id, value: root.id %>
-    <%= hidden_field_tag :redirect_to, admin_pages_path %>
+    <%= form.hidden_field :public, value: Alchemy::Language.all.size == 1 %>
     <div class="submit">
       <%= form.button _t("create_tree_as_new_language", language: @language.name) %>
     </div>

--- a/bin/alchemy
+++ b/bin/alchemy
@@ -63,7 +63,7 @@ class AlchemyInstaller < Thor
 ::                                                                     ::
 :: Open your browser and enter the following URL:                      ::
 ::                                                                     ::
-:: http://localhost:3000/                                              ::
+:: http://localhost:3000/admin                                         ::
 ::                                                                     ::
 :: and follow the on screen instructions to complete the installation. ::
 ::                                                                     ::

--- a/config/alchemy/config.yml
+++ b/config/alchemy/config.yml
@@ -79,12 +79,12 @@ output_image_jpg_quality: 85
 preprocess_image_resize:
 image_output_format: jpg
 
-# This is the default language for the seeder.
+# This is the default language for new sites.
 default_language:
-  code: de
-  name: Deutsch
-  page_layout: intro
-  frontpage_name: Intro
+  code: en
+  name: English
+  page_layout: index
+  frontpage_name: Index
 
 # === Mailer Settings:
 #

--- a/lib/rails/generators/alchemy/scaffold/files/_article_editor.html.erb
+++ b/lib/rails/generators/alchemy/scaffold/files/_article_editor.html.erb
@@ -1,0 +1,5 @@
+<%= element_editor_for(element) do |el| -%>
+  <%= el.edit :headline %>
+  <%= el.edit :picture, crop: true, fixed_ratio: false %>
+  <%= el.edit :text %>
+<%- end -%>

--- a/lib/rails/generators/alchemy/scaffold/files/_article_view.html.erb
+++ b/lib/rails/generators/alchemy/scaffold/files/_article_view.html.erb
@@ -1,0 +1,7 @@
+<%- cache(element) do -%>
+  <%= element_view_for(element, tag: 'article') do |el| -%>
+    <h2><%= el.render :headline %></h2>
+    <%= el.render :picture, image_size: '1200x600' %>
+    <%= el.render :text %>
+  <%- end -%>
+<%- end -%>

--- a/lib/rails/generators/alchemy/scaffold/files/alchemy.de.yml
+++ b/lib/rails/generators/alchemy/scaffold/files/alchemy.de.yml
@@ -1,0 +1,31 @@
+de:
+  alchemy:
+
+    # Translations for page layout names
+    page_layout_names:
+      index: Startseite
+
+    # Translations for element names
+    element_names:
+      article: Artikel
+
+    # Translations for content names
+    content_names:
+      headline: Überschrift
+      text: Text
+      picture: Bild
+
+    # Default texts for new contents created
+    default_content_texts:
+      article_headline: "Willkommen auf Ihrer Alchemy Seite"
+      article_text: '<p>Als erstes sollte man sich mit der Struktur von Alchemy vertraut machen. <a class="external" href="http://guides.alchemy-cms.com/edge/alchemy_approach.html" target="_blank" data-link-target="blank">Mehr dazu in den Guidelines</a>.</p><p>Die wichtigsten beiden Dinge die man über Alchemy wissen muss sind Elemente und Seitentypen.</p><p><span style="text-decoration: underline;"><strong>Elemente:</strong></span></p><p>Mit Alchemy kann man eine Seite in Inhaltsbereiche aufteilen, Elemente. Diese Elemente werden aus verschiedenen Grundtypen (Essenzen) zusammengesetzt. Die Essenzen sind:</p><ul><li>EssenceText - <em>Eine Zeile Text</em></li><li>EssenceRichtext - <em>Ein TinyMCE basierter formatierter Textblock</em></li><li>EssencePicture - <em>Ein Verweis auf ein Bild</em></li><li>EssenceHtml - <em>HTML Code</em></li><li>EssenceSelect - <em>Eine Auswahl an Werten</em></li><li>EssenceBoolean - <em>Eine Checkbox</em></li></ul><p>Elemente werden in einer YAML Datei definiert: <strong>config/alchemy/elements.yml</strong></p><p><a class="external" href="http://guides.alchemy-cms.com/edge/elements.html" target="_blank" data-link-target="blank">Mehr über Elemente und wie sie definiert werden, kann in den Guidelines nachgelesen werden.</a></p><p><span style="text-decoration: underline;"><strong>Seitentypen:</strong></span></p><p>Es können verschiedene Seitentypen definiert werden. Diesen können Elemente zugewiesen und ihr Verhalten definiert werden.</p><p>Seitentypen werden ein einer YAML Datei definiert: <strong>config/alchemy/page_layouts.yml</strong></p><p><a class="external" href="http://guides.alchemy-cms.com/edge/page_layouts.html" target="_blank" data-link-target="blank">Mehr über das Erstellen von Seitentypen kann in den Guidelines nachgelesen werden.</a></p>'
+
+    # Hint texts for elements
+    element_hints:
+      article: "Dies ist ein Hinweistext für das Artikel Element. Dieser Text kann in der `config/locales/alchemy.de.yml` Datei angepasst werden."
+
+    # Hint texts for contents
+    content_hints:
+      headline: "Dies ist ein einzeiliger unformatierter Text"
+      picture: "Bilder werden in der Bibliothek gespeichert. Ein Bild kann mehrfach einem Element zugewiesen werden. Auch ein Bildauswahlwerkzeug ist in Alchemy integriert."
+      text: "Dies ist ein formatierbarer Textblock. Die Einstellungen des Editors können angepasst werden. Siehe http://guides.alchemy-cms.com/edge/customize_tinymce.html"

--- a/lib/rails/generators/alchemy/scaffold/files/alchemy.elements.css.scss
+++ b/lib/rails/generators/alchemy/scaffold/files/alchemy.elements.css.scss
@@ -1,0 +1,30 @@
+article {
+  width: 50%;
+  font: 16px/20px Helvetica, Arial, sans-serif;
+  color: #333;
+  margin: 1em auto;
+  padding: 0.5em 1em;
+  background: #f4f4f4;
+
+  h2 {
+    font-size: 24px;
+    line-height: 1.25;
+    font-weight: bold;
+  }
+
+  a {
+    color: #5588D3;
+  }
+
+  img {
+    max-width: 100%;
+  }
+
+  figure {
+    margin: 0;
+  }
+
+  figcaption {
+    font-size: 14px;
+  }
+}

--- a/lib/rails/generators/alchemy/scaffold/files/alchemy.en.yml
+++ b/lib/rails/generators/alchemy/scaffold/files/alchemy.en.yml
@@ -1,0 +1,31 @@
+en:
+  alchemy:
+
+    # Translations for page layout names
+    page_layout_names:
+      index: Homepage
+
+    # Translations for element names
+    element_names:
+      article: Article
+
+    # Translations for content names
+    content_names:
+      headline: Headline
+      text: Text
+      picture: Picture
+
+    # Default texts for new contents created
+    default_content_texts:
+      article_headline: "Welcome to your first Alchemy CMS page"
+      article_text: '<p><strong>How to get started.</strong></p><p>First of all you should read about Alchemy and its architecture in the <a class="external" href="http://guides.alchemy-cms.com/edge/alchemy_approach.html" target="_blank" data-link-target="blank">guidelines</a>.</p><p>The most important things to know about Alchemy are elements and page layouts.</p><p><span style="text-decoration: underline;"><strong>Elements:</strong></span></p><p>With Alchemy you can split pages into content parts, elements. These elements can be defined out of several base content types: essences. The basic essences are:</p><ul><li>EssenceText - <em>A single line of text</em></li><li>EssenceRichtext - <em>A TinyMCE powered formatted text block</em></li><li>EssencePicture - <em>A reference to an image</em></li><li>EssenceHtml - <em>HTML embed code</em></li><li>EssenceSelect - <em>A selection of values</em></li><li>EssenceBoolean - <em>A checkbox</em></li></ul><p>Elements get defined in a YAML file <strong>config/alchemy/elements.yml</strong></p><p><a class="external" href="http://guides.alchemy-cms.com/edge/elements.html" target="_blank" data-link-target="blank">Read more about elements and how to define them in the guidelines.</a></p><p><span style="text-decoration: underline;"><strong>Page types:</strong></span></p><p>You can define several types of pages, called page layouts. You can assign elements to page layouts and control how elements and the page of a certain layout behave.</p><p>Page layouts get defined in a YAML file <strong>config/alchemy/page_layouts.yml</strong></p><p><a class="external" href="http://guides.alchemy-cms.com/edge/page_layouts.html" target="_blank" data-link-target="blank">Read more about defining page layouts in the guidelines.</a></p>'
+
+    # Hint texts for elements
+    element_hints:
+      article: "This is a hint text for the article element. You can change this text in `config/locales/alchemy.en.yml`. Feel free to change it as you like, it's yours."
+
+    # Hint texts for contents
+    content_hints:
+      headline: "This is a single line of unformatable Text"
+      picture: "Pictures are stored in the library. You can assign a picture multiple times throughout your site. Alchemy has an image cropper build right in."
+      text: "This is a rich text block powered by TinyMCE editor. You can change the configuration of the editor. See http://guides.alchemy-cms.com/edge/customize_tinymce.html"

--- a/lib/rails/generators/alchemy/scaffold/files/application.html.erb
+++ b/lib/rails/generators/alchemy/scaffold/files/application.html.erb
@@ -2,7 +2,9 @@
 <html>
 <head>
   <%= render_meta_data %>
-  <%= stylesheet_link_tag 'application' %>
+  <%= stylesheet_link_tag 'application', media: 'all' %>
+  <%= javascript_include_tag 'application' %>
+  <%= csrf_meta_tags %>
 </head>
 <body>
   <%= yield %>

--- a/lib/rails/generators/alchemy/scaffold/files/elements.yml
+++ b/lib/rails/generators/alchemy/scaffold/files/elements.yml
@@ -1,3 +1,19 @@
 # == In this configuration you setup Alchemy´s element layouts.
 #
 # For further informations please see http://guides.alchemy-cms.com/create_elements.html
+
+- name: article
+  hint: true
+  unique: true
+  contents:
+  - name: headline
+    type: EssenceText
+    default: :article_headline
+    hint: true
+  - name: picture
+    type: EssencePicture
+    hint: true
+  - name: text
+    type: EssenceRichtext
+    default: :article_text
+    hint: true

--- a/lib/rails/generators/alchemy/scaffold/scaffold_generator.rb
+++ b/lib/rails/generators/alchemy/scaffold/scaffold_generator.rb
@@ -28,24 +28,33 @@ module Alchemy
       end
 
       def copy_files
-        copy_file "#{File.dirname(__FILE__)}/files/elements.yml", "#{Rails.root}/config/alchemy/elements.yml"
+        copy_file "#{current_path}/files/elements.yml", "#{Rails.root}/config/alchemy/elements.yml"
         template "page_layouts.yml.tt", "#{Rails.root}/config/alchemy/page_layouts.yml"
-        copy_file "#{File.dirname(__FILE__)}/files/application.html.erb", "#{Rails.root}/app/views/layouts/application.html.erb"
-        copy_file "#{File.dirname(__FILE__)}/files/_standard.html.erb", "#{Rails.root}/app/views/alchemy/page_layouts/_standard.html.erb"
+        copy_file "#{current_path}/files/alchemy.en.yml", "#{Rails.root}/config/locales/alchemy.en.yml"
+        copy_file "#{current_path}/files/alchemy.de.yml", "#{Rails.root}/config/locales/alchemy.de.yml"
+        copy_file "#{current_path}/files/application.html.erb", "#{Rails.root}/app/views/layouts/application.html.erb"
+        copy_file "#{current_path}/files/_standard.html.erb", "#{Rails.root}/app/views/alchemy/page_layouts/_standard.html.erb"
+        copy_file "#{current_path}/files/_article_view.html.erb", "#{Rails.root}/app/views/alchemy/elements/_article_view.html.erb"
+        copy_file "#{current_path}/files/_article_editor.html.erb", "#{Rails.root}/app/views/alchemy/elements/_article_editor.html.erb"
+        copy_file "#{current_path}/files/alchemy.elements.css.scss", "#{Rails.root}/app/assets/stylesheets/alchemy.elements.css.scss"
       end
 
-    private
+      private
 
       def config_path
-        @config_path ||= File.expand_path('../../../../../config/alchemy', File.dirname(__FILE__))
+        @config_path ||= File.expand_path('../../../../../config/alchemy', current_path)
       end
 
       def copy_alchemy_views
         ALCHEMY_VIEWS.each do |dir|
-          src = File.expand_path("../../../../../app/views/alchemy/#{dir}", File.dirname(__FILE__))
+          src = File.expand_path("../../../../../app/views/alchemy/#{dir}", current_path)
           dest = Rails.root.join('app/views/alchemy', dir)
           directory src, dest
         end
+      end
+
+      def current_path
+        @current_path ||= File.dirname(__FILE__)
       end
 
     end

--- a/lib/rails/generators/alchemy/scaffold/templates/page_layouts.yml.tt
+++ b/lib/rails/generators/alchemy/scaffold/templates/page_layouts.yml.tt
@@ -1,7 +1,8 @@
-# == This file defines the page_layouts for new pages.
+# == This file defines the page layouts for new pages.
 #
 # For further informations please see http://guides.alchemy-cms.com/create_page_layouts.html
 
 - name: <%= Alchemy::Config.get(:default_language)['page_layout'] %>
   unique: true
-  elements: []
+  elements: [article]
+  autogenerate: [article]

--- a/lib/tasks/alchemy/install.rake
+++ b/lib/tasks/alchemy/install.rake
@@ -1,14 +1,24 @@
 require 'thor'
 
-class Alchemy::RoutesInjector < Thor
+class Alchemy::InstallTask < Thor
   include Thor::Actions
 
   no_tasks do
-    def inject
-      mountpoint = ask "\nWhere do you want to mount Alchemy CMS? (DEFAULT: /)"
+    def inject_routes
+      mountpoint = ask "\nAt which path do you want to mount Alchemy CMS at? (DEFAULT: At root path '/')"
       mountpoint = "/" if mountpoint.empty?
       sentinel = /\.routes\.draw do(?:\s*\|map\|)?\s*$/
       inject_into_file "./config/routes.rb", "\n  mount Alchemy::Engine => '#{mountpoint}'\n", { after: sentinel, verbose: true }
+    end
+
+    def set_primary_language
+      code = ask "\nWhat's the language code of your site's primary language? (DEFAULT: en)"
+      code = "en" if code.empty?
+      name = ask "What's the name of your site's primary language? (DEFAULT: English)"
+      name = "English" if name.empty?
+      gsub_file "./config/alchemy/config.yml", /default_language:\n\s\scode:\sen\n\s\sname:\sEnglish/m do |match|
+        match = "default_language:\n  code: #{code}\n  name: #{name}"
+      end
     end
   end
 
@@ -16,17 +26,26 @@ end
 
 namespace :alchemy do
 
-  desc "Creates, migrates and seeds the database to run Alchemy."
-  task prepare: ["db:create", "alchemy:install:migrations", "db:migrate", "alchemy:db:seed"]
-
   desc "Installs Alchemy CMS into your app."
-  task install: ["alchemy:prepare", "alchemy:mount"] do
+  task :install do
+    puts "\nAlchemy Installer"
+    puts "-----------------"
+    Rake::Task["alchemy:mount"].invoke
     system('rails g alchemy:scaffold') || exit!(1)
+    Alchemy::InstallTask.new.set_primary_language
+    Rake::Task["db:create"].invoke
+    Rake::Task["alchemy:install:migrations"].invoke
+    Rake::Task["db:migrate"].invoke
+    Rake::Task["alchemy:db:seed"].invoke
+    puts "\nAlchemy successfully installed."
+    puts "\nNow start the server with:"
+    puts "\n$ bin/rails server"
+    puts "\nand point your browser to http://localhost:3000/admin and follow the onscreen instructions to finalize the installation."
   end
 
   desc "Mounts Alchemy into your routes."
   task :mount do
-    Alchemy::RoutesInjector.new.inject
+    Alchemy::InstallTask.new.inject_routes
   end
 
 end

--- a/spec/controllers/admin/languages_controller_spec.rb
+++ b/spec/controllers/admin/languages_controller_spec.rb
@@ -13,16 +13,23 @@ describe Alchemy::Admin::LanguagesController do
 
     context "when default_language.page_layout is set" do
       it "should use it as page_layout-default for the new language" do
-        Alchemy::Config.should_receive(:get).with(:default_language) { {'page_layout' => "new_standard"} }
+        # FML :/
+        Alchemy::Config.stub(:get) do |arg|
+          if arg == :default_language
+            {'page_layout' => "new_standard"}
+          else
+            Alchemy::Config.show[arg.to_s]
+          end
+        end
         get :new
         assigns(:language).page_layout.should eql("new_standard")
       end
     end
 
     context "when default_language or page_layout aren't configured" do
-      it "should fallback to 'intro'" do
+      it "should fallback to one configured in config.yml" do
         get :new
-        assigns(:language).page_layout.should eql("intro")
+        assigns(:language).page_layout.should eql("index")
       end
     end
 

--- a/spec/features/page_feature_spec.rb
+++ b/spec/features/page_feature_spec.rb
@@ -77,7 +77,7 @@ module Alchemy
         context "requested url is only the urlname" do
           it "then it should redirect to pages url with nested language." do
             visit '/home'
-            page.current_path.should == '/de/home'
+            page.current_path.should == '/en/home'
           end
         end
 
@@ -90,8 +90,8 @@ module Alchemy
           before { Alchemy.user_class.stub(:admins).and_return([1, 2]) }
 
           it "should render 404 if urlname and lang parameter do not belong to same page" do
-            FactoryGirl.create(:english)
-            visit "/en/#{public_page_1.urlname}"
+            FactoryGirl.create(:klingonian)
+            visit "/kl/#{public_page_1.urlname}"
             page.status_code.should == 404
           end
 
@@ -111,7 +111,7 @@ module Alchemy
         end
 
         it "should redirect from nested language code url to normal url" do
-          visit "/de/#{public_page_1.urlname}"
+          visit "/en/#{public_page_1.urlname}"
           page.current_path.should == "/#{public_page_1.urlname}"
         end
 
@@ -127,7 +127,7 @@ module Alchemy
           end
 
           it "with normal url, if requested url has nested language code and is not public" do
-            visit '/de/not-public'
+            visit '/en/not-public'
             page.current_path.should == '/public-child'
           end
         end

--- a/spec/features/translation_integration_spec.rb
+++ b/spec/features/translation_integration_spec.rb
@@ -35,14 +35,14 @@ describe "Translation integration" do
         page.should have_content('Willkommen')
       end
     end
-  end
 
-  context "with translated header" do
-    before { Capybara.current_driver = :rack_test_translated_header }
+    context "with translated header" do
+      before { Capybara.current_driver = :rack_test_translated_header }
 
-    it "should use the browsers language setting if no other parameter is given" do
-      visit root_path
-      ::I18n.locale.should == :de
+      it "should use the browsers language setting if no other parameter is given" do
+        visit admin_dashboard_path
+        page.should have_content('Willkommen')
+      end
     end
   end
 end

--- a/spec/helpers/pages_helper_spec.rb
+++ b/spec/helpers/pages_helper_spec.rb
@@ -370,13 +370,13 @@ module Alchemy
           context "with options[:reverse]" do
             context "set to false" do
               it "should render the language links in an ascending order" do
-                expect(helper.language_links(reverse: false)).to have_selector("a.de + a.kl")
+                expect(helper.language_links(reverse: false)).to have_selector("a.en + a.kl")
               end
             end
 
             context "set to true" do
               it "should render the language links in a descending order" do
-                expect(helper.language_links(reverse: true)).to have_selector("a.kl + a.de")
+                expect(helper.language_links(reverse: true)).to have_selector("a.kl + a.en")
               end
             end
           end


### PR DESCRIPTION
This changes `rake alchemy:install` task:
- Redirects to `admin/pages` after signup, so the create language root form shows up directly after signing up
- Adds a `index` page layout (the new default for seeded language), that generates the new `article` element
- Adds an `article` element, that serves as example element with lots of hints and default texts
- Adds a post install message to point users to the `rake alchemy:install` task

This will help new Alchemy users to easier adopt.
