### PR TITLE
Fix typo in ignored upload folder

### DIFF
--- a/bin/alchemy
+++ b/bin/alchemy
@@ -79,7 +79,7 @@ EOF
       <<-GITIGNORE
 
 # Ignore Alchemy uploads folder
-upload/*
+uploads/*
 
 # Ignore sensitive data
 config/database.yml


### PR DESCRIPTION
Currently the created folder was name `uploads` but the ignored folder was `upload`
