### PR TITLE
Show hints for EssenceBoolean contents in backend

### DIFF
--- a/app/views/alchemy/essences/_essence_boolean_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_boolean_editor.html.erb
@@ -9,8 +9,8 @@
       style: local_assigns.fetch(:html_options, {})[:style] %>
     <label for="<%= content.form_field_id %>" style="display: inline">
       <%= render_content_name(content) %>
-      <%= render_hint_for(content) %>
-      <%= delete_content_link(content) %>
     </label>
+    <%= delete_content_link(content) %>
+    <%= render_hint_for(content) %>
   </div>
 <% end %>

--- a/app/views/alchemy/essences/_essence_boolean_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_boolean_editor.html.erb
@@ -9,6 +9,7 @@
       style: local_assigns.fetch(:html_options, {})[:style] %>
     <label for="<%= content.form_field_id %>" style="display: inline">
       <%= render_content_name(content) %>
+      <%= render_hint_for(content) %>
       <%= delete_content_link(content) %>
     </label>
   </div>

--- a/spec/views/essences/essence_boolean_editor_spec.rb
+++ b/spec/views/essences/essence_boolean_editor_spec.rb
@@ -7,6 +7,7 @@ describe 'alchemy/essences/_essence_boolean_editor' do
   before do
     allow(view).to receive(:render_content_name).and_return(content.name)
     allow(view).to receive(:delete_content_link).and_return('')
+    allow(view).to receive(:render_hint_for).and_return('')
   end
 
   it "renders a checkbox" do


### PR DESCRIPTION
Content hints haven't been shown for EssenceBoolean contents in the backend.