### PR TITLE
add support for soft deletable pages

### DIFF
--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -31,6 +31,7 @@
 #  language_id      :integer
 #  cached_tag_list  :text
 #  published_at     :datetime
+#  deleted_at       :datetime
 #
 
 module Alchemy
@@ -38,6 +39,7 @@ module Alchemy
     include Alchemy::Hints
     include Alchemy::Logger
     include Alchemy::Touching
+    include Alchemy::SoftDeleteable
 
     DEFAULT_ATTRIBUTES_FOR_COPY = {
       :do_not_autogenerate => true,
@@ -73,6 +75,8 @@ module Alchemy
     has_many :folded_pages
     has_many :legacy_urls, :class_name => 'Alchemy::LegacyPageUrl'
     belongs_to :language
+
+    default_scope { not_deleted }
 
     validates_presence_of :language, :on => :create, :unless => :root
     validates_presence_of :page_layout, :unless => :systempage?

--- a/db/migrate/20150511051944_add_deleted_at_to_alchemy_pages.rb
+++ b/db/migrate/20150511051944_add_deleted_at_to_alchemy_pages.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToAlchemyPages < ActiveRecord::Migration
+  def change
+    add_column :alchemy_pages, :deleted_at, :timestamp
+  end
+end

--- a/lib/alchemy/engine.rb
+++ b/lib/alchemy/engine.rb
@@ -45,6 +45,7 @@ require_relative './ssl_protection'
 require_relative './resource'
 require_relative './tinymce'
 require_relative './touching'
+require_relative './soft_deleteable'
 
 # Require hacks
 require_relative './kaminari/scoped_pagination_url_helper'

--- a/lib/alchemy/soft_deleteable.rb
+++ b/lib/alchemy/soft_deleteable.rb
@@ -1,0 +1,37 @@
+module Alchemy
+  module SoftDeleteable
+    # DeleteNotSupport is raised when delete is called instead of soft_delete
+    #
+    DeleteNotSupported = Class.new(StandardError)
+
+    def self.included(soft_deleteable)
+      soft_deleteable.class_eval do
+        scope :not_deleted, -> { where(deleted_at: nil) }
+        alias_method :destroy_without_soft_delete, :destroy
+      end
+    end
+
+    # Sets the deleted_at timestamp to indicate a soft delete
+    #
+    def soft_delete
+      if persisted?
+        self.deleted_at = Time.now
+        save(validate: false)
+      else
+        true
+      end
+    end
+
+    def deleted?
+      deleted_at.present?
+    end
+
+    def delete
+      raise DeleteNotSupported
+    end
+
+    def destroy
+      run_callbacks(:destroy) { soft_delete }
+    end
+  end
+end

--- a/spec/controllers/admin/pages_controller_spec.rb
+++ b/spec/controllers/admin/pages_controller_spec.rb
@@ -431,6 +431,7 @@ module Alchemy
         before { clipboard['pages'] = [{'id' => page.id.to_s}] }
 
         it "should also remove the page from clipboard" do
+          expect_any_instance_of(Page).to receive(:soft_delete).and_return true
           alchemy_xhr :post, :destroy, {id: page.id, _method: :delete}
           expect(clipboard['pages']).to be_empty
         end

--- a/spec/dummy/db/migrate/20150511051944_add_deleted_at_to_alchemy_pages.rb
+++ b/spec/dummy/db/migrate/20150511051944_add_deleted_at_to_alchemy_pages.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToAlchemyPages < ActiveRecord::Migration
+  def change
+    add_column :alchemy_pages, :deleted_at, :timestamp
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150412103152) do
+ActiveRecord::Schema.define(version: 20150511051944) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string   "name"
@@ -233,6 +233,7 @@ ActiveRecord::Schema.define(version: 20150412103152) do
     t.integer  "language_id"
     t.text     "cached_tag_list"
     t.datetime "published_at"
+    t.datetime "deleted_at"
   end
 
   add_index "alchemy_pages", ["language_id"], name: "index_pages_on_language_id"

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -14,6 +14,15 @@ module Alchemy
     let(:news_page)     { FactoryGirl.create(:public_page, page_layout: 'news', do_not_autogenerate: false) }
 
 
+    # Scopes
+
+    context 'scopes' do
+      it 'it uses not_deleted as default scope' do
+        expect(Page).to receive(:not_deleted)
+        Page.first
+      end
+    end
+
     # Validations
 
     context 'validations' do


### PR DESCRIPTION
This is a first draft how soft delete could be integrated into the backend, as well as my attempt to start contributing to alchemy :)

There are still some things which need to be discussed:

- is the chosen approach consistent with alchemy source?
- should we also soft delete entities related to pages (e.g. cascading deletes, elements,…)?
- how should this be integrated into the ui?
- is there something missing?

related to the **Mark Page as deleted instead of deleting it** trello ticket. 
Looking forward to your feedback :)