### PR TITLE
New EssenceFile content option `only` and `except`. Closes #626

### DIFF
--- a/app/controllers/alchemy/admin/attachments_controller.rb
+++ b/app/controllers/alchemy/admin/attachments_controller.rb
@@ -5,7 +5,15 @@ module Alchemy
 
       def index
         @attachments = Attachment.all
-        @attachments = @attachments.tagged_with(params[:tagged_with]) if params[:tagged_with].present?
+        if params[:only].present?
+          @attachments = @attachments.where("file_mime_type LIKE '%#{params[:only]}%'")
+        end
+        if params[:except].present?
+          @attachments = @attachments.where("file_mime_type NOT LIKE '%#{params[:except]}%'")
+        end
+        if params[:tagged_with].present?
+          @attachments = @attachments.tagged_with(params[:tagged_with])
+        end
         @attachments = @attachments.find_paginated(params, 15, sort_order)
         @options = options_from_params
         if in_overlay?

--- a/app/controllers/alchemy/admin/essence_files_controller.rb
+++ b/app/controllers/alchemy/admin/essence_files_controller.rb
@@ -6,14 +6,14 @@ module Alchemy
       helper "Alchemy::Admin::Contents"
 
       def edit
-        @content = Content.find(params[:id])
+        @essence_file = EssenceFile.find(params[:id])
+        @content = @essence_file.content
         @options = options_from_params
-        @essence_file = @content.essence
       end
 
       def update
         @essence_file = EssenceFile.find(params[:id])
-        @essence_file.update_attributes(params[:essence_file])
+        @essence_file.update(params[:essence_file])
       end
 
       def assign
@@ -22,7 +22,6 @@ module Alchemy
         @content.essence.attachment = @attachment
         @options = options_from_params
       end
-
     end
   end
 end

