### PR TITLE
Fix: Permit picture thumbnails for guest users.

### DIFF
--- a/app/controllers/alchemy/pictures_controller.rb
+++ b/app/controllers/alchemy/pictures_controller.rb
@@ -11,6 +11,7 @@ module Alchemy
     def show
       @size = params[:size]
       expires_in 1.month, public: !@picture.restricted?
+
       respond_to { |format| send_image(processed_image, format) }
     end
 
@@ -28,8 +29,7 @@ module Alchemy
     end
 
     def zoom
-      image_file = @picture.image_file
-      respond_to { |format| send_image(image_file, format) }
+      respond_to { |format| send_image(@picture.image_file, format) }
     end
 
     private

--- a/lib/alchemy/permissions.rb
+++ b/lib/alchemy/permissions.rb
@@ -46,7 +46,7 @@ module Alchemy
           p.public? && !p.restricted?
         end
         can :see,               Alchemy::Page,       restricted: false, visible: true
-        can([:show, :download], Alchemy::Picture)    { |p| !p.restricted? }
+        can(:display,           Alchemy::Picture)    { |p| !p.restricted? }
       end
     end
 
@@ -72,7 +72,7 @@ module Alchemy
           p.public?
         end
         can :see,               Alchemy::Page,      restricted: true, visible: true
-        can [:show, :download], Alchemy::Picture
+        can :display,           Alchemy::Picture
         can [:read, :update],   Alchemy.user_class, id: @user.id
       end
     end
@@ -99,22 +99,22 @@ module Alchemy
         ]
 
         # Controller actions
-        can :leave,                     :alchemy_admin
-        can [:info, :help],             :alchemy_admin_dashboard
-        can :manage,                    :alchemy_admin_clipboard
-        can :index,                     :trash
-        can :edit,                      :alchemy_admin_layoutpages
+        can :leave,                 :alchemy_admin
+        can [:info, :help],         :alchemy_admin_dashboard
+        can :manage,                :alchemy_admin_clipboard
+        can :index,                 :trash
+        can :edit,                  :alchemy_admin_layoutpages
 
         # Resources
-        can [:read, :download],         Alchemy::Attachment
-        can :manage,                    Alchemy::Content
-        can :manage,                    Alchemy::Element
-        can :manage,                    Alchemy::EssenceFile
-        can :manage,                    Alchemy::EssencePicture
-        can :manage,                    Alchemy::LegacyPageUrl
-        can :edit_content,              Alchemy::Page
-        can [:read, :thumbnail, :info], Alchemy::Picture
-        can [:read, :autocomplete],     Alchemy::Tag
+        can [:read, :download],     Alchemy::Attachment
+        can :manage,                Alchemy::Content
+        can :manage,                Alchemy::Element
+        can :manage,                Alchemy::EssenceFile
+        can :manage,                Alchemy::EssencePicture
+        can :manage,                Alchemy::LegacyPageUrl
+        can :edit_content,          Alchemy::Page
+        can [:read, :info],         Alchemy::Picture
+        can [:read, :autocomplete], Alchemy::Tag
       end
     end
 
@@ -203,6 +203,11 @@ module Alchemy
         :unlock,
         :visit,
         to: :edit_content
+
+      alias_action :show,
+        :thumbnail,
+        :zoom,
+        to: :display
     end
 
     # Include the role specific permissions.

--- a/spec/controllers/pictures_controller_spec.rb
+++ b/spec/controllers/pictures_controller_spec.rb
@@ -19,11 +19,36 @@ module Alchemy
         create(:picture, image_file: fixture_file_upload(File.expand_path('../../fixtures/80x60.png', __FILE__), 'image/png'))
       end
 
-      before { sign_in(editor_user) }
-
       it "renders the original image without any resizing" do
         alchemy_get :zoom, id: picture.id, name: picture.urlname, format: :png, sh: picture.security_token
         expect(response.body[0x10..0x18].unpack('NN')).to eq([80, 60])
