### PR TITLE
Symlink tmp/cache on deployments

### DIFF
--- a/lib/alchemy/capistrano.rb
+++ b/lib/alchemy/capistrano.rb
@@ -23,18 +23,17 @@ include Alchemy::Tasks::Helpers
         run "mkdir -p #{shared_path}/uploads/pictures"
         run "mkdir -p #{shared_path}/uploads/attachments"
         run "mkdir -p #{shared_picture_cache_path}"
-        run "mkdir -p #{shared_path}/cache/assets"
+        run "mkdir -p #{shared_path}/cache"
       end
 
-      # This task sets the symlinks for uploads, assets and picture cache folder.
+      # This task symlinks the uploads, picture and general cache folder to the new release.
       desc "Sets the symlinks for uploads and picture cache folder. Called after deploy:finalize_update"
       task :symlink, :roles => :app do
         run "rm -rf #{release_path}/uploads"
         run "ln -nfs #{shared_path}/uploads #{release_path}/"
         run "mkdir -p #{public_path_with_mountpoint}"
         run "ln -nfs #{shared_picture_cache_path} #{public_path_with_mountpoint('pictures')}"
-        run "mkdir -p #{release_path}/tmp/cache"
-        run "ln -nfs #{shared_path}/cache/assets #{release_path}/tmp/cache/assets"
+        run "ln -nfs #{shared_path}/cache #{release_path}/tmp/cache"
       end
 
       def shared_picture_cache_path


### PR DESCRIPTION
When deploying an Alchemy app with capistrano the `tmp/cache` was not shared between releases. This commit symlinks the whole cache folder to the shared directory to make sure existing cache is not gone after the deployment of a new release.

Background: Alchemy's publishing feature relies on the cache. When you publish a page the dependent cache is getting swiped. Not sharing the cache between releases means public pages which have unpublished content were published just after a deployment.