### PR TITLE
Refactor request based specs.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Alchemy::Engine.routes.draw do
         :as => :show_picture
   get '/pictures/:id/zoom/:name.:format' => 'pictures#zoom',
         :as => :zoom_picture
-  get "/pictures/:id/thumbnails/:size(/:crop)(/:crop_from/:crop_size)/:name.:format" => 'pictures#thumbnail',
+  get "/pictures/:id/thumbnails(/:size)(/:crop)(/:crop_from/:crop_size)/:name.:format" => 'pictures#thumbnail',
         :as => :thumbnail, :defaults => {:format => 'png', :name => "thumbnail"}
 
   get '/admin/leave' => 'admin/base#leave', :as => :leave_admin

--- a/lib/alchemy/test_support/controller_requests.rb
+++ b/lib/alchemy/test_support/controller_requests.rb
@@ -1,37 +1,73 @@
-# Based on spree commerce controller hacks.
-# https://github.com/spree/spree/blob/master/core/spec/support/controller_hacks.rb
-# Thanks!
-
+# Use this module to easily test Alchemy actions within Alchemy components
+# or inside your application to test routes for the mounted Alchemy engine.
+#
+# Inside your spec_helper.rb, include this module inside the RSpec.configure
+# block by doing this:
+#
+#   require 'alchemy/test_support/controller_requests'
+#   RSpec.configure do |c|
+#     c.include Alchemy::TestSupport::ControllerRequests, type: :controller
+#   end
+#
+# Then, in your controller tests, you can access alchemy routes like this:
+#
+#   require 'spec_helper'
+#
+#   describe Alchemy::Admin::PagesController do
+#     it "can see all the pages" do
+#       alchemy_get :index
+#     end
+#   end
+#
+# Use alchemy_get, alchemy_post, alchemy_put or alchemy_delete to make requests
+# to the Alchemy engine, and use regular get, post, put or delete to make
+# requests to your application.
+#
+# Note: Based on Spree::TestingSupport::ControllerRequests. Thanks <3
+#
 module Alchemy
   module TestSupport
     module ControllerRequests
+      extend ActiveSupport::Concern
 
-      def get(action, parameters = nil, session = nil, flash = nil)
+      # Executes a request simulating GET HTTP method
+      def alchemy_get(action, parameters = nil, session = nil, flash = nil)
         process_alchemy_action(action, parameters, session, flash, "GET")
       end
 
-      # Executes a request simulating POST HTTP method and set/volley the response
-      def post(action, parameters = nil, session = nil, flash = nil)
+      # Executes a request simulating POST HTTP method
+      def alchemy_post(action, parameters = nil, session = nil, flash = nil)
         process_alchemy_action(action, parameters, session, flash, "POST")
       end
 
-      # Executes a request simulating PUT HTTP method and set/volley the response
-      def put(action, parameters = nil, session = nil, flash = nil)
+      # Executes a request simulating PUT HTTP method
+      def alchemy_put(action, parameters = nil, session = nil, flash = nil)
         process_alchemy_action(action, parameters, session, flash, "PUT")
       end
 
-      # Executes a request simulating DELETE HTTP method and set/volley the response
-      def delete(action, parameters = nil, session = nil, flash = nil)
+      # Executes a request simulating DELETE HTTP method
+      def alchemy_delete(action, parameters = nil, session = nil, flash = nil)
         process_alchemy_action(action, parameters, session, flash, "DELETE")
+      end
+
+      # Executes a simulated XHR request
+      def alchemy_xhr(method, action, parameters = nil, session = nil, flash = nil)
+        process_alchemy_xhr_action(method, action, parameters, session, flash)
       end
 
       private
 
       def process_alchemy_action(action, parameters = nil, session = nil, flash = nil, method = "GET")
+        @routes = Alchemy::Engine.routes
         parameters ||= {}
-        process(action, method, parameters.merge!(:use_route => :alchemy), session, flash)
+        process(action, method, parameters, session, flash)
       end
 
+      def process_alchemy_xhr_action(method, action, parameters = nil, session = nil, flash = nil)
+        @routes = Alchemy::Engine.routes
+        parameters ||= {}
+        xml_http_request(method, action, parameters, session, flash)
+      end
     end
   end
 end

--- a/spec/controllers/admin/attachments_controller_spec.rb
+++ b/spec/controllers/admin/attachments_controller_spec.rb
@@ -11,13 +11,13 @@ module Alchemy
     describe "#index" do
       it "should always paginate the records" do
         expect(Attachment).to receive(:find_paginated)
-        get :index
+        alchemy_get :index
       end
 
       context "when params[:tagged_with] is set" do
         it "should filter the records by tags" do
           expect(Attachment).to receive(:tagged_with).and_return(Attachment.all)
-          get :index, tagged_with: "pdf"
+          alchemy_get :index, tagged_with: "pdf"
         end
       end
 
@@ -27,7 +27,7 @@ module Alchemy
         context "is set" do
           it "it renders the archive_overlay partial" do
             expect(Content).to receive(:find_by).and_return(content)
-            get :index, {content_id: content.id}
+            alchemy_get :index, {content_id: content.id}
             expect(response).to render_template(partial: '_archive_overlay')
             expect(assigns(:content)).to eq(content)
           end
@@ -35,7 +35,7 @@ module Alchemy
 
         context "is not set" do
           it "should render the default index view" do
-            get :index
+            alchemy_get :index
             expect(response).to render_template(:index)
           end
         end
@@ -47,7 +47,7 @@ module Alchemy
 
         context 'with params[:only]' do
           it 'only loads attachments with matching content type' do
-            get :index, only: 'jpeg'
+            alchemy_get :index, only: 'jpeg'
             expect(assigns(:attachments).to_a).to eq([jpg])
             expect(assigns(:attachments).to_a).to_not eq([png])
           end
@@ -55,7 +55,7 @@ module Alchemy
 
         context 'with params[:except]' do
           it 'does not load attachments with matching content type' do
-            get :index, except: 'jpeg'
+            alchemy_get :index, except: 'jpeg'
             expect(assigns(:attachments).to_a).to eq([png])
             expect(assigns(:attachments).to_a).to_not eq([jpg])
           end
@@ -69,7 +69,7 @@ module Alchemy
       end
 
       it "renders the show template" do
-        get :show, id: attachment.id
+        alchemy_get :show, id: attachment.id
         expect(response).to render_template(:show)
       end
     end
@@ -82,19 +82,19 @@ module Alchemy
         end
 
         it "should set @while_assigning to true" do
-          get :new
+          alchemy_get :new
           expect(assigns(:while_assigning)).to eq(true)
         end
 
         it "should set @swap to params[:swap]" do
-          get :new, swap: 'true'
+          alchemy_get :new, swap: 'true'
           expect(assigns(:swap)).to eq('true')
         end
       end
     end
 
     describe '#create' do
-      subject { post :create, params }
+      subject { alchemy_post :create, params }
 
       let(:attachment) { mock_model('Attachment', name: 'contract.pdf', to_jq_upload: {}) }
       let(:params)     { {attachment: {name: ''}} }
@@ -145,7 +145,7 @@ module Alchemy
     end
 
     describe '#update' do
-      subject { put :update, attachment: {name: ''} }
+      subject { alchemy_put :update, {id: 1, attachment: {name: ''}} }
 
       let(:attachment) { build_stubbed(:attachment) }
 
@@ -184,7 +184,7 @@ module Alchemy
 
       it "destroys the attachment and sets and success message" do
         expect(attachment).to receive(:destroy)
-        xhr :delete, :destroy
+        alchemy_xhr :delete, :destroy, id: 1
         expect(assigns(:attachment)).to eq(attachment)
         expect(assigns(:url)).not_to be_blank
         expect(flash[:notice]).not_to be_blank
@@ -198,13 +198,13 @@ module Alchemy
       end
 
       it "should assign @attachment with Attachment found by id" do
-        get :download, id: attachment.id
+        alchemy_get :download, id: attachment.id
         expect(assigns(:attachment)).to eq(attachment)
       end
 
       it "should send the data to the browser" do
         expect(controller).to receive(:send_data)
-        get :download, id: attachment.id
+        alchemy_get :download, id: attachment.id
       end
     end
   end

--- a/spec/controllers/admin/clipboard_controller_spec.rb
+++ b/spec/controllers/admin/clipboard_controller_spec.rb
@@ -18,13 +18,13 @@ module Alchemy
 
       describe "#insert" do
         it "should hold element ids" do
-          xhr :post, :insert, {remarkable_type: 'elements', remarkable_id: element.id}
+          alchemy_xhr :post, :insert, {remarkable_type: 'elements', remarkable_id: element.id}
           expect(session[:alchemy_clipboard]['elements']).to eq([{'id' => element.id.to_s, 'action' => 'copy'}])
         end
 
         it "should not have the same element twice" do
           session[:alchemy_clipboard]['elements'] = [{'id' => element.id.to_s, 'action' => 'copy'}]