+      end
+
+      context "Requesting a picture that is assigned with restricted pages only" do
+        before do
+          essence = restricted_element.contents.where(name: 'image').first.essence
+          essence.picture_id = picture.id
+          essence.save
+        end
+
+        context "as guest user" do
+          it "should not render the picture, but redirect to login path" do
+            alchemy_get :zoom, id: picture.id, name: picture.urlname, format: :png, sh: picture.security_token
+            expect(response.status).to eq(302)
+            expect(response).to redirect_to(Alchemy.login_path)
+          end
+        end
+
+        context "as member user" do
+          before do
+            sign_in(member_user)
+          end
+
+          it "should render the picture" do
+            alchemy_get :zoom, id: picture.id, name: picture.urlname, format: :png, sh: picture.security_token
+            expect(response.status).to eq(200)
+          end
+        end
       end
     end
 
@@ -35,27 +60,180 @@ module Alchemy
           request.session_options.fetch(:skip) { false }
         }.to(true)
       end
-    end
 
-    context "Requesting a picture with tempared security token" do
-      it "should render status 400" do
-        alchemy_get :show, id: picture.id, name: picture.urlname, format: :png, sh: '14m4b4dh4ck3r'
-        expect(response.status).to eq(400)
+      context "Requesting a picture with tempared security token" do
+        it "should render status 400" do
+          alchemy_get :show, id: picture.id, name: picture.urlname, format: :png, sh: '14m4b4dh4ck3r'
+          expect(response.status).to eq(400)
+        end
       end
-    end
 
-    context "Requesting a picture with another format then the original image" do
-      it "should convert the picture format" do
-        alchemy_get :show, id: picture.id, name: picture.urlname, format: :jpeg, sh: picture.security_token
-        expect(response.content_type).to eq('image/jpeg')
+      context "Requesting a picture with another format then the original image" do
+        it "should convert the picture format" do
+          alchemy_get :show, id: picture.id, name: picture.urlname, format: :jpeg, sh: picture.security_token
+          expect(response.content_type).to eq('image/jpeg')
+        end
       end
-    end
 
