### PR TITLE
Fix SimpleForm Initializer

### DIFF
--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title><%= render_alchemy_title %></title>
-    <link rel="shortcut icon" href="/assets/alchemy/favicon.ico">
+    <link rel="shortcut icon" href="<%= asset_path('alchemy/favicon.ico') %>">
     <%= csrf_meta_tag %>
     <meta name="robots" content="noindex">
     <%= stylesheet_link_tag('alchemy/admin', :media => 'screen', "data-turbolinks-track" => true) %>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -100,7 +100,7 @@ SimpleForm.setup do |config|
   config.label_class = 'control-label'
 
   # You can define the class to use on all forms. Default is simple_form.
-  config.default_form_class = nil
+  # config.default_form_class = nil
 
   # You can define which elements should obtain additional classes
   # config.generate_additional_classes_for = [:wrapper, :label, :input]


### PR DESCRIPTION
Two minor changes.

1. Use asset_path helper for the favicon.  Otherwise it throws 404 errors if you configure rails to use a different base asset path (ie. for a CDN)
2. Fix for the simple_form initializer to be backward compatible with v3.0 of simpleform (See commit message for more detail)