### PR TITLE
Paint the background of dialogs grey

### DIFF
--- a/app/assets/stylesheets/alchemy/dialogs.scss
+++ b/app/assets/stylesheets/alchemy/dialogs.scss
@@ -158,6 +158,7 @@
   @include box-sizing(border-box);
   position: relative;
   color: $text-color;
+  background-color: $light-gray;
 
   .message {
     margin: 8px;


### PR DESCRIPTION
When the screen is y-narrow and a dialog does not get the correct height in
the options hash, all input elements below that height don't have a background.
This is a dirty fix for that. The proper fix would be to adjust the div
`alchemy-dialog-modal` to the height of its child elements - but I don't know
how to do that...
