### PR TITLE
Fixes clipboard for Rails 4.1

### DIFF
--- a/app/controllers/alchemy/admin/base_controller.rb
+++ b/app/controllers/alchemy/admin/base_controller.rb
@@ -60,7 +60,9 @@ module Alchemy
       end
 
       def get_clipboard
-        session[:clipboard] ||= Clipboard.new
+        clipboard = Clipboard.new(session[:clipboard])
+        session[:clipboard] = clipboard.items
+        clipboard
       rescue NoMethodError => e
         exception_logger(e)
         @notice = "You have an old style clipboard in your session. Please remove your cookies and try again."

--- a/app/controllers/alchemy/admin/clipboard_controller.rb
+++ b/app/controllers/alchemy/admin/clipboard_controller.rb
@@ -17,6 +17,7 @@ module Alchemy
         unless @clipboard.contains? params[:remarkable_type], params[:remarkable_id]
           @clipboard.push params[:remarkable_type], {:id => params[:remarkable_id], :action => params[:remove] ? 'cut' : 'copy'}
         end
+        update_session
         respond_to do |format|
           format.js
         end
@@ -26,19 +27,26 @@ module Alchemy
         @clipboard = get_clipboard
         @item = model_class.find(params[:remarkable_id])
         @clipboard.remove params[:remarkable_type], params[:remarkable_id]
+        update_session
         respond_to do |format|
           format.js
         end
       end
 
       def clear
-        session[:clipboard].clear(params[:remarkable_type])
+        @clipboard = get_clipboard
+        @clipboard.clear(params[:remarkable_type])
+        update_session
       end
 
     private
 
       def model_class
         "alchemy/#{params[:remarkable_type]}".classify.constantize
+      end
+
+      def update_session
+        session[:clipboard] = @clipboard.items
       end
 
     end

--- a/app/models/alchemy/clipboard.rb
+++ b/app/models/alchemy/clipboard.rb
@@ -11,8 +11,8 @@ module Alchemy
 
     attr_accessor :items
 
-    def initialize
-      @items = self.class.empty_clipboard
+    def initialize(items)
+      @items = items.is_a?(Hash) ? items.with_indifferent_access : self.class.empty_clipboard
     end
 
     # Returns all items of the collection from category (+:elements+ or +:pages+)


### PR DESCRIPTION
Not sure if this is the best approach but it seems to work and I needed this fixed. Feel free to modify if there's a better way.

Starting in Rails 4.1, Marshal is no longer used to serialize cookie values and the new format is JSON-based (http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#cookies-serializer). Because the format is based on JSON, all Hashes get their keys stringified. This will automatically create a new clipboard for a broken session containing a string such as  or a clipboard stored with an existing cookie. Fixes #539.
