### PR TITLE
Fix publish button permissions. Closes #741

### DIFF
--- a/app/views/alchemy/admin/pages/edit.html.erb
+++ b/app/views/alchemy/admin/pages/edit.html.erb
@@ -70,15 +70,15 @@
     <% end %>
     <label><%= _t(:page_properties) %></label>
   </div>
-  <% if configuration(:cache_pages) && !@page.layoutpage? %>
-  <div class="button_with_label">
-    <%= form_tag alchemy.publish_admin_page_path(@page), id: 'publish_page_form' do %>
-      <button class="icon_button" title="<%= _t(:explain_publishing) %>">
-        <%= render_icon('publish') %>
-      </button>
-      <label><%= _t("Publish page") %></label>
-    <% end %>
-  </div>
+  <% if can?(:publish, @page) && !@page.layoutpage? %>
+    <div class="button_with_label">
+      <%= form_tag alchemy.publish_admin_page_path(@page), id: 'publish_page_form' do %>
+        <%= button_tag class: 'icon_button', title: _t(:explain_publishing) do %>
+          <%= render_icon('publish') %>
+        <% end %>
+        <label><%= _t("Publish page") %></label>
+      <% end %>
+    </div>
   <% end %>
   <div class="toolbar_spacer"></div>
   <div class="select_with_label">

--- a/lib/alchemy/permissions.rb
+++ b/lib/alchemy/permissions.rb
@@ -145,6 +145,7 @@ module Alchemy
           :destroy,
           :flush,
           :order,
+          :publish,
           :sort,
           :switch_language
         ], Alchemy::Page
@@ -197,7 +198,6 @@ module Alchemy
         :fold,
         :info,
         :link,
-        :publish,
         :read,
         :update,
         :unlock,

--- a/spec/dummy/app/models/dummy_user.rb
+++ b/spec/dummy/app/models/dummy_user.rb
@@ -6,6 +6,6 @@ class DummyUser < ActiveRecord::Base
   end
 
   def alchemy_roles
-    %w(admin)
+    @alchemy_roles || %w(admin)
   end
 end

--- a/spec/features/admin/page_editing_feature_spec.rb
+++ b/spec/features/admin/page_editing_feature_spec.rb
@@ -1,95 +1,135 @@
 require 'spec_helper'
 
 describe 'Page editing feature' do
-  let(:a_page) { FactoryGirl.create(:public_page, visible: true) }
+  let(:a_page) { create(:page) }
 
-  before { authorize_as_admin }
+  context 'as author' do
+    before { authorize_as_admin(build(:author_user)) }
 
-  context "in configure overlay" do
+    it 'cannot publish page.' do
+      visit alchemy.edit_admin_page_path(a_page)
+      expect(page).to_not have_selector('#publish_page_form')
+    end
+  end
 
-    context "when editing a normal page" do
-      it "should show all relevant input fields" do
-        visit alchemy.configure_admin_page_path(a_page)
-        expect(page).to have_selector('input#page_urlname')
-        expect(page).to have_selector('input#page_title')
-        expect(page).to have_selector('input#page_robot_index')
-        expect(page).to have_selector('input#page_robot_follow')
-      end
+  context 'as editor' do
+    before { authorize_as_admin(build(:editor_user)) }
 
-      context "with sitemaps show_flag config option set to true" do
-        before do
-          allow(Alchemy::Config).to receive(:get) { |arg| arg == :sitemap ? {'show_flag' => true} : Alchemy::Config.show[arg.to_s] }
-        end
-
-        it "should show sitemap checkbox" do
-          visit alchemy.configure_admin_page_path(a_page)
-          expect(page).to have_selector('input[type="checkbox"]#page_sitemap')
-        end
-      end
-
-      context "with sitemaps show_flag config option set to false" do
-        before do
-          allow(Alchemy::Config).to receive(:get) { |arg| arg == :sitemap ? {'show_flag' => false} : Alchemy::Config.show[arg.to_s] }
-        end
-
-        it "should show sitemap checkbox" do
-          visit alchemy.configure_admin_page_path(a_page)
-          expect(page).to_not have_selector('input[type="checkbox"]#page_sitemap')
-        end
-      end
+    it 'can publish page.' do
+      visit alchemy.edit_admin_page_path(a_page)
+      find('#publish_page_form button').click
+      expect(page).to have_content Alchemy::I18n.t(:page_published, name: a_page.name)
     end
 
