### PR TITLE
[Fix] Adds `publish_unpublished_public_pages` upgrade task

### DIFF
--- a/lib/alchemy/upgrader/three_point_zero.rb
+++ b/lib/alchemy/upgrader/three_point_zero.rb
@@ -16,6 +16,19 @@ module Alchemy
       end
     end
 
+    def publish_unpublished_public_pages
+      desc 'Sets `published_at` of public pages without a `published_at` date set to their `updated_at` value'
+      public_pages = Alchemy::Page.published.where('published_at IS NULL')
+      if public_pages.any?
+        public_pages.each do |page|
+          page.update_column(:published_at, page.updated_at)
+          log "Sets `published_at` of #{page.name} to #{page.updated_at}"
+        end
+      else
+        log 'No unpublished public pages found.', :skip
+      end
+    end
+
     def alchemy_3_todos
       notice = <<-NOTE
 


### PR DESCRIPTION
While upgrading to Alchemy 3.0 we introduced the `published_at` column to pages, but we never set the published at date for existing pages. So Alchemy thinks these pages have never been published and therefore the `cache_key` gets wrong date.
