### PR TITLE
adds link class dropdown for tinymce alchemy_link dialog

### DIFF
--- a/app/views/alchemy/admin/pages/_external_link.html.erb
+++ b/app/views/alchemy/admin/pages/_external_link.html.erb
@@ -18,6 +18,14 @@
     <%= text_field_tag "external_link_title", '', class: 'link_title' %>
   </div>
   <div class="input select">
+    <label for="external_class" class="control-label">
+      <%= _t(:class) %>
+    </label>
+    <%= select_tag(:external_class,
+       options_for_select([[_t('Please choose'), '']]),
+       class: 'alchemy_selectbox link_class') %>
+  </div>
+  <div class="input select">
     <label for="external_link_target" class="control-label">
       <%= _t("Open Link in") %>
     </label>
@@ -26,6 +34,7 @@
       class: 'alchemy_selectbox link_target' %>
   </div>
   <div class="submit">
+    <%= hidden_field_tag(:external_link_class) %>
     <%= link_to _t(:apply), '#', class: 'create-link button', 'data-link-type' => 'external' %>
   </div>
 <% end %>

--- a/app/views/alchemy/admin/pages/_internal_link.html.erb
+++ b/app/views/alchemy/admin/pages/_internal_link.html.erb
@@ -19,6 +19,14 @@
       options_for_select([[_t('Please choose'), '']]),
       class: 'alchemy_selectbox') %>
   </div>
+  <div class="input select">
+    <label for="internal_class" class="control-label">
+      <%= _t(:class) %>
+    </label>
+    <%= select_tag(:internal_class,
+       options_for_select([[_t('Please choose'), '']]),
+       class: 'alchemy_selectbox link_class') %>
+  </div>
   <div class="input text">
     <label for="internal_link_title" class="control-label">
       <%= _t(:link_title) %>
@@ -35,6 +43,7 @@
   </div>
   <div class="submit">
     <%= hidden_field_tag(:internal_urlname) %>
+    <%= hidden_field_tag(:internal_link_class) %>
     <%= hidden_field_tag(:page_anchor) %>
     <%= link_to _t(:apply), '', class: 'create-link button', 'data-link-type' => 'internal' %>
   </div>


### PR DESCRIPTION
This brings over the element class functionality that the default tinymce link plugin has.
Let me know if tests are needed and where to put them, I couldn't find any specs regarding the fields inside the link dialog.

To use, add the class list config inside the tinymce initializer.
```
Alchemy::Tinymce.init = {
    link_class_list: [
        {title: 'Blue-Green Link', value: 'blue-green-link'},
        {title: 'Primary Button', value: 'primary-btn'},
        {title: 'Large Primary Button', value: 'primary-btn large'},
        {title: 'Secondary Button', value: 'secondary-btn'}
    ]
}
```
The dropdown is hidden if no class list is defined.