### PR TITLE
Use Rails' default exception handling while in page preview.

### DIFF
--- a/app/controllers/alchemy/admin/base_controller.rb
+++ b/app/controllers/alchemy/admin/base_controller.rb
@@ -13,7 +13,7 @@ module Alchemy
       rescue_from Exception do |exception|
         if exception.is_a? CanCan::AccessDenied
           permission_denied(exception)
-        elsif Rails.env.test?
+        elsif raise_exception?
           raise
         else
           exception_handler(exception)
@@ -149,6 +149,19 @@ module Alchemy
         else
           {}
         end.symbolize_keys
+      end
+
+      # This method decides if we want to raise an exception or not.
+      #
+      # I.e. in test environment.
+      #
+      def raise_exception?
+        Rails.env.test? || is_page_preview?
+      end
+
+      # Are we currently in the page edit mode page preview.
+      def is_page_preview?
+        controller_path == 'alchemy/admin/pages' && action_name == 'show'
       end
 
     end

--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -31,9 +31,6 @@ module Alchemy
         # Setting the locale to pages language, so the page content has it's correct translations.
         ::I18n.locale = @page.language_code
         render layout: 'application'
-      rescue Exception => e
-        exception_logger(e)
-        render file: Rails.root.join('public', '500.html'), status: 500, layout: false
       end
 
       def info

--- a/spec/controllers/admin/base_controller_spec.rb
+++ b/spec/controllers/admin/base_controller_spec.rb
@@ -32,4 +32,43 @@ describe Alchemy::Admin::BaseController do
     end
   end
 
+  describe '#raise_exception?' do
+    subject { controller.send(:raise_exception?) }
+
+    context 'in test mode' do
+      before { Rails.env.stub(test?: true) }
+      it { should be_true }
+    end
+
+    context 'in page preview' do
+      before { controller.stub(is_page_preview?: true) }
+      it { should be_true }
+    end
+
+    context 'not in test mode' do
+      before { Rails.env.stub(test?: false) }
+      it { should be_false }
+
+      context 'and not in page preview' do
+        before { controller.stub(is_page_preview?: false) }
+        it { should be_false }
+      end
+    end
+  end
+
+  describe '#is_page_preview?' do
+    subject { controller.send(:is_page_preview?) }
+
+    it { should be_false }
+
+    context 'is pages controller and show action' do
+      before do
+        controller.stub(controller_path: 'alchemy/admin/pages')
+        controller.stub(action_name: 'show')
+      end
+
+      it { should be_true }
+    end
+  end
+
 end


### PR DESCRIPTION
When we are in page preview while editing a page, we should not rescue the exceptions.
We should use the default Rails behaviour of showing a meaningful error explanation in development mode and the 500 page while in production mode.