-          xhr :post, :insert, {remarkable_type: 'elements', remarkable_id: element.id}
+          alchemy_xhr :post, :insert, {remarkable_type: 'elements', remarkable_id: element.id}
           expect(session[:alchemy_clipboard]['elements'].collect { |e| e['id'] }).not_to eq([element.id, element.id])
         end
       end
@@ -33,7 +33,7 @@ module Alchemy
         it "should remove element ids from clipboard" do
           session[:alchemy_clipboard]['elements'] = [{'id' => element.id.to_s, 'action' => 'copy'}]
           session[:alchemy_clipboard]['elements'] << {'id' => another_element.id.to_s, 'action' => 'copy'}
-          xhr :delete, :remove, {remarkable_type: 'elements', remarkable_id: another_element.id}
+          alchemy_xhr :delete, :remove, {remarkable_type: 'elements', remarkable_id: another_element.id}
           expect(session[:alchemy_clipboard]['elements']).to eq([{'id' => element.id.to_s, 'action' => 'copy'}])
         end
       end
@@ -43,7 +43,7 @@ module Alchemy
       context "with elements as remarkable_type" do
         it "should clear the elements clipboard" do
           session[:alchemy_clipboard]['elements'] = [{'id' => element.id.to_s}]
-          xhr :delete, :clear, {remarkable_type: 'elements'}
+          alchemy_xhr :delete, :clear, {remarkable_type: 'elements'}
           expect(session[:alchemy_clipboard]['elements']).to be_empty
         end
       end
@@ -51,7 +51,7 @@ module Alchemy
       context "with pages as remarkable_type" do
         it "should clear the pages clipboard" do
           session[:alchemy_clipboard]['pages'] = [{'id' => public_page.id.to_s}]
-          xhr :delete, :clear, {remarkable_type: 'pages'}
+          alchemy_xhr :delete, :clear, {remarkable_type: 'pages'}
           expect(session[:alchemy_clipboard]['pages']).to be_empty
         end
       end

--- a/spec/controllers/admin/contents_controller_spec.rb
+++ b/spec/controllers/admin/contents_controller_spec.rb
@@ -19,12 +19,12 @@ module Alchemy
 
         it "creates a content from name" do
           expect(Content).to receive(:create_from_scratch).and_return(content)
-          xhr :post, :create, {content: {element_id: element.id, name: 'headline'}}
+          alchemy_xhr :post, :create, {content: {element_id: element.id, name: 'headline'}}
         end
 
         it "creates a content from essence_type" do
           expect(Content).to receive(:create_from_scratch).and_return(content)
-          xhr :post, :create, {content: {element_id: element.id, essence_type: 'EssencePicture'}}
+          alchemy_xhr :post, :create, {content: {element_id: element.id, essence_type: 'EssencePicture'}}
         end
       end
 
@@ -34,14 +34,14 @@ module Alchemy
         end
 
         it "adds it into the gallery editor" do
-          xhr :post, :create, attributes
+          alchemy_xhr :post, :create, attributes
           expect(assigns(:content_dom_id)).to eq("#add_picture_#{element.id}")
         end
 
         context 'with picture_id given' do
           it "assigns the picture" do
             expect_any_instance_of(Content).to receive(:update_essence).with(picture_id: '1')
-            xhr :post, :create, attributes.merge(picture_id: '1')
+            alchemy_xhr :post, :create, attributes.merge(picture_id: '1')
           end
         end
       end
@@ -54,7 +54,7 @@ module Alchemy
 
       it "should update a content via ajax" do
         expect(content.essence).to receive(:update).with('ingredient' => 'Peters Petshop')
-        xhr :post, :update, {id: content.id, content: {ingredient: 'Peters Petshop'}}
+        alchemy_xhr :post, :update, {id: content.id, content: {ingredient: 'Peters Petshop'}}
       end
     end
 
@@ -62,7 +62,7 @@ module Alchemy
       context "with content_ids in params" do
         it "should reorder the contents" do
           content_ids = element.contents.essence_texts.pluck(:id)
-          xhr :post, :order, {content_ids: content_ids.reverse}
+          alchemy_xhr :post, :order, {content_ids: content_ids.reverse}
           expect(response.status).to eq(200)
           expect(element.contents.essence_texts.pluck(:id)).to eq(content_ids.reverse)
         end

--- a/spec/controllers/admin/dashboard_controller_spec.rb
+++ b/spec/controllers/admin/dashboard_controller_spec.rb
@@ -13,12 +13,12 @@ module Alchemy
       end
 
       it "assigns @last_edited_pages" do
-        get :index
+        alchemy_get :index
         expect(assigns(:last_edited_pages)).to eq([])
       end
 
       it "assigns @locked_pages" do
-        get :index
+        alchemy_get :index
         expect(assigns(:locked_pages)).to eq([])
       end
 
@@ -31,14 +31,14 @@ module Alchemy
           end
 
           it "assigns @online_users" do
-            get :index
+            alchemy_get :index
             expect(assigns(:online_users)).to eq([another_user])
           end
         end
 
         context 'without other users online' do
           it "does not assign @online_users" do
-            get :index
+            alchemy_get :index
             expect(assigns(:online_users)).to eq([])
           end
         end
@@ -51,20 +51,20 @@ module Alchemy
         end
 
         it "assigns @first_time" do
-          get :index
+          alchemy_get :index
           expect(assigns(:first_time)).to eq(false)
         end
       end
 
       it "assigns @sites" do
-        get :index
+        alchemy_get :index
         expect(assigns(:sites)).to eq(Site.all)
       end
     end
 
     describe '#info' do
       it "assigns @alchemy_version with the current Alchemy version" do
-        get :info
+        alchemy_get :info
         expect(assigns(:alchemy_version)).to eq(Alchemy.version)
       end
     end
@@ -77,7 +77,7 @@ module Alchemy
         }
 
         it "should render 'false'" do
-          get :update_check
+          alchemy_get :update_check
           expect(response.body).to eq('false')
         end
       end
@@ -89,7 +89,7 @@ module Alchemy
         }
 
         it "should render 'true'" do
-          get :update_check
+          alchemy_get :update_check
           expect(response.body).to eq('true')
         end
       end
@@ -103,7 +103,7 @@ module Alchemy
         }
 
         it "should have response code of 200" do
-          get :update_check
+          alchemy_get :update_check
           expect(response.code).to eq('200')
         end
       end
@@ -117,7 +117,7 @@ module Alchemy
         }
 
         it "should have response code of 200" do
-          get :update_check
+          alchemy_get :update_check
           expect(response.code).to eq('200')
         end
       end
@@ -130,7 +130,7 @@ module Alchemy
         }
 
         it "should have status code 503" do
-          get :update_check
+          alchemy_get :update_check
           expect(response.code).to eq('503')
         end
       end

--- a/spec/controllers/admin/essence_files_controller_spec.rb
+++ b/spec/controllers/admin/essence_files_controller_spec.rb
@@ -18,12 +18,12 @@ module Alchemy
       end
 
       it "assigns @essence_file with the EssenceFile found by id" do
-        get :edit, id: essence_file.id
+        alchemy_get :edit, id: essence_file.id
         expect(assigns(:essence_file)).to eq(essence_file)
       end
 
       it "should assign @content with essence_file's content" do
-        get :edit, id: essence_file.id
+        alchemy_get :edit, id: essence_file.id
         expect(assigns(:content)).to eq(content)
       end
     end
@@ -36,7 +36,7 @@ module Alchemy
       end
 
       it "should update the attributes of essence_file" do
-        xhr :put, :update, id: essence_file.id, essence_file: {title: 'new title', css_class: 'left'}
+        alchemy_xhr :put, :update, id: essence_file.id, essence_file: {title: 'new title', css_class: 'left'}
         expect(essence_file.title).to eq 'new title'
         expect(essence_file.css_class).to eq 'left'
       end
@@ -52,18 +52,18 @@ module Alchemy
       end
 
       it "should assign @attachment with the Attachment found by attachment_id" do
-        xhr :put, :assign, content_id: content.id, attachment_id: attachment.id
+        alchemy_xhr :put, :assign, content_id: content.id, attachment_id: attachment.id
         expect(assigns(:attachment)).to eq(attachment)
       end
 
       it "should assign @content.essence.attachment with the attachment found by id" do
         expect(content.essence).to receive(:attachment=).with(attachment)
