### PR TITLE
Add down migration for initial alchemy tables

### DIFF
--- a/db/migrate/20130827094554_alchemy_two_point_six.rb
+++ b/db/migrate/20130827094554_alchemy_two_point_six.rb
@@ -310,6 +310,88 @@ class AlchemyTwoPointSix < ActiveRecord::Migration
         t.string "name"
       end
     end
+  end
+
+  def down
+    if table_exists?('alchemy_attachments')
+      drop_table "alchemy_attachments"
+    end
+
+    if table_exists?('alchemy_cells')
+      drop_table "alchemy_cells"
+    end
+
+    if table_exists?('alchemy_contents')
+      drop_table "alchemy_contents"
+    end
+
+    if table_exists?('alchemy_elements')
+      drop_table "alchemy_elements"
+    end
+
+    if table_exists?('alchemy_elements_alchemy_pages')
+      drop_table "alchemy_elements_alchemy_pages"
+    end
+
+    if table_exists?('alchemy_essence_booleans')
+      drop_table "alchemy_essence_booleans"
+    end
+
+    if table_exists?('alchemy_essence_dates')
+      drop_table "alchemy_essence_dates"
+    end
+
+    if table_exists?('alchemy_essence_files')
+      drop_table "alchemy_essence_files"
+    end
+
+    if table_exists?('alchemy_essence_htmls')
+      drop_table "alchemy_essence_htmls"
+    end
+
+    if table_exists?('alchemy_essence_links')
+      drop_table "alchemy_essence_links"
+    end
+
+    if table_exists?('alchemy_essence_pictures')
+      drop_table "alchemy_essence_pictures"
+    end
+
+    if table_exists?('alchemy_essence_richtexts')
+      drop_table "alchemy_essence_richtexts"
+    end
+
+    if table_exists?('alchemy_essence_selects')
+      drop_table "alchemy_essence_selects"
+    end
+
+    if table_exists?('alchemy_essence_texts')
+      drop_table "alchemy_essence_texts"
+    end
+
+    if table_exists?('alchemy_folded_pages')
+      drop_table "alchemy_folded_pages"
+    end
+
+    if table_exists?('alchemy_languages')
+      drop_table "alchemy_languages"
+    end
+
+    if table_exists?('alchemy_legacy_page_urls')
+      drop_table "alchemy_legacy_page_urls"
+    end
+
+    if table_exists?('alchemy_pages')
+      drop_table "alchemy_pages"
+    end
+
+    if table_exists?('alchemy_pictures')
+      drop_table "alchemy_pictures"
+    end
+
+    if table_exists?('alchemy_sites')
+      drop_table "alchemy_sites"
+    end
 
   end
 end


### PR DESCRIPTION
For pre-existing Rails app, user may want to remove Alchemy tables, so this is the down version of the initial migration.

I didn't do anything with `tags` or `taggings`, since Alchemy doesn't really "own" those tables, and the parent Rails app may already be using `acts_as_taggable_on` gem. Wasn't sure if there's a better way to handle this? Maybe there should be an "Uninstalling Alchemy" section on the README?