### PR TITLE
Patch Rspec::ActiveModel::Mocks to work with Rails 4.2.1

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,7 @@ require 'alchemy/test_support/factories'
 
 require_relative "support/hint_examples.rb"
 require_relative "support/transformation_examples.rb"
+require_relative "support/rspec-activemodel-mocks_patch.rb"
 
 ActionMailer::Base.delivery_method = :test
 ActionMailer::Base.perform_deliveries = true

--- a/spec/support/rspec-activemodel-mocks_patch.rb
+++ b/spec/support/rspec-activemodel-mocks_patch.rb
@@ -1,0 +1,8 @@
+# Manually applied the patch from https://github.com/jdelStrother/rspec-activemodel-mocks/commit/1211c347c5a574739616ccadf4b3b54686f9051f
+if Gem.loaded_specs['rspec-activemodel-mocks'].version.to_s != "1.0.1"
+  raise "RSpec-ActiveModel-Mocks version has changed, please check if the behaviour has already been fixed: https://github.com/rspec/rspec-activemodel-mocks/pull/10
+If so, this patch might be obsolete-"
+end
+RSpec::ActiveModel::Mocks::Mocks::ActiveRecordInstanceMethods.class_eval do
+  alias_method :_read_attribute, :[]
+end


### PR DESCRIPTION
I applied this patch: https://github.com/rspec/rspec-activemodel-mocks/pull/10 manually and built a version-check into it, to notifiy when the behaviour is fixed in rspec-activemodel-mocks