### PR TITLE
Use Regexp to get Alchemy's mount point.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,10 +4,7 @@ Alchemy::Engine.routes.draw do
 
   get '/sitemap.xml' => 'pages#sitemap', format: 'xml'
 
-  get '/admin' => redirect(
-    "#{Alchemy::MountPoint.get}/admin/dashboard"
-  )
-
+  get '/admin' => redirect('admin/dashboard')
   get '/admin/dashboard' => 'admin/dashboard#index',
         :as => :admin_dashboard
   get '/admin/dashboard/info' => 'admin/dashboard#info',

--- a/lib/alchemy/mount_point.rb
+++ b/lib/alchemy/mount_point.rb
@@ -1,41 +1,41 @@
 module Alchemy
-  # Utitlities for Alchemy's mount point in the host rails app.
+
+  # Utilities for Alchemy's mount point in the host rails app.
   #
   class MountPoint
+    MOUNT_POINT_REGEXP = /mount\sAlchemy::Engine\s=>\s['|"](\/\w*)['|"]/
 
-    # Returns the path of Alchemy's mount point in current rails app.
-    #
-    # @param [Boolean] remove_leading_slash_if_blank
-    #   Pass false to not return a leading slash on empty mount point.
-    #
-    def self.get(remove_leading_slash_if_blank = true)
-      if self.mount_point == "/" && remove_leading_slash_if_blank
-        self.mount_point.gsub(/\A\/\z/, '')
-      else
-        self.mount_point
+    class << self
+
+      # Returns the path of Alchemy's mount point in current rails app.
+      #
+      # @param [Boolean] remove_leading_slash_if_blank
+      #   Pass false to not return a leading slash on empty mount point.
+      #
+      def get(remove_leading_slash_if_blank = true)
+        if path == "/" && remove_leading_slash_if_blank
+          path.gsub(/\A\/\z/, '')
+        else
+          path
+        end
+      end
+
+      # Returns the mount point path from the Rails app routes.
+      #
+      def path
+        match = File.read(routes_file_path).match(MOUNT_POINT_REGEXP)
+        if match.nil?
+          raise "Alchemy mount point not found! Please run `bin/rake alchemy:mount'"
+        else
+          match[1]
+        end
+      end
+
+      private
+
+      def routes_file_path
+        Rails.root.join('config/routes.rb')
       end
     end
-
-    # Returns the routes object from Alchemy in the host app.
-    #
-    def self.routes
-      ::Rails.application.routes.named_routes[:alchemy]
-    end
-
-    # Returns the raw mount point path from the Rails app routes.
-    #
-    # If Alchemy is not mounted in the main app, it falls back to root path.
-    #
-    def self.mount_point
-      if self.routes.nil?
-        ::Rails.logger.warn <<-WARN
-Alchemy is not mounted! Falling back to root path (/).
-If you want to change Alchemy's mount point, please mount Alchemy::Engine in your config/routes.rb file.
-WARN
-        return '/'
-      end
-      routes.path.spec.to_s
-    end
-
   end
 end


### PR DESCRIPTION
Go' old regular expression is way more reliable and faster then requiring the whole rails to boot only to get this path.