### PR TITLE
Use correct branches when using alchemy bin

### DIFF
--- a/lib/rails/templates/alchemy.rb
+++ b/lib/rails/templates/alchemy.rb
@@ -1,6 +1,6 @@
 # This rails template installs Alchemy and all depending gems.
 require File.expand_path('../../../alchemy/version', __FILE__)
 
-gem 'alchemy_cms', github: 'magiclabs/alchemy_cms', branch: 'master'
-gem 'alchemy-devise', github: 'magiclabs/alchemy-devise', branch: 'master'
+gem 'alchemy_cms', github: 'magiclabs/alchemy_cms', branch: '3.0-stable'
+gem 'alchemy-devise', github: 'magiclabs/alchemy-devise', branch: '2.0-stable'
 gem 'capistrano', '~> 2.15.5', group: 'development'


### PR DESCRIPTION
When creating a new Alchemy app with the `alchemy` binary, the master
branches of alchemy_cms and alchemy-devise were used. That lead to
unsatisfiable dependencies.

This should fix #732