### PR TITLE
Rename user factories

### DIFF
--- a/lib/alchemy/test_support/factories.rb
+++ b/lib/alchemy/test_support/factories.rb
@@ -2,23 +2,23 @@ require 'factory_girl'
 
 FactoryGirl.define do
 
-  factory :user, class: 'DummyUser' do
+  factory :alchemy_user, class: 'DummyUser' do
     sequence(:email) { |n| "john.#{n}@doe.com" }
     password 's3cr3t'
 
-    factory :admin_user do
+    factory :alchemy_admin_user do
       alchemy_roles ['admin']
     end
 
-    factory :member_user do
+    factory :alchemy_member_user do
       alchemy_roles ['member']
     end
 
-    factory :author_user do
+    factory :alchemy_author_user do
       alchemy_roles ['author']
     end
 
-    factory :editor_user do
+    factory :alchemy_editor_user do
       alchemy_roles ['editor']
     end
   end

--- a/spec/controllers/admin/pages_controller_spec.rb
+++ b/spec/controllers/admin/pages_controller_spec.rb
@@ -367,7 +367,7 @@ module Alchemy
 
       describe '#edit' do
         let!(:page)       { create(:page) }
-        let!(:other_user) { create(:author_user) }
+        let!(:other_user) { create(:alchemy_author_user) }
 
         context 'if page is locked by another user' do
           before { page.lock_to!(other_user) }

--- a/spec/features/admin/page_editing_feature_spec.rb
+++ b/spec/features/admin/page_editing_feature_spec.rb
@@ -4,7 +4,7 @@ describe 'Page editing feature' do
   let(:a_page) { create(:page) }
 
   context 'as author' do
-    before { authorize_as_admin(build(:author_user)) }
+    before { authorize_as_admin(build(:alchemy_author_user)) }
 
     it 'cannot publish page.' do
       visit alchemy.edit_admin_page_path(a_page)
@@ -13,7 +13,7 @@ describe 'Page editing feature' do
   end
 
   context 'as editor' do
-    before { authorize_as_admin(build(:editor_user)) }
+    before { authorize_as_admin(build(:alchemy_editor_user)) }
 
     it 'can publish page.' do
       visit alchemy.edit_admin_page_path(a_page)

--- a/spec/features/page_feature_spec.rb
+++ b/spec/features/page_feature_spec.rb
@@ -275,7 +275,7 @@ module Alchemy
       end
 
       context 'as a member user' do
-        before { authorize_as_admin(create(:member_user)) }
+        before { authorize_as_admin(create(:alchemy_member_user)) }
 
         it "I am able to visit the page" do
           visit restricted_page.urlname

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1661,7 +1661,7 @@ module Alchemy
 
     context 'indicate page editors' do
       let(:page) { Page.new }
-      let(:user) { create(:editor_user) }
+      let(:user) { create(:alchemy_editor_user) }
 
       describe '#creator' do
         before { page.update(creator_id: user.id) }


### PR DESCRIPTION
To avoid conflicts with existing user classes all user factories are
now prefixed with alchemy_

Fixes #654