--- a/app/views/alchemy/essences/_essence_file_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_file_editor.html.erb
@@ -3,11 +3,9 @@
 <% dialog_link = link_to_dialog('',
   alchemy.admin_attachments_path(
     content_id: content.id,
-    only: content_settings_value(content,
-      :file_assign_show_only,
+    only: content_settings_value(content, :only,
       local_assigns.fetch(:options, {})),
-    except: content_settings_value(content,
-      :file_assign_do_not_show,
+    except: content_settings_value(content, :except,
       local_assigns.fetch(:options, {})),
     options: local_assigns.fetch(:options, {}).to_json
   ),
@@ -26,35 +24,33 @@
   <%= label_and_remove_link(content) %>
   <div class="file" id="file_<%= content.id %>">
     <div class="file_icon">
-    <% if content.ingredient.nil? %>
-      <%= dialog_link %>
-    <% else %>
+    <% if content.ingredient %>
       <%= render_icon(content.ingredient.icon_css_class) %>
+    <% else %>
+      <%= dialog_link %>
     <% end %>
     </div>
     <div class="file_name">
       <%= content.ingredient.try(:name) ||
         ("&#x2190;" + _t(:assign_file_from_archive)).html_safe %>
     </div>
-    <% unless content.ingredient.nil? %>
+    <div class="essence_file_tools">
+      <%= dialog_link %>
+      <%= link_to_dialog '',
+        alchemy.edit_admin_essence_file_path(
+          id: content.essence.id,
+          options: local_assigns.fetch(:options, {}).to_json
+        ),
+        {
+          title: _t(:edit_file_properties),
+          size: '400x165'
+        },
+        class: 'edit_file',
+        title: _t(:edit_file_properties) %>
+    </div>
+    <% if content.ingredient %>
       <%= hidden_field_tag content.form_field_name(:attachment_id),
         content.ingredient.id %>
-      <div class="essence_file_tools">
-        <%= dialog_link %>
-        <%= link_to_dialog '',
-          url_for(
-            controller: 'essence_files',
-            action: 'edit',
-            options: local_assigns.fetch(:options, {}).to_json,
-            id: content
-          ),
-          {
-            title: _t(:edit_file_properties),
-            size: '400x165'
-          },
-          class: 'edit_file',
-          title: _t(:edit_file_properties) %>
-      </div>
     <% end %>
   </div>
 </div>

--- a/spec/controllers/admin/attachments_controller_spec.rb
+++ b/spec/controllers/admin/attachments_controller_spec.rb
@@ -40,6 +40,27 @@ module Alchemy
           end
         end
       end
+
+      describe 'only and expect options' do
+        let!(:png) { create(:attachment) }
+        let!(:jpg) { create(:attachment, file: File.new(File.expand_path('../../../../spec/fixtures/image3.jpeg', __FILE__))) }
+
+        context 'with params[:only]' do
+          it 'only loads attachments with matching content type' do
+            get :index, only: 'jpeg'
+            expect(assigns(:attachments).to_a).to eq([jpg])
+            expect(assigns(:attachments).to_a).to_not eq([png])
+          end
+        end
+
+        context 'with params[:except]' do
+          it 'does not load attachments with matching content type' do
+            get :index, except: 'jpeg'
+            expect(assigns(:attachments).to_a).to eq([png])
+            expect(assigns(:attachments).to_a).to_not eq([jpg])
+          end
+        end
+      end
     end
 
     describe '#show' do

--- a/spec/controllers/admin/essence_files_controller_spec.rb
+++ b/spec/controllers/admin/essence_files_controller_spec.rb
@@ -6,23 +6,25 @@ module Alchemy
       sign_in(admin_user)
     end
 
-    let(:content)      { mock_model('Content', essence: essence_file) }
-    let(:essence_file) { mock_model('EssenceFile', :attachment= => nil) }
+    let(:essence_file) { mock_model('EssenceFile', :attachment= => nil, content: content) }
+    let(:content)      { mock_model('Content') }
     let(:attachment)   { mock_model('Attachment') }
 
     describe '#edit' do
       before do
-        expect(Content).to receive(:find).and_return(content)
+        expect(EssenceFile).to receive(:find)
+          .with(essence_file.id.to_s)
+          .and_return(essence_file)
       end
 
-      it "should assign @content with the Content found by id" do
-        get :edit, content_id: content.id
+      it "assigns @essence_file with the EssenceFile found by id" do
+        get :edit, id: essence_file.id
+        expect(assigns(:essence_file)).to eq(essence_file)
+      end
+
+      it "should assign @content with essence_file's content" do
+        get :edit, id: essence_file.id
         expect(assigns(:content)).to eq(content)
-      end
-
-      it "should assign @essence_file with content's essence" do
-        get :edit, content_id: content.id
-        expect(assigns(:essence_file)).to eq(content.essence)
       end
     end
 
@@ -32,7 +34,7 @@ module Alchemy
       end
 
       it "should update the attributes of essence_file" do
-        expect(essence_file).to receive(:update_attributes).and_return(true)
+        expect(essence_file).to receive(:update).and_return(true)
         xhr :put, :update, id: essence_file.id
       end
     end
@@ -41,6 +43,7 @@ module Alchemy
       before do
         expect(Content).to receive(:find_by).and_return(content)
         expect(Attachment).to receive(:find_by).and_return(attachment)
+        allow(content).to receive(:essence).and_return(essence_file)
       end
 
       it "should assign @attachment with the Attachment found by attachment_id" do
@@ -52,8 +55,6 @@ module Alchemy
         expect(content.essence).to receive(:attachment=).with(attachment)
         xhr :put, :assign, content_id: content.id, attachment_id: attachment.id
       end
-
     end
-
   end
 end

--- a/spec/views/essences/essence_file_editor_spec.rb
+++ b/spec/views/essences/essence_file_editor_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe 'alchemy/essences/_essence_editor_view' do
+  let(:file)       { File.new(File.expand_path('../../../fixtures/image with spaces.png', __FILE__)) }
+  let(:attachment) { mock_model('Attachment', file: file, name: 'image', file_name: 'Image', icon_css_class: 'image') }
+  let(:essence)    { mock_model('EssenceFile', attachment: attachment) }
+  let(:content)    { mock_model('Content', essence: essence, settings: {}, dom_id: 'essence_file_1', form_field_name: '"contents[1][attachment_id]"') }
+
+  subject do
+    render partial: "alchemy/essences/essence_file_editor", locals: {content: content}
+    rendered
+  end
+
+  before do
+    view.class.send :include, Alchemy::Admin::BaseHelper
+    allow(view).to receive(:_t).and_return('')
+    allow(view).to receive(:label_and_remove_link).and_return('')
+  end
+
+  context 'with ingredient present' do
+    before do
+      allow(content).to receive(:ingredient).and_return(attachment)
+    end
+
+    it "renders a hidden field with attachment id" do
+      is_expected.to have_selector("input[type='hidden'][value='#{attachment.id}']")
+    end
+
+    it "renders a link to open the attachment library overlay" do
+      is_expected.to have_selector("a.assign_file[href='/admin/attachments?content_id=#{content.id}&options=%7B%7D']")
+    end
+
+    it "renders a link to edit the essence" do
+      is_expected.to have_selector("a.edit_file[href='/admin/essence_files/#{essence.id}/edit?options=%7B%7D']")
+    end
+
+    context 'with content settings `only`' do
+      it "renders a link to open the attachment library overlay with only pdfs" do
+        expect(content).to receive(:settings).at_least(:once).and_return({only: 'pdf'})
+        is_expected.to have_selector("a.assign_file[href='/admin/attachments?content_id=#{content.id}&only=pdf&options=%7B%7D']")
+      end
+    end
+
+    context 'with content settings `except`' do
+      it "renders a link to open the attachment library overlay without pdfs" do
+        expect(content).to receive(:settings).at_least(:once).and_return({except: 'pdf'})
+        is_expected.to have_selector("a.assign_file[href='/admin/attachments?content_id=#{content.id}&except=pdf&options=%7B%7D']")
+      end
+    end
+  end
+
+  context 'without ingredient present' do
+    before do
+      allow(content).to receive(:ingredient).and_return(nil)
+    end
+
+    it "does not render a hidden field with attachment id" do
+      is_expected.to_not have_selector("input[type='hidden']")
+    end
+  end
+end


### PR DESCRIPTION
You can now pass `only` and/or `except` option to `EssenceFile` content settings. It will not/only load attachments with matching content type.

Example:

```
contents:
- name: pdf
  type: EssenceFile
  settings:
    only: pdf
```

Will only show pdfs in the attachment library overlay. Using `except` will do the opposite.
