### PR TITLE
Bump act-as-taggable-on to 3.2.6 and include the necessary migrations

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'rails',                            '>= 4.0', '< 5.0'
   gem.add_runtime_dependency 'actionpack-page_caching',          '~> 1.0.0'
   gem.add_runtime_dependency 'awesome_nested_set',               '~> 3.0.0.rc.2'
-  gem.add_runtime_dependency 'acts-as-taggable-on',              '~> 3.0.0'
+  gem.add_runtime_dependency 'acts-as-taggable-on',              '~> 3.1'
   gem.add_runtime_dependency 'cancan',                           '~> 1.6.10'
   gem.add_runtime_dependency 'dragonfly',                        '~> 1.0.1'
   gem.add_runtime_dependency 'kaminari',                         '~> 0.15.0'

--- a/db/migrate/20140701160159_add_taggings_counter_cache_to_tags.rb
+++ b/db/migrate/20140701160159_add_taggings_counter_cache_to_tags.rb
@@ -1,0 +1,14 @@
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration
+  def self.up
+    add_column :tags, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, :taggings)
+    end
+  end
+
+  def self.down
+    remove_column :tags, :taggings_count
+  end
+end

--- a/db/migrate/20140701160225_add_missing_taggable_index.rb
+++ b/db/migrate/20140701160225_add_missing_taggable_index.rb
@@ -1,0 +1,9 @@
+class AddMissingTaggableIndex < ActiveRecord::Migration
+  def self.up
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/spec/dummy/db/migrate/20140701160159_add_taggings_counter_cache_to_tags.rb
+++ b/spec/dummy/db/migrate/20140701160159_add_taggings_counter_cache_to_tags.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20140701160159_add_taggings_counter_cache_to_tags.rb

--- a/spec/dummy/db/migrate/20140701160225_add_missing_taggable_index.rb
+++ b/spec/dummy/db/migrate/20140701160225_add_missing_taggable_index.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20140701160225_add_missing_taggable_index.rb

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140107192720) do
+ActiveRecord::Schema.define(version: 20140701160225) do
 
   create_table "alchemy_attachments", force: true do |t|
     t.string   "name"
@@ -304,9 +304,11 @@ ActiveRecord::Schema.define(version: 20140107192720) do
   end
 
   add_index "taggings", ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+  add_index "taggings", ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context"
 
   create_table "tags", force: true do |t|
-    t.string "name"
+    t.string  "name"
+    t.integer "taggings_count", default: 0
   end
 
   add_index "tags", ["name"], name: "index_tags_on_name", unique: true


### PR DESCRIPTION
Acts-as-taggable-on 3.0 has just been updated to a version that breaks alchemy
builds with PostgreSQL and MySQL. This makes every pull request fail. This is
an attempt to update it to the latest version and see whether with this PR
the Travis builds go through again.

I've tested tagging locally, and it does work as expected with this and Postgres.

Even if this passes Travis: This has to be tested manually; I'm not at all sure
I'm doing the Right Thing here.
