### PR TITLE
Use `alchemy_display_name` to represent the currently logged in user.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ Example:
       end
     end
 
+**Optionally** you can add a `alchemy_display_name` method that returns a name representing the currently logged in user. This is used in the admin views.
+
+Example:
+
+    def alchemy_display_name
+      "#{first_name} #{last_name}".strip
+    end
+
 Testing
 -------
 

--- a/app/assets/stylesheets/alchemy/frame.scss
+++ b/app/assets/stylesheets/alchemy/frame.scss
@@ -158,17 +158,21 @@ div#overlay_text_box {
 
 div#user_info {
   position: absolute;
-  z-index: 10;
-  line-height: 27px;
-  height: 29px;
-  font-size: 11px;
+  top: 0;
   right: 65px;
-  top: -3px;
+  z-index: 10;
+  line-height: 26px;
+  font-size: 11px;
   padding: 0 8px;
   background-color: $light-blue;
 
   .select2-container {
-    margin-right: 2 * $default-margin;
+    margin-top: -2px;
+    margin-right: $default-margin;
+  }
+
+  .current-user-name {
+    padding-right: $default-padding;
   }
 }
 

--- a/app/helpers/alchemy/admin/base_helper.rb
+++ b/app/helpers/alchemy/admin/base_helper.rb
@@ -14,6 +14,18 @@ module Alchemy
       include Alchemy::BaseHelper
       include Alchemy::Admin::NavigationHelper
 
+      # Returns a string showing the name of the currently logged in user.
+      #
+      # In order to represent your own +User+'s class instance,
+      # you should add a +alchemy_display_name+ method to your +User+ class
+      #
+      def current_alchemy_user_name
+        name = current_alchemy_user.try(:alchemy_display_name)
+        if name.present?
+          content_tag :span, "#{_t('Logged in as')} #{name}", class: 'current-user-name'
+        end
+      end
+
       # This helper renders the link to an dialog.
       #
       # We use this for our fancy modal dialogs in the Alchemy cockpit.

--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -70,11 +70,10 @@
         <%= yield(:toolbar) %>
       </div>
       <div id="user_info">
+        <%= current_alchemy_user_name %>
         <%= select_tag 'change_locale',
           options_for_select(translations_for_select, ::I18n.locale),
           class: 'alchemy_selectbox tiny' %>
-        <%= _t('Logged in as') %>
-        <%= current_alchemy_user.try(:name) %>
       </div>
     </div>
     <% end %>

--- a/spec/helpers/admin/base_helper_spec.rb
+++ b/spec/helpers/admin/base_helper_spec.rb
@@ -228,5 +228,25 @@ module Alchemy
       end
     end
 
+    describe '#current_alchemy_user_name' do
+      subject { helper.current_alchemy_user_name }
+
+      before { helper.stub(current_alchemy_user: user) }
+
+      context 'with a user having a `alchemy_display_name` method' do
+        let(:user) { mock('User', alchemy_display_name: 'Peter Schroeder') }
+
+        it "Returns a span showing the name of the currently logged in user." do
+          should have_content("#{Alchemy::I18n.t('Logged in as')} Peter Schroeder")
+          should have_selector("span.current-user-name")
+        end
+      end
+
+      context 'with a user not having a `alchemy_display_name` method' do
+        let(:user) { mock('User', name: 'Peter Schroeder') }
+
+        it { should be_nil }
+      end
+    end
   end
 end


### PR DESCRIPTION
To make this better adoptable for applications hosting Alchemy or engines, we do not assume `name` on the user class.
