### PR TITLE
Change the breadcrumb helper into a class method.

### DIFF
--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -1,10 +1,5 @@
 module Alchemy
   class PagesController < Alchemy::BaseController
-    # We need to include this helper because we need the breadcrumb method.
-    # And we cannot define the breadcrump method as helper_method, because rspec does not see helper_methods.
-    # Not the best solution, but's working.
-    # Anyone with a better idea please provide a patch.
-    include Alchemy::BaseHelper
 
     before_action :enforce_primary_host_for_site
     before_action :render_page_or_redirect, only: [:show]

--- a/app/helpers/alchemy/base_helper.rb
+++ b/app/helpers/alchemy/base_helper.rb
@@ -54,13 +54,6 @@ module Alchemy
       end
     end
 
-    # Returns an array of all pages in the same branch from current.
-    # I.e. used to find the active page in navigation.
-    def breadcrumb(current)
-      return [] if current.nil?
-      current.self_and_ancestors.where("parent_id IS NOT NULL")
-    end
-
     # Returns the Alchemy configuration.
     #
     # *DO NOT REMOVE THIS HERE.*
@@ -104,6 +97,5 @@ module Alchemy
         page
       end
     end
-
   end
 end

--- a/app/helpers/alchemy/pages_helper.rb
+++ b/app/helpers/alchemy/pages_helper.rb
@@ -207,8 +207,8 @@ module Alchemy
 
     # Returns true if page is in the active branch
     def page_active?(page)
-      @breadcrumb ||= breadcrumb(@page)
-      @breadcrumb.include?(page)
+      @_page_ancestors ||= Page.ancestors_for(@page)
+      @_page_ancestors.include?(page)
     end
 
     # Returns +'active'+ if the given external page is in the current url path or +nil+.
@@ -235,7 +235,7 @@ module Alchemy
         reverse: false,
         link_active_page: false
       }.merge(options)
-      pages = breadcrumb(options[:page]).accessible_by(current_ability, :see)
+      pages = Page.ancestors_for(options[:page]).accessible_by(current_ability, :see)
       pages = pages.restricted if options.delete(:restricted_only)
       pages.to_a.reverse! if options[:reverse]
       if options[:without].present?

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -199,7 +199,14 @@ module Alchemy
         options
       end
 
-    private
+      # Returns an array of all pages in the same branch from current.
+      # I.e. used to find the active page in navigation.
+      def ancestors_for(current)
+        return [] if current.nil?
+        current.self_and_ancestors.contentpages
+      end
+
+      private
 
       # Aggregates the attributes from given source for copy of page.
       #

--- a/spec/helpers/base_helper_spec.rb
+++ b/spec/helpers/base_helper_spec.rb
@@ -40,26 +40,6 @@ module Alchemy
       end
     end
 
-    describe '#breadcrumb' do
-      let(:lang_root) { Page.language_root_for(Language.default.id) }
-      let(:parent)    { FactoryGirl.create(:public_page) }
-      let(:page)      { FactoryGirl.create(:public_page, parent_id: parent.id) }
-
-      it "returns an array of all parents including self" do
-        expect(helper.breadcrumb(page)).to eq([lang_root, parent, page])
-      end
-
-      it "does not include the root page" do
-        expect(helper.breadcrumb(page)).not_to include(Page.root)
-      end
-
-      context "with current page nil" do
-        it "should return an empty array" do
-          expect(helper.breadcrumb(nil)).to eq([])
-        end
-      end
-    end
-
     describe '#page_or_find' do
       let(:page) { FactoryGirl.create(:public_page) }
 
@@ -83,8 +63,6 @@ module Alchemy
           expect(helper.page_or_find(page)).to eq(page)
         end
       end
-
     end
-
   end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -416,6 +416,26 @@ module Alchemy
       end
     end
 
+    describe '.ancestors_for' do
+      let(:lang_root) { Page.language_root_for(Language.default.id) }
+      let(:parent)    { create(:public_page) }
+      let(:page)      { create(:public_page, parent_id: parent.id) }
+
+      it "returns an array of all parents including self" do
+        expect(Page.ancestors_for(page)).to eq([lang_root, parent, page])
+      end
+
+      it "does not include the root page" do
+        expect(Page.ancestors_for(page)).not_to include(Page.root)
+      end
+
+      context "with current page nil" do
+        it "should return an empty array" do
+          expect(Page.ancestors_for(nil)).to eq([])
+        end
+      end
+    end
+
     describe '.contentpages' do
       before do
         layoutroot = Page.find_or_create_layout_root_for(klingonian.id)


### PR DESCRIPTION
The breadcrumb helper has always been very cumbersome. It now is a class method on Page model and can therefore used everywhere in the system not only in view contexts; what makes this very hard testable and could override existing breadcrumb helpers in the main app.