-    context "when editing a global page" do
-      let(:layout_page) { FactoryGirl.create(:page, layoutpage: true) }
+    context 'while editing a global page' do
+      let(:a_page) { create(:page, layoutpage: true) }
 
-      it "should not show the input fields for normal pages" do
-        visit alchemy.edit_admin_layoutpage_path(layout_page)
-        expect(page).to_not have_selector('input#page_urlname')
-        expect(page).to_not have_selector('input#page_title')
-        expect(page).to_not have_selector('input#page_robot_index')
-        expect(page).to_not have_selector('input#page_robot_follow')
-      end
-    end
-
-    context "when page is taggable" do
-      before { expect_any_instance_of(Alchemy::Page).to receive(:taggable?).and_return(true) }
-
-      it "should show the tag_list input field" do
-        visit alchemy.configure_admin_page_path(a_page)
-        expect(page).to have_selector('input#page_tag_list')
+      it 'cannot publish page.' do
+        visit alchemy.edit_admin_page_path(a_page)
+        expect(page).to_not have_selector('#publish_page_form')
       end
     end
   end
 
-  context "in preview frame" do
-    it "the menubar does not render on the page" do
-      visit alchemy.admin_page_path(a_page)
-      expect(page).not_to have_selector('#alchemy_menubar')
-    end
+  context 'as admin' do
+    let(:a_page) { create(:public_page, visible: true) }
 
-    it "navigation links are not clickable" do
-      visit alchemy.admin_page_path(a_page)
-      within('#navigation') do
-        expect(page).to have_selector('a[href="javascript: void(0)"]')
+    before { authorize_as_admin }
+
+    context "in configure overlay" do
+      context "when editing a normal page" do
+        it "should show all relevant input fields" do
+          visit alchemy.configure_admin_page_path(a_page)
+          expect(page).to have_selector('input#page_urlname')
+          expect(page).to have_selector('input#page_title')
+          expect(page).to have_selector('input#page_robot_index')
+          expect(page).to have_selector('input#page_robot_follow')
+        end
+
+        context "with sitemaps show_flag config option set to true" do
+          before do
+            allow(Alchemy::Config).to receive(:get) do |arg|
+              arg == :sitemap ? {'show_flag' => true} : Alchemy::Config.show[arg.to_s]
+            end
+          end
+
+          it "should show sitemap checkbox" do
+            visit alchemy.configure_admin_page_path(a_page)
+            expect(page).to have_selector('input[type="checkbox"]#page_sitemap')
+          end
+        end
+
+        context "with sitemaps show_flag config option set to false" do
+          before do
+            allow(Alchemy::Config).to receive(:get) do |arg|
+              arg == :sitemap ? {'show_flag' => false} : Alchemy::Config.show[arg.to_s]
+            end
+          end
+
+          it "should not show sitemap checkbox" do
+            visit alchemy.configure_admin_page_path(a_page)
+            expect(page).to_not have_selector('input[type="checkbox"]#page_sitemap')
+          end
+        end
+      end
+
+      context "when editing a global page" do
+        let(:layout_page) { create(:page, layoutpage: true) }
+
+        it "should not show the input fields for normal pages" do
+          visit alchemy.edit_admin_layoutpage_path(layout_page)
+          expect(page).to_not have_selector('input#page_urlname')
+          expect(page).to_not have_selector('input#page_title')
+          expect(page).to_not have_selector('input#page_robot_index')
+          expect(page).to_not have_selector('input#page_robot_follow')
+        end
+      end
+
+      context "when page is taggable" do
+        before do
+          expect_any_instance_of(Alchemy::Page)
+            .to receive(:taggable?).and_return(true)
+        end
+
+        it "should show the tag_list input field" do
+          visit alchemy.configure_admin_page_path(a_page)
+          expect(page).to have_selector('input#page_tag_list')
+        end
       end
     end
