### PR TITLE
Fixes pages_controller etag and last-modified headers.

### DIFF
--- a/app/models/alchemy/page/natures.rb
+++ b/app/models/alchemy/page/natures.rb
@@ -101,5 +101,14 @@ module Alchemy
       end
     end
 
+    # We use the published_at value for the cache_key.
+    #
+    # If no published_at value is set yet, i.e. because it was never published,
+    # we return the updated_at value.
+    #
+    def published_at
+      read_attribute(:published_at) || updated_at
+    end
+
   end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -174,5 +174,30 @@ module Alchemy
         end
       end
     end
+
+    describe '#page_etag' do
+      subject { controller.send(:page_etag) }
+
+      before do
+        page.stub(cache_key: 'aaa')
+        controller.instance_variable_set('@page', page)
+      end
+
+      it "returns the etag for response headers" do
+        expect(subject).to eq('aaa')
+      end
+
+      context 'with author user logged in' do
+        let(:author_user) { mock_model(Alchemy.user_class, alchemy_roles: [:author], cache_key: 'bbb') }
+
+        before do
+          sign_in(author_user)
+        end
+
+        it "returns another etag for response headers" do
+          expect(subject).to eq('aaabbb')
+        end
+      end
+    end
   end
 end

--- a/spec/features/page_feature_spec.rb
+++ b/spec/features/page_feature_spec.rb
@@ -179,7 +179,7 @@ module Alchemy
 
       context "rendering for authors" do
         it "is allowed" do
-          authorize_as_admin(mock_model('DummyUser', alchemy_roles: %w(author), language: 'en'))
+          authorize_as_admin(mock_model('DummyUser', alchemy_roles: %w(author), language: 'en', cache_key: 'aaa'))
           visit "/#{public_page_1.urlname}"
           within('body') { page.should have_selector('#alchemy_menubar') }
         end
@@ -187,7 +187,7 @@ module Alchemy
 
       context "rendering for editors" do
         it "is allowed" do
-          authorize_as_admin(mock_model('DummyUser', alchemy_roles: %w(editor), language: 'en'))
+          authorize_as_admin(mock_model('DummyUser', alchemy_roles: %w(editor), language: 'en', cache_key: 'aaa'))
           visit "/#{public_page_1.urlname}"
           within('body') { page.should have_selector('#alchemy_menubar') }
         end
@@ -195,7 +195,7 @@ module Alchemy
 
       context "rendering for admins" do
         it "is allowed" do
-          authorize_as_admin
+          authorize_as_admin(mock_model('DummyUser', alchemy_roles: %w(admin), language: 'en', cache_key: 'aaa'))
           visit "/#{public_page_1.urlname}"
           within('body') { page.should have_selector('#alchemy_menubar') }
         end
@@ -203,7 +203,7 @@ module Alchemy
 
       context "contains" do
         before do
-          authorize_as_admin
+          authorize_as_admin(mock_model('DummyUser', alchemy_roles: %w(admin), language: 'en', cache_key: 'aaa'))
           visit "/#{public_page_1.urlname}"
         end
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1356,5 +1356,25 @@ module Alchemy
       end
     end
 
+    describe '#published_at' do
+      context 'with published_at date set' do
+        let(:published_at) { Time.now }
+        let(:page)         { build_stubbed(:page, published_at: published_at) }
+
+        it "returns the published_at value from database" do
+          expect(page.published_at).to eq(published_at)
+        end
+      end
+
+      context 'with published_at is nil' do
+        let(:updated_at) { Time.now }
+        let(:page)       { build_stubbed(:page, published_at: nil, updated_at: updated_at) }
+
+        it "returns the updated_at value" do
+          expect(page.published_at).to eq(updated_at)
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
The current implementation always delivers the same etag, regardless of the logged in state of a user.
If a user is logged in and has sufficient rights to edit a page (aka. an author), the menu bar will be displayed while browsing the site. The problem is, that this will be cached by http caches like varnish and rack/cache.

This fix changes the etag so it reflects the current users state.

Also this fix ensures that a last-modified header gets returned, even if published_at was never set, aka, it's nil. In this case it will return updated_at.
