### PR TITLE
Prevent to overwrite custom NonStupidDigestAssets.whitelist

### DIFF
--- a/lib/alchemy/engine.rb
+++ b/lib/alchemy/engine.rb
@@ -79,7 +79,7 @@ module Alchemy
     end
 
     initializer 'alchemy.non_digest_assets' do |app|
-      NonStupidDigestAssets.whitelist = [/^tinymce\//]
+      NonStupidDigestAssets.whitelist += [/^tinymce\//]
     end
 
     config.after_initialize do


### PR DESCRIPTION
alchemy_cms actually overwriting all custom Non StupidDigestAssets.whitelist not allowing people to add their own.
