### PR TITLE
Added a format contraint so that alchemy only serves html for the pages

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -159,8 +159,7 @@ Alchemy::Engine.routes.draw do
 
   # The page show action has to be last route
   get '(/:lang)/*urlname(.:format)' => 'pages#show',
-      :format => true,
-      :constraints => {:lang => /[a-z]{2}(-[a-z]{2})?/, :format => 'html'},
+      :constraints => {:lang => /[a-z]{2}(-[a-z]{2})?/, :format => :html },
       :as => :show_page
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -159,7 +159,8 @@ Alchemy::Engine.routes.draw do
 
   # The page show action has to be last route
   get '(/:lang)/*urlname(.:format)' => 'pages#show',
-      :constraints => {:lang => /[a-z]{2}(-[a-z]{2})?/},
+      :format => true,
+      :constraints => {:lang => /[a-z]{2}(-[a-z]{2})?/, :format => 'html'},
       :as => :show_page
 
 end

--- a/spec/routing/routing_spec.rb
+++ b/spec/routing/routing_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "The Routing" do
+describe "The Routing", type: :routing do
 
   routes { Alchemy::Engine.routes }
 
@@ -21,6 +21,15 @@ describe "The Routing" do
   end
 
   describe "nested url" do
+
+    describe "non html requests" do
+      it "should not be handled by alchemy/pages controller" do
+        expect({
+          :get => "/products/my-product.jpg"
+        }).not_to be_routable
+      end
+    end
+
 
     context "one level deep nested" do
 


### PR DESCRIPTION
This prevents the pages controller from receiving images and what not, which are not found, and caught by any previous middleware or route.

That broke a few specs (80). I will have a look.