### PR TITLE
Stick RSpec to version 2.x

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'non-stupid-digest-assets',         '~> 1.0.3'
   gem.add_runtime_dependency 'active_model_serializers',         '~> 0.8.1'
 
-  gem.add_development_dependency 'rspec-rails'
+  gem.add_development_dependency 'rspec-rails', '~> 2.0'
   gem.add_development_dependency 'capybara'
   gem.add_development_dependency 'factory_girl_rails'
 


### PR DESCRIPTION
RSpec 3.0 has just been released. Since they use a new syntax now, many
tests broke. For the time being, stick RSpec to the latest 2.x version, no? :)

Thanks, and keep up the good work :)
