### PR TITLE
Fixes #707 allow attributes for essence_file

### DIFF
--- a/app/controllers/alchemy/admin/essence_files_controller.rb
+++ b/app/controllers/alchemy/admin/essence_files_controller.rb
@@ -3,17 +3,17 @@ module Alchemy
     class EssenceFilesController < Alchemy::Admin::BaseController
       authorize_resource class: Alchemy::EssenceFile
 
+      before_filter :load_essence_file, only: [:edit, :update]
+
       helper "Alchemy::Admin::Contents"
 
       def edit
-        @essence_file = EssenceFile.find(params[:id])
         @content = @essence_file.content
         @options = options_from_params
       end
 
       def update
-        @essence_file = EssenceFile.find(params[:id])
-        @essence_file.update(params[:essence_file])
+        @essence_file.update(essence_file_params)
       end
 
       def assign
@@ -21,6 +21,16 @@ module Alchemy
         @attachment = Attachment.find_by(id: params[:attachment_id])
         @content.essence.attachment = @attachment
         @options = options_from_params
+      end
+
+      private
+
+      def essence_file_params
+        params.require(:essence_file).permit(:title, :css_class)
+      end
+
+      def load_essence_file
+        @essence_file = EssenceFile.find(params[:id])
       end
     end
   end

--- a/spec/controllers/admin/essence_files_controller_spec.rb
+++ b/spec/controllers/admin/essence_files_controller_spec.rb
@@ -29,13 +29,16 @@ module Alchemy
     end
 
     describe '#update' do
+      let(:essence_file) { FactoryGirl.create(:essence_file) }
+
       before do
         expect(EssenceFile).to receive(:find).and_return(essence_file)
       end
 
       it "should update the attributes of essence_file" do
-        expect(essence_file).to receive(:update).and_return(true)
-        xhr :put, :update, id: essence_file.id
+        xhr :put, :update, id: essence_file.id, essence_file: {title: 'new title', css_class: 'left'}
+        expect(essence_file.title).to eq 'new title'
+        expect(essence_file.css_class).to eq 'left'
       end
     end
 


### PR DESCRIPTION
* Allow `title` and `css_class` attributes when updating `essence_file`.
* Reduce code duplication.
* Changed spec to use database and fail if attributes were not allowed.