### PR TITLE
Allow custom table_name_prefix

### DIFF
--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -156,7 +156,7 @@ module Alchemy
       # /slug/tree => slug/tree
       urlname = (request.fullpath[1..-1] if request.fullpath[0] == '/') || request.fullpath
 
-      LegacyPageUrl.joins(:page).where(urlname: urlname, alchemy_pages: {language_id: Language.current.id})
+      LegacyPageUrl.joins(:page).where(urlname: urlname, Page.table_name => {language_id: Language.current.id})
     end
 
     def last_legacy_url

--- a/app/helpers/alchemy/admin/elements_helper.rb
+++ b/app/helpers/alchemy/admin/elements_helper.rb
@@ -105,8 +105,8 @@ module Alchemy
       #
       def update_essence_select_elements(page, element)
         elements = page.elements.not_trashed.joins(:contents)
-          .where("alchemy_contents.element_id != #{element.id}")
-          .where("alchemy_contents.essence_type" => "Alchemy::EssenceSelect")
+          .where("#{Content.table_name}.element_id != #{element.id}")
+          .where("#{Content.table_name}.essence_type" => "Alchemy::EssenceSelect")
         return if elements.blank?
         elements.collect do |element|
           render 'alchemy/admin/elements/refresh_editor', element: element

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -37,7 +37,7 @@ module Alchemy
     belongs_to :page
     has_and_belongs_to_many :touchable_pages, -> { uniq },
       class_name: 'Alchemy::Page',
-      join_table: 'alchemy_elements_alchemy_pages'
+      join_table: ElementToPage.table_name
 
     validates_presence_of :name, :on => :create
     validates_format_of :name, :on => :create, :with => /\A[a-z0-9_-]+\z/
@@ -57,7 +57,7 @@ module Alchemy
     scope :excluded,          ->(names) { where(arel_table[:name].not_in(names)) }
     scope :not_in_cell,       -> { where(cell_id: nil) }
     scope :in_cell,           -> { where("#{self.table_name}.cell_id IS NOT NULL") }
-    scope :from_current_site, -> { where(alchemy_languages: {site_id: Site.current || Site.default}).joins(page: 'language') }
+    scope :from_current_site, -> { where(Language.table_name => {site_id: Site.current || Site.default}).joins(page: 'language') }
 
     delegate :restricted?, to: :page, allow_nil: true
 
@@ -384,7 +384,7 @@ module Alchemy
     # Returns an array of all EssenceRichtext contents ids
     #
     def richtext_contents_ids
-      contents.essence_richtexts.pluck('alchemy_contents.id')
+      contents.essence_richtexts.pluck("#{Content.table_name}.id")
     end
 
     # The names of all cells from given page this element could be placed in.

--- a/app/models/alchemy/element_to_page.rb
+++ b/app/models/alchemy/element_to_page.rb
@@ -1,0 +1,7 @@
+module Alchemy
+  class ElementToPage
+    def self.table_name
+      [Element.table_name, Page.table_name].join('_')
+    end
+  end
+end

--- a/app/models/alchemy/language.rb
+++ b/app/models/alchemy/language.rb
@@ -37,7 +37,7 @@ module Alchemy
     before_save :remove_old_default, if: proc { |m| m.default_changed? && m != Language.default }
 
     scope :published,      -> { where(public: true) }
-    scope :with_root_page, -> { joins(:pages).where(alchemy_pages: {language_root: true}) }
+    scope :with_root_page, -> { joins(:pages).where(Page.table_name => {language_root: true}) }
     scope :on_site,        ->(s) { s.present? ? where(site_id: s) : all }
     default_scope { on_site(Site.current) }
 

--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -8,7 +8,9 @@ module Alchemy
 
       has_many :elements, -> { order(:position) }
       has_many :contents, :through => :elements
-      has_and_belongs_to_many :to_be_sweeped_elements, -> { uniq }, class_name: 'Alchemy::Element', join_table: 'alchemy_elements_alchemy_pages'
+      has_and_belongs_to_many :to_be_sweeped_elements, -> { uniq },
+        class_name: 'Alchemy::Element',
+        join_table: ElementToPage.table_name
 
       after_create :autogenerate_elements, :unless => proc { systempage? || do_not_autogenerate }
       after_update :trash_not_allowed_elements, :if => :page_layout_changed?
@@ -169,7 +171,7 @@ module Alchemy
     # Returns an array of all EssenceRichtext contents ids
     #
     def richtext_contents_ids
-      contents.essence_richtexts.pluck('alchemy_contents.id')
+      contents.essence_richtexts.pluck("#{Content.table_name}.id")
     end
 
     private

--- a/app/models/alchemy/page/page_scopes.rb
+++ b/app/models/alchemy/page/page_scopes.rb
@@ -83,7 +83,7 @@ module Alchemy
       # All pages from +Alchemy::Site.current+
       #
       scope :from_current_site, -> {
-        where(alchemy_languages: {site_id: Site.current || Site.default}).joins(:language)
+        where(Language.table_name => {site_id: Site.current || Site.default}).joins(:language)
       }
 
       # All pages for xml sitemap

--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -71,7 +71,7 @@ module Alchemy
     }
 
     scope :deletable, -> {
-      where("#{self.table_name}.id NOT IN (SELECT picture_id FROM alchemy_essence_pictures)")
+      where("#{self.table_name}.id NOT IN (SELECT picture_id FROM #{EssencePicture.table_name})")
     }
 
     scope :without_tag, -> {

--- a/lib/alchemy/essence.rb
+++ b/lib/alchemy/essence.rb
@@ -41,7 +41,7 @@ module Alchemy #:nodoc:
           has_one :page,    :through => :element, class_name: "Alchemy::Page"
 
           scope :available,    -> { joins(:element).merge(Alchemy::Element.available) }
-          scope :from_element, ->(name) { joins(:element).where(alchemy_elements: { name: name }) }
+          scope :from_element, ->(name) { joins(:element).where(Element.table_name => { name: name }) }
 
           delegate :restricted?, to: :page,    allow_nil: true
           delegate :trashed?,    to: :element, allow_nil: true

--- a/spec/models/element_to_page_spec.rb
+++ b/spec/models/element_to_page_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+module Alchemy
+  describe ElementToPage do
+
+    # ClassMethods
+
+    describe '.table_name' do
+      it "should return table name" do
+        expect(ElementToPage.table_name).to eq('alchemy_elements_alchemy_pages')
+      end
+    end
+  end
+end


### PR DESCRIPTION
These changes should enable the usage of a different table name prefix.
'alchemy_' prefix should not be hardcoded.

I've done it on 3.1-stable as this is what I'm using now but should be ported to master.