-  end
 
-  context 'in element panel' do
-    let!(:everything_page) { create(:page, page_layout: 'everything', do_not_autogenerate: false) }
+    context "in preview frame" do
+      it "the menubar does not render on the page" do
+        visit alchemy.admin_page_path(a_page)
+        expect(page).not_to have_selector('#alchemy_menubar')
+      end
 
-    it "renders essence editors for all elements" do
-      visit alchemy.admin_elements_path(page_id: everything_page.id)
+      it "navigation links are not clickable" do
+        visit alchemy.admin_page_path(a_page)
+        within('#navigation') do
+          expect(page).to have_selector('a[href="javascript: void(0)"]')
+        end
+      end
+    end
 
-      expect(page).to have_selector('div.content_editor.essence_boolean')
-      expect(page).to have_selector('div.content_editor.essence_date')
-      expect(page).to have_selector('div.content_editor.essence_file')
-      expect(page).to have_selector('div.content_editor.essence_html_editor')
-      expect(page).to have_selector('div.content_editor.essence_link')
-      expect(page).to have_selector('div.content_editor.essence_picture_editor')
-      expect(page).to have_selector('div.content_editor.essence_richtext')
-      expect(page).to have_selector('div.content_editor.essence_select')
-      expect(page).to have_selector('div.content_editor.essence_text')
+    context 'in element panel' do
+      let!(:everything_page) do
+        create(:page, page_layout: 'everything', do_not_autogenerate: false)
+      end
+
+      it "renders essence editors for all elements" do
+        visit alchemy.admin_elements_path(page_id: everything_page.id)
+
+        expect(page).to have_selector('div.content_editor.essence_boolean')
+        expect(page).to have_selector('div.content_editor.essence_date')
+        expect(page).to have_selector('div.content_editor.essence_file')
+        expect(page).to have_selector('div.content_editor.essence_html_editor')
+        expect(page).to have_selector('div.content_editor.essence_link')
+        expect(page).to have_selector('div.content_editor.essence_picture_editor')
+        expect(page).to have_selector('div.content_editor.essence_richtext')
+        expect(page).to have_selector('div.content_editor.essence_select')
+        expect(page).to have_selector('div.content_editor.essence_text')
+      end
     end
   end
 end

--- a/spec/libraries/permissions_spec.rb
+++ b/spec/libraries/permissions_spec.rb
@@ -150,7 +150,10 @@ describe Alchemy::Permissions do
       is_expected.to be_able_to(:link, Alchemy::Page)
       is_expected.to be_able_to(:visit, Alchemy::Page)
       is_expected.to be_able_to(:unlock, Alchemy::Page)
-      is_expected.to be_able_to(:publish, Alchemy::Page)
+    end
+
+    it "can not publish pages" do
+      is_expected.to_not be_able_to(:publish, Alchemy::Page)
     end
 
     it "can manage elements" do
@@ -206,6 +209,10 @@ describe Alchemy::Permissions do
       is_expected.to be_able_to(:order, Alchemy::Page)
       is_expected.to be_able_to(:sort, Alchemy::Page)
       is_expected.to be_able_to(:switch_language, Alchemy::Page)
+    end
+
+    it "can publish pages" do
+      is_expected.to be_able_to(:publish, Alchemy::Page)
     end
 
     it "can not see invisible pages" do


### PR DESCRIPTION
Not the cache_pages configuration option should set the buttons visibility, the users role should.

This fixes this as only editors and admin can publish pages from now on. Authors are not able to publish pages anymore. They need to ask their editor to publish the changes for them.