### PR TITLE
Fixes failing spec caused by imprecise date comparison on slow CI server...

### DIFF
--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -188,9 +188,10 @@ module Alchemy
           end
 
           it "should not update already set published_at" do
-            page.update_attributes!(published_at: 2.weeks.ago)
+            past_date = 2.weeks.ago
+            page.update_attributes!(published_at: past_date)
             page.update_attributes!(public: true)
-            page.read_attribute(:published_at).should be_within(1.second).of(2.weeks.ago)
+            page.read_attribute(:published_at).should eq(past_date)
           end
         end
 


### PR DESCRIPTION
I noticed a failing spec on travis a few times now (e.g.: https://travis-ci.org/magiclabs/alchemy_cms/jobs/37617484). I changed the way of the date comparison in the spec to make sure it also passes on slow CI servers.
