### PR TITLE
Make the default-button extend a mixin

### DIFF
--- a/app/assets/stylesheets/alchemy/_extends.scss
+++ b/app/assets/stylesheets/alchemy/_extends.scss
@@ -47,12 +47,6 @@
   line-height: 0;
 }
 
-%button-defaults {
-  @include sassy-button('simple', $sb-border-radius, $sb-font-size, $sb-base-color, $sb-second-color, $sb-text-color, $sb-text-style, $sb-pseudo-states, $sb-ie-support);
-  border-color: $button-border-color;
-  margin: $default-form-field-margin;
-}
-
 %field-with-error {
   border-color: $error_border_color;
   color: $error_text_color;

--- a/app/assets/stylesheets/alchemy/_mixins.scss
+++ b/app/assets/stylesheets/alchemy/_mixins.scss
@@ -9,6 +9,12 @@
   }
 }
 
+@mixin button-defaults {
+  @include sassy-button('simple', $sb-border-radius, $sb-font-size, $sb-base-color, $sb-second-color, $sb-text-color, $sb-text-style, $sb-pseudo-states, $sb-ie-support);
+  border-color: $button-border-color;
+  margin: $default-form-field-margin;
+}
+
 @mixin default-label-style {
   font-size: 10px;
   text-shadow: #fff 0 1px 2px;

--- a/app/assets/stylesheets/alchemy/buttons.scss
+++ b/app/assets/stylesheets/alchemy/buttons.scss
@@ -1,5 +1,5 @@
 button, input[type="submit"], a.button, input.button {
-  @extend %button-defaults;
+  @include button-defaults;
 
   &.small {
     padding: 2px 2*$default-padding;

--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -305,12 +305,12 @@ div#cells {
   right: 0;
 
   .icon_button {
+    @include button-defaults;
     margin: 0 0 0 4px;
     padding: 3px;
     position: absolute;
     bottom: 4px;
     right: 28px;
-    @extend %button-defaults;
     @include border-radius(0);
 
     &.unlink {

--- a/app/assets/stylesheets/alchemy/menubar.scss
+++ b/app/assets/stylesheets/alchemy/menubar.scss
@@ -62,7 +62,7 @@
       text-align: center;
 
       a, button {
-        @extend %button-defaults;
+        @include button-defaults;
         padding-left: $default-padding;
         padding-right: $default-padding;
         width: 100%;

--- a/app/assets/stylesheets/alchemy/selects.scss
+++ b/app/assets/stylesheets/alchemy/selects.scss
@@ -1,5 +1,5 @@
 select {
-  @extend %button-defaults;
+  @include button-defaults;
   height: 29px;
   padding: 0.4em 0.6em;
 }

--- a/app/assets/stylesheets/alchemy/upload.scss
+++ b/app/assets/stylesheets/alchemy/upload.scss
@@ -5,7 +5,7 @@ a#uploadswitcher, a.underline {
 .upload-container {
 
   label {
-    @extend %button-defaults;
+    @include button-defaults;
     text-align: center;
     width: 80px;
   }


### PR DESCRIPTION
I was experiencing strange-looking buttons on an EssenceLink, which were
due to a non-working override on an extend. It can be made to work by
simply converting the extend to an include, so I did that.