### PR TITLE
order of before actions (page loading)

### DIFF
--- a/lib/alchemy/controller_actions.rb
+++ b/lib/alchemy/controller_actions.rb
@@ -3,8 +3,7 @@ module Alchemy
     extend ActiveSupport::Concern
 
     included do
-      before_action :set_current_alchemy_site
-      before_action :set_alchemy_language
+      prepend_before_action :set_alchemy_language, :set_current_alchemy_site
 
       helper 'alchemy/pages'
 


### PR DESCRIPTION
in multisite environment it is important to set the current site and language first

related to #764 