### PR TITLE
Set page's published_at when not using publish!

### DIFF
--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -84,6 +84,7 @@ module Alchemy
     before_save :set_language_code, if: -> { language.present? }, unless: :systempage?
     before_save :set_restrictions_to_child_pages, if: :restricted_changed?, unless: :systempage?
     before_save :inherit_restricted_status, if: -> { parent && parent.restricted? }, unless: :systempage?
+    before_save :update_published_at, if: -> { public && read_attribute(:published_at).nil? }, unless: :systempage?
     before_create :set_language_from_parent_or_default, if: -> { language_id.blank? }, unless: :systempage?
     after_update :create_legacy_url, if: :urlname_changed?, unless: :redirects_to_external?
 
@@ -390,6 +391,10 @@ module Alchemy
     # Stores the old urlname in a LegacyPageUrl
     def create_legacy_url
       legacy_urls.find_or_create_by(urlname: urlname_was)
+    end
+
+    def update_published_at
+      self.published_at = Time.now
     end
 
   end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -180,6 +180,26 @@ module Alchemy
             page.legacy_urls.should be_empty
           end
         end
+
+        context "public has changed" do
+          it "should update published_at" do
+            page.update_attributes!(public: true)
+            page.read_attribute(:published_at).should be_within(1.second).of(Time.now)
+          end
+
+          it "should not update already set published_at" do
+            page.update_attributes!(published_at: 2.weeks.ago)
+            page.update_attributes!(public: true)
+            page.read_attribute(:published_at).should be_within(1.second).of(2.weeks.ago)
+          end
+        end
+
+        context "public has not changed" do
+          it "should not update published_at" do
+            page.update_attributes!(name: 'New Name')
+            page.read_attribute(:published_at).should be_nil
+          end
+        end
       end
 
       context 'after_move' do


### PR DESCRIPTION
Before, `published_at` was only set when you explicitly called
`Alchemy::Page#publish!`. It wasn't set when a user just edited the
page properties and changed the public flag to true. This commit
changes this. Whenever a page is made public, it's `published_at`
timestamp is set if it wasn't set before.
