### PR TITLE
Allow picture render size to be flexible in width or height

### DIFF
--- a/app/controllers/alchemy/admin/essence_pictures_controller.rb
+++ b/app/controllers/alchemy/admin/essence_pictures_controller.rb
@@ -75,7 +75,14 @@ module Alchemy
 
       def sizes_from_essence
         return if @essence_picture.render_size.blank?
-        @essence_picture.render_size.split('x')
+        size_x, size_y = @essence_picture.render_size.split('x').map(&:to_i)
+        if size_x.zero? || size_y.nil? || size_y.zero?
+          size_x_of_original = @essence_picture.picture.image_file_width 
+          size_y_of_original = @essence_picture.picture.image_file_height
+          size_x = size_x_of_original * size_y / size_y_of_original if size_x.zero?
+          size_y = size_y_of_original * size_x / size_x_of_original if size_y.nil? || size_y.zero?
+        end
+        [size_x, size_y]
       end
 
       def sizes_string

--- a/app/controllers/alchemy/pictures_controller.rb
+++ b/app/controllers/alchemy/pictures_controller.rb
@@ -90,6 +90,7 @@ module Alchemy
         image_file.process(:resize, resize_string)
       elsif params[:crop] == 'crop' && @size.present?
         width, height = @size.split('x').collect(&:to_i)
+        raise ArgumentError, "You have to state both width and height in the form 'widthxheight' when cropping" if width.nil? || height.nil?
         # prevent upscaling unless :upsample param is true
         # unfurtunally dragonfly does not handle this correctly while cropping
         unless params[:upsample] == 'true'

--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -144,6 +144,7 @@ module Alchemy
       return "111x93" if size == "111x93" || size.blank?
       x = size.split('x')[0].to_i
       y = size.split('x')[1].to_i
+      return "111x93" if x.zero? || y.zero?
       if (x > y)
         zoom_factor = 111.0 / x
         new_x = 111

--- a/spec/controllers/admin/essence_pictures_controller_spec.rb
+++ b/spec/controllers/admin/essence_pictures_controller_spec.rb
@@ -41,7 +41,7 @@ module Alchemy
         before do
           picture.image_file_width = 300
           picture.image_file_height = 250
-          essence.should_receive(:picture).and_return(picture)
+          essence.should_receive(:picture).any_number_of_times.and_return(picture)
         end
 
         context 'with no render_size present in essence' do
@@ -67,14 +67,30 @@ module Alchemy
         end
 
         context 'with render_size present in essence' do
-          before do
+          it "sets sizes from these values" do
             essence.stub(:render_size).and_return('30x25')
+
+            get :crop, id: 1
+            expect(assigns(:size_x)).to eq(30)
+            expect(assigns(:size_y)).to eq(25)
           end
 
-          it "sets sizes from these values" do
-            get :crop, id: 1
-            expect(assigns(:size_x)).to eq('30')
-            expect(assigns(:size_y)).to eq('25')
+          context 'when width or height is not fixed' do
+            it 'infers the height from the image file preserving the aspect ratio' do
+              essence.stub(:render_size).and_return('30')
+
+              get :crop, id: 1
+              expect(assigns(:size_x)).to eq(30)
+              expect(assigns(:size_y)).to eq(25)
+            end
+
+            it 'infers the height from the image file preserving the aspect ratio' do
+              essence.stub(:render_size).and_return('x25')
+
+              get :crop, id: 1
+              expect(assigns(:size_x)).to eq(30)
+              expect(assigns(:size_y)).to eq(25)
+            end
           end
         end
 


### PR DESCRIPTION
Before, you had to state render sizes in the format '300x200'.

Now, you can use e.g. '300' for inferring the height from the image file preserving the aspect ratio (or 'x200' for inferring the width).

These two additional ways of specifying the image geometry are provided by the used image processing library Image Magick (and its wrapper dragonfly), see http://www.imagemagick.org/script/command-line-processing.php#geometry.

The only problems with stating render sizes in the form of '300' or '300x200' were the thumbnail and cropping tool box in the admin interface; the image processing worked correctly out of the box in the frontend.
