### PR TITLE
add tests for legacy url with unknown format & parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ spec/dummy/config/locales/**/*
 /.ruby-version
 /index/
 /.bundle/
+.rbenv-version

--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -78,7 +78,10 @@ module Alchemy
         redirect_to signup_path
       elsif @page.nil? && last_legacy_url
         @page = last_legacy_url.page
-        redirect_page
+
+        # This drops the given query string.
+        redirect_legacy_page
+
       elsif @page.blank?
         raise_not_found_error
       elsif multi_language? && params[:lang].blank?
@@ -128,6 +131,17 @@ module Alchemy
       redirect_to show_page_path(additional_params.merge(options)), :status => 301
     end
 
+    # Use the bare minimum to redirect to @page
+    # Don't use query string of legacy urlname
+    def redirect_legacy_page(options={})
+      defaults = {
+        :lang => (multi_language? ? @page.language_code : nil),
+        :urlname => @page.urlname
+      }
+      options = defaults.merge(options)
+      redirect_to show_page_path(options), :status => 301
+    end
+
     def additional_params
       params.each do |key, value|
         params[key] = nil if ["action", "controller", "urlname", "lang"].include?(key)
@@ -135,7 +149,11 @@ module Alchemy
     end
 
     def legacy_urls
-      LegacyPageUrl.joins(:page).where(urlname: params[:urlname], alchemy_pages: {language_id: Language.current.id})
+
+      # /slug/tree => slug/tree
+      urlname = (request.fullpath[1..-1] if request.fullpath[0] == '/') || request.fullpath
+
+      LegacyPageUrl.joins(:page).where(urlname: urlname, alchemy_pages: {language_id: Language.current.id})
     end
 
     def last_legacy_url

--- a/spec/features/page_feature_spec.rb
+++ b/spec/features/page_feature_spec.rb
@@ -33,6 +33,15 @@ module Alchemy
           PagesController.any_instance.stub(:multi_language?).and_return(true)
         end
 
+        let(:second_page) { FactoryGirl.create(:public_page, name: 'Second Page') }
+        let(:legacy_url) { LegacyPageUrl.create(urlname: 'index.php?option=com_content&view=article&id=48&Itemid=69', page: second_page) }
+
+        it "should redirect legacy url with unknown format & query string" do
+          visit "/#{legacy_url.urlname}"
+          URI.parse(page.current_url).query.should == nil
+          URI.parse(page.current_url).request_uri.should == "/en/#{second_page.urlname}"
+        end
+
         context "if no language params are given" do
           it "should redirect to url with nested language code" do
             visit "/#{public_page_1.urlname}"
@@ -108,6 +117,15 @@ module Alchemy
         before do
           PagesController.any_instance.stub(:multi_language?).and_return(false)
           Config.stub(:get) { |arg| arg == :url_nesting ? false : Config.parameter(arg) }
+        end
+
+        let(:second_page) { FactoryGirl.create(:public_page, name: 'Second Page') }
+        let(:legacy_url) { LegacyPageUrl.create(urlname: 'index.php?option=com_content&view=article&id=48&Itemid=69', page: second_page) }
+
+        it "should redirect legacy url with unknown format & query string" do
+          visit "/#{legacy_url.urlname}"
+          URI.parse(page.current_url).query.should == nil
+          URI.parse(page.current_url).request_uri.should == "/#{second_page.urlname}"
         end
 
         it "should redirect from nested language code url to normal url" do


### PR DESCRIPTION
There is missing page feature test for legacy urls like
`/index.php?option=com_content&view=article&id=48&Itemid=69`
Url like that would not be redirected right now to the appropriate page.
