### PR TITLE
Processes ERB in yaml config files for page layouts, cells, and elements

### DIFF
--- a/app/models/alchemy/cell.rb
+++ b/app/models/alchemy/cell.rb
@@ -56,7 +56,7 @@ module Alchemy
     private
 
       def read_yml_file
-        ::YAML.load_file(yml_file_path) || []
+        ::YAML.load(ERB.new(File.read(yml_file_path)).result) || []
       end
 
       def yml_file_path

--- a/app/models/alchemy/element/definitions.rb
+++ b/app/models/alchemy/element/definitions.rb
@@ -23,7 +23,7 @@ module Alchemy
       #
       def read_definitions_file
         if ::File.exists?(definitions_file_path)
-          ::YAML.load_file(definitions_file_path) || []
+          ::YAML.load(ERB.new(File.read(definitions_file_path)).result) || []
         else
           raise LoadError, "Could not find elements.yml file! Please run `rails generate alchemy:scaffold`"
         end

--- a/lib/alchemy/page_layout.rb
+++ b/lib/alchemy/page_layout.rb
@@ -157,7 +157,7 @@ module Alchemy
       #
       def read_layouts_file
         if File.exists?(layouts_file_path)
-          YAML.load_file(layouts_file_path) || []
+          YAML.load(ERB.new(File.read(layouts_file_path)).result) || []
         else
           raise LoadError, "Could not find page_layouts.yml file! Please run `rails generate alchemy:scaffold`"
         end

--- a/spec/dummy/config/alchemy/cells.yml
+++ b/spec/dummy/config/alchemy/cells.yml
@@ -1,2 +1,5 @@
 - name: right_column
   elements: [search]
+
+- name: <%= 'erb_' + 'cell' %>
+  elements: [text]

--- a/spec/dummy/config/alchemy/elements.yml
+++ b/spec/dummy/config/alchemy/elements.yml
@@ -102,3 +102,8 @@
     type: EssenceSelect
   - name: essence_text
     type: EssenceText
+
+- name: <%= 'erb_' + 'element' %>
+  contents:
+  - name: text
+    type: EssenceRichtext

--- a/spec/dummy/config/alchemy/page_layouts.yml
+++ b/spec/dummy/config/alchemy/page_layouts.yml
@@ -26,3 +26,6 @@
 - name: external
   unique: false
   redirects_to_external: true
+
+- name: <%= 'erb_' + 'layout' %>
+  unique: true

--- a/spec/libraries/page_layout_spec.rb
+++ b/spec/libraries/page_layout_spec.rb
@@ -14,8 +14,12 @@ module Alchemy
         expect(subject.collect { |l| l['name'] }).to include('standard')
       end
 
+      it "should allow erb generated layouts" do
+        expect(subject.collect { |l| l['name'] }).to include('erb_layout')
+      end
+
       context "with empty layouts file" do
-        before { expect(YAML).to receive(:load_file).and_return(false) }
+        before { expect(YAML).to receive(:load).and_return(false) }
 
         it "returns empty array" do
           is_expected.to eq([])

--- a/spec/models/cell_spec.rb
+++ b/spec/models/cell_spec.rb
@@ -10,6 +10,10 @@ module Alchemy
       it "should return an Array" do
         expect(Cell.definitions).to be_a(Array)
       end
+
+      it "should allow erb generated definitions" do
+        expect(Cell.definitions.collect {|d| d['name']}).to include('erb_cell')
+      end
     end
 
     describe '.definition_for' do

--- a/spec/models/element_spec.rb
+++ b/spec/models/element_spec.rb
@@ -33,6 +33,10 @@ module Alchemy
     end
 
     describe '.definitions' do
+      it "should allow erb generated elements" do
+        expect(Element.definitions.collect {|el| el['name']}).to include('erb_element')
+      end
+
       context "without existing yml files" do
         before { allow(File).to receive(:exists?).and_return(false) }
 
@@ -42,7 +46,8 @@ module Alchemy
       end
 
       context "without any definitions in elements.yml" do
-        before { allow(YAML).to receive(:load_file).and_return(false) } # Yes, YAML.load_file returns false if an empty file exists.
+        # Yes, YAML.load returns false if an empty file exists.
+        before { allow(YAML).to receive(:load).and_return(false) }
 
         it "should return an empty array" do
           expect(Element.definitions).to eq([])


### PR DESCRIPTION
* In Rails you can put ERB in the config files (e.g. database.yml) and it will be parsed before it is loaded. This pull request makes alchemy consistent with Rails behavior.
* It will allow parts of a page to be generated programatically (which I would like to try)
* It will allow me to include yaml files in other yaml files (which will help my team structure their code better)