### PR TITLE
Revert "Make ApplicationController patch reloadable"

### DIFF
--- a/lib/alchemy/engine.rb
+++ b/lib/alchemy/engine.rb
@@ -85,6 +85,9 @@ module Alchemy
 
     config.after_initialize do
       require_relative './userstamp'
+    end
+
+    config.to_prepare do
       # In order to have Alchemy's helpers and basic controller methods
       # available in the host app, we patch the ApplicationController.
       ApplicationController.send(:include, Alchemy::ControllerActions)


### PR DESCRIPTION
This partly reverts commit 7443016f4d0cf95526e921a25e81b6b2c7fe45a6.

I reverted the change made to remove ```config.to_prepare```. it fixes #678