-        xhr :put, :assign, content_id: content.id, attachment_id: attachment.id
+        alchemy_xhr :put, :assign, content_id: content.id, attachment_id: attachment.id
       end
 
       it "updates the @content.updated_at column" do
         expect {
-          xhr :put, :assign, content_id: content.id, attachment_id: attachment.id
+          alchemy_xhr :put, :assign, content_id: content.id, attachment_id: attachment.id
         }.to change(content, :updated_at)
       end
     end

--- a/spec/controllers/admin/essence_pictures_controller_spec.rb
+++ b/spec/controllers/admin/essence_pictures_controller_spec.rb
@@ -15,7 +15,7 @@ module Alchemy
       end
 
       it 'should assign @essence_picture and @content instance variables' do
-        post :edit, id: 1, content_id: 1
+        alchemy_post :edit, id: 1, content_id: 1
         expect(assigns(:essence_picture)).to be_a(EssencePicture)
         expect(assigns(:content)).to be_a(Content)
       end
@@ -32,7 +32,7 @@ module Alchemy
         end
 
         it "renders error message" do
-          get :crop, id: 1
+          alchemy_get :crop, id: 1
           expect(assigns(:no_image_notice)).to eq(Alchemy::I18n.t(:no_image_for_cropper_found))
         end
       end
@@ -60,14 +60,14 @@ module Alchemy
 
           context 'with sizes in params' do
             it "sets sizes to given values" do
-              get :crop, id: 1, options: {image_size: '300x250'}
+              alchemy_get :crop, id: 1, options: {image_size: '300x250'}
               expect(assigns(:min_size)).to eq({ width: 300, height: 250 })
             end
           end
 
           context 'with no sizes in params' do
             it "sets sizes to zero" do
-              get :crop, id: 1
+              alchemy_get :crop, id: 1
               expect(assigns(:min_size)).to eq({ width: 0, height: 0 })
             end
           end
@@ -77,7 +77,7 @@ module Alchemy
           it "sets sizes from these values" do
             expect(essence).to receive(:render_size).at_least(:once).and_return('30x25')
 
-            get :crop, id: 1
+            alchemy_get :crop, id: 1
             expect(assigns(:min_size)).to eq({ width: 30, height: 25 })
           end
 
@@ -85,14 +85,14 @@ module Alchemy
             it 'infers the height from the image file preserving the aspect ratio' do
               expect(essence).to receive(:render_size).at_least(:once).and_return('30x')
 
-              get :crop, id: 1
+              alchemy_get :crop, id: 1
               expect(assigns(:min_size)).to eq({ width: 30, height: 0})
             end
 
             it 'does not infer the height from the image file preserving the aspect ratio' do
               expect(essence).to receive(:render_size).at_least(:once).and_return('x25')
 
-              get :crop, id: 1, options: { fixed_ratio: "2"}
+              alchemy_get :crop, id: 1, options: { fixed_ratio: "2"}
               expect(assigns(:min_size)).to eq({ width: 50, height: 25 })
             end
           end
@@ -101,14 +101,14 @@ module Alchemy
             it 'width is given, it infers the height from width and ratio' do
               expect(essence).to receive(:render_size).at_least(:once).and_return('30x')
 
-              get :crop, id: 1, options: { fixed_ratio: "0.5" }
+              alchemy_get :crop, id: 1, options: { fixed_ratio: "0.5" }
               expect(assigns(:min_size)).to eq({ width: 30, height: 60 })
             end
 
             it 'infers the height from the image file preserving the aspect ratio' do
               expect(essence).to receive(:render_size).at_least(:once).and_return('x25')
 
-              get :crop, id: 1
+              alchemy_get :crop, id: 1
               expect(assigns(:min_size)).to eq({ width: 0, height: 25})
             end
           end
@@ -121,7 +121,7 @@ module Alchemy
           end
 
           it "assigns default mask boxes" do
-            get :crop, id: 1
+            alchemy_get :crop, id: 1
             expect(assigns(:initial_box)).to eq(default_mask)
             expect(assigns(:default_box)).to eq(default_mask)
           end
@@ -137,7 +137,7 @@ module Alchemy
 
           it "assigns cropping boxes" do
             expect(essence).to receive(:cropping_mask).and_return(mask)
-            get :crop, id: 1
+            alchemy_get :crop, id: 1
             expect(assigns(:initial_box)).to eq(mask)
             expect(assigns(:default_box)).to eq(default_mask)
           end
@@ -145,14 +145,14 @@ module Alchemy
 
         context 'with fixed_ratio set to false' do
           it "sets ratio to false" do
-            get :crop, id: 1, options: {fixed_ratio: false}
+            alchemy_get :crop, id: 1, options: {fixed_ratio: false}
             expect(assigns(:ratio)).to eq(false)
           end
         end
 
         context 'with no fixed_ratio set in params' do
           it "sets a fixed ratio from sizes" do
-            get :crop, id: 1, options: {image_size: '80x60'}
+            alchemy_get :crop, id: 1, options: {image_size: '80x60'}
             expect(assigns(:ratio)).to eq(80.0/60.0)
           end
         end
@@ -169,12 +169,12 @@ module Alchemy
 
       it "updates the essence attributes" do
         expect(essence).to receive(:update).and_return(true)
-        xhr :put, :update, id: 1, essence_picture: attributes
+        alchemy_xhr :put, :update, id: 1, essence_picture: attributes
       end
 
       it "saves the cropping mask" do
         expect(essence).to receive(:update).and_return(true)
-        xhr :put, :update, id: 1, essence_picture: {render_size: '1x1', crop_from: '0x0', crop_size: '100x100'}
+        alchemy_xhr :put, :update, id: 1, essence_picture: {render_size: '1x1', crop_from: '0x0', crop_size: '100x100'}
       end
     end
 
@@ -188,13 +188,13 @@ module Alchemy
       end
 
       it "should assign a Picture" do
-        xhr :put, :assign, content_id: '1', picture_id: '1'
+        alchemy_xhr :put, :assign, content_id: '1', picture_id: '1'
         expect(assigns(:content).essence.picture).to eq(picture)
       end
 
       it "updates the content timestamp" do
         expect {
-          xhr :put, :assign, content_id: '1', picture_id: '1'
+          alchemy_xhr :put, :assign, content_id: '1', picture_id: '1'
         }.to change(content, :updated_at)
       end
     end

--- a/spec/controllers/admin/languages_controller_spec.rb
+++ b/spec/controllers/admin/languages_controller_spec.rb
@@ -19,7 +19,7 @@ describe Alchemy::Admin::LanguagesController do
       end
 
       it "uses it as page_layout-default for the new language" do
-        get :new
+        alchemy_get :new
         expect(assigns(:language).page_layout).to eq("new_standard")
       end
     end
@@ -36,7 +36,7 @@ describe Alchemy::Admin::LanguagesController do
       end
 
       it "falls back to default database value." do
-        get :new
+        alchemy_get :new
         expect(assigns(:language).page_layout).to eq("intro")
       end
     end
@@ -53,7 +53,7 @@ describe Alchemy::Admin::LanguagesController do
       end
 
       it "falls back to default database value." do
-        get :new
+        alchemy_get :new
         expect(assigns(:language).page_layout).to eq("intro")
       end
     end

--- a/spec/controllers/admin/layoutpages_controller_spec.rb
+++ b/spec/controllers/admin/layoutpages_controller_spec.rb
@@ -9,17 +9,17 @@ module Alchemy
 
     describe "#index" do
       it "should assign @locked_pages" do
-        get :index
+        alchemy_get :index
         expect(assigns(:locked_pages)).to eq([])
       end
 
       it "should assign @layout_root" do
-        get :index
+        alchemy_get :index
         expect(assigns(:layout_root)).to be_a(Page)
       end
 
       it "should assign @languages" do
-        get :index
+        alchemy_get :index
         expect(assigns(:languages).first).to be_a(Language)
       end
     end

--- a/spec/controllers/admin/pages_controller_spec.rb
+++ b/spec/controllers/admin/pages_controller_spec.rb
@@ -6,7 +6,7 @@ module Alchemy
 
     context 'a guest' do
       it 'can not access page tree' do
-        get :index
+        alchemy_get :index
         expect(request).to redirect_to(Alchemy.login_path)
       end
     end
@@ -15,7 +15,7 @@ module Alchemy
       before { sign_in(member_user) }
 
       it 'can not access page tree' do
-        get :index
+        alchemy_get :index
         expect(request).to redirect_to(root_path)
       end
     end
@@ -35,7 +35,7 @@ module Alchemy
           end
 
           it "assigns @page_root variable" do
-            get :index
+            alchemy_get :index
             expect(assigns(:page_root)).to be(language_root)
           end
         end
@@ -49,7 +49,7 @@ module Alchemy
           end
 
           it "it assigns current language" do
-            get :index
+            alchemy_get :index
             expect(assigns(:language)).to be(language)
           end
         end
