### PR TITLE
Use Alchemy.user_class's primary_key to find user.

### DIFF
--- a/app/models/alchemy/page/page_users.rb
+++ b/app/models/alchemy/page/page_users.rb
@@ -5,19 +5,19 @@ module Alchemy
     # Returns the creator of this page.
     #
     def creator
-      Alchemy.user_class.try(:find_by, {id: creator_id})
+      get_page_user(creator_id)
     end
 
     # Returns the last updater of this page.
     #
     def updater
-      Alchemy.user_class.try(:find_by, {id: updater_id})
+      get_page_user(updater_id)
     end
 
     # Returns the user currently editing this page.
     #
     def locker
-      Alchemy.user_class.try(:find_by, {id: locked_by})
+      get_page_user(locked_by)
     end
 
     # Returns the name of the creator of this page.
@@ -47,5 +47,12 @@ module Alchemy
       (locker && locker.try(:name)) || I18n.t('unknown')
     end
 
+    private
+
+    def get_page_user(id)
+      if Alchemy.user_class.respond_to? :primary_key
+        Alchemy.user_class.try(:find_by, {Alchemy.user_class.primary_key => id})
+      end
+    end
   end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1552,21 +1552,81 @@ module Alchemy
         it "returns the user that created the page" do
           expect(page.creator).to eq(user)
         end
+
+        context 'with user class having a different primary key' do
+          before do
+            allow(Alchemy.user_class)
+              .to receive(:primary_key)
+              .and_return('user_id')
+
+            allow(page)
+              .to receive(:creator_id)
+              .and_return(1)
+          end
+
+          it "returns the user that created the page" do
+            expect(Alchemy.user_class)
+              .to receive(:find_by)
+              .with({'user_id' => 1})
+
+            page.creator
+          end
+        end
       end
 
       describe '#updater' do
         before { page.update(updater_id: user.id) }
 
-        it "returns the user that created the page" do
+        it "returns the user that updated the page" do
           expect(page.updater).to eq(user)
+        end
+
+        context 'with user class having a different primary key' do
+          before do
+            allow(Alchemy.user_class)
+              .to receive(:primary_key)
+              .and_return('user_id')
+
+            allow(page)
+              .to receive(:updater_id)
+              .and_return(1)
+          end
+
+          it "returns the user that updated the page" do
+            expect(Alchemy.user_class)
+              .to receive(:find_by)
+              .with({'user_id' => 1})
+
+            page.updater
+          end
         end
       end
 
       describe '#locker' do
         before { page.update(locked_by: user.id) }
 
-        it "returns the user that created the page" do
+        it "returns the user that locked the page" do
           expect(page.locker).to eq(user)
+        end
+
+        context 'with user class having a different primary key' do
+          before do
+            allow(Alchemy.user_class)
+              .to receive(:primary_key)
+              .and_return('user_id')
+
+            allow(page)
+              .to receive(:locked_by)
+              .and_return(1)
+          end
+
+          it "returns the user that locked the page" do
+            expect(Alchemy.user_class)
+              .to receive(:find_by)
+              .with({'user_id' => 1})
+
+            page.locker
+          end
         end
       end
 


### PR DESCRIPTION
The primary key to find `page.creator`, `page.updater` and `page.locker` is hard coded to `:id`, this fixes this by using the `primary_key` class method, that the user class provides (ie. ActiveRecord based classes).

Closes #710