### PR TITLE
fix Page#previous_page

### DIFF
--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -356,7 +356,7 @@ module Alchemy
         .where(["#{self.class.table_name}.lft #{dir} ?", lft])
         .where(public: options[:public])
         .where(restricted: options[:restricted])
-        .order(dir == '>' ? 'lft' : 'lft DESC')
+        .reorder(dir == '>' ? 'lft' : 'lft DESC')
         .limit(1).first
     end
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1035,6 +1035,7 @@ module Alchemy
       describe '#previous' do
         it "should return the previous page on the same level" do
           center_page.previous.should == public_page
+          next_page.previous.should == center_page
         end
 
         context "no previous page on same level present" do


### PR DESCRIPTION
because of a faulty ordering it was always displaying the first, not the previous page
