### PR TITLE
Fix locale setting in some circumstances

### DIFF
--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -94,8 +94,6 @@ module Alchemy
       elsif @page.has_controller?
         redirect_to main_app.url_for(@page.controller_and_action)
       else
-        # setting the language to page.language to be sure it's correct
-        set_alchemy_language(@page.language)
         if params[:urlname].blank?
           @root_page = @page
         else

--- a/lib/alchemy/controller_actions.rb
+++ b/lib/alchemy/controller_actions.rb
@@ -3,8 +3,8 @@ module Alchemy
     extend ActiveSupport::Concern
 
     included do
-      before_action :set_current_alchemy_site
-      before_action :set_alchemy_language
+      prepend_before_action :set_alchemy_language
+      prepend_before_action :set_current_alchemy_site
 
       helper 'alchemy/pages'
 


### PR DESCRIPTION
I've had issues with `::I18n.locale` not being set correctly on a
multi-language site. On my installation, `#set_alchemy_language`
would sometimes be called after `#set_locale`, which was the reason
for that strange behaviour. Actively marking `#set_alchemy_language`
as a `prepend_before_action`, thereby specifying the sequence of things, fixed that.

However, I could not (for the love of god) reproduce the failing behaviour
in a test. This is why there is no test for this.

Things were complicated further by `#set_alchemy_language` being
called in the default `else` branch of `PagesController#render_page_or_redirect`.
There should in my opinion never be a case where the page has a different language
than `Language.current`, as it is scoped against that in `PagesController#load_page`.

In the interest of simplification, I removed that line.

If someone has an idea of how to reproduce the strange behaviour,
I'd be happy to include a test.