### PR TITLE
correcting 'sitemap' show flag for 2.7

### DIFF
--- a/app/views/alchemy/admin/pages/configure.html.erb
+++ b/app/views/alchemy/admin/pages/configure.html.erb
@@ -17,7 +17,7 @@
         <%= f.label :visible %><br/>
         <%= f.check_box :restricted %>
         <%= f.label :restricted %>
-        <% if configuration(:sitemap)[:show_flag] %><br/>
+        <% if configuration(:sitemap)['show_flag'] %><br/>
         <%= f.check_box :sitemap %>
         <%= f.label :sitemap %>
         <% end %>


### PR DESCRIPTION
The sitemap flag did not show up in the page edit overlay when setting these config options:

sitemap:
  show_root: true
  show_flag: true

Searching through the more recent source code, I realized that you were referring to :show_flag instead of 'show_flag'. I tested this using my fork and it works as it should. Please pull this change so I can edit my site's sitemap. 

Thanks! 
