### PR TITLE
make essence_link_view display the link title between <a> tags

### DIFF
--- a/app/views/alchemy/essences/_essence_link_view.html.erb
+++ b/app/views/alchemy/essences/_essence_link_view.html.erb
@@ -1,6 +1,6 @@
 <% cache(content) do %>
 <% if content.ingredient %>
-<%- options[:text] ||= content.ingredient %>
+<%- options[:text] ||= content.essence.link_title %>
 <%- html_options = { target: content.essence.link_target == "blank" ? "_blank" : nil }.merge(html_options) %>
 <%= link_to options[:text], content.ingredient, html_options -%>
 <% end %>


### PR DESCRIPTION
the current version of the default partial somewhat counter-
intuitively renders the path or url (that which usually comes
after the href) twice: once after the href and once as the link
text. there is a field link_title - this should be rendered in-
stead. shouldn't it?

keep up the good work! :)
