### PR TITLE
Deprecate take_me_for_preview and rename it to as_element_title

### DIFF
--- a/app/models/alchemy/content.rb
+++ b/app/models/alchemy/content.rb
@@ -184,7 +184,10 @@ module Alchemy
 
     # Returns true if this content should be taken for element preview.
     def preview_content?
-      !!description['take_me_for_preview']
+      if description['take_me_for_preview']
+        ActiveSupport::Deprecation.warn("Content definition's `take_me_for_preview` key is deprecated. Please use `as_element_title` instead.")
+      end
+      !!description['take_me_for_preview'] || !!description['as_element_title']
     end
 
     # Proxy method that returns the preview text from essence.

--- a/app/models/alchemy/element/presenters.rb
+++ b/app/models/alchemy/element/presenters.rb
@@ -39,7 +39,7 @@ module Alchemy
     #
     # It's taken from the first Content found in the +elements.yml+ description file.
     #
-    # You can flag a Content as +take_me_for_preview+ to take this as preview.
+    # You can flag a Content as +as_element_title+ to take this as preview.
     #
     # @param maxlength [Fixnum] (30)
     #   Length of characters after the text will be cut off.
@@ -63,7 +63,7 @@ module Alchemy
     #         type: EssenceText
     #       - name: text
     #         type EssenceRichtext
-    #         take_me_for_preview: true
+    #         as_element_title: true
     #
     # With "I want to tell you a funky story" as stripped_body for the EssenceRichtext Content produces:
     #

--- a/spec/dummy/config/alchemy/elements.yml
+++ b/spec/dummy/config/alchemy/elements.yml
@@ -74,7 +74,7 @@
       - presence
   - name: subject
     type: EssenceText
-    take_me_for_preview: true
+    as_element_title: true
     validate:
       - presence
   - name: success_page

--- a/spec/models/content_spec.rb
+++ b/spec/models/content_spec.rb
@@ -257,6 +257,37 @@ module Alchemy
       end
     end
 
+    describe '#preview_content?' do
+      let(:content) { build_stubbed(:content) }
+
+      context 'not defined as preview content' do
+        it "returns false" do
+          expect(content.preview_content?).to be_false
+        end
+      end
+
+      context 'defined as preview content via take_me_for_preview' do
+        before { content.stub(description: {'take_me_for_preview' => true}) }
+
+        it "returns true" do
+          expect(content.preview_content?).to be_true
+        end
+
+        it "display deprecation warning" do
+          expect(ActiveSupport::Deprecation).to receive(:warn)
+          content.preview_content?
+        end
+      end
+
+      context 'defined as preview content via as_element_title' do
+        before { content.stub(description: {'as_element_title' => true}) }
+
+        it "returns true" do
+          expect(content.preview_content?).to be_true
+        end
+      end
+    end
+
     describe '#preview_text' do
       let(:essence) { mock_model(EssenceText, preview_text: 'Lorem') }
       let(:content) { c = Content.new; c.essence = essence; c }


### PR DESCRIPTION
The content definition has an option to mark it as element preview title. The option was named take_me_for_preview. This now is named as_element_title.
