### PR TITLE
Add added_attributes to Alchemy::Resource

### DIFF
--- a/lib/alchemy/resource.rb
+++ b/lib/alchemy/resource.rb
@@ -34,10 +34,13 @@ module Alchemy
   #
   # == Add attributes
   #
-  # You might want to show or sort by some more attributes that might be methods. These attributes will be skipped (not editable) by default.
-  # To define your own set of added attributes, define a class method +added_alchemy_resource_attributes like the following:
+  # You might want to show or sort by some more attributes that might be methods.
+  # These attributes will be restricted (not editable) by default, and you cannot search for them, either.
+  # To define your own set of added attributes, define a class method +additional_alchemy_resource_attributes like the following:
   #
-  #     def self.added_alchemy_resource_attributes
+  # === Example
+  #
+  #     def self.additional_alchemy_resource_attributes
   #       [
   #         {name: 'location', type: 'string'},
   #         {name: 'attending', type: 'boolean'}
@@ -151,7 +154,7 @@ module Alchemy
 
     def attributes
       @_attributes ||= self.model.columns.collect do |col|
-        unless self.skipped_attributes.include?(col.name)
+        unless skipped_attributes.include?(col.name)
           {
             name: col.name,
             type: resource_column_type(col),
@@ -162,7 +165,7 @@ module Alchemy
     end
 
     def editable_attributes
-      attributes.reject { |h| self.restricted_attributes.map(&:to_s).include?(h[:name].to_s) }
+      attributes.reject { |h| restricted_attributes.map(&:to_s).include?(h[:name].to_s) }
     end
 
     # Returns all columns that are searchable
@@ -170,7 +173,7 @@ module Alchemy
     # For now it only uses string type columns
     #
     def searchable_attributes
-      self.attributes.select { |a| a[:type].to_sym == :string }
+      self.attributes.select { |a| a[:type].to_sym == :string } - added_attributes
     end
 
     def in_engine?
@@ -197,6 +200,19 @@ module Alchemy
       false
     end
 
+    # Return attributes that should be viewable but not editable.
+    #
+    def restricted_attributes
+      if model.respond_to?(:restricted_alchemy_resource_attributes)
+        attrs = model.restricted_alchemy_resource_attributes
+      else
+        attrs = []
+      end
+      attrs + added_attributes
+    end
+
+    private
+
     # Return attributes that should neither be viewable nor editable.
     #
     def skipped_attributes
@@ -211,25 +227,12 @@ module Alchemy
     # activerecord attributes.
     #
     def added_attributes
-      if model.respond_to?(:added_alchemy_resource_attributes)
-        model.added_alchemy_resource_attributes
+      if model.respond_to?(:additional_alchemy_resource_attributes)
+        model.additional_alchemy_resource_attributes
       else
         []
       end
     end
-
-    # Return attributes that should be viewable but not editable.
-    #
-    def restricted_attributes
-      if model.respond_to?(:restricted_alchemy_resource_attributes)
-        attrs = model.restricted_alchemy_resource_attributes
-      else
-        attrs = []
-      end
-      attrs + added_attributes
-    end
-
-    private
 
     def guess_model_from_controller_path
       resource_array.join('/').classify.constantize

--- a/lib/alchemy/resource.rb
+++ b/lib/alchemy/resource.rb
@@ -32,11 +32,14 @@ module Alchemy
   #       %w(id updated_at secret_token remote_ip)
   #     end
   #
-  # == Add attributes
+  # == Adding non-database attributes attributes
   #
-  # You might want to show or sort by some more attributes that might be methods.
-  # These attributes will be restricted (not editable) by default, and you cannot search for them, either.
-  # To define your own set of added attributes, define a class method +additional_alchemy_resource_attributes like the following:
+  # You might want to show some more attributes that which are not in the database, but methods on
+  # your object. These attributes will be restricted (not editable) by default, and you cannot
+  # search for them or sort by them, either.
+  #
+  # To define your own set of additional attributes, define a class method
+  # +additional_alchemy_resource_attributes like the following:
   #
   # === Example
   #
@@ -161,7 +164,7 @@ module Alchemy
             relation: resource_relation(col.name)
           }.delete_if { |k, v| v.nil? }
         end
-      end.compact + added_attributes
+      end.compact + additional_attributes
     end
 
     def editable_attributes
@@ -173,7 +176,7 @@ module Alchemy
     # For now it only uses string type columns
     #
     def searchable_attributes
-      self.attributes.select { |a| a[:type].to_sym == :string } - added_attributes
+      attributes.select { |a| a[:type].to_sym == :string } - additional_attributes
     end
 
     def in_engine?
@@ -208,7 +211,7 @@ module Alchemy
       else
         attrs = []
       end
-      attrs + added_attributes
+      attrs + additional_attributes
     end
 
     private
@@ -226,7 +229,7 @@ module Alchemy
     # Return attributes that should be viewable, but are not regular
     # activerecord attributes.
     #
-    def added_attributes
+    def additional_attributes
       if model.respond_to?(:additional_alchemy_resource_attributes)
         model.additional_alchemy_resource_attributes
       else

--- a/spec/libraries/resource_spec.rb
+++ b/spec/libraries/resource_spec.rb
@@ -208,7 +208,7 @@ module Alchemy
           end
         end
 
-        it "includes the added attributes" do
+        it "includes the additional attributes" do
           expect(subject).to include({name: "foo", type: :string})
         end
       end
@@ -276,7 +276,7 @@ module Alchemy
           end
         end
 
-        it "does not include the added attributes" do
+        it "does not include the additional attributes" do
           expect(subject).not_to include({name: "foo", type: "string"})
         end
       end


### PR DESCRIPTION
We'd like to be able to see some more attributes in our resource
module than just the DB columns. For that, we propose a method
`added_alchemy_resource_attributes`, which specifies those attribute
**getters** that should be displayed alongside the database columns.