### PR TITLE
Relax sprockets version

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'select2-rails',                    ['>= 3.5.9.1', '< 4.0']
   gem.add_runtime_dependency 'simple_form',                      ['~> 3.0']
   gem.add_runtime_dependency 'spinner.rb'
-  gem.add_runtime_dependency 'sprockets',                        ['~> 2.11.3']
+  gem.add_runtime_dependency 'sprockets',                        ['~> 2.11']
   gem.add_runtime_dependency 'turbolinks',                       ['~> 2.5']
   gem.add_runtime_dependency 'tvdeyen-handles_sortable_columns', ['~> 0.1.5']
   gem.add_runtime_dependency 'uglifier',                         ['>= 1.3.0']


### PR DESCRIPTION
Spree 3.0.0.beta depends on sprockets 2.12.3, thereby I thought the best approach would be to relax the version constraint.