@@ -67,7 +67,7 @@ module Alchemy
         it "should remove the cache of all pages" do
           expect(page_1).to receive(:publish!)
           expect(page_2).to receive(:publish!)
-          xhr :post, :flush
+          alchemy_xhr :post, :flush
         end
       end
 
@@ -79,7 +79,7 @@ module Alchemy
           before { clipboard['pages'] = [{'id' => page.id.to_s, 'action' => 'copy'}] }
 
           it "should load all pages from clipboard" do
-            xhr :get, :new, {page_id: page.id}
+            alchemy_xhr :get, :new, {page_id: page.id}
             expect(assigns(:clipboard_items)).to be_kind_of(Array)
           end
         end
@@ -94,23 +94,23 @@ module Alchemy
         end
 
         it "should assign @preview_mode with true" do
-          get :show, id: page.id
+          alchemy_get :show, id: page.id
           expect(assigns(:preview_mode)).to eq(true)
         end
 
         it "should store page as current preview" do
           Page.current_preview = nil
-          get :show, id: page.id
+          alchemy_get :show, id: page.id
           expect(Page.current_preview).to eq(page)
         end
 
         it "should set the I18n locale to the pages language code" do
-          get :show, id: page.id
+          alchemy_get :show, id: page.id
           expect(::I18n.locale).to eq(:nl)
         end
 
         it "renders the application layout" do
-          get :show, id: page.id
+          alchemy_get :show, id: page.id
           expect(response).to render_template(layout: 'application')
         end
       end
@@ -125,7 +125,7 @@ module Alchemy
         let(:set_of_pages) { [page_item_1] }
 
         it "stores the new order" do
-          xhr :post, :order, set: set_of_pages.to_json
+          alchemy_xhr :post, :order, set: set_of_pages.to_json
           page_1.reload
           expect(page_1.descendants).to eq([page_2, page_3])
         end
@@ -136,7 +136,7 @@ module Alchemy
           end
 
           it "updates the pages urlnames" do
-            xhr :post, :order, set: set_of_pages.to_json
+            alchemy_xhr :post, :order, set: set_of_pages.to_json
             [page_1, page_2, page_3].map(&:reload)
             expect(page_1.urlname).to eq("#{page_1.slug}")
             expect(page_2.urlname).to eq("#{page_1.slug}/#{page_2.slug}")
@@ -154,7 +154,7 @@ module Alchemy
             end
 
             it "does not use this pages slug in urlnames of descendants" do
-              xhr :post, :order, set: set_of_pages.to_json
+              alchemy_xhr :post, :order, set: set_of_pages.to_json
               [page_1, page_2, page_3].map(&:reload)
               expect(page_1.urlname).to eq("#{page_1.slug}")
               expect(page_2.urlname).to eq("#{page_1.slug}/#{page_2.slug}")
@@ -173,7 +173,7 @@ module Alchemy
             end
 
             it "does not use this pages slug in urlnames of descendants" do
-              xhr :post, :order, set: set_of_pages.to_json
+              alchemy_xhr :post, :order, set: set_of_pages.to_json
               [page_1, page_2, page_3].map(&:reload)
               expect(page_3.urlname).to eq("#{page_1.slug}/#{page_3.slug}")
             end
@@ -191,7 +191,7 @@ module Alchemy
             end
 
             it "updates restricted status of descendants" do
-              xhr :post, :order, set: set_of_pages.to_json
+              alchemy_xhr :post, :order, set: set_of_pages.to_json
               page_3.reload
               expect(page_3.restricted).to be_truthy
             end
@@ -208,19 +208,19 @@ module Alchemy
 
             it "does not raise error" do
               expect {
-                xhr :post, :order, set: set_of_pages.to_json
+                alchemy_xhr :post, :order, set: set_of_pages.to_json
               }.not_to raise_error
             end
 
             it "still generates the correct urlname on page_3" do
-              xhr :post, :order, set: set_of_pages.to_json
+              alchemy_xhr :post, :order, set: set_of_pages.to_json
               [page_1, page_2, page_3].map(&:reload)
               expect(page_3.urlname).to eq("#{page_1.slug}/#{page_2.slug}/#{page_3.slug}")
             end
           end
 
           it "creates legacy urls" do
-            xhr :post, :order, set: set_of_pages.to_json
+            alchemy_xhr :post, :order, set: set_of_pages.to_json
             [page_2, page_3].map(&:reload)
             expect(page_2.legacy_urls.size).to eq(1)
             expect(page_3.legacy_urls.size).to eq(1)
@@ -232,10 +232,10 @@ module Alchemy
         render_views
 
         context "with page having nested urlname" do
-          let(:page) { create(:page, name: 'Foobar') }
+          let(:page) { create(:page, name: 'Foobar', urlname: 'foobar') }
 
           it "should always show the slug" do
-            xhr :get, :configure, {id: page.id}
+            alchemy_xhr :get, :configure, {id: page.id}
             expect(response.body).to match /value="foobar"/
           end
         end
@@ -254,21 +254,21 @@ module Alchemy
 
           it "is nested under given parent" do
             allow(controller).to receive(:edit_admin_page_path).and_return('bla')
-            xhr :post, :create, {page: page_params}
+            alchemy_xhr :post, :create, {page: page_params}
             expect(assigns(:page).parent_id).to eq(parent.id)
           end
 
           it "redirects to edit page template" do
             page = mock_model('Page')
             expect(controller).to receive(:edit_admin_page_path).and_return('bla')
-            post :create, page: page_params
+            alchemy_post :create, page: page_params
             expect(response).to redirect_to('bla')
           end
 
           context "if new page can not be saved" do
             it "renders the create form" do
               allow_any_instance_of(Page).to receive(:save).and_return(false)
-              post :create, page: {name: 'page'}
+              alchemy_post :create, page: {name: 'page'}
               expect(response).to render_template('new')
             end
           end
@@ -279,7 +279,7 @@ module Alchemy
             end
 
             it "should redirect to given url" do
-              post :create, page: page_params, redirect_to: admin_pictures_path
+              alchemy_post :create, page: page_params, redirect_to: admin_pictures_path
               expect(response).to redirect_to(admin_pictures_path)
             end
 
@@ -288,7 +288,7 @@ module Alchemy
 
               it "should render the `new` template" do
                 allow_any_instance_of(Page).to receive(:save).and_return(false)
-                xhr :post, :create, page: {name: 'page'}, redirect_to: admin_pictures_path
+                alchemy_xhr :post, :create, page: {name: 'page'}, redirect_to: admin_pictures_path
                 expect(response.body).to match /form.+action=\"\/admin\/pages\"/
               end
             end
@@ -297,7 +297,7 @@ module Alchemy
           context 'with page redirecting to external' do
             it "redirects to sitemap" do
               expect_any_instance_of(Page).to receive(:redirects_to_external?).and_return(true)
-              post :create, page: page_params
+              alchemy_post :create, page: page_params
               expect(response).to redirect_to(admin_pages_path)
             end
           end
@@ -319,7 +319,7 @@ module Alchemy
             ).and_return(
               mock_model('Page', save: true, name: 'pasted Page', redirects_to_external?: false)
             )
-            xhr :post, :create, {paste_from_clipboard: page_in_clipboard.id, page: {parent_id: parent.id, name: 'pasted Page'}}
+            alchemy_xhr :post, :create, {paste_from_clipboard: page_in_clipboard.id, page: {parent_id: parent.id, name: 'pasted Page'}}
           end
         end
       end
@@ -342,25 +342,25 @@ module Alchemy
 
         it "should copy the language root page over to the other language" do
           expect(Page).to receive(:copy).with(language_root_to_copy_from, {language_id: '2', language_code: 'it'})
-          post :copy_language_tree, params
+          alchemy_post :copy_language_tree, params
         end
 
         it "should move the newly created language-root-page below the absolute root page" do
           expect(copy_of_language_root).to receive(:move_to_child_of).with(root_page)
-          post :copy_language_tree, params
+          alchemy_post :copy_language_tree, params
         end
 
         it "should copy all childs of the original page over to the new created one" do
           expect(controller).to receive(:language_root_to_copy_from).and_return(language_root_to_copy_from)
           expect(controller).to receive(:copy_of_language_root).and_return(copy_of_language_root)
           expect(language_root_to_copy_from).to receive(:copy_children_to).with(copy_of_language_root)
-          post :copy_language_tree, params
+          alchemy_post :copy_language_tree, params
         end
 
         it "should redirect to admin_pages_path" do
           allow(controller).to receive(:copy_of_language_root)
           allow(controller).to receive(:language_root_to_copy_from).and_return(double(copy_children_to: nil))
