### PR TITLE
Refactors essence validations and changes its API.

### DIFF
--- a/app/models/alchemy/message.rb
+++ b/app/models/alchemy/message.rb
@@ -42,7 +42,7 @@ module Alchemy
 
       case field.to_sym
       when :email
-        validates_format_of field, with: Alchemy::Config.get(:email_regexp), if: -> { email.present? }
+        validates_format_of field, with: Alchemy::Config.get('format_matchers')['email'], if: -> { email.present? }
       when :email_confirmation
         validates_confirmation_of :email
       end

--- a/config/alchemy/config.yml
+++ b/config/alchemy/config.yml
@@ -174,4 +174,15 @@ link_target_options: [blank]
 # Should pages that redirect to an external url open the link in a new tab/window?
 open_external_links_in_new_tab: true
 
-email_regexp: !ruby/regexp '/\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/'
+# === Format matchers
+#
+# Named aliases for regular expressions that can be used in various places.
+# The most common use case is the format validation of essences, or attribute validations of your individual models.
+#
+# == Example:
+#
+#   validates_format_of :url, with: Alchemy::Config.get('format_matchers')['url']
+#
+format_matchers:
+  email: !ruby/regexp '/\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/'
+  url: !ruby/regexp '/\A[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?\z/ix'

--- a/lib/alchemy/essence.rb
+++ b/lib/alchemy/essence.rb
@@ -29,10 +29,10 @@ module Alchemy #:nodoc:
         }.update(options)
 
         class_eval <<-EOV
-          attr_accessor :validation_errors
+          attr_writer :validation_errors
           include Alchemy::Essence::InstanceMethods
           stampable stamper_class_name: Alchemy.user_class_name
-          validate :essence_validations, :on => :update
+          validate :validate_ingredient, :on => :update, :if => 'validations.any?'
           has_many :contents, :as => :essence
           has_many :elements, :through => :contents
           has_many :pages, :through => :elements
@@ -65,20 +65,24 @@ module Alchemy #:nodoc:
       #
       # Essence validations can be set inside the config/elements.yml file.
       #
-      # Currently supported validations are:
+      # Supported validations are:
       #
       # * presence
-      # * format
       # * uniqueness
+      # * format
       #
-      # If you want to validate the format you must additionally pass validate_format_as or validate_format_with:
+      # format needs to come with a regex or a predefined matcher string as its value.
+      # There are already predefined format matchers listed in the config/alchemy/config.yml file.
+      # It is also possible to add own format matchers there.
       #
-      # * validate_format_with has to be regex
-      # * validate_format_as can be one of:
-      # ** url
-      # ** email
+      # Example of format matchers in config/alchemy/config.yml:
       #
-      # Example:
+      # format_matchers:
+      #   email: !ruby/regexp '/\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/'
+      #   url:   !ruby/regexp '/\A[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?\z/ix'
+      #   ssl:   !ruby/regexp '/https:\/\/[\S]+/'
+      #
+      # Example of an element definition with essence validations:
       #
       #   - name: person
       #     contents:
@@ -87,45 +91,56 @@ module Alchemy #:nodoc:
       #       validate: [presence]
       #     - name: email
       #       type: EssenceText
-      #       validate: [format]
-      #       validate_format_as: 'email'
+      #       validate: [format: 'email']
       #     - name: homepage
       #       type: EssenceText
-      #       validate: [format]
-      #       validate_format_with: '^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$'
+      #       validate: [format: !ruby/regexp '^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$']
       #
