### PR TITLE
Fixes #704 Always check if locale is available

### DIFF
--- a/spec/features/translation_integration_spec.rb
+++ b/spec/features/translation_integration_spec.rb
@@ -2,17 +2,19 @@ require 'spec_helper'
 
 describe "Translation integration" do
   context "in admin backend" do
-    before { authorize_as_admin(mock_model('DummyUser', alchemy_roles: %w(admin), language: 'de')) }
+    let(:dummy_user) { mock_model('DummyUser', alchemy_roles: %w(admin), language: 'de') }
+
+    before { authorize_as_admin(dummy_user) }
 
     it "should be possible to set the locale of the admin backend via params" do
-      visit admin_dashboard_path(locale: 'de')
-      expect(page).to have_content('Willkommen')
+      visit admin_dashboard_path(locale: 'nl')
+      expect(page).to have_content('Welkom')
     end
 
     it "should store the current locale in the session" do
-      visit admin_dashboard_path(locale: 'de')
+      visit admin_dashboard_path(locale: 'nl')
       visit admin_dashboard_path
-      expect(page).to have_content('Willkommen')
+      expect(page).to have_content('Welkom')
     end
 
     it "should be possible to change the current locale in the session" do
@@ -34,14 +36,15 @@ describe "Translation integration" do
         visit admin_dashboard_path
         expect(page).to have_content('Willkommen')
       end
-    end
 
-    context "with translated header" do
-      before { Capybara.current_driver = :rack_test_translated_header }
+      context "if user has no preferred locale" do
+        let(:dummy_user) { mock_model('DummyUser', alchemy_roles: %w(admin), language: nil) }
 
-      it "should use the browsers language setting if no other parameter is given" do
-        visit admin_dashboard_path
-        expect(page).to have_content('Willkommen')
+        it "should use the browsers language setting" do
+          page.driver.header 'ACCEPT-LANGUAGE', 'es-ES'
+          visit admin_dashboard_path
+          expect(page).to have_content('Bienvenido')
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,9 +43,6 @@ Capybara.default_selector = :css
 Capybara.register_driver :poltergeist do |app|
   Capybara::Poltergeist::Driver.new(app)
 end
-Capybara.register_driver(:rack_test_translated_header) do |app|
-  Capybara::RackTest::Driver.new(app, headers: { 'HTTP_ACCEPT_LANGUAGE' => 'de' })
-end
 Capybara.javascript_driver = :poltergeist
 Capybara.ignore_hidden_elements = false
 


### PR DESCRIPTION
In a rails app `config.i18n.enforce_available_locales` is set to true by default, so we need to check if the chosen locales are available in the app before we switch over to them.

Also refactored some tests that have not been very reliable before (the user's locale is `de` and we expected to switch to `de` by given params. The expectation could have been satisfied just because the users locale might be used, while the test should have been failed instead.). Its better to switch to some other languages to make sure the expectation is not fulfilled by something that was not desired to test.