-    context "Requesting a picture with not allowed format" do
-      it "should raise error" do
-        expect {
-          alchemy_get :show, id: picture.id, name: picture.urlname, format: :wim, sh: picture.security_token
-        }.to raise_error(ActionController::UnknownFormat)
+      context "Requesting a picture with not allowed format" do
+        it "should raise error" do
+          expect {
+            alchemy_get :show, id: picture.id, name: picture.urlname, format: :wim, sh: picture.security_token
+          }.to raise_error(ActionController::UnknownFormat)
+        end
+      end
+
+      context "Requesting a picture that has no image file attached" do
+        before do
+          expect(picture).to receive(:image_file).and_return(nil)
+          expect(Picture).to receive(:find).and_return(picture)
+        end
+
+        it "raises missing file error" do
+          expect {
+            alchemy_get :show, id: picture.id, name: picture.urlname, format: :png, sh: picture.security_token
+          }.to raise_error(Alchemy::MissingImageFileError)
+        end
+      end
+
+      context "Requesting a picture with crop_from and crop_size parameters" do
+        let(:picture) do
+          create(:picture, image_file: fixture_file_upload(File.expand_path('../../fixtures/500x500.png', __FILE__), 'image/png'))
+        end
+
+        it "renders the cropped picture" do
+          alchemy_get :show, id: picture.id, name: picture.urlname, crop: 'crop', size: '123x44', crop_size: '123x44',
+            crop_from: '0x0', format: :png,
+            sh: picture.security_token(crop_size: '123x44', crop_from: '0x0', crop: true, size: '123x44')
+          expect(response.body[0x10..0x18].unpack('NN')).to eq([123, 44])
+        end
+      end
+
+      context "Requesting a picture with crop_from and crop_size parameters with different size param" do
+        let(:picture) do
+          create(:picture, image_file: fixture_file_upload(File.expand_path('../../fixtures/500x500.png', __FILE__), 'image/png'))
+        end
+
+        it "renders the cropped picture" do
+          alchemy_get :show,
+            id: picture.id,
+            name: picture.urlname,
+            crop: 'crop',
+            size: '100x100',
+            crop_size: '200x200',
+            crop_from: '0x0',
+            format: :png,
+            sh: picture.security_token(
+              crop_size: '200x200',
+              crop_from: '0x0',
+              crop: true,
+              size: '100x100'
+            )
+         expect(response.body[0x10..0x18].unpack('NN')).to eq [100, 100]
+        end
+      end
+
+      context "Requesting a picture with crop_from and crop_size parameters with larger size param" do
+        let(:picture) do
+          create(:picture, image_file: fixture_file_upload(File.expand_path('../../fixtures/500x500.png', __FILE__), 'image/png'))
+        end
+
+        it "renders the cropped picture without upsampling" do
+          alchemy_get :show,
+            id: picture.id,
+            name: picture.urlname,
+            crop: 'crop',
+            size: '400x400',
+            crop_size: '200x200',
+            crop_from: '0x0',
+            format: :png,
+            sh: picture.security_token(
+              crop_size: '200x200',
+              crop_from: '0x0',
+              crop: true,
+              size: '400x400'
+            )
+          expect(response.body[0x10..0x18].unpack('NN')).to eq [200, 200]
+        end
+      end
+
+      context "Requesting a picture with crop_from and crop_size parameters with larger size param and upsample set" do
+        let(:picture) do
+          create(:picture, image_file: fixture_file_upload(File.expand_path('../../fixtures/500x500.png', __FILE__), 'image/png'))
+        end
+
+        it "renders the cropped picture with upsampling" do
+          alchemy_get :show,
+            id: picture.id,
+            name: picture.urlname,
+            crop: 'crop',
+            size: '400x400',
+            crop_size: '200x200',
+            crop_from: '0x0',
+            format: :png,
+            upsample: 'true',
+            sh: picture.security_token(
+              crop_size: '200x200',
+              crop_from: '0x0',
+              crop: true,
+              size: '400x400',
+              upsample: 'true'
+            )
+          expect(response.body[0x10..0x18].unpack('NN')).to eq [400, 400]
+        end
+      end
+
+      context "Requesting a picture that is not assigned with any page" do
+        it "should render the picture" do
+          alchemy_get :show, id: picture.id, name: picture.urlname, format: :png, sh: picture.security_token
+          expect(response.status).to eq(200)
+        end
+      end
+
+      context "Requesting a picture that is assigned on restricted and non-restricted pages" do
+        before do
+          essence = element.contents.where(name: 'image').first.essence
+          essence.picture_id = picture.id
+          essence.save
+
+          essence = restricted_element.contents.where(name: 'image').first.essence
+          essence.picture_id = picture.id
+          essence.save
+        end
+
+        context "as guest user" do
+          it "should render the picture" do
+            alchemy_get :show, id: picture.id, name: picture.urlname, format: :png, sh: picture.security_token
+            expect(response.status).to eq(200)
+          end
+        end
+      end
+
+      context "Requesting a picture that is assigned with restricted pages only" do
+        before do
+          essence = restricted_element.contents.where(name: 'image').first.essence
+          essence.picture_id = picture.id
+          essence.save
+        end
+
+        context "as guest user" do
+          it "should not render the picture, but redirect to login path" do
+            alchemy_get :show, id: picture.id, name: picture.urlname, format: :png, sh: picture.security_token
+            expect(response.status).to eq(302)
+            expect(response).to redirect_to(Alchemy.login_path)
+          end
+        end
+
+        context "as member user" do
+          before do
+            sign_in(member_user)
+          end
+
+          it "should render the picture" do
+            alchemy_get :show, id: picture.id, name: picture.urlname, format: :png, sh: picture.security_token
+            expect(response.status).to eq(200)
+          end
+        end
       end
     end
 
@@ -63,8 +241,6 @@ module Alchemy
       let(:picture) do
         create(:picture, image_file: fixture_file_upload(File.expand_path('../../fixtures/500x500.png', __FILE__), 'image/png'))
       end
-
-      before { sign_in(author_user) }
 
       context 'with size param set to small' do
         it "resizes the image to 80x60 while maintaining aspect ratio" do
