### PR TITLE
Remove condition for user role execution

### DIFF
--- a/lib/alchemy/permissions.rb
+++ b/lib/alchemy/permissions.rb
@@ -183,7 +183,7 @@ module Alchemy
     def user_role_rules
       return [] if @user.alchemy_roles.nil?
       @user.alchemy_roles.each do |role|
-        exec_role_rules(role) if @user.alchemy_roles.include?(role)
+        exec_role_rules(role)
       end
     end
 


### PR DESCRIPTION
Since we iterate through the users roles, we do not need to double-check if that roles array contain that role on which we are currently pointing at.