### PR TITLE
Stops enforcing users to use rails 4.0.x when using the alchemy command.

### DIFF
--- a/bin/alchemy
+++ b/bin/alchemy
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # encoding: UTF-8
-gem 'rails', '~> 4.0.2'
+gem 'rails', '~> 4.0'
 
 require 'rails/version'
 require "thor"


### PR DESCRIPTION
When using the alchemy command (bin/alchemy) users were forced to use rails 4.0.x.
With this change users can also use rails 4.x.x.
