### PR TITLE
Fix refresh event binding on preview frame.

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.element_editors.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.element_editors.js.coffee
@@ -47,7 +47,7 @@ Alchemy.ElementEditors =
     self.scrollToElement this
     self.selectElementInPreview id
 
-  # Selcts and scrolls to element with given id in the preview window.
+  # Selects and scrolls to element with given id in the preview window.
   #
   selectElementInPreview: (id) ->
     $frame_elements = document.getElementById("alchemy_preview_window").contentWindow.jQuery("[data-alchemy-element]")

--- a/app/assets/javascripts/alchemy/alchemy.preview.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.preview.js.coffee
@@ -63,12 +63,13 @@ Alchemy.initAlchemyPreviewMode = ($) ->
         $el = $(e.delegateTarget)
         $elements = @$previewElements
         offset = @scrollOffset
+        el_offset = $el.offset()
         e.preventDefault()
         $elements.removeClass("selected").css(@getStyle("reset"))
         $el.addClass("selected").css(@getStyle("selected"))
         $("html, body").animate
-          scrollTop: $el.offset().top - offset
-          scrollLeft: $el.offset().left - offset
+          scrollTop: el_offset.top - offset
+          scrollLeft: el_offset.left - offset
         , 400
         return
 

--- a/app/assets/javascripts/alchemy/alchemy.preview_window.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.preview_window.js.coffee
@@ -29,6 +29,8 @@ Alchemy.PreviewWindow =
   refresh: (callback) ->
     $iframe = $('#alchemy_preview_window')
     @_showSpinner()
+    # We need to be sure that no load event is binded on the preview frame.
+    $iframe.off('load')
     $iframe.load (e) =>
       @_hideSpinner()
       if callback


### PR DESCRIPTION
Everytime we update an element we bind the load event on preview frame.

This patch removes any load event before binding it again.
