### PR TITLE
Have guest user permissions for logged in users without role

### DIFF
--- a/lib/alchemy/permissions.rb
+++ b/lib/alchemy/permissions.rb
@@ -182,7 +182,7 @@ module Alchemy
     private
 
     def user_role_rules
-      return [] if @user.alchemy_roles.nil?
+      return alchemy_guest_user_rules if @user.alchemy_roles.blank?
       @user.alchemy_roles.each do |role|
         exec_role_rules(role)
       end

--- a/spec/libraries/permissions_spec.rb
+++ b/spec/libraries/permissions_spec.rb
@@ -251,4 +251,13 @@ describe Alchemy::Permissions do
       is_expected.to be_able_to(:manage, Alchemy::Site)
     end
   end
+
+  context "A logged in user without a role" do
+    let(:user) { mock_user([]) }
+
+    it "can only see visible not restricted pages (like the guest role)" do
+      is_expected.to be_able_to(:see, visible_page)
+      is_expected.not_to be_able_to(:see, not_visible_page)
+    end
+  end
 end


### PR DESCRIPTION
Before a logged in user that didn't have any alchemy roles had less permissions than a guest user.