### PR TITLE
Message model validates fields with 'email' in name with regexp for email format.

### DIFF
--- a/app/models/alchemy/message.rb
+++ b/app/models/alchemy/message.rb
@@ -28,10 +28,10 @@ module Alchemy
       validates_presence_of field
 
       case field.to_sym
-      when :email
+      when /email/
         validates_format_of field,
           with: Alchemy::Config.get('format_matchers')['email'],
-          if: -> { email.present? }
+          if: -> { send(field).present? }
       when :email_confirmation
         validates_confirmation_of :email
       end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
 module Alchemy
+  Config.get(:mailer)['fields'].push('email_of_my_boss')
+  Config.get(:mailer)['validate_fields'].push('email_of_my_boss')
+
   describe Message do
     let(:message) { Message.new }
 
@@ -18,15 +21,28 @@ module Alchemy
       end
     end
 
-    it "validates attributes defined in mailer config" do
-      Config.get(:mailer)['validate_fields'].each do |field|
-        expect(message).to have(1).error_on(field)
+    context "validation of" do
+      context "all fields defined in mailer config" do
+        it "adds errors on that fields" do
+          Config.get(:mailer)['validate_fields'].each do |field|
+            expect(message).to have(1).error_on(field)
+          end
+        end
       end
-    end
 
-    it "validates email format" do
-      message.email = 'wrong email format'
-      expect(message.errors_on(:email)).to include("is invalid")
+      context 'field containing email in its name' do
+        context "when field has a value" do
+          it "adds error notice (is invalid) to the field" do
+            message.email_of_my_boss = 'wrong email format'
+            expect(message.errors_on(:email_of_my_boss)).to include("is invalid")
+          end
+        end
+        context "when field is blank" do
+          it "adds error notice (can't be blank) to the field" do
+            expect(message.errors_on(:email_of_my_boss)).to include("can't be blank")
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Before this change Message fields like 'backoffice_email' were not validated with email format. This was because the field name had to be exactly 'email'.

This commit opens this fixed naming demand: Every field name containing the word email will be validated for email format.
