### PR TITLE
allow for active model serializer 0.9

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'spinner.rb'
   gem.add_runtime_dependency 'turbolinks',                       '~> 2.0'
   gem.add_runtime_dependency 'non-stupid-digest-assets',         '~> 1.0.3'
-  gem.add_runtime_dependency 'active_model_serializers',         '~> 0.8.1'
+  gem.add_runtime_dependency 'active_model_serializers',         '>= 0.8.1', '< 0.10.0'
 
   gem.add_development_dependency 'rspec-rails', '~> 2.0'
   gem.add_development_dependency 'capybara'


### PR DESCRIPTION
When installing some gems that may be using Active Model Serializer version 0.9 (_cough_ [Spree Wombat](https://github.com/spree/spree_wombat/blob/2-2-stable/spree_wombat.gemspec#L17)), Bundler is not able to resolve the dependencies.

To fix this, I simply add a minimum version (0.8.1) and a maximum version (0.10.0).
