### PR TITLE
Fixes picture assignment in an element editor.

### DIFF
--- a/app/controllers/alchemy/admin/essence_pictures_controller.rb
+++ b/app/controllers/alchemy/admin/essence_pictures_controller.rb
@@ -41,6 +41,7 @@ module Alchemy
       def assign
         @picture = Picture.find_by_id(params[:picture_id])
         @content.essence.picture = @picture
+        @content.touch # We need to touch manually because its not saved yet.
         @element = @content.element
         @dragable = @options[:grouped]
         @options = @options.merge(dragable: @dragable)


### PR DESCRIPTION
Since the editor partial is getting cached, we need to touch the content manually when assigning a picture. Otherwise it would just render the cached content which is the same as before.
