### PR TITLE
Adds new helper `content_settings_value`

### DIFF
--- a/app/helpers/alchemy/admin/essences_helper.rb
+++ b/app/helpers/alchemy/admin/essences_helper.rb
@@ -59,13 +59,14 @@ module Alchemy
 
       def essence_picture_thumbnail(content, options)
         return if content.ingredient.blank?
-        crop = !(content.essence.crop_size.blank? && content.essence.crop_from.blank?) || (options[:crop] == true || options[:crop] == "true")
+        crop = !(content.essence.crop_size.blank? && content.essence.crop_from.blank?) ||
+          (content_settings_value(content, :crop, options) == true || content_settings_value(content, :crop, options) == "true")
         image_options = {
-          size: content.essence.thumbnail_size(content.essence.render_size.blank? ? options[:size] : content.essence.render_size, crop),
+          size: content.essence.thumbnail_size(content.essence.render_size.blank? ? content_settings_value(content, :size, options) : content.essence.render_size, crop),
           crop_from: content.essence.crop_from.blank? ? nil : content.essence.crop_from,
           crop_size: content.essence.crop_size.blank? ? nil : content.essence.crop_size,
           crop: crop ? 'crop' : nil,
-          upsample: options[:upsample]
+          upsample: content_settings_value(content, :upsample, options)
         }
         image_tag(
           alchemy.thumbnail_path({

--- a/app/helpers/alchemy/essences_helper.rb
+++ b/app/helpers/alchemy/essences_helper.rb
@@ -92,7 +92,10 @@ module Alchemy
     # Renders a essence picture
     #
     def render_essence_picture_view(content, options, html_options)
-      options = {show_caption: true, disable_link: false}.update(options)
+      options = {
+        show_caption: true,
+        disable_link: false
+      }.update(content.settings).update(options)
       return if content.ingredient.blank?
       if content.essence.caption.present? && options[:show_caption]
         caption = content_tag(:figcaption, content.essence.caption, id: "#{dom_id(content.ingredient)}_caption", class: "image_caption")
@@ -119,6 +122,16 @@ module Alchemy
       else
         output
       end
+    end
+
+    # Fetches value from settings of given content
+    #
+    # @param content [Alchemy::Content] - The content that settings should be taken
+    # @param key [Symbol]               - The hash key you want to fetch the value from
+    # @param options [Hash]             - An optional Hash that can override the settings.
+    #                                     Normally passed as options hash into the content editor view
+    def content_settings_value(content, key, options = {})
+      content.settings.update(options || {}).symbolize_keys[key.to_sym]
     end
 
   end

--- a/app/models/alchemy/content.rb
+++ b/app/models/alchemy/content.rb
@@ -99,9 +99,7 @@ module Alchemy
     # Settings from the elements.yml definition
     def settings
       return {} if description.blank?
-      @settings ||= description['settings']
-      return {} if @settings.blank?
-      @settings.symbolize_keys
+      @settings ||= description.fetch('settings', {}).symbolize_keys
     end
 
     def siblings

--- a/app/views/alchemy/essences/_essence_boolean_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_boolean_editor.html.erb
@@ -1,11 +1,12 @@
 <% cache(content) do %>
-  <div class="content_editor essence_boolean" id="<%= content.dom_id %>">
-    <input type="hidden" value="0" name="<%= content.form_field_name %>" />
-    <%= check_box_tag(content.form_field_name, 1,
-      !content.ingredient.nil? ? content.ingredient : options[:default_value],
-      :class => html_options[:class],
-      :style => html_options[:style]
-    ) %>
+  <div class="content_editor essence_boolean" id="<%= content.dom_id %>" data-content-id="<%= content.id %>">
+    <input type="hidden" value="0" name="<%= content.form_field_name %>">
+    <%= check_box_tag content.form_field_name, 1,
+      content.ingredient.presence || content_settings_value(
+        content, :default_value,
+        local_assigns.fetch(:options, {})),
+      class: local_assigns.fetch(:html_options, {})[:class],
+      style: local_assigns.fetch(:html_options, {})[:style] %>
     <label for="<%= content.form_field_id %>" style="display: inline">
       <%= render_content_name(content) %>
       <%= delete_content_link(content) %>

--- a/app/views/alchemy/essences/_essence_boolean_view.html.erb
+++ b/app/views/alchemy/essences/_essence_boolean_view.html.erb
@@ -1,3 +1,3 @@
-<% cache(content) do %>
-<%= _t(content.ingredient) %>
-<% end %>
+<%- cache(content) do -%>
+<%= _t(content.ingredient) -%>
+<%- end -%>

--- a/app/views/alchemy/essences/_essence_date_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_date_editor.html.erb
@@ -1,13 +1,19 @@
-<div class="content_editor essence_date" id="<%= content.dom_id %>">
+<% cache(content) do %>
+<div class="content_editor essence_date" id="<%= content.dom_id %>" data-content-id="<%= content.id %>">
   <%= label_and_remove_link(content) %>
   <%= alchemy_datepicker(
     content.essence, :date, {
       name: content.form_field_name,
       id: content.form_field_id,
-      value: options[:default_value]
+      value: content_settings_value(
+        content,
+        :default_value,
+        local_assigns.fetch(:options, {})
+      )
     }
   ) %>
   <label for="<%= content.form_field_id %>" style="cursor: pointer; display: inline; display: inline-block; position: relative; top: 3px; margin: 0;">
     <span class="ui-icon ui-icon-calendar"></span>
   </label>
 </div>
+<% end %>

--- a/app/views/alchemy/essences/_essence_date_view.html.erb
+++ b/app/views/alchemy/essences/_essence_date_view.html.erb
@@ -1,9 +1,11 @@
-<% cache(content) do %>
-<% if content.ingredient.present? %>
-<% if options[:date_format].to_s == 'rfc822' %>
+<%- cache(content) do -%>
+<%- date_format = content_settings_value(content, :date_format,
+  local_assigns.fetch(:options, {})) -%>
+<%- if content.ingredient.present? -%>
+<%- if date_format == 'rfc822' -%>
 <%= content.ingredient.to_s(:rfc822) %>
-<% else %>
-<%= l(content.ingredient, format: options[:date_format]) %>
-<% end %>
-<% end %>
-<% end %>
+<%- else -%>
+<%= l(content.ingredient, format: date_format) %>
+<%- end -%>
+<%- end -%>
+<%- end -%>

--- a/app/views/alchemy/essences/_essence_file_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_file_editor.html.erb
@@ -1,66 +1,61 @@
-<div class="content_editor essence_file" id="<%= content.dom_id %>">
-  <label style="display: inline">
-    <%= render_content_name(content) %>
-    <%= delete_content_link(content) %>
-  </label>
+<% cache(content) do %>
+
+<% dialog_link = link_to_dialog('',
+  alchemy.admin_attachments_path(
+    content_id: content.id,
+    only: content_settings_value(content,
+      :file_assign_show_only,
+      local_assigns.fetch(:options, {})),
+    except: content_settings_value(content,
+      :file_assign_do_not_show,
+      local_assigns.fetch(:options, {})),
+    options: local_assigns.fetch(:options, {}).to_json
+  ),
+  {
+    title: _t(:assign_file),
+    size: '780x585',
+    padding: false
+  },
+  {
+    class: 'assign_file',
+    title: _t(:assign_file)
+  }
+) %>
+
+<div class="content_editor essence_file" id="<%= content.dom_id %>" data-content-id="<%= content.id %>">
+  <%= label_and_remove_link(content) %>
   <div class="file" id="file_<%= content.id %>">
     <div class="file_icon">
     <% if content.ingredient.nil? %>
-      <%= link_to_dialog '',
-        alchemy.admin_attachments_path(
-          content_id: content.id,
-          only: options[:file_assign_show_only],
-          except: options[:file_assign_do_not_show],
-          options: options.to_json
-        ),
-        {
-          title: _t(:assign_file),
-          size: '780x585',
-          padding: false
-        },
-        class: 'assign_file',
-        title: _t(:assign_file)
-      %>
+      <%= dialog_link %>
     <% else %>
       <%= render_icon(content.ingredient.icon_css_class) %>
     <% end %>
     </div>
     <div class="file_name">
-      <%= content.ingredient.name rescue ("&#x2190;" + _t(:assign_file_from_archive)).html_safe %>
+      <%= content.ingredient.try(:name) ||
+        ("&#x2190;" + _t(:assign_file_from_archive)).html_safe %>
     </div>
     <% unless content.ingredient.nil? %>
-    <%= hidden_field_tag content.form_field_name(:attachment_id), content.ingredient.id %>
-    <div class="essence_file_tools">
-      <%= link_to_dialog '',
-        alchemy.admin_attachments_path(
-          content_id: content.id,
-          only: options[:file_assign_show_only],
-          except: options[:file_assign_do_not_show],
-          options: options.to_json
-        ),
-        {
-          title: _t(:assign_file),
-          size: '780x585',
-          padding: false
-        },
-        class: 'assign_file',
-        title: _t(:assign_file)
-      %>
-      <%= link_to_dialog '',
-        url_for(
-          controller: 'essence_files',
-          action: 'edit',
-          options: options.to_json,
-          id: content
-        ),
-        {
-          title: _t(:edit_file_properties),
-          size: '400x165'
-        },
-        class: 'edit_file',
-        title: _t(:edit_file_properties)
-      %>
-    </div>
+      <%= hidden_field_tag content.form_field_name(:attachment_id),
+        content.ingredient.id %>
+      <div class="essence_file_tools">
+        <%= dialog_link %>
+        <%= link_to_dialog '',
+          url_for(
+            controller: 'essence_files',
+            action: 'edit',
+            options: local_assigns.fetch(:options, {}).to_json,
+            id: content
+          ),
+          {
+            title: _t(:edit_file_properties),
+            size: '400x165'
+          },
+          class: 'edit_file',
+          title: _t(:edit_file_properties) %>
+      </div>
     <% end %>
   </div>
 </div>
+<% end %>

--- a/app/views/alchemy/essences/_essence_file_view.html.erb
+++ b/app/views/alchemy/essences/_essence_file_view.html.erb
@@ -1,10 +1,10 @@
-<% cache(content) do %>
-<% if attachment = content.ingredient %>
+<%- cache(content) do -%>
+<%- if attachment = content.ingredient -%>
 <%= link_to(
   h(attachment.name),
   alchemy.download_attachment_path(attachment),
   class: "file_link #{content.essence.css_class.blank? ? "" : content.essence.css_class}",
   title: "#{content.essence.title.blank? ? attachment.file_name : content.essence.title}"
-) %>
-<% end %>
-<% end %>
+) -%>
+<%- end -%>
+<%- end -%>

--- a/app/views/alchemy/essences/_essence_html_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_html_editor.html.erb
@@ -1,8 +1,9 @@
-<div class="content_editor essence_html_editor"<%= " style=\"float: left;\"" if options[:css_class] == "text_short" %>>
+<% cache(content) do %>
+<div class="content_editor essence_html_editor" data-content-id="<%= content.id %>">
   <%= label_and_remove_link(content) %>
   <%= text_area_tag(
     content.form_field_name,
-    content.ingredient,
-    :class => 'thin_border'
+    content.ingredient
   ) %>
 </div>
+<% end %>

--- a/app/views/alchemy/essences/_essence_link_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_link_editor.html.erb
@@ -1,19 +1,21 @@
 <% cache(content) do %>
-<div class="content_editor essence_link" id="<%= content.dom_id %>">
-  <label><%= render_content_name(content) %></label>
-  <%= text_field_tag(
-    '',
-    content.ingredient,
-    :class => "thin_border text_with_icon disabled",
-    :name => nil,
-    :id => nil,
-    :disabled => true
-  ) %>
-  <%= hidden_field_tag content.form_field_name(:link), content.essence.link %>
-  <%= hidden_field_tag content.form_field_name(:link_title), content.essence.link_title %>
-  <%= hidden_field_tag content.form_field_name(:link_class_name), content.essence.link_class_name %>
-  <%= hidden_field_tag content.form_field_name(:link_target), content.essence.link_target %>
-  <%= render 'alchemy/essences/shared/linkable_essence_tools', :content => content %>
+<div class="content_editor essence_link" id="<%= content.dom_id %>" data-content-id="<%= content.id %>">
+  <%= label_and_remove_link(content) %>
+  <%= text_field_tag '', content.ingredient,
+    class: "thin_border text_with_icon disabled",
+    name: nil,
+    id: nil,
+    disabled: true
+  %>
+  <%= hidden_field_tag content.form_field_name(:link),
+    content.essence.link %>
+  <%= hidden_field_tag content.form_field_name(:link_title),
+    content.essence.link_title %>
+  <%= hidden_field_tag content.form_field_name(:link_class_name),
+    content.essence.link_class_name %>
+  <%= hidden_field_tag content.form_field_name(:link_target),
+    content.essence.link_target %>
+  <%= render 'alchemy/essences/shared/linkable_essence_tools', content: content %>
 </div>
 <script type="text/javascript" charset="utf-8">
   $('#<%= content.form_field_id(:link) %>').on('change', function() {

--- a/app/views/alchemy/essences/_essence_link_view.html.erb
+++ b/app/views/alchemy/essences/_essence_link_view.html.erb
@@ -1,7 +1,11 @@
-<% cache(content) do %>
-<% if content.ingredient %>
-<%- options[:text] ||= content.ingredient %>
-<%- html_options = { target: content.essence.link_target == "blank" ? "_blank" : nil }.merge(html_options) %>
-<%= link_to options[:text], content.ingredient, html_options -%>
-<% end %>
-<% end %>
+<%- cache(content) do -%>
+<%- if content.ingredient.present? -%>
+<%- html_options = {
+  target: content.essence.link_target == "blank" ? "_blank" : nil
+}.merge(local_assigns.fetch(:html_options, {})) -%>
+<%= link_to(content.ingredient, html_options) do -%>
+<%= content_settings_value(content, :text, local_assigns.fetch(:options, {})) ||
+  content.ingredient -%>
+<%- end -%>
+<%- end -%>
+<%- end -%>

--- a/app/views/alchemy/essences/_essence_picture_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_picture_editor.html.erb
@@ -1,11 +1,7 @@
-<div id="<%= content.dom_id %>" class="essence_picture_editor<%= ' dragable_picture' if options[:dragable] %><%= ' content_editor' unless options[:grouped] %>">
+<% cache(content) do %>
+<div id="<%= content.dom_id %>" class="essence_picture_editor<%= ' dragable_picture' if options[:dragable] %><%= ' content_editor' unless options[:grouped] %>" data-content-id="<%= content.id %>">
   <% unless options[:grouped] %>
-  <label>
-    <% if content.has_hint? %>
-      <%= render_hint_for(content) %>
-    <% end %>
-    <%= render_content_name(content) %>
-  </label>
+  <%= label_and_remove_link(content) %>
   <% end %>
   <div class="picture_thumbnail">
     <span class="picture_tool delete">
@@ -40,7 +36,7 @@
         <% end %>
       </div>
     </div>
-    <%- unless options[:css_class].blank? || content.essence.css_class.blank? -%>
+    <%- if content.essence.css_class.present? -%>
     <div class="essence_picture_css_class">
       <%= _t("alchemy.essence_pictures.css_classes.#{content.essence.css_class}", default: content.essence.css_class.camelcase) %>
     </div>
@@ -60,3 +56,4 @@
   <%= hidden_field_tag content.form_field_name(:link_class_name), content.essence.link_class_name %>
   <%= hidden_field_tag content.form_field_name(:link_target), content.essence.link_target %>
 </div>
+<% end %>

--- a/app/views/alchemy/essences/_essence_picture_view.html.erb
+++ b/app/views/alchemy/essences/_essence_picture_view.html.erb
@@ -1,3 +1,5 @@
 <% cache(content) do %>
-<%= render_essence_picture_view(content, options, html_options) %>
+<%= render_essence_picture_view content,
+  local_assigns.fetch(:options, {}),
+  local_assigns.fetch(:html_options, {}) %>
 <% end %>

--- a/app/views/alchemy/essences/_essence_richtext_view.html.erb
+++ b/app/views/alchemy/essences/_essence_richtext_view.html.erb
@@ -1,4 +1,5 @@
-<% cache(content) do %>
-<% options = local_assigns.fetch(:options, {}) %>
-<%= raw content.essence.send(options[:plain_text] ? :stripped_body : :body) %>
-<% end %>
+<%- cache(content) do -%>
+<%- options = local_assigns.fetch(:options, {}) -%>
+<%- plain_text = !!content_settings_value(content, :plain_text, options) -%>
+<%= raw content.essence.send(plain_text ? :stripped_body : :body) -%>
+<%- end -%>

--- a/app/views/alchemy/essences/_essence_select_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_select_editor.html.erb
@@ -1,35 +1,25 @@
 <% cache(content) do %>
-  <div class="content_editor essence_select<%= options[:display_inline].to_s == 'true' ? ' display_inline' : '' %>" id="<%= content.dom_id %>">
+  <%- select_values = content_settings_value(content,
+    :select_values, local_assigns.fetch(:options, {})) -%>
 
-  <%= label_and_remove_link(content) %>
+  <div class="content_editor essence_select<%= options[:display_inline].to_s == 'true' ? ' display_inline' : '' %>" id="<%= content.dom_id %>" data-content-id="<%= content.id %>">
+    <%= label_and_remove_link(content) %>
 
-  <% if options[:select_values].nil? %>
+    <% if select_values.nil? %>
+      <%= warning(':select_values is nil', "<strong>No select values given.</strong><br>Please provide :<code>select_values</code> either as argument to <code>render_essence_editor</code> helper or as setting on the content definition in <code>elements.yml</code>.".html_safe) %>
+    <% else %>
+      <%  if select_values.is_a?(Hash)
+            options_tags = grouped_options_for_select select_values,
+              content.ingredient, ''
+          else
+            options_tags = options_for_select select_values,
+              content.ingredient
+          end %>
 
-    <%= warning('options[:select_values] is nil', "No select values given. Please provide :select_values as argument to render_essence_editor_by_name() helper inside this element editor view.") %>
-
-  <% else %>
-
-    <%
-    if options[:select_values].is_a?(Hash)
-      options_tags = grouped_options_for_select(
-        options[:select_values],
-        content.ingredient,
-        ''
-      )
-    else
-      options_tags = options_for_select(
-        options[:select_values],
-        content.ingredient
-      )
-    end
-    %>
-
-    <%= select_tag(content.form_field_name, options_tags, {
-      :class => ["alchemy_selectbox", "essence_editor_select", html_options[:class]].join(' '),
-      :style => html_options[:style]
-    }) %>
-
-  <% end %>
-
+      <%= select_tag content.form_field_name, options_tags, {
+        class: ["alchemy_selectbox", "essence_editor_select", html_options[:class]].join(' '),
+        style: html_options[:style]
+      } %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/alchemy/essences/_essence_text_view.html.erb
+++ b/app/views/alchemy/essences/_essence_text_view.html.erb
@@ -1,7 +1,8 @@
-<% cache(content) do %>
-<% options = local_assigns.fetch(:options, {}) %>
-<% html_options = local_assigns.fetch(:html_options, {}) %>
-<%- if content.essence.link.blank? || options[:disable_link] -%>
+<%- cache(content) do -%>
+<%- options = local_assigns.fetch(:options, {}) -%>
+<%- html_options = local_assigns.fetch(:html_options, {}) -%>
+<%- if content.essence.link.blank? ||
+    content_settings_value(content, :disable_link, options) -%>
 <%= content.ingredient -%>
 <%- else -%>
 <%= link_to(
@@ -12,6 +13,6 @@
     target: (content.essence.link_target == "blank" ? "_blank" : nil),
     'data-link-target' => content.essence.link_target
   }.merge(html_options)
-) %>
+) -%>
 <%- end -%>
-<% end %>
+<%- end -%>

--- a/spec/dummy/app/views/alchemy/elements/_all_you_can_eat_editor.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_all_you_can_eat_editor.html.erb
@@ -1,0 +1,11 @@
+<%= element_editor_for(element) do |el| -%>
+  <%= el.edit :essence_boolean %>
+  <%= el.edit :essence_date %>
+  <%= el.edit :essence_file %>
+  <%= el.edit :essence_html %>
+  <%= el.edit :essence_link %>
+  <%= el.edit :essence_picture %>
+  <%= el.edit :essence_richtext %>
+  <%= el.edit :essence_select %>
+  <%= el.edit :essence_text %>
+<%- end -%>

--- a/spec/dummy/config/alchemy/elements.yml
+++ b/spec/dummy/config/alchemy/elements.yml
@@ -81,3 +81,24 @@
     type: EssenceSelect
     validate:
       - presence
+
+- name: all_you_can_eat
+  contents:
+  - name: essence_boolean
+    type: EssenceBoolean
+  - name: essence_date
+    type: EssenceDate
+  - name: essence_file
+    type: EssenceFile
+  - name: essence_html
+    type: EssenceHtml
+  - name: essence_link
+    type: EssenceLink
+  - name: essence_picture
+    type: EssencePicture
+  - name: essence_richtext
+    type: EssenceRichtext
+  - name: essence_select
+    type: EssenceSelect
+  - name: essence_text
+    type: EssenceText

--- a/spec/dummy/config/alchemy/page_layouts.yml
+++ b/spec/dummy/config/alchemy/page_layouts.yml
@@ -5,6 +5,10 @@
   elements: [article, header]
   autogenerate: [header, article]
 
+- name: everything
+  elements: [all_you_can_eat]
+  autogenerate: [all_you_can_eat]
+
 - name: news
   feed: true
   unique: true

--- a/spec/features/admin/page_editing_feature_spec.rb
+++ b/spec/features/admin/page_editing_feature_spec.rb
@@ -73,4 +73,22 @@ describe 'Page editing feature' do
       end
     end
   end
+
+  context 'in element panel' do
+    let!(:everything_page) { create(:page, page_layout: 'everything', do_not_autogenerate: false) }
+
+    it "renders essence editors for all elements" do
+      visit alchemy.admin_elements_path(page_id: everything_page.id)
+
+      page.should have_selector('div.content_editor.essence_boolean')
+      page.should have_selector('div.content_editor.essence_date')
+      page.should have_selector('div.content_editor.essence_file')
+      page.should have_selector('div.content_editor.essence_html_editor')
+      page.should have_selector('div.content_editor.essence_link')
+      page.should have_selector('div.content_editor.essence_picture_editor')
+      page.should have_selector('div.content_editor.essence_richtext')
+      page.should have_selector('div.content_editor.essence_select')
+      page.should have_selector('div.content_editor.essence_text')
+    end
+  end
 end

--- a/spec/helpers/admin/essences_helper_spec.rb
+++ b/spec/helpers/admin/essences_helper_spec.rb
@@ -100,6 +100,7 @@ describe Alchemy::Admin::EssencesHelper do
 
     context 'when given content has no ingredient' do
       before { content.stub(:ingredient).and_return(nil) }
+
       it "should return nil" do
         expect(helper.essence_picture_thumbnail(content, {})).to eq(nil)
       end

--- a/spec/helpers/essences_helper_spec.rb
+++ b/spec/helpers/essences_helper_spec.rb
@@ -80,4 +80,75 @@ describe Alchemy::EssencesHelper do
       render_essence_view_by_name(element, 'intro').should have_content 'hello!'
     end
   end
+
+  describe 'content_settings_value' do
+    subject { content_settings_value(content, key, options) }
+
+    let(:key) { :key }
+
+    context 'with content having settings' do
+      let(:content) { double(settings: {key: 'content_settings_value'}) }
+
+      context 'and empty options' do
+        let(:options) { {} }
+
+        it "returns the value for key from content settings" do
+          expect(subject).to eq('content_settings_value')
+        end
+      end
+
+      context 'and nil options' do
+        let(:options) { nil }
+
+        it "returns the value for key from content settings" do
+          expect(subject).to eq('content_settings_value')
+        end
+      end
+
+      context 'but same key present in options' do
+        let(:options) { {key: 'options_value'} }
+
+        it "returns the value for key from options" do
+          expect(subject).to eq('options_value')
+        end
+      end
+    end
+
+    context 'with content having no settings' do
+      let(:content) { double(settings: {}) }
+
+      context 'and empty options' do
+        let(:options) { {} }
+
+        it { expect(subject).to eq(nil) }
+      end
+
+      context 'but key present in options' do
+        let(:options) { {key: 'options_value'} }
+
+        it "returns the value for key from options" do
+          expect(subject).to eq('options_value')
+        end
+      end
+    end
+
+    context 'with content having settings with string as key' do
+      let(:content) { double(settings: {'key' => 'value_from_string_key'}) }
+      let(:options) { {} }
+
+      it "returns value" do
+        expect(subject).to eq('value_from_string_key')
+      end
+    end
+
+    context 'with key passed as string' do
+      let(:content) { double(settings: {key: 'value_from_symbol_key'}) }
+      let(:key)     { 'key' }
+      let(:options) { {} }
+
+      it "returns value" do
+        expect(subject).to eq('value_from_symbol_key')
+      end
+    end
+  end
 end

--- a/spec/models/content_spec.rb
+++ b/spec/models/content_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Alchemy
   describe Content do
-    let(:element) { FactoryGirl.create(:element, name: 'headline', :create_contents_after_create => true) }
+    let(:element) { create(:element, name: 'headline', :create_contents_after_create => true) }
     let(:content) { element.contents.find_by_essence_type('Alchemy::EssenceText') }
 
     it "should return the ingredient from its essence" do
@@ -310,6 +310,23 @@ module Alchemy
 
     it_behaves_like "having a hint" do
       let(:subject) { Content.new }
+    end
+
+    describe '#settings' do
+      let(:element) { build_stubbed(:element, name: 'article') }
+      let(:content) { build_stubbed(:content, name: 'headline', element: element) }
+
+      it "returns the settings hash from description" do
+        expect(content.settings).to eq({deletable: true})
+      end
+
+      context 'if settings are not defined' do
+        let(:content) { build_stubbed(:content, name: 'intro', element: element) }
+
+        it "returns empty hash" do
+          expect(content.settings).to eq({})
+        end
+      end
     end
 
   end

--- a/spec/views/essences/essence_boolean_editor_spec.rb
+++ b/spec/views/essences/essence_boolean_editor_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'alchemy/essences/_essence_boolean_editor' do
+  let(:essence) { Alchemy::EssenceBoolean.new(ingredient: false) }
+  let(:content) { Alchemy::Content.new(essence: essence, name: 'Boolean') }
+
+  before do
+    view.stub(:render_content_name).and_return(content.name)
+    view.stub(:delete_content_link).and_return('')
+  end
+
+  it "renders a checkbox" do
+    render partial: "alchemy/essences/essence_boolean_editor", locals: {content: content}
+    expect(rendered).to have_selector('input[type="checkbox"]')
+  end
+
+  context 'with default value given in view local options' do
+    it "checks the checkbox" do
+      render partial: "alchemy/essences/essence_boolean_editor", locals: {content: content, options: {default_value: true}}
+      expect(rendered).to have_selector('input[type="checkbox"][checked="checked"]')
+    end
+  end
+
+  context 'with default value given in content settings' do
+    before { content.stub(settings: {default_value: true}) }
+
+    it "checks the checkbox" do
+      render partial: "alchemy/essences/essence_boolean_editor", locals: {content: content}
+      expect(rendered).to have_selector('input[type="checkbox"][checked="checked"]')
+    end
+  end
+end

--- a/spec/views/essences/essence_link_view_spec.rb
+++ b/spec/views/essences/essence_link_view_spec.rb
@@ -27,4 +27,15 @@ describe 'alchemy/essences/_essence_link_view' do
       expect(rendered).to eq('<a href="http://google.com">Google</a>')
     end
   end
+
+  context 'with text setting on content description' do
+    before do
+      content.stub(settings: {text: 'Yahoo'})
+    end
+
+    it "renders a link" do
+      render content.essence, content: content, options: options, html_options: {}
+      expect(rendered).to eq('<a href="http://google.com">Yahoo</a>')
+    end
+  end
 end

--- a/spec/views/essences/essence_picture_view_spec.rb
+++ b/spec/views/essences/essence_picture_view_spec.rb
@@ -12,7 +12,7 @@ describe "essences/_essence_picture_view" do
   end
 
   context "with caption" do
-    let(:options) { {show_caption: true} }
+    let(:options) { {} }
     let(:html_options) { {} }
 
     subject do
@@ -25,6 +25,52 @@ describe "essences/_essence_picture_view" do
 
     it "should enclose the image in a <figure> element" do
       should have_selector('figure img')
+    end
+
+    it "should shows the caption" do
+      should have_selector('figure figcaption')
+      should have_content('This is a cute cat')
+    end
+
+    context "but disabled in the options" do
+      let(:options) { {show_caption: false} }
+
+      it "should not enclose the image in a <figure> element" do
+        should_not have_selector('figure img')
+      end
+
+      it "should not show the caption" do
+        should_not have_selector('figure figcaption')
+        should_not have_content('This is a cute cat')
+      end
+    end
+
+    context "but disabled in the content settings" do
+      before do
+        content.stub(settings: {show_caption: false})
+      end
+
+      it "should not enclose the image in a <figure> element" do
+        should_not have_selector('figure img')
+      end
+
+      it "should not show the caption" do
+        should_not have_selector('figure figcaption')
+        should_not have_content('This is a cute cat')
+      end
+
+      context 'but enabled in the options hash' do
+        let(:options) { {show_caption: true} }
+
+        it "should enclose the image in a <figure> element" do
+          should have_selector('figure img')
+        end
+
+        it "should shows the caption" do
+          should have_selector('figure figcaption')
+          should have_content('This is a cute cat')
+        end
+      end
     end
 
     context "and essence with css class" do
@@ -80,5 +126,4 @@ describe "essences/_essence_picture_view" do
       end
     end
   end
-
 end

--- a/spec/views/essences/essence_richtext_view_spec.rb
+++ b/spec/views/essences/essence_richtext_view_spec.rb
@@ -17,4 +17,16 @@ describe 'alchemy/essences/_essence_richtext_view' do
       expect(rendered).to_not have_selector('h1')
     end
   end
+
+  context 'with content.settings[:plain_text] true' do
+    before do
+      content.stub(settings: {plain_text: true})
+    end
+
+    it "renders the text body" do
+      render content.essence, content: content
+      expect(rendered).to have_content('Lorem ipsum dolor sit amet consectetur adipiscing elit.')
+      expect(rendered).to_not have_selector('h1')
+    end
+  end
 end

--- a/spec/views/essences/essence_text_view_spec.rb
+++ b/spec/views/essences/essence_text_view_spec.rb
@@ -35,6 +35,18 @@ describe 'alchemy/essences/_essence_text_view' do
         expect(rendered).to_not have_selector('a')
       end
     end
+
+    context 'but with content settings disable_link set to true' do
+      before do
+        content.stub(settings: {disable_link: true})
+      end
+
+      it "only renders the ingredient" do
+        render content.essence, content: content
+        expect(rendered).to have_content('Hello World')
+        expect(rendered).to_not have_selector('a')
+      end
+    end
   end
 
 end


### PR DESCRIPTION
This helper returns a value either from `content.settings` or from `options` hash.

What this brings?

You can now set essence view partial options in the `elements.yml` file:

```
- name: image
  contents:
  - name: image
    type: EssencePicture
    settings:
      image_size: '100x80'
```

This also adds a lots of specs for essence views and editor partials.
