### PR TITLE
Only cache page if caching is enabled in Rails app

### DIFF
--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -184,7 +184,9 @@ module Alchemy
     # @returns Boolean
     #
     def cache_page?
-      return false unless @page && Alchemy::Config.get(:cache_pages)
+      return false if @page.nil? ||
+        !Rails.application.config.action_controller.perform_caching ||
+        !Alchemy::Config.get(:cache_pages)
       page_layout = PageLayout.get(@page.page_layout)
       page_layout['cache'] != false && page_layout['searchresults'] != true
     end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -229,5 +229,47 @@ module Alchemy
         end
       end
     end
+
+    describe '#cache_page?' do
+      subject { controller.send(:cache_page?) }
+
+      before do
+        Rails.application.config.action_controller.perform_caching = true
+        controller.instance_variable_set('@page', page)
+      end
+
+      it 'returns true when everthing is alright' do
+        expect(subject).to be true
+      end
+
+      it 'returns false when the Rails app does not perform caching' do
+        Rails.application.config.action_controller.perform_caching = false
+        expect(subject).to be false
+      end
+
+      it 'returns false when there is no page' do
+        controller.instance_variable_set('@page', nil)
+        expect(subject).to be false
+      end
+
+      it 'returns false when caching is deactivated in the Alchemy config' do
+        allow(Alchemy::Config).to receive(:get).with(:cache_pages).and_return(false)
+        expect(subject).to be false
+      end
+
+      it 'returns false when the page layout is set to cache = false' do
+        page_layout = PageLayout.get('news')
+        page_layout['cache'] = false
+        allow(PageLayout).to receive(:get).with('news').and_return(page_layout)
+        expect(subject).to be false
+      end
+
+      it 'returns false when the page layout is set to searchresults = true' do
+        page_layout = PageLayout.get('news')
+        page_layout['searchresults'] = true
+        allow(PageLayout).to receive(:get).with('news').and_return(page_layout)
+        expect(subject).to be false
+      end
+    end
   end
 end


### PR DESCRIPTION
HTTP caching was enabled in the development environment, because Alchemy didn't check for the Rails application configuration.