### PR TITLE
Feature - site switching without changing hosts

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.initializer.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.initializer.js.coffee
@@ -30,6 +30,12 @@ Alchemy.Initializer = ->
     delimiter = if url.match(/\?/) then '&' else '?'
     window.location.href = "#{url}#{delimiter}locale=#{$(this).val()}"
 
+  # Site select handler
+  $('select#change_site').on 'change', (e) ->
+    url = window.location.pathname
+    delimiter = if url.match(/\?/) then '&' else '?'
+    window.location.href = "#{url}#{delimiter}site_id=#{$(this).val()}"
+
   # Submit forms of selects with `data-autosubmit="true"`
   $('select[data-auto-submit="true"]').on 'change', (e) ->
     Alchemy.pleaseWaitOverlay()

--- a/app/helpers/alchemy/admin/base_helper.rb
+++ b/app/helpers/alchemy/admin/base_helper.rb
@@ -64,6 +64,13 @@ module Alchemy
         end
       end
 
+      # Used for site selector in Alchemy cockpit.
+      def sites_for_select
+        Alchemy::Site.all.map do |site|
+          [site.name, site.id]
+        end
+      end
+
       # Returns a javascript driven live filter for lists.
       #
       # The items must have a html +name+ attribute that holds the filterable value.

--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -86,9 +86,11 @@
         <%= select_tag 'change_locale',
           options_for_select(translations_for_select, ::I18n.locale),
           class: 'alchemy_selectbox tiny' %>
+        <%- if multi_site? -%>
         <%= select_tag 'change_site',
           options_for_select(sites_for_select, Alchemy::Site.current.id),
           class: 'alchemy_selectbox tiny' %>
+        <%- end -%>
       </div>
     </div>
     <% end %>

--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -86,6 +86,9 @@
         <%= select_tag 'change_locale',
           options_for_select(translations_for_select, ::I18n.locale),
           class: 'alchemy_selectbox tiny' %>
+        <%= select_tag 'change_site',
+          options_for_select(sites_for_select, Alchemy::Site.current.id),
+          class: 'alchemy_selectbox tiny' %>
       </div>
     </div>
     <% end %>

--- a/lib/alchemy/controller_actions.rb
+++ b/lib/alchemy/controller_actions.rb
@@ -46,7 +46,16 @@ module Alchemy
     # Returns the current site.
     #
     def current_alchemy_site
-      @current_alchemy_site ||= Site.find_for_host(request.host)
+      @current_alchemy_site ||= begin
+        site_id = params[:site_id] || session[:site_id]
+        if site_id.nil?
+          session.delete :site_id
+          Site.find_for_host(request.host)
+        else
+          session[:site_id] = site_id
+          Site.find(site_id)
+        end
+      end
     end
 
     # Ensures usage of Alchemy's permissions class.

--- a/spec/features/admin/site_select_feature_spec.rb
+++ b/spec/features/admin/site_select_feature_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'Site select' do
+
+  before do
+    authorize_as_admin
+  end
+
+  it "does not display the site change" do
+    visit admin_dashboard_path
+    expect(page).not_to have_select('change_site')
+  end
+
+  context "multiple sites" do
+    let!(:a_site) { FactoryGirl.create(:site) }
+
+    it "contains all sites in a selectbox" do
+      visit admin_dashboard_path
+      expect(page).to have_select('change_site', options: [Alchemy::Site.default.name, a_site.name], selected: Alchemy::Site.default.name)
+    end
+
+    context 'when requesting non-default site' do
+      it "provides the correct site" do
+        visit admin_pages_path(site_id: a_site.id)
+        expect(page).to have_select('change_site', selected: a_site.name)
+
+        visit admin_dashboard_path
+        expect(page).to have_select('change_site', selected: a_site.name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR aims to ease administrative affords for Alchemy installations with multiple sites by adding support for inline site switching.

When you use Alchemy to manage multiple sites you need to login using the host of the desired site in order to manage the content. 
This is because the `current_alchemy_site` controller action loads the site by host only.

I'v added a tiny site selection widget to the top menu which can be used to change the site without changing the host.

The current implementation was modelled after the way the language selection works. If a request parameter named `site_id` is present the desired site is loaded by id and the `site_id` is persisted in the session to allow subsequent requests which don't carry the `site_id` parameter to still refer to the desired site.

While this works I'd prefer a more explicit approach which would `POST` to `change_site` or similar, but this works as well.

Feedback is welcome.