-          post :copy_language_tree, params
+          alchemy_post :copy_language_tree, params
           expect(response).to redirect_to(admin_pages_path)
         end
       end
@@ -378,7 +378,7 @@ module Alchemy
             end
 
             it 'redirects to sitemap' do
-              get :edit, id: page.id
+              alchemy_get :edit, id: page.id
               expect(response).to redirect_to(admin_pages_path)
             end
           end
@@ -389,7 +389,7 @@ module Alchemy
             end
 
             it 'renders the edit view' do
-              get :edit, id: page.id
+              alchemy_get :edit, id: page.id
               expect(response).to render_template(:edit)
             end
           end
@@ -402,7 +402,7 @@ module Alchemy
           end
 
           it 'renders the edit view' do
-            get :edit, id: page.id
+            alchemy_get :edit, id: page.id
             expect(response).to render_template(:edit)
           end
         end
@@ -413,13 +413,13 @@ module Alchemy
           end
 
           it 'renders the edit view' do
-            get :edit, id: page.id
+            alchemy_get :edit, id: page.id
             expect(response).to render_template(:edit)
           end
 
           it "lockes the page to myself" do
             expect_any_instance_of(Page).to receive(:lock_to!)
-            get :edit, id: page.id
+            alchemy_get :edit, id: page.id
           end
         end
       end
@@ -431,7 +431,7 @@ module Alchemy
         before { clipboard['pages'] = [{'id' => page.id.to_s}] }
 
         it "should also remove the page from clipboard" do
-          xhr :post, :destroy, {id: page.id, _method: :delete}
+          alchemy_xhr :post, :destroy, {id: page.id, _method: :delete}
           expect(clipboard['pages']).to be_empty
         end
       end
@@ -446,7 +446,7 @@ module Alchemy
 
         it "should publish the page" do
           expect(page).to receive(:publish!)
-          post :publish, { id: page.id }
+          alchemy_post :publish, { id: page.id }
         end
       end
 
@@ -460,7 +460,7 @@ module Alchemy
         end
 
         it "should redirect to the page path" do
-          expect(post :visit, id: page.id).to redirect_to(show_page_path(urlname: 'home'))
+          expect(alchemy_post :visit, id: page.id).to redirect_to(show_page_path(urlname: 'home'))
         end
       end
 
@@ -473,7 +473,7 @@ module Alchemy
 
           it "should fold the page" do
             expect(page).to receive(:fold!).with(user.id, true).and_return(true)
-            xhr :post, :fold, id: page.id
+            alchemy_xhr :post, :fold, id: page.id
           end
         end
 
@@ -482,7 +482,7 @@ module Alchemy
 
           it "should unfold the page" do
             expect(page).to receive(:fold!).with(user.id, false).and_return(true)
-            xhr :post, :fold, id: page.id
+            alchemy_xhr :post, :fold, id: page.id
           end
         end
       end
@@ -491,7 +491,7 @@ module Alchemy
         before { allow(Page).to receive(:language_root_for).and_return(mock_model(Alchemy::Page)) }
 
         it "should assign @sorting with true" do
-          xhr :get, :sort
+          alchemy_xhr :get, :sort
           expect(assigns(:sorting)).to eq(true)
         end
       end
@@ -506,17 +506,17 @@ module Alchemy
         end
 
         it "should unlock the page" do
-          xhr :post, :unlock, id: "#{page.id}"
+          alchemy_xhr :post, :unlock, id: "#{page.id}"
         end
 
         context 'requesting for html format' do
           it "should redirect to admin_pages_path" do
-            expect(post :unlock, id: page.id).to redirect_to(admin_pages_path)
+            expect(alchemy_post :unlock, id: page.id).to redirect_to(admin_pages_path)
           end
 
           context 'if passing :redirect_to through params' do
             it "should redirect to the given path" do
-              expect(post :unlock, id: page.id, redirect_to: 'this/path').to redirect_to('this/path')
+              expect(alchemy_post :unlock, id: page.id, redirect_to: 'this/path').to redirect_to('this/path')
             end
           end
         end
@@ -530,12 +530,12 @@ module Alchemy
         end
 
         it "should store the current language in session" do
-          get :switch_language, {language_id: language.id}
+          alchemy_get :switch_language, {language_id: language.id}
           expect(session[:alchemy_language_id]).to eq(language.id)
         end
 
         it "should redirect to sitemap" do
-          expect(get :switch_language, {language_id: language.id}).to redirect_to(admin_pages_path)
+          expect(alchemy_get :switch_language, {language_id: language.id}).to redirect_to(admin_pages_path)
         end
 
         context "coming from layoutpages" do
@@ -544,7 +544,7 @@ module Alchemy
           }
 
           it "should redirect to layoutpages" do
-            expect(get :switch_language, {language_id: language.id}).to redirect_to(admin_layoutpages_path)
+            expect(alchemy_get :switch_language, {language_id: language.id}).to redirect_to(admin_layoutpages_path)
           end
         end
       end

--- a/spec/controllers/admin/pictures_controller_spec.rb
+++ b/spec/controllers/admin/pictures_controller_spec.rb
@@ -10,20 +10,20 @@ module Alchemy
     describe "#index" do
       it "should always paginate the records" do
         expect(Picture).to receive(:find_paginated)
-        get :index
+        alchemy_get :index
       end
 
       context "when params[:filter] is set" do
         it "should filter the pictures collection by the given filter string." do
           expect(Picture).to receive(:filtered_by).with('recent').and_return(Picture.all)
-          get :index, filter: 'recent'
+          alchemy_get :index, filter: 'recent'
         end
       end
 
       context "when params[:tagged_with] is set" do
         it "should filter the records by tags" do
           expect(Picture).to receive(:tagged_with).and_return(Picture.all)
-          get :index, tagged_with: "red"
+          alchemy_get :index, tagged_with: "red"
         end
       end
 
@@ -34,19 +34,19 @@ module Alchemy
           end
 
           it "for html requests it renders the archive_overlay partial" do
-            get :index, {element_id: 1}
+            alchemy_get :index, {element_id: 1}
             expect(response).to render_template(partial: '_archive_overlay')
           end
 
           it "for ajax requests it renders the archive_overlay template" do
-            xhr :get, :index, {element_id: 1}
+            alchemy_xhr :get, :index, {element_id: 1}
             expect(response).to render_template(:archive_overlay)
           end
         end
 
         context "is not set" do
           it "should render the default index view" do
-            get :index
+            alchemy_get :index
             expect(response).to render_template(:index)
           end
         end
@@ -54,7 +54,7 @@ module Alchemy
     end
 
     describe '#new' do
-      subject { get :new, params }
+      subject { alchemy_get :new, params }
 
       let(:params) { Hash.new }
 
@@ -93,7 +93,7 @@ module Alchemy
     end
 
     describe '#create' do
-      subject { post :create, params }
+      subject { alchemy_post :create, params }
 
       let(:params)  { {picture: {name: ''}} }
       let(:picture) { mock_model('Picture', humanized_name: 'Cute kittens', to_jq_upload: {}) }
@@ -166,20 +166,20 @@ module Alchemy
       before { expect(Picture).to receive(:where).and_return(pictures) }
 
       it 'assigns pictures instance variable' do
-        get :edit_multiple
+        alchemy_get :edit_multiple
         expect(assigns(:pictures)).to eq(pictures)
       end
 
       it 'assigns tags instance variable' do
-        get :edit_multiple
+        alchemy_get :edit_multiple
         expect(assigns(:tags)).to include('kitten')
       end
     end
 
     describe '#update' do
-      subject { put :update, picture: {name: ''} }
+      subject { alchemy_put :update, {id: 1, picture: {name: ''}} }
 
-      let(:picture) { mock_model('Picture', name: 'Cute kitten') }
+      let(:picture) { build_stubbed(:picture, name: 'Cute kitten') }
 
       before do
         expect(Picture).to receive(:find).and_return(picture)
@@ -226,13 +226,13 @@ module Alchemy
       end
 
       it "loads and assigns pictures" do
-        post :update_multiple
+        alchemy_post :update_multiple
         expect(assigns(:pictures)).to eq(pictures)
       end
     end
 
     describe "#delete_multiple" do
-      subject { delete :delete_multiple, picture_ids: picture_ids }
+      subject { alchemy_delete :delete_multiple, picture_ids: picture_ids }
 
       let(:deletable_picture)     { mock_model('Picture', name: 'pic of the pig', deletable?: true) }
       let(:not_deletable_picture) { mock_model('Picture', name: 'pic of the chick', deletable?: false) }
@@ -295,7 +295,7 @@ module Alchemy
     end
 
     describe '#destroy' do
-      let(:picture) { mock_model('Picture', name: 'Cute kitten') }
+      let(:picture) { build_stubbed(:picture, name: 'Cute kitten') }
 
       before do
         expect(Picture).to receive(:find).and_return(picture)
