### PR TITLE
Fix image loading spinner for already loaded images

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.base.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.base.js.coffee
@@ -46,16 +46,17 @@ $.extend Alchemy,
   # fades the image after its been loaded
   ImageLoader: (scope = document, options = {color: '#fff'}) ->
     $('img', scope).each ->
-      image = $(this).hide()
-      $parent = image.parent()
-      spinner = Alchemy.Spinner.small options
-      spinner.spin $parent[0]
-      image.on 'load', ->
-        spinner.stop()
-        image.fadeIn 400
-      image.on 'error', ->
-        spinner.stop()
-        $parent.html('<span class="icon warn"/>')
+      if !this.complete
+        image = $(this).hide()
+        $parent = image.parent()
+        spinner = Alchemy.Spinner.small options
+        spinner.spin $parent[0]
+        image.on 'load', ->
+          spinner.stop()
+          image.fadeIn 400
+        image.on 'error', ->
+          spinner.stop()
+          $parent.html('<span class="icon warn"/>')
 
   removePicture: (selector) ->
     $form_field = $(selector)


### PR DESCRIPTION
When images are being cached by the browser, no load event is fired, so the image loading js hides the image forever. This checks to see whether the image has already been loaded before setting up a loading spinner.