### PR TITLE
Prefix bug

### DIFF
--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -17,7 +17,7 @@
         <% if ActionController::Base.config.asset_host_set? %>
         base: '<%= asset_url(assets_prefix + '/tinymce') %>',
         <% else %>
-        base: '<%= asset_path('tinymce') %>',
+        base: '<%= asset_path('/tinymce') %>',
         <% end %>
         suffix: '.min'
       };

--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -17,7 +17,7 @@
         <% if ActionController::Base.config.asset_host_set? %>
         base: '<%= asset_url(assets_prefix + '/tinymce') %>',
         <% else %>
-        base: '<%= asset_path(assets_prefix + '/tinymce') %>',
+        base: '<%= asset_path('tinymce') %>',
         <% end %>
         suffix: '.min'
       };

--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -17,7 +17,7 @@
         <% if ActionController::Base.config.asset_host_set? %>
         base: '<%= asset_url(assets_prefix + '/tinymce') %>',
         <% else %>
-        base: '<%= asset_path('/tinymce') %>',
+        base: '<%= asset_path('tinymce') %>',
         <% end %>
         suffix: '.min'
       };

--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -15,7 +15,7 @@
       // Setting TinyMCE path.
       var tinyMCEPreInit = {
         <% if ActionController::Base.config.asset_host_set? %>
-        base: '<%= asset_url(assets_prefix + '/tinymce') %>',
+        base: '<%= asset_url('tinymce') %>',
         <% else %>
         base: '<%= asset_path('tinymce') %>',
         <% end %>


### PR DESCRIPTION
Asset names passed to helpers should not include the "/assets/" prefix. Instead of "/assets/tinymce", use "tinymce"