### PR TITLE
Allow ERB in database.yml

### DIFF
--- a/lib/alchemy/tasks/helpers.rb
+++ b/lib/alchemy/tasks/helpers.rb
@@ -13,7 +13,7 @@ module Alchemy
       def database_config
         raise "Could not find #{database_config_file}!" if !File.exists?(database_config_file)
         @database_config ||= begin
-          config_file = YAML.load_file(database_config_file)
+          config_file = YAML.load(ERB.new(File.read(database_config_file)).result)
           config_file.fetch(environment)
           rescue KeyError
             raise "Database configuration for #{environment} not found!"

--- a/spec/tasks/helpers_spec.rb
+++ b/spec/tasks/helpers_spec.rb
@@ -8,10 +8,8 @@ module Alchemy
   end
 
   describe "Tasks:Helpers" do
-
     let(:config) do
-      {
-        'test' => {
+      { 'test' => {
           'adapter'  => 'mysql2',
           'username' => 'testuser',
           'password' => '123456',
@@ -21,8 +19,16 @@ module Alchemy
     end
 
     before do
-      allow(File).to receive(:exists?).and_return( true)
-      allow(YAML).to receive(:load_file).and_return(config)
+      allow(File).to receive(:exists?) { true }
+      allow(File).to receive(:read) do
+<<-END
+test:
+  adapter: mysql2
+  username: testuser
+  password: "123456"
+  host: localhost
+END
+      end
     end
 
     describe "#database_dump_command" do
@@ -68,7 +74,7 @@ module Alchemy
 
           context "and the host is anything but not localhost" do
             before do
-              allow(YAML).to receive(:load_file).and_return({'test' => {'host' => 'mydomain.com'}})
+              allow(File).to receive(:read).and_return("test:\n  host: mydomain.com")
             end
             it { is_expected.to include("--host='mydomain.com'") }
           end
@@ -97,7 +103,7 @@ module Alchemy
 
           context "and the host is anything but not localhost" do
             before do
-              allow(YAML).to receive(:load_file).and_return({'test' => {'host' => 'mydomain.com'}})
+              allow(File).to receive(:read).and_return("test:\n  host: mydomain.com")
             end
             it { is_expected.to include("--host='mydomain.com'") }
           end
@@ -152,7 +158,7 @@ module Alchemy
 
           context "and the host is anything but not localhost" do
             before do
-              allow(YAML).to receive(:load_file).and_return({'test' => {'host' => 'mydomain.com'}})
+              allow(File).to receive(:read).and_return("test:\n  host: mydomain.com")
             end
             it { is_expected.to include("--host='mydomain.com'") }
           end
@@ -181,7 +187,7 @@ module Alchemy
 
           context "and the host is anything but not localhost" do
             before do
-              allow(YAML).to receive(:load_file).and_return({'test' => {'host' => 'mydomain.com'}})
+              allow(File).to receive(:read).and_return("test:\n  host: mydomain.com")
             end
             it { is_expected.to include("--host='mydomain.com'") }
           end


### PR DESCRIPTION
Recent versions of Rails allow ERB in the `database.yml` file, and
without this commit, the importing of the DB configuration will fail
miserably if the config file actually has ERB.