### PR TITLE
Fixes preprocess_image_resize Config option.

### DIFF
--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -39,9 +39,13 @@ module Alchemy
       raise PictureInUseError, I18n.t(:cannot_delete_picture_notice) % { name: name }
     end
 
+    # Enables Dragonfly image processing
     dragonfly_accessor :image_file, app: :alchemy_pictures do
-      if Config.get(:preprocess_image_resize).present?
-        after_assign { |a| a.process!(:resize, "#{Config.get(:preprocess_image_resize)}>") }
+      # Preprocess after uploading the picture
+      after_assign do |p|
+        if Config.get(:preprocess_image_resize).present?
+          p.thumb!("#{Config.get(:preprocess_image_resize)}>")
+        end
       end
     end
 

--- a/spec/models/picture_spec.rb
+++ b/spec/models/picture_spec.rb
@@ -32,6 +32,25 @@ module Alchemy
       picture.should be_valid
     end
 
+    context 'with enabled preprocess_image_resize config option' do
+      let(:image_file) do
+        File.new(File.expand_path('../../fixtures/80x60.png', __FILE__))
+      end
+
+      before do
+        Config.stub(:get) do |arg|
+          if arg == :preprocess_image_resize
+            '10x10'
+          end
+        end
+      end
+
+      it "it resizes the image after upload" do
+        picture = Picture.new(image_file: image_file)
+        expect(picture.image_file.data[0x10..0x18].unpack('NN')).to eq([10, 8])
+      end
+    end
+
     describe '#suffix' do
       it "should return the suffix of original filename" do
         pic = stub_model(Picture, image_file_name: 'kitten.JPG')


### PR DESCRIPTION
The configuration option `preprocess_image_resize` was not compatible with Dragonfly 1.0 syntax.
