### PR TITLE
Normalize Essence Type: Allow Essences outside Alchemy

### DIFF
--- a/app/models/alchemy/content/factory.rb
+++ b/app/models/alchemy/content/factory.rb
@@ -122,19 +122,26 @@ module Alchemy
       # Returns a normalized Essence type
       #
       # Adds Alchemy module name in front of given essence type
+      # unless there is a Class with the specified name that is an essence.
       #
       # @param [String]
       #   the essence type to normalize
       #
       def normalize_essence_type(essence_type)
         essence_type = essence_type.classify
-        if essence_type.match(/\AAlchemy::/)
-          essence_type
-        else
-          essence_type.gsub!(/\AEssence/, 'Alchemy::Essence')
-        end
+        return essence_type if is_an_essence?(essence_type)
+
+        "Alchemy::#{essence_type}"
       end
 
+      private
+
+      def is_an_essence?(essence_type)
+        klass = Module.const_get(essence_type)
+        klass.is_a?(Class) && klass.new.acts_as_essence?
+      rescue NameError
+        false
+      end
     end # end class methods
 
     # Instance Methods
@@ -179,6 +186,5 @@ module Alchemy
       }
       attributes
     end
-
   end
 end

--- a/spec/models/content_spec.rb
+++ b/spec/models/content_spec.rb
@@ -22,6 +22,12 @@ module Alchemy
           expect(Content.normalize_essence_type('EssenceText')).to eq("Alchemy::EssenceText")
         end
       end
+
+      context "passing non-namespaced essence type for an existing non-namespaced essence" do
+        it "should not add alchemy namespace" do
+          expect(Content.normalize_essence_type('DummyModel')).to eq("DummyModel")
+        end
+      end
     end
 
     describe '#normalized_essence_type' do


### PR DESCRIPTION
I have an Event model outside the Alchemy namespace that perfectly
acts_as_essence. However, I can't use it on pages, because the
"normalize_essence_type" method adds the Alchemy namespace even though
its not necessary.

Initially I though about actually removing the method, but that would be
very cumbersome as then all type entries in the elements.yml file would
have to be namespaced, too - so I included a check for whether a class
with that name exists and an instance of that class would act as an
essence.

This is a follow-up to c1fa728.