@@ -303,7 +303,7 @@ module Alchemy
 
       it "destroys the picture and sets and success message" do
         expect(picture).to receive(:destroy)
-        delete :destroy
+        alchemy_delete :destroy, id: picture.id
         expect(assigns(:picture)).to eq(picture)
         expect(flash[:notice]).not_to be_blank
       end
@@ -314,12 +314,12 @@ module Alchemy
         end
 
         it "shows error notice" do
-          delete :destroy
+          alchemy_delete :destroy, id: picture.id
           expect(flash[:error]).not_to be_blank
         end
 
         it "redirects to index" do
-          delete :destroy
+          alchemy_delete :destroy, id: picture.id
           expect(response).to redirect_to admin_pictures_path
         end
       end
@@ -328,7 +328,7 @@ module Alchemy
     describe '#flush' do
       it "removes the complete pictures cache" do
         expect(FileUtils).to receive(:rm_rf).with(Rails.root.join('public', '', 'pictures'))
-        xhr :post, :flush
+        alchemy_xhr :post, :flush
       end
     end
 

--- a/spec/controllers/admin/resources_controller_spec.rb
+++ b/spec/controllers/admin/resources_controller_spec.rb
@@ -1,9 +1,9 @@
 require "spec_helper"
 
-class EventsController < Alchemy::Admin::ResourcesController
+class Admin::EventsController < Alchemy::Admin::ResourcesController
 end
 
-describe EventsController do
+describe Admin::EventsController do
   it "should include ResourcesHelper" do
     expect(controller.respond_to?(:resource_window_size)).to be_truthy
   end

--- a/spec/controllers/admin/trash_controller_spec.rb
+++ b/spec/controllers/admin/trash_controller_spec.rb
@@ -14,13 +14,13 @@ module Alchemy
       }
 
       it "should hold trashed elements" do
-        get :index, :page_id => alchemy_page.id
+        alchemy_get :index, :page_id => alchemy_page.id
         expect(response.body).to have_selector("#element_#{element.id}.element_editor")
       end
 
       it "should not hold elements that are not trashed" do
         element = FactoryGirl.create(:element, :page => alchemy_page, :public => false)
-        get :index, :page_id => alchemy_page.id
+        alchemy_get :index, :page_id => alchemy_page.id
         expect(response.body).not_to have_selector("#element_#{element.id}.element_editor")
       end
 
@@ -34,7 +34,7 @@ module Alchemy
           end
 
           it "unique elements should be draggable" do
-            get :index, page_id: alchemy_page.id
+            alchemy_get :index, page_id: alchemy_page.id
             expect(response.body).to have_selector("#element_#{trashed.id}.element_editor.draggable")
           end
         end
@@ -49,7 +49,7 @@ module Alchemy
           end
 
           it "unique elements should not be draggable" do
-            get :index, page_id: page.id
+            alchemy_get :index, page_id: page.id
             expect(response.body).to have_selector("#element_#{trashed.id}.element_editor.not-draggable")
           end
         end
@@ -58,7 +58,7 @@ module Alchemy
       describe "#clear" do
         it "should destroy all containing elements" do
           expect(Element.trashed).not_to be_empty
-          xhr :post, :clear, page_id: alchemy_page.id
+          alchemy_xhr :post, :clear, page_id: alchemy_page.id
           expect(Element.trashed).to be_empty
         end
       end

--- a/spec/controllers/alchemy/admin/tags_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/tags_controller_spec.rb
@@ -10,7 +10,7 @@ module Alchemy
           render_views
 
           it "does not create tag" do
-            post :create, tag: {name: ''}
+            alchemy_post :create, tag: {name: ''}
             expect(response.body).to have_content("can't be blank")
           end
         end
@@ -18,7 +18,7 @@ module Alchemy
         context 'with required params' do
           it "creates tag and redirects to tags view" do
             expect {
-              post :create, tag: {name: 'Foo'}
+              alchemy_post :create, tag: {name: 'Foo'}
             }.to change { ActsAsTaggableOn::Tag.count }.by(1)
             expect(response).to redirect_to admin_tags_path
           end
@@ -32,7 +32,7 @@ module Alchemy
         before { another_tag; tag }
 
         it "loads alls tags but not the one editing" do
-          get :edit, id: tag.id
+          alchemy_get :edit, id: tag.id
           expect(assigns(:tags)).to include(another_tag)
           expect(assigns(:tags)).not_to include(tag)
         end
@@ -42,7 +42,7 @@ module Alchemy
         let(:tag) { ActsAsTaggableOn::Tag.create(name: 'Sputz') }
 
         it "changes tags name" do
-          put :update, id: tag.id, tag: {name: 'Foo'}
+          alchemy_put :update, id: tag.id, tag: {name: 'Foo'}
           expect(response).to redirect_to(admin_tags_path)
           expect(tag.reload.name).to eq('Foo')
         end
@@ -53,7 +53,7 @@ module Alchemy
           it "replaces tag with other tag" do
             expect(Alchemy::Tag).to receive(:replace)
             expect_any_instance_of(ActsAsTaggableOn::Tag).to receive(:destroy)
-            put :update, id: tag.id, tag: {merge_to: another_tag.id}
+            alchemy_put :update, id: tag.id, tag: {merge_to: another_tag.id}
             expect(response).to redirect_to(admin_tags_path)
           end
         end

--- a/spec/controllers/alchemy/api/contents_controller_spec.rb
+++ b/spec/controllers/alchemy/api/contents_controller_spec.rb
@@ -8,7 +8,7 @@ module Alchemy
       let!(:content) { create(:content, element: element) }
 
       it "returns all public contents as json objects" do
-        get :index, format: :json
+        alchemy_get :index, format: :json
         expect(response.status).to eq(200)
         expect(response.content_type).to eq('application/json')
         expect(response.body).to_not eq('{"contents":[]}')
@@ -19,7 +19,7 @@ module Alchemy
         let!(:other_content) { create(:content, element: other_element) }
 
         it "returns only contents from this element" do
-          get :index, element_id: element.id, format: :json
+          alchemy_get :index, element_id: element.id, format: :json
           expect(response.status).to eq(200)
           expect(response.content_type).to eq('application/json')
           expect(response.body).to_not eq('{"contents":[]}')
@@ -39,7 +39,7 @@ module Alchemy
         end
 
         it "responds to json" do
-          get :show, id: content.id, format: :json
+          alchemy_get :show, id: content.id, format: :json
           expect(response.status).to eq(200)
           expect(response.content_type).to eq('application/json')
         end
@@ -48,7 +48,7 @@ module Alchemy
           let(:page) { create(:page, restricted: true) }
 
           it "responds with 403" do
-            get :show, id: content.id, format: :json
+            alchemy_get :show, id: content.id, format: :json
             expect(response.content_type).to eq('application/json')
             expect(response.status).to eq(403)
           end
@@ -61,7 +61,7 @@ module Alchemy
         let!(:content) { create(:content, element: element) }
 
         it 'returns the named content from element with given id.' do
