### PR TITLE
will look for name or first_name of user

### DIFF
--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -74,7 +74,7 @@
           options_for_select(translations_for_select, ::I18n.locale),
           class: 'alchemy_selectbox tiny' %>
         <%= _t('Logged in as') %>
-        <%= current_alchemy_user.try(:name) %>
+        <%= current_alchemy_user.try(:name) || current_alchemy_user.try(:first_name) %>
       </div>
     </div>
     <% end %>


### PR DESCRIPTION
Instead of looking for just the `name` property, I have updated it to look for `name` or `first_name`. This is helpful as in a large amount of my projects I collect the first name and the last name of the user and split them up into their own columns.
