### PR TITLE
Fix file assignment

### DIFF
--- a/app/controllers/alchemy/admin/essence_files_controller.rb
+++ b/app/controllers/alchemy/admin/essence_files_controller.rb
@@ -16,11 +16,21 @@ module Alchemy
         @essence_file.update(essence_file_params)
       end
 
+      # Assigns file, but does not saves it.
+      #
+      # When the user saves the element the content gets updated as well.
+      #
       def assign
         @content = Content.find_by(id: params[:content_id])
         @attachment = Attachment.find_by(id: params[:attachment_id])
         @content.essence.attachment = @attachment
         @options = options_from_params
+
+        # We need to update timestamp here because we don't save yet,
+        # but the cache needs to be get invalid.
+        # And we don't user @content.touch here, because that updates
+        # also the element and page timestamps what we don't want yet.
+        @content.update_column(:updated_at, Time.now)
       end
 
       private

--- a/app/controllers/alchemy/admin/essence_pictures_controller.rb
+++ b/app/controllers/alchemy/admin/essence_pictures_controller.rb
@@ -36,15 +36,20 @@ module Alchemy
 
       # Assigns picture, but does not saves it.
       #
-      # When the user press save on the element, it gets saved.
+      # When the user saves the element the content gets updated as well.
       #
       def assign
         @picture = Picture.find_by(id: params[:picture_id])
         @content.essence.picture = @picture
-        @content.touch # We need to touch manually because its not saved yet.
         @element = @content.element
         @dragable = @options[:grouped]
         @options = @options.merge(dragable: @dragable)
+
+        # We need to update timestamp here because we don't save yet,
+        # but the cache needs to be get invalid.
+        # And we don't user @content.touch here, because that updates
+        # also the element and page timestamps what we don't want yet.
+        @content.update_column(:updated_at, Time.now)
       end
 
       def destroy

--- a/spec/controllers/admin/essence_files_controller_spec.rb
+++ b/spec/controllers/admin/essence_files_controller_spec.rb
@@ -43,6 +43,8 @@ module Alchemy
     end
 
     describe '#assign' do
+      let(:content) { create(:content) }
+
       before do
         expect(Content).to receive(:find_by).and_return(content)
         expect(Attachment).to receive(:find_by).and_return(attachment)
@@ -57,6 +59,12 @@ module Alchemy
       it "should assign @content.essence.attachment with the attachment found by id" do
         expect(content.essence).to receive(:attachment=).with(attachment)
         xhr :put, :assign, content_id: content.id, attachment_id: attachment.id
+      end
+
+      it "updates the @content.updated_at column" do
+        expect {
+          xhr :put, :assign, content_id: content.id, attachment_id: attachment.id
+        }.to change(content, :updated_at)
       end
     end
   end

--- a/spec/controllers/admin/essence_pictures_controller_spec.rb
+++ b/spec/controllers/admin/essence_pictures_controller_spec.rb
@@ -179,6 +179,8 @@ module Alchemy
     end
 
     describe '#assign' do
+      let(:content) { create(:content) }
+
       before do
         expect(Content).to receive(:find).and_return(content)
         expect(content).to receive(:essence).at_least(:once).and_return(essence)
@@ -188,6 +190,12 @@ module Alchemy
       it "should assign a Picture" do
         xhr :put, :assign, content_id: '1', picture_id: '1'
         expect(assigns(:content).essence.picture).to eq(picture)
+      end
+
+      it "updates the content timestamp" do
+        expect {
+          xhr :put, :assign, content_id: '1', picture_id: '1'
+        }.to change(content, :updated_at)
       end
     end
   end


### PR DESCRIPTION
Fixes cache invalidation while assigning attachments. Also fixes the usage of `@content.touch` while attaching pictures.