-      def essence_validations
-        self.validation_errors ||= []
-        return true if description.blank? || description['validate'].blank?
-        description['validate'].each do |validation|
-          if validation == 'presence' && ingredient.blank?
-            self.validation_errors << :blank
-          elsif validation == 'format'
-            if description['validate_format_as'].blank? && !description['validate_format_with'].blank?
-              matcher = Regexp.new(description['validate_format_with'])
-            elsif !description['validate_format_as'].blank? && description['validate_format_with'].blank?
-              case description['validate_format_as']
-              when 'email'
-              then
-                matcher = Alchemy::Config.get(:email_regexp)
-              when 'url'
-              then
-                matcher = /\A[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?\z/ix
-              else
-                raise "No validation format matcher found for #{description['validate_format_as']}"
-              end
-            else
-              raise 'No validation format matcher given'
-            end
-            if ingredient.to_s.match(matcher).nil?
-              self.validation_errors << :invalid
-            end
-          elsif validation == 'uniqueness' && acts_as_essence_class.where("#{ingredient_column}" => ingredient).where.not(id: self.id).any?
-            self.validation_errors << :taken
+      # Example of an element definition with chained validations.
+      #
+      #   - name: person
+      #     contents:
+      #     - name: name
+      #       type: EssenceText
+      #       validate: [presence, uniqueness, format: 'name']
+      #
+      def validate_ingredient
+        validations.each do |validation|
+          if validation.respond_to?(:keys)
+            validation.map {|key,value| self.send("validate_#{key}", validation) }
+          else
+            self.send("validate_#{validation}")
           end
         end
-        self.validation_errors.each do |validation_error|
-          self.errors.add(self.ingredient_column, validation_error)
+      end
+
+      def validations
+        @validations ||= description.present? ? description['validate'] || [] : []
+      end
+
+      def validation_errors
+        @validation_errors ||= []
+      end
+
+      def validate_presence
+        if ingredient.blank?
+          errors.add(ingredient_column, :blank)
+          validation_errors << :blank
+        end
+      end
+
+      def validate_uniqueness
+        if acts_as_essence_class.where("#{ingredient_column}" => ingredient).where.not(id: self.id).any?
+          errors.add(ingredient_column, :taken)
+          validation_errors << :taken
+        end
+      end
+
+      def validate_format(validation)
+        matcher = Config.get('format_matchers')["#{validation['format']}"] || validation['format']
+        if ingredient.to_s.match(Regexp.new(matcher)).nil?
+          errors.add(ingredient_column, :invalid)
+          validation_errors << :invalid
         end
       end
 

--- a/lib/alchemy/test_support/essence_shared_examples.rb
+++ b/lib/alchemy/test_support/essence_shared_examples.rb
@@ -80,7 +80,21 @@ module Alchemy
       end
     end
 
-    context 'with ingredient validation for' do
+    describe 'validations' do
+      context 'without essence description in elements.yml' do
+        it 'should return an empty array' do
+          essence.stub(:description).and_return nil
+          expect(essence.validations).to eq([])
+        end
+      end
+
+      context 'without validations defined in essence description in elements.yml' do
+        it 'should return an empty array' do
+          essence.stub(:description).and_return({name: 'test', type: 'EssenceText'})
+          expect(essence.validations).to eq([])
+        end
+      end
+
       describe 'presence' do
         before do
           essence.stub(:description).and_return({'validate' => ['presence']})

--- a/spec/models/essence_text_spec.rb
+++ b/spec/models/essence_text_spec.rb
@@ -60,5 +60,55 @@ module Alchemy
       end
     end
 
+    describe 'validations' do
+      describe 'format' do
+
+        context 'given a regex string' do
+          before do
+            essence.stub(:description).and_return({'validate' => [{'format' => /\Ahttps:\/\/[\S]+/}]})
+          end
+
+          context 'when ingredient string does not match the given regex' do
+            before { essence.update(essence.ingredient_column.to_sym => 'http://alchemy-cms.com') }
+
+            it 'should not be valid' do
+              expect(essence).to_not be_valid
+            end
+          end
+
+          context 'when ingredient string matches the given regex' do
+            before { essence.update(essence.ingredient_column.to_sym => 'https://alchemy-cms.com') }
+
+            it 'should be valid' do
+              expect(essence).to be_valid
+            end
+          end
+        end
+
+        context 'given a key from the config`s format_matcher list' do
+          before do
+            essence.stub(:description).and_return({'validate' => [{'format' => 'email'}]})
+          end
+
+          context 'when ingredient string does not match the given format matcher' do
+            before { essence.update(essence.ingredient_column.to_sym => ingredient_value) }
+
+            it 'should not be valid' do
+              expect(essence).to_not be_valid
+            end
+          end
+
+          context 'when ingredient string matches the given format matcher' do
+            before { essence.update(essence.ingredient_column.to_sym => 'email@email.com') }
+
+            it 'should be valid' do
+              expect(essence).to be_valid
+            end
+          end
+        end
+
+      end
+    end
+
   end
 end


### PR DESCRIPTION
The API of the format validations for essences is changed by this commit. It makes the usage more easy and intuitive.

It also brings a new feature: You can define individual format matchers in the config.yml that can be used in different places, i.e. for more than one essence definition without repeating the regex again and again.

What happened exactly:
- Splits the huge essence_validations method into smaller parts.
- Removed the necessity of format_as/format_with being defined as separate keys in elements.yml
- Merged the notation of format_with and format_as to format.
- Added predefined format_matchers in config.yml and enables one to define own matchers.

Usage examples in elements.yml:

```
# Validates the url content to start with https://
- name: url
  type: EssenceText
  validate: [format: !ruby/regexp '/\Ahttps:\/\/[\S]+/']

# Validates the email content for the correct format by looking up the regex from the format_matchers in the config.yml
- name: email
  type: EssenceText
  validate: [format: 'email']

# Chaining validations
- name: email
  type: EssenceText
  validate: [presence, uniqueness, format: 'email']
```
