### PR TITLE
Adds available_locales setter to Alchemy::I18n module.

### DIFF
--- a/lib/alchemy/i18n.rb
+++ b/lib/alchemy/i18n.rb
@@ -45,7 +45,13 @@ module Alchemy
     end
 
     def self.available_locales
-      translation_files.collect { |f| f.match(/.{2}\.yml$/).to_s.gsub(/\.yml/, '') }
+      @@available_locales ||= nil
+      @@available_locales || translation_files.collect { |f| f.match(/.{2}\.yml$/).to_s.gsub(/\.yml/, '').to_sym }
+    end
+
+    def self.available_locales=(locales)
+      @@available_locales = Array(locales).map { |locale| locale.to_sym }
+      @@available_locales = nil if @@available_locales.empty?
     end
 
     def self.translation_files

--- a/spec/features/admin/locale_select_feature_spec.rb
+++ b/spec/features/admin/locale_select_feature_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'Locale select' do
+  let(:a_page) { FactoryGirl.create(:public_page) }
+  before do
+    Alchemy::I18n.stub(translation_files: ['alchemy.kl.yml', 'alchemy.jp.yml', 'alchemy.cz.yml'])
+    authorize_as_admin
+  end
+
+  it "contains all locales in a selectbox" do
+    visit admin_dashboard_path
+    expect(page).to have_select('change_locale', options: ['Kl', 'Jp', 'Cz'])
+  end
+
+  context 'when having available_locales set for Alchemy::I18n' do
+    before { Alchemy::I18n.stub(available_locales: [:jp, :cz]) }
+    it "provides only that locales" do
+      visit admin_dashboard_path
+      expect(page).to have_select('change_locale', options: ['Jp', 'Cz'])
+    end
+  end
+end

--- a/spec/libraries/i18n_spec.rb
+++ b/spec/libraries/i18n_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+module Alchemy
+  describe I18n do
+    describe '.translation_files' do
+      subject { I18n.translation_files }
+      it      { should be_a Array }
+      it      { should be_any { |f| f =~ /alchemy.*.yml/ } }
+    end
+
+    describe '.available_locales' do
+      subject { I18n.available_locales }
+      before  { I18n.stub(translation_files: ['alchemy.kl.yml']) }
+      it      { should be_a Array }
+      it      { should include :kl }
+
+      context 'when locales are already set in @@available_locales' do
+        before { I18n.class_variable_set(:@@available_locales, [:kl, :jp]) }
+        it     { should eq([:kl, :jp]) }
+      end
+    end
+
+    describe '.available_locales=' do
+      it "assigns the given locales to @@available_locales" do
+        I18n.available_locales = [:kl, :nl, :cn]
+        expect(I18n.class_variable_get(:@@available_locales)).to eq([:kl, :nl, :cn])
+      end
+    end
+  end
+end


### PR DESCRIPTION
With this feature developers can dictate which translations are provided for the user in the backend. (I.e. if Alchemy had 10 translations, but the developer don't want to provide all of them.)

It can be used with a simple initializer in the host app: `Alchemy::I18n.available_locales = [:en, :de]`