-          get :show, element_id: element.id, name: content.name, format: :json
+          alchemy_get :show, element_id: element.id, name: content.name, format: :json
           expect(response.status).to eq(200)
           expect(response.content_type).to eq('application/json')
           expect(response.body).to match(/element_id\"\:#{element.id}/)

--- a/spec/controllers/alchemy/api/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/api/elements_controller_spec.rb
@@ -7,7 +7,7 @@ module Alchemy
       let!(:element) { create(:element, page: page) }
 
       it "returns all public elements as json objects" do
-        get :index, format: :json
+        alchemy_get :index, format: :json
         expect(response.status).to eq(200)
         expect(response.content_type).to eq('application/json')
         expect(response.body).to_not eq('{"elements":[]}')
@@ -18,7 +18,7 @@ module Alchemy
         let!(:other_element) { create(:element, page: other_page) }
 
         it "returns only elements from this element" do
-          get :index, page_id: other_page.id, format: :json
+          alchemy_get :index, page_id: other_page.id, format: :json
           expect(response.status).to eq(200)
           expect(response.content_type).to eq('application/json')
           expect(response.body).to_not eq('{"elements":[]}')
@@ -31,7 +31,7 @@ module Alchemy
         let!(:other_element) { create(:element, page: page, name: 'news') }
 
         it "returns only elements named like this." do
-          get :index, named: 'news', format: :json
+          alchemy_get :index, named: 'news', format: :json
           expect(response.status).to eq(200)
           expect(response.content_type).to eq('application/json')
           expect(response.body).to_not eq('{"elements":[]}')
@@ -50,7 +50,7 @@ module Alchemy
       end
 
       it "responds to json" do
-        get :show, id: element.id, format: :json
+        alchemy_get :show, id: element.id, format: :json
         expect(response.status).to eq(200)
         expect(response.content_type).to eq('application/json')
       end
@@ -59,7 +59,7 @@ module Alchemy
         let(:page) { build_stubbed(:page, restricted: true) }
 
         it "responds with 403" do
-          get :show, id: element.id, format: :json
+          alchemy_get :show, id: element.id, format: :json
           expect(response.content_type).to eq('application/json')
           expect(response.status).to eq(403)
         end

--- a/spec/controllers/alchemy/api/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/api/pages_controller_spec.rb
@@ -7,7 +7,7 @@ module Alchemy
       let!(:page)    { create(:public_page) }
 
       it "returns all public pages as json objects" do
-        get :index, format: :json
+        alchemy_get :index, format: :json
         expect(response.status).to eq(200)
         expect(response.content_type).to eq('application/json')
         expect(response.body).to_not eq('{"pages":[]}')
@@ -17,7 +17,7 @@ module Alchemy
         let!(:other_page) { create(:public_page, page_layout: 'news') }
 
         it "returns only pages from this element" do
-          get :index, page_layout: 'news', format: :json
+          alchemy_get :index, {page_layout: 'news', format: :json}
           expect(response.status).to eq(200)
           expect(response.content_type).to eq('application/json')
           expect(response.body).to_not eq('{"pages":[]}')
@@ -28,23 +28,23 @@ module Alchemy
 
     describe '#show' do
       context 'for existing page' do
-        let(:page) { build_stubbed(:public_page) }
+        let(:page) { build_stubbed(:public_page, urlname: 'a-page') }
 
         before do
           expect(Page).to receive(:find_by).and_return(page)
         end
 
         it "responds to json" do
-          get :show, urlname: page.urlname, format: :json
+          alchemy_get :show, {urlname: page.urlname, format: :json}
           expect(response.status).to eq(200)
           expect(response.content_type).to eq('application/json')
         end
 
         context 'requesting an restricted page' do
-          let(:page) { build_stubbed(:page, restricted: true) }
+          let(:page) { build_stubbed(:page, restricted: true, urlname: 'a-page') }
 
           it "responds with 403" do
-            get :show, urlname: page.urlname, format: :json
+            alchemy_get :show, {urlname: page.urlname, format: :json}
             expect(response.content_type).to eq('application/json')
             expect(response.status).to eq(403)
             expect(response.body).to eq('{"error":"Not authorized"}')
@@ -52,10 +52,10 @@ module Alchemy
         end
 
         context 'requesting a not public page' do
-          let(:page) { build_stubbed(:page) }
+          let(:page) { build_stubbed(:page, urlname: 'a-page') }
 
           it "responds with 403" do
-            get :show, urlname: page.urlname, format: :json
+            alchemy_get :show, {urlname: page.urlname, format: :json}
             expect(response.content_type).to eq('application/json')
             expect(response.status).to eq(403)
             expect(response.body).to eq('{"error":"Not authorized"}')
@@ -65,7 +65,7 @@ module Alchemy
 
       context 'requesting an unknown page' do
         it "responds with 404" do
-          get :show, urlname: 'not-existing', format: :json
+          alchemy_get :show, {urlname: 'not-existing', format: :json}
           expect(response.content_type).to eq('application/json')
           expect(response.status).to eq(404)
           expect(response.body).to eq('{"error":"Record not found"}')
@@ -76,7 +76,7 @@ module Alchemy
         let(:page) { create(:public_page) }
 
         it "responds with json" do
-          get :show, id: page.id, format: :json
+          alchemy_get :show, {id: page.id, format: :json}
           expect(response.status).to eq(200)
           expect(response.content_type).to eq('application/json')
         end

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -5,7 +5,7 @@ module Alchemy
     let(:attachment) { build_stubbed(:attachment) }
 
     it "should raise ActiveRecord::RecordNotFound for requesting not existing attachments" do
-      expect { get :download, id: 0 }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { alchemy_get :download, id: 0 }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     context 'with public attachment' do
@@ -14,13 +14,13 @@ module Alchemy
       end
 
       it "sends download as attachment." do
-        get :download, :id => attachment.id
+        alchemy_get :download, :id => attachment.id
         expect(response.status).to eq(200)
         expect(response.headers['Content-Disposition']).to match(/attachment/)
       end
 
       it "sends download inline." do
-        get :show, :id => attachment.id
+        alchemy_get :show, :id => attachment.id
         expect(response.status).to eq(200)
         expect(response.headers['Content-Disposition']).to match(/inline/)
       end
@@ -34,13 +34,13 @@ module Alchemy
 
       context 'as anonymous user' do
         it "should not be possible to download attachments from restricted pages" do
-          get :download, :id => attachment.id
+          alchemy_get :download, :id => attachment.id
           expect(response.status).to eq(302)
           expect(response).to redirect_to(Alchemy.login_path)
         end
 
         it "should not be possible to see attachments from restricted pages" do
-          get :show, :id => attachment.id
+          alchemy_get :show, :id => attachment.id
           expect(response.status).to eq(302)
           expect(response).to redirect_to(Alchemy.login_path)
         end
@@ -50,12 +50,12 @@ module Alchemy
         before { sign_in(member_user) }
 
         it "should be possible to download attachments from restricted pages" do
-          get :download, :id => attachment.id
+          alchemy_get :download, :id => attachment.id
           expect(response.status).to eq(200)
         end
 
         it "should be possible to see attachments from restricted pages" do
-          get :show, :id => attachment.id
+          alchemy_get :show, :id => attachment.id
           expect(response.status).to eq(200)
         end
       end

--- a/spec/controllers/elements_controller_spec.rb
+++ b/spec/controllers/elements_controller_spec.rb
@@ -2,30 +2,36 @@ require 'spec_helper'
 
 module Alchemy
   describe ElementsController do
-    let(:public_page)         { FactoryGirl.create(:public_page) }
-    let(:element)             { FactoryGirl.create(:element, :page => public_page, :name => 'download') }
-    let(:restricted_page)     { FactoryGirl.create(:public_page, :restricted => true) }
-    let(:restricted_element)  { FactoryGirl.create(:element, :page => restricted_page, :name => 'download') }
+    let(:public_page)         { create(:public_page) }
+    let(:element)             { create(:element, page: public_page, name: 'download') }
+    let(:restricted_page)     { create(:public_page, restricted: true) }
+    let(:restricted_element)  { create(:element, page: restricted_page, name: 'download') }
 
     describe '#show' do
       it "should render available elements" do
-        get :show, :id => element.id
+        alchemy_get :show, id: element.id
         expect(response.status).to eq(200)
       end
 
       it "should raise ActiveRecord::RecordNotFound error for trashed elements" do
         element.trash!
-        expect { get(:show, :id => element.id) }.to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          alchemy_get :show, id: element.id
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it "should raise ActiveRecord::RecordNotFound error for unpublished elements" do
-        element.update_attributes(:public => false)
-        expect { get(:show, :id => element.id) }.to raise_error(ActiveRecord::RecordNotFound)
+        element.update_attributes(public: false)
+        expect {
+          alchemy_get :show, id: element.id
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       context "for guest user" do
         it "should raise ActiveRecord::RecordNotFound error for elements of restricted pages" do
-          expect { get(:show, :id => restricted_element.id) }.to raise_error(ActiveRecord::RecordNotFound)
+          expect {
+            alchemy_get :show, id: restricted_element.id
+          }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
 
@@ -33,7 +39,7 @@ module Alchemy
         before { sign_in(member_user) }
 
         it "should render elements of restricted pages" do
-          get :show, :id => restricted_element.id
+          alchemy_get :show, id: restricted_element.id
           expect(response.status).to eq(200)
         end
       end

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -13,14 +13,14 @@ module Alchemy
       let(:page) { mock_model('Page', {urlname: 'contact', page_layout: 'contact'}) }
 
       it "should redirect to @page" do
-        expect(get :index).to redirect_to(show_page_path(urlname: page.urlname))
+        expect(alchemy_get :index).to redirect_to(show_page_path(urlname: page.urlname))
       end
     end
 
     describe "#new" do
       it "should render the alchemy/pages/show template" do
-        get :new
-        expect(get :new).to render_template('alchemy/pages/show')
+        alchemy_get :new
+        expect(alchemy_get :new).to render_template('alchemy/pages/show')
       end
     end
 
@@ -34,7 +34,7 @@ module Alchemy
       let(:message) { Message.new }
 
       it "should raise ActiveRecord::RecordNotFound if element of contactform could not be found" do
-        expect { post :create }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { alchemy_post :create }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       context "if validation of message" do
@@ -51,7 +51,7 @@ module Alchemy
           end
 
           it "should render 'alchemy/pages/show' template" do
-            expect(post :create).to render_template('alchemy/pages/show')
+            expect(alchemy_post :create).to render_template('alchemy/pages/show')
           end
         end
 
@@ -63,7 +63,7 @@ module Alchemy
 
           it "Messages should call Messages#contact_form_mail to send the email" do
             expect(Messages).to receive(:contact_form_mail)
-            post :create
+            alchemy_post :create
           end
 
           describe '#mail_to' do
@@ -76,7 +76,7 @@ module Alchemy
 
               it "returns the ingredient" do
                 expect(Messages).to receive(:contact_form_mail).with(message, 'peter@schroeder.de', '', '')
-                post :create
+                alchemy_post :create
               end
             end
 
@@ -89,7 +89,7 @@ module Alchemy
 
               it "returns the config value" do
                 expect(Messages).to receive(:contact_form_mail).with(message, 'your.mail@your-domain.com', '', '')
-                post :create
+                alchemy_post :create
               end
             end
           end
@@ -104,7 +104,7 @@ module Alchemy
 
               it "returns the ingredient" do
                 expect(Messages).to receive(:contact_form_mail).with(message, '', 'peter@schroeder.de', '')
-                post :create
+                alchemy_post :create
               end
             end
 
@@ -117,7 +117,7 @@ module Alchemy
 
               it "returns the config value" do
                 expect(Messages).to receive(:contact_form_mail).with(message, '', 'your.mail@your-domain.com', '')
-                post :create
+                alchemy_post :create
               end
             end
           end
@@ -132,7 +132,7 @@ module Alchemy
 
               it "returns the ingredient" do
                 expect(Messages).to receive(:contact_form_mail).with(message, '', '', 'A new message')
-                post :create
+                alchemy_post :create
               end
             end
 
@@ -145,7 +145,7 @@ module Alchemy
 
               it "returns the config value" do
                 expect(Messages).to receive(:contact_form_mail).with(message, '', '', 'A new contact form message')
-                post :create
+                alchemy_post :create
               end
             end
           end
@@ -157,7 +157,7 @@ module Alchemy
               end
 
               it "should redirect to the given urlname" do
-                expect(post :create).to redirect_to(show_page_path(urlname: 'success-page'))
+                expect(alchemy_post :create).to redirect_to(show_page_path(urlname: 'success-page'))
               end
             end
 
@@ -173,7 +173,7 @@ module Alchemy
                 end
 
                 it "redirect to the given success page" do
-                  expect(post :create).to redirect_to(show_page_path(urlname: 'mailer-config-success-page'))
+                  expect(alchemy_post :create).to redirect_to(show_page_path(urlname: 'mailer-config-success-page'))
                 end
               end
 
@@ -187,7 +187,7 @@ module Alchemy
 
                 it "should redirect to the language root page" do
                   expect(Language).to receive(:current).and_return(language)
-                  expect(post :create).to redirect_to(show_page_path(urlname: 'lang-root'))
+                  expect(alchemy_post :create).to redirect_to(show_page_path(urlname: 'lang-root'))
                 end
               end
             end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -15,7 +15,7 @@ module Alchemy
       before { allow(controller).to receive(:current_alchemy_user).and_return(author_user) }
 
       it "should not be able to visit a unpublic page" do
-        get :show, urlname: unpublic.urlname
+        alchemy_get :show, urlname: unpublic.urlname
         expect(response.status).to eq(404)
       end
     end
@@ -24,20 +24,20 @@ module Alchemy
       render_views
 
       it "should render a rss feed" do
-        get :show, urlname: page.urlname, format: :rss
+        alchemy_get :show, urlname: page.urlname, format: :rss
         expect(response.content_type).to eq('application/rss+xml')
       end
 
       it "should include content" do
         page.elements.first.content_by_name('news_headline').essence.update_attributes({body: 'Peters Petshop'})
-        get :show, urlname: 'news', format: :rss
+        alchemy_get :show, urlname: 'news', format: :rss
         expect(response.body).to match /Peters Petshop/
       end
     end
 
     context "requested for a page that does not contain a feed" do
       it "should render xml 404 error" do
-        get :show, urlname: default_language_root.urlname, format: :rss
+        alchemy_get :show, urlname: default_language_root.urlname, format: :rss
         expect(response.status).to eq(404)
       end
     end
@@ -45,7 +45,7 @@ module Alchemy
     describe "Layout rendering" do
       context "with ajax request" do
         it "should not render a layout" do
-          xhr :get, :show, urlname: page.urlname
+          alchemy_xhr :get, :show, urlname: page.urlname
           expect(response).to render_template(:show)
           expect(response).not_to render_template(layout: 'application')
         end
@@ -67,7 +67,7 @@ module Alchemy
 
       context "with correct levelnames in params" do
         it "should show the requested page" do
-          get :show, {urlname: 'catalog/products/screwdriver'}
+          alchemy_get :show, {urlname: 'catalog/products/screwdriver'}
           expect(response.status).to eq(200)
           expect(response.body).to have_content("screwdriver")
         end
@@ -75,7 +75,7 @@ module Alchemy
 
       context "with incorrect levelnames in params" do
         it "should render a 404 page" do
-          get :show, {urlname: 'catalog/faqs/screwdriver'}
+          alchemy_get :show, {urlname: 'catalog/faqs/screwdriver'}
           expect(response.status).to eq(404)
           expect(response.body).to have_content('The page you were looking for doesn\'t exist')
         end
@@ -84,7 +84,7 @@ module Alchemy
 
     context "when a non-existent page is requested" do
       it "should rescue a RoutingError with rendering a 404 page." do
-        get :show, {urlname: 'doesntexist'}
+        alchemy_get :show, {urlname: 'doesntexist'}
         expect(response.status).to eq(404)
         expect(response.body).to have_content('The page you were looking for doesn\'t exist')
       end
@@ -139,38 +139,38 @@ module Alchemy
 
         it "should redirect permanently to page that belongs to legacy page url even if url has an unknown format & get parameters" do
           expect(request).to receive(:fullpath).at_least(:once).and_return(legacy_url4.urlname)
-          get :show, urlname: "index.php"
+          alchemy_get :show, urlname: "index.php"
           expect(response.status).to eq(301)
           expect(response).to redirect_to("/#{second_page.urlname}")
         end
 
         it "should not pass query string for legacy routes" do
           expect(request).to receive(:fullpath).at_least(:once).and_return(legacy_url3.urlname)
-          get :show, urlname: "index.php"
+          alchemy_get :show, urlname: "index.php"
           expect(URI.parse(response["Location"]).query).to be_nil
         end
 
         it "should only redirect to legacy url if no page was found for urlname" do
-          get :show, urlname: legacy_page.urlname
+          alchemy_get :show, urlname: legacy_page.urlname
           expect(response.status).to eq(200)
           expect(response).not_to redirect_to("/#{page.urlname}")
         end
 
         it "should redirect to last page that has that legacy url" do
           expect(request).to receive(:fullpath).at_least(:once).and_return(legacy_url2.urlname)
-          get :show, urlname: legacy_url2.urlname
+          alchemy_get :show, urlname: legacy_url2.urlname
           expect(response).to redirect_to("/#{second_page.urlname}")
         end
 
         it "should redirect even if the url has get parameters" do
           expect(request).to receive(:fullpath).at_least(:once).and_return(legacy_url3.urlname)
-          get :show, urlname: legacy_url3.urlname
+          alchemy_get :show, urlname: legacy_url3.urlname
           expect(response).to redirect_to("/#{second_page.urlname}")
         end
 
         it "should redirect even if the url has nested urlname" do
           expect(request).to receive(:fullpath).at_least(:once).and_return(legacy_url5.urlname)
-          get :show, urlname: legacy_url5.urlname
+          alchemy_get :show, urlname: legacy_url5.urlname
           expect(response).to redirect_to("/#{second_page.urlname}")
         end
       end
@@ -184,12 +184,12 @@ module Alchemy
 
         context "with no lang parameter present" do
           it "should store defaults language id in the session." do
-            get :show, urlname: 'a-public-page'
+            alchemy_get :show, urlname: 'a-public-page'
             expect(controller.session[:alchemy_language_id]).to eq(Language.default.id)
           end
 
           it "should store default language as class var." do
-            get :show, urlname: 'a-public-page'
+            alchemy_get :show, urlname: 'a-public-page'
             expect(Language.current).to eq(Language.default)
           end
         end


### PR DESCRIPTION
In order to get Rails 5 compatibility, we can't use the old `use_route` option in controller requests any more.

As in spree we introduced a `alchemy_%{HTTP_VERB}` methods to test requests against alchemy controllers.

This also fixes a lot of false positives regarding route based request specs \o/