### PR TITLE
Fix a position bug occuring when deleting elements by updating acts_as_list

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -39,7 +39,7 @@ POST_INSTALL
   s.add_runtime_dependency %q<dragonfly>,                        ["~> 0.9.14"]
   s.add_runtime_dependency %q<kaminari>,                         ["~> 0.14.1"]
   s.add_runtime_dependency %q<acts_as_ferret>,                   ["~> 0.5"]
-  s.add_runtime_dependency %q<acts_as_list>,                     [">= 0.4.0"]
+  s.add_runtime_dependency %q<acts_as_list>,                     ["~> 0.3", "< 0.4.0"]
   s.add_runtime_dependency %q<magiclabs-userstamp>,              ["~> 2.0.2"]
   s.add_runtime_dependency %q<dynamic_form>,                     ["~> 1.1"]
   s.add_runtime_dependency %q<jquery-rails>,                     ["~> 3.0.4"]


### PR DESCRIPTION
When I delete a page element, I cannot re-add further ones because of a validation error: "position already taken", see [this screen capture](https://www.dropbox.com/s/8hc2qu6rt8rbegk/alchemy_cms_bug_acts_as_list.mov).

Updating acts_as_list solves this issue.
