### PR TITLE
Adds Upgrader module with note for User model extraction in v2.9

### DIFF
--- a/lib/alchemy/upgrader.rb
+++ b/lib/alchemy/upgrader.rb
@@ -5,6 +5,7 @@ module Alchemy
 
     Dir["#{File.dirname(__FILE__)}/upgrader/*.rb"].each { |f| require f }
 
+    extend Alchemy::Upgrader::TwoPointNine
     extend Alchemy::Upgrader::TwoPointSix
     extend Alchemy::Upgrader::TwoPointFive
     extend Alchemy::Upgrader::TwoPointFour

--- a/lib/alchemy/upgrader/two_point_nine.rb
+++ b/lib/alchemy/upgrader/two_point_nine.rb
@@ -1,0 +1,33 @@
+module Alchemy
+  module Upgrader::TwoPointNine
+
+    private
+
+    def alchemy_29_todos
+      notice = <<-NOTE
+
+Alchemy User Class Removed
+--------------------------
+
+We removed the user model from the Alchemy core!
+
+You have to provide your own user model or
+add the `alchemy-devise` gem to your Gemfile.
+
+If you want to use the default user class from Alchemy:
+
+  # Gemfile
+  gem 'alchemy-devise', '~> 1.1'
+
+  $ bin/rake alchemy_devise:install:migrations db:migrate
+
+In order to add your own user class to Alchemy, please
+make shure it meets the API:
+
+https://github.com/magiclabs/alchemy_cms/blob/2.9-stable/lib/alchemy/auth_accessors.rb
+
+NOTE
+      todo notice
+    end
+  end
+end


### PR DESCRIPTION
The note states to use `gem 'alchemy-devise', '~> 1.1'`. To avoid confusion, the alchemy-devise v1.1 should get released when alchemy_cms v2.9 got released.
