### PR TITLE
Prevent PictureController from sending Set-Cookie

### DIFF
--- a/app/controllers/alchemy/pictures_controller.rb
+++ b/app/controllers/alchemy/pictures_controller.rb
@@ -46,6 +46,7 @@ module Alchemy
     end
 
     def send_image(image, format)
+      request.session_options[:skip] = true
       ALLOWED_IMAGE_TYPES.each do |type|
         format.send(type) do
           if type == 'jpeg'

--- a/spec/controllers/pictures_controller_spec.rb
+++ b/spec/controllers/pictures_controller_spec.rb
@@ -27,6 +27,16 @@ module Alchemy
       end
     end
 
+    describe '#show' do
+      it "skips the session cookie" do
+        expect {
+          alchemy_get :show, id: picture.id, name: picture.urlname, format: :png, sh: picture.security_token
+        }.to change {
+          request.session_options.fetch(:skip) { false }
+        }.to(true)
+      end
+    end
+
     context "Requesting a picture with tempared security token" do
       it "should render status 400" do
         alchemy_get :show, id: picture.id, name: picture.urlname, format: :png, sh: '14m4b4dh4ck3r'


### PR DESCRIPTION
The PictureController will send Set-Cookie headers even when it sends
images. This prevents most caches like Varnish from caching the image
even though correct Cache-Control headers are set. Not sending
Set-Cookie should not be a problem for those files as they are never
used to create or keep a session.