@@ -100,157 +276,31 @@ module Alchemy
           expect(response.body[0x10..0x18].unpack('NN')).to eq([33, 33])
         end
       end
-    end
 
-    context "Requesting a picture that has no image file attached" do
-      before do
-        expect(picture).to receive(:image_file).and_return(nil)
-        expect(Picture).to receive(:find).and_return(picture)
-      end
-
-      it "raises missing file error" do
-        expect {
-          alchemy_get :show, id: picture.id, name: picture.urlname, format: :png, sh: picture.security_token
-        }.to raise_error(Alchemy::MissingImageFileError)
-      end
-    end
-
-    context "Requesting a picture with crop_from and crop_size parameters" do
-      let(:picture) do
-        create(:picture, image_file: fixture_file_upload(File.expand_path('../../fixtures/500x500.png', __FILE__), 'image/png'))
-      end
-
-      it "renders the cropped picture" do
-        alchemy_get :show, id: picture.id, name: picture.urlname, crop: 'crop', size: '123x44', crop_size: '123x44',
-          crop_from: '0x0', format: :png,
-          sh: picture.security_token(crop_size: '123x44', crop_from: '0x0', crop: true, size: '123x44')
-        expect(response.body[0x10..0x18].unpack('NN')).to eq([123, 44])
-      end
-    end
-
-    context "Requesting a picture with crop_from and crop_size parameters with different size param" do
-      let(:picture) do
-        create(:picture, image_file: fixture_file_upload(File.expand_path('../../fixtures/500x500.png', __FILE__), 'image/png'))
-      end
-
-      it "renders the cropped picture" do
-        alchemy_get :show,
-          id: picture.id,
-          name: picture.urlname,
-          crop: 'crop',
-          size: '100x100',
-          crop_size: '200x200',
-          crop_from: '0x0',
-          format: :png,
-          sh: picture.security_token(
-            crop_size: '200x200',
-            crop_from: '0x0',
-            crop: true,
-            size: '100x100'
-          )
-       expect(response.body[0x10..0x18].unpack('NN')).to eq [100, 100]
-      end
-    end
-
-    context "Requesting a picture with crop_from and crop_size parameters with larger size param" do
-      let(:picture) do
-        create(:picture, image_file: fixture_file_upload(File.expand_path('../../fixtures/500x500.png', __FILE__), 'image/png'))
-      end
-
-      it "renders the cropped picture without upsampling" do
-        alchemy_get :show,
-          id: picture.id,
-          name: picture.urlname,
-          crop: 'crop',
-          size: '400x400',
-          crop_size: '200x200',
-          crop_from: '0x0',
-          format: :png,
-          sh: picture.security_token(
-            crop_size: '200x200',
-            crop_from: '0x0',
-            crop: true,
-            size: '400x400'
-          )
-        expect(response.body[0x10..0x18].unpack('NN')).to eq [200, 200]
-      end
-    end
-
-    context "Requesting a picture with crop_from and crop_size parameters with larger size param and upsample set" do
-      let(:picture) do
-        create(:picture, image_file: fixture_file_upload(File.expand_path('../../fixtures/500x500.png', __FILE__), 'image/png'))
-      end
-
-      it "renders the cropped picture with upsampling" do
-        alchemy_get :show,
-          id: picture.id,
-          name: picture.urlname,
-          crop: 'crop',
-          size: '400x400',
-          crop_size: '200x200',
-          crop_from: '0x0',
-          format: :png,
-          upsample: 'true',
-          sh: picture.security_token(
-            crop_size: '200x200',
-            crop_from: '0x0',
-            crop: true,
-            size: '400x400',
-            upsample: 'true'
-          )
-        expect(response.body[0x10..0x18].unpack('NN')).to eq [400, 400]
-      end
-    end
-
-    context "Requesting a picture that is not assigned with any page" do
-      it "should render the picture" do
-        alchemy_get :show, id: picture.id, name: picture.urlname, format: :png, sh: picture.security_token
-        expect(response.status).to eq(200)
-      end
-    end
-
-    context "Requesting a picture that is assigned on restricted and non-restricted pages" do
-      before do
-        essence = element.contents.where(name: 'image').first.essence
-        essence.picture_id = picture.id
-        essence.save
-
-        essence = restricted_element.contents.where(name: 'image').first.essence
-        essence.picture_id = picture.id
-        essence.save
-      end
-
-      context "as guest user" do
-        it "should render the picture" do
-          alchemy_get :show, id: picture.id, name: picture.urlname, format: :png, sh: picture.security_token
-          expect(response.status).to eq(200)
-        end
-      end
-    end
-
-    context "Requesting a picture that is assigned with restricted pages only" do
-      before do
-        essence = restricted_element.contents.where(name: 'image').first.essence
-        essence.picture_id = picture.id
-        essence.save
-      end
-
-      context "as guest user" do
-        it "should not render the picture, but redirect to login path" do
-          alchemy_get :show, id: picture.id, name: picture.urlname, format: :png, sh: picture.security_token
-          expect(response.status).to eq(302)
-          expect(response).to redirect_to(Alchemy.login_path)
-        end
-      end
-
-      context "as member user" do
+      context "Requesting a picture that is assigned with restricted pages only" do
         before do
-          sign_in(member_user)
+          essence = restricted_element.contents.where(name: 'image').first.essence
+          essence.picture_id = picture.id
+          essence.save
         end
 
-        it "should render the picture" do
-          alchemy_get :show, id: picture.id, name: picture.urlname, format: :png, sh: picture.security_token
-          expect(response.status).to eq(200)
+        context "as guest user" do
+          it "should not render the picture, but redirect to login path" do
+            alchemy_get :thumbnail, id: picture.id, name: picture.urlname, format: :png, sh: picture.security_token
+            expect(response.status).to eq(302)
+            expect(response).to redirect_to(Alchemy.login_path)
+          end
+        end
+
+        context "as member user" do
+          before do
+            sign_in(member_user)
+          end
+
+          it "should render the picture" do
+            alchemy_get :thumbnail, id: picture.id, name: picture.urlname, format: :png, sh: picture.security_token
+            expect(response.status).to eq(200)
+          end
         end
       end
     end

--- a/spec/libraries/permissions_spec.rb
+++ b/spec/libraries/permissions_spec.rb
@@ -33,14 +33,13 @@ describe Alchemy::Permissions do
       is_expected.not_to be_able_to(:show, restricted_attachment)
     end
 
-    it "can only download not restricted pictures" do
-      is_expected.to be_able_to(:download, picture)
-      is_expected.not_to be_able_to(:download, restricted_picture)
-    end
-
     it "can only see not restricted pictures" do
       is_expected.to be_able_to(:show, picture)
+      is_expected.to be_able_to(:thumbnail, picture)
+      is_expected.to be_able_to(:zoom, picture)
       is_expected.not_to be_able_to(:show, restricted_picture)
+      is_expected.not_to be_able_to(:thumbnail, restricted_picture)
+      is_expected.not_to be_able_to(:zoom, restricted_picture)
     end
 
     it "can only visit not restricted pages" do
@@ -83,14 +82,13 @@ describe Alchemy::Permissions do
       is_expected.to be_able_to(:show, restricted_attachment)
     end
 
-    it "can download all pictures" do
-      is_expected.to be_able_to(:download, picture)
-      is_expected.to be_able_to(:download, restricted_picture)
-    end
-
     it "can see all pictures" do
       is_expected.to be_able_to(:show, picture)
+      is_expected.to be_able_to(:thumbnail, picture)
+      is_expected.to be_able_to(:zoom, picture)
       is_expected.to be_able_to(:show, restricted_picture)
+      is_expected.to be_able_to(:thumbnail, restricted_picture)
+      is_expected.to be_able_to(:zoom, restricted_picture)
     end
 
     it "can visit restricted pages" do


### PR DESCRIPTION
Although not in the admin namespace, thumbnail generation and showing the picture in full resolution isn't allowed for guest users. This commit fixes this behavior.