### PR TITLE
Revert inflect.acronym 'API'

### DIFF
--- a/app/controllers/alchemy/api/base_controller.rb
+++ b/app/controllers/alchemy/api/base_controller.rb
@@ -1,5 +1,5 @@
 module Alchemy
-  class API::BaseController < Alchemy::BaseController
+  class Api::BaseController < Alchemy::BaseController
     layout false
     respond_to :json
 

--- a/app/controllers/alchemy/api/contents_controller.rb
+++ b/app/controllers/alchemy/api/contents_controller.rb
@@ -1,5 +1,5 @@
 module Alchemy
-  class API::ContentsController < API::BaseController
+  class Api::ContentsController < Api::BaseController
 
     # Returns all contents as json object
     #

--- a/app/controllers/alchemy/api/elements_controller.rb
+++ b/app/controllers/alchemy/api/elements_controller.rb
@@ -1,5 +1,5 @@
 module Alchemy
-  class API::ElementsController < API::BaseController
+  class Api::ElementsController < Api::BaseController
 
     # Returns all elements as json object
     #

--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -1,5 +1,5 @@
 module Alchemy
-  class API::PagesController < API::BaseController
+  class Api::PagesController < Api::BaseController
     before_action :load_page, only: [:show]
 
     # Returns all pages as json object

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,3 +1,0 @@
-ActiveSupport::Inflector.inflections(:en) do |inflect|
-  inflect.acronym 'API'
-end

--- a/spec/controllers/alchemy/api/contents_controller_spec.rb
+++ b/spec/controllers/alchemy/api/contents_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Alchemy
-  describe API::ContentsController do
+  describe Api::ContentsController do
     describe '#index' do
       let!(:page)    { create(:page) }
       let!(:element) { create(:element, page: page) }

--- a/spec/controllers/alchemy/api/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/api/elements_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Alchemy
-  describe API::ElementsController do
+  describe Api::ElementsController do
     describe '#index' do
       let!(:page)    { create(:public_page) }
       let!(:element) { create(:element, page: page) }

--- a/spec/controllers/alchemy/api/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/api/pages_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Alchemy
-  describe API::PagesController do
+  describe Api::PagesController do
 
     describe '#index' do
       let!(:page)    { create(:public_page) }


### PR DESCRIPTION
Candidate code to fix issue https://github.com/AlchemyCMS/alchemy_cms/issues/701

**What does this PR do?**
In order to restore compatibility with Spree naming conventions, this PR:
* removes the inflect.acronym 'API'
* removes the empty file initializers/inflections.rb
* renames the API controller classes from API::XXX to Api::XXX
* updates the controller specs

**How should a Reviewer Assess This PR?**
Run the standard rspec tests using ```bundle exec rspec```.

In addition, run ```rails c``` in ```spec\dummy``` and verify that ```"spree/api/shipments".camelize => "Spree::Api::Shipments"```