### PR TITLE
Fix thumbnail_size calculation for 0x0 crop size values

### DIFF
--- a/app/models/alchemy/picture/transformations.rb
+++ b/app/models/alchemy/picture/transformations.rb
@@ -173,17 +173,24 @@ module Alchemy
     # This function takes a target and a base dimensions hash and returns
     # the dimensions of the image when the base dimensions hash fills
     # the target.
+    #
     # Aspect ratio will be preserved.
     #
     def size_when_fitting(target, dimensions = get_base_dimensions)
-      zoom_x = dimensions[:width].to_f / target[:width]
-      zoom_y = dimensions[:height].to_f / target[:height]
+      zoom = [
+        dimensions[:width].to_f / target[:width],
+        dimensions[:height].to_f / target[:height]
+      ].max
 
-      zoom = [zoom_x, zoom_y].max
-      {
-        width: (dimensions[:width] / zoom).round.to_i,
-        height: (dimensions[:height] / zoom).round.to_i
-      }
+      if zoom == 0.0
+        width = target[:width]
+        height = target[:height]
+      else
+        width = (dimensions[:width] / zoom).round
+        height = (dimensions[:height] / zoom).round
+      end
+
+      {width: width.to_i, height: height.to_i}
     end
 
     # Given a point as a Hash with :x and :y, and a mask with

--- a/spec/support/transformation_examples.rb
+++ b/spec/support/transformation_examples.rb
@@ -28,6 +28,13 @@ module Alchemy
           expect(picture.thumbnail_size()).to eq('111x83')
         end
       end
+
+      context "picture has crop_size of 0x0" do
+        it "returns default thumbnail size" do
+          allow(picture).to receive(:crop_size) { "0x0" }
+          expect(picture.thumbnail_size()).to eq('111x93')
+        end
+      end
     end
 
     describe '#landscape_format?' do


### PR DESCRIPTION
In very rare circumstances (so rare I can't even reproduce) we have 0x0 crop size values for EssencePictures.

This patch fixes this, as this returns the default thumbnail size of 111x93 pixels, if such value exists.