### PR TITLE
Fixes updating of page urlname path.

### DIFF
--- a/app/assets/stylesheets/alchemy/sitemap.scss
+++ b/app/assets/stylesheets/alchemy/sitemap.scss
@@ -262,7 +262,7 @@ div.page_infos {
 }
 
 .alchemy-dialog .page_status {
-  margin: 4px 4px 0 0;
+  margin: 2px 4px 0 0;
 }
 
 #sitemap {

--- a/app/models/alchemy/page/page_naming.rb
+++ b/app/models/alchemy/page/page_naming.rb
@@ -72,11 +72,11 @@ module Alchemy
     def set_urlname
       if Config.get(:url_nesting)
         url_name = [
-          parent.nil? || parent.language_root? ? nil : parent.urlname,
-          convert_url_name((urlname.blank? ? name : slug))
+          parent_urlname,
+          convert_url_name(urlname.blank? ? name : slug)
         ].compact.join('/')
       else
-        url_name = convert_url_name((urlname.blank? ? name : urlname))
+        url_name = convert_url_name(urlname.blank? ? name : urlname)
       end
       write_attribute :urlname, url_name
     end
@@ -97,6 +97,13 @@ module Alchemy
       else
         url_name
       end
+    end
+
+    # Urlname of parent page.
+    # Returns nil, if the parent is either a language root page or the root page itself
+    def parent_urlname
+      return if parent.nil? || parent.language_root? || parent.root?
+      parent.urlname
     end
   end
 end

--- a/app/views/alchemy/admin/pages/_page.html.erb
+++ b/app/views/alchemy/admin/pages/_page.html.erb
@@ -12,7 +12,7 @@
           alchemy.info_admin_page_path(page),
           {
             title: _t(:page_infos),
-            size: '480x290'
+            size: '520x290'
           },
           {
             title: _t(:page_infos),

--- a/app/views/alchemy/admin/pages/edit.html.erb
+++ b/app/views/alchemy/admin/pages/edit.html.erb
@@ -32,7 +32,7 @@
       alchemy.info_admin_page_path(@page),
       {
         title: _t(:page_infos),
-        size: '480x320'
+        size: '520x320'
       },
       {
         class: 'icon_button',

--- a/app/views/alchemy/admin/pages/info.html.erb
+++ b/app/views/alchemy/admin/pages/info.html.erb
@@ -5,8 +5,17 @@
   <% end %>
   <% end %>
   <div class="value">
-    <label><%= _t(:page_type) %></label>
+    <label><%= Alchemy::Page.human_attribute_name(:page_layout) %></label>
     <p><%= @page.layout_display_name %></p>
+  </div>
+  <div class="value">
+  <% if @page.redirects_to_external? %>
+    <label><%= Alchemy::Page.human_attribute_name(:urlname) %></label>
+    <p><%= @page.urlname %></p>
+  <% else %>
+    <label><%= Alchemy::LegacyPageUrl.human_attribute_name(:urlname) %></label>
+    <p><%= "/#{@page.urlname}" %></p>
+  <% end %>
   </div>
   <div class="value">
     <label><%= _t(:page_status) %></label>

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1203,12 +1203,13 @@ module Alchemy
     end
 
     context 'urlname updating' do
-      let(:parentparent) { FactoryGirl.create(:page, name: 'parentparent', visible: true) }
-      let(:parent)       { FactoryGirl.create(:page, parent_id: parentparent.id, name: 'parent', visible: true) }
-      let(:page)         { FactoryGirl.create(:page, parent_id: parent.id, name: 'page', visible: true) }
-      let(:invisible)    { FactoryGirl.create(:page, parent_id: page.id, name: 'invisible', visible: false) }
-      let(:contact)      { FactoryGirl.create(:page, parent_id: invisible.id, name: 'contact', visible: true) }
-      let(:external)     { FactoryGirl.create(:page, parent_id: parent.id, name: 'external', page_layout: 'external', urlname: 'http://google.com') }
+      let(:parentparent)  { FactoryGirl.create(:page, name: 'parentparent', visible: true) }
+      let(:parent)        { FactoryGirl.create(:page, parent_id: parentparent.id, name: 'parent', visible: true) }
+      let(:page)          { FactoryGirl.create(:page, parent_id: parent.id, name: 'page', visible: true) }
+      let(:invisible)     { FactoryGirl.create(:page, parent_id: page.id, name: 'invisible', visible: false) }
+      let(:contact)       { FactoryGirl.create(:page, parent_id: invisible.id, name: 'contact', visible: true) }
+      let(:external)      { FactoryGirl.create(:page, parent_id: parent.id, name: 'external', page_layout: 'external', urlname: 'http://google.com') }
+      let(:language_root) { parentparent.parent }
 
       context "with activated url_nesting" do
         before { Config.stub(:get).and_return(true) }
@@ -1218,7 +1219,9 @@ module Alchemy
         end
 
         it "should not include the root page" do
-          page.urlname.should_not =~ /root/
+          Page.root.update_column(:urlname, 'root')
+          language_root.update(urlname: 'new-urlname')
+          language_root.urlname.should_not =~ /root/
         end
 
         it "should not include the language root page" do


### PR DESCRIPTION
The logic of the Page#set_urlname method does not take the root page into account. So if one updates a language root page, then the urlname would include the root page urlname ('root').

This commit also includes an addition to the page info view. It now includes the complete urlname path.
