### PR TITLE
Move Element content related methods into modules.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -251,6 +251,7 @@ Style/ClassCheck:
 
 # Align with the style guide.
 Style/CollectionMethods:
+  Enabled: false
   # Mapping from undesired method to desired_method
   # e.g. to use `detect` over `find`:
   #
@@ -344,12 +345,14 @@ Style/EmptyLinesAroundBlockBody:
     - no_empty_lines
 
 Style/EmptyLinesAroundClassBody:
+  Enabled: false
   EnforcedStyle: no_empty_lines
   SupportedStyles:
     - empty_lines
     - no_empty_lines
 
 Style/EmptyLinesAroundModuleBody:
+  Enabled: false
   EnforcedStyle: no_empty_lines
   SupportedStyles:
     - empty_lines

--- a/app/models/alchemy/element/element_contents.rb
+++ b/app/models/alchemy/element/element_contents.rb
@@ -1,0 +1,155 @@
+# Methods concerning contents for elements
+#
+module Alchemy
+  module Element::ElementContents
+
+    # Find first content from element by given name.
+    def content_by_name(name)
+      contents_by_name(name).first
+    end
+
+    # Find first content from element by given essence type.
+    def content_by_type(essence_type)
+      contents_by_type(essence_type).first
+    end
+
+    # All contents from element by given name.
+    def contents_by_name(name)
+      contents.where(name: name)
+    end
+    alias_method :all_contents_by_name, :contents_by_name
+
+    # All contents from element by given essence type.
+    def contents_by_type(essence_type)
+      contents.where(essence_type: Content.normalize_essence_type(essence_type))
+    end
+    alias_method :all_contents_by_type, :contents_by_type
+
+    # Updates all related contents by calling +update_essence+ on each of them.
+    #
+    # @param contents_attributes [Hash]
+    #   Hash of contents attributes.
+    #   The keys has to be the #id of the content to update.
+    #   The values a Hash of attribute names and values
+    #
+    # @return [Boolean]
+    #   True if +errors+ are blank or +contents_attributes+ hash is nil
+    #
+    # == Example
+    #
+    #   @element.update_contents(
+    #     "1" => {ingredient: "Title"},
+    #     "2" => {link: "https://google.com"}
+    #   )
+    #
+    def update_contents(contents_attributes)
+      return true if contents_attributes.nil?
+      contents.each do |content|
+        content_hash = contents_attributes["#{content.id}"] || next
+        content.update_essence(content_hash) || errors.add(:base, :essence_validation_failed)
+      end
+      errors.blank?
+    end
+
+    # Returns the content that is marked as rss title.
+    #
+    # Mark a content as rss title in your +elements.yml+ file:
+    #
+    #   - name: news
+    #     contents:
+    #     - name: headline
+    #       type: EssenceText
+    #       rss_title: true
+    #
+    def content_for_rss_title
+      content_for_rss_meta('title')
+    end
+
+    # Returns the content that is marked as rss description.
+    #
+    # Mark a content as rss description in your +elements.yml+ file:
+    #
+    #   - name: news
+    #     contents:
+    #     - name: body
+    #       type: EssenceRichtext
+    #       rss_description: true
+    #
+    def content_for_rss_description
+      content_for_rss_meta('description')
+    end
+
+    # Returns the array with the hashes for all element contents in the elements.yml file
+    def content_definitions
+      return nil if definition.blank?
+      definition['contents']
+    end
+    alias_method :content_descriptions, :content_definitions
+
+    # Returns the definition for given content_name
+    def content_definition_for(content_name)
+      if content_descriptions.blank?
+        log_warning "Element #{name} is missing the content definition for #{content_name}"
+        return nil
+      else
+        content_definitions.detect { |d| d['name'] == content_name }
+      end
+    end
+    alias_method :content_description_for, :content_definition_for
+
+    # Returns the definition for given content_name inside the available_contents
+    def available_content_definition_for(content_name)
+      return nil if available_contents.blank?
+      available_contents.detect { |d| d['name'] == content_name }
+    end
+    alias_method :available_content_description_for, :available_content_definition_for
+
+    # The collection of available essence_types that can be created for
+    # this element depending on its description in +elements.yml+.
+    def available_contents
+      definition['available_contents']
+    end
+
+    # Returns an array of all EssenceRichtext contents ids
+    #
+    def richtext_contents_ids
+      richtext_contents.pluck("#{Content.table_name}.id")
+    end
+
+    # All contents that are type of EssenceRichtext.
+    def rtf_contents
+      contents.essence_richtexts
+    end
+    alias_method :richtext_contents, :rtf_contents
+
+    # True, if any of the element's contents has essence validations defined.
+    def has_validations?
+      !contents.detect(&:has_validations?).blank?
+    end
+
+    # All element contents where the essence validation has failed.
+    def contents_with_errors
+      contents.select(&:essence_validation_failed?)
+    end
+
+    private
+
+    def content_for_rss_meta(type)
+      description = content_descriptions.detect { |c| c["rss_#{type}"] }
+      return if description.blank?
+      contents.find_by(name: description['name'])
+    end
+
+    # creates the contents for this element as described in the elements.yml
+    def create_contents
+      contents = []
+      if definition["contents"].blank?
+        log_warning "Could not find any content descriptions for element: #{name}"
+      else
+        definition["contents"].each do |content_hash|
+          contents << Content.create_from_scratch(self, content_hash.symbolize_keys)
+        end
+      end
+    end
+  end
+end

--- a/app/models/alchemy/element/element_essences.rb
+++ b/app/models/alchemy/element/element_essences.rb
@@ -1,0 +1,110 @@
+module Alchemy
+  module Element::ElementEssences
+
+    # Returns the contents essence value (aka. ingredient) for passed content name.
+    def ingredient(name)
+      content = content_by_name(name)
+      return nil if content.blank?
+      content.ingredient
+    end
+
+    # True if the element has a content for given name,
+    # that has an essence value (aka. ingredient) that is not blank.
+    def has_ingredient?(name)
+      ingredient(name).present?
+    end
+
+    # Returns all essence errors in the format of:
+    #
+    #   {
+    #     essence.content.name => [
+    #       error_message_for_validation_1,
+    #       error_message_for_validation_2
+    #     ]
+    #   }
+    #
+    # Get translated error messages with +Element#essence_error_messages+
+    #
+    def essence_errors
+      essence_errors = {}
+      essences.each do |essence|
+        unless essence.errors.blank?
+          essence_errors[essence.content.name] = essence.validation_errors
+        end
+      end
+      essence_errors
+    end
+
+    # Essence validation errors
+    #
+    # == Error messages are translated via I18n
+    #
+    # Inside your translation file add translations like:
+    #
+    #   alchemy:
+    #     content_validations:
+    #       name_of_the_element:
+    #         name_of_the_content:
+    #           validation_error_type: Error Message
+    #
+    # NOTE: +validation_error_type+ has to be one of:
+    #
+    #   * blank
+    #   * taken
+    #   * invalid
+    #
+    # === Example:
+    #
+    #   de:
+    #     alchemy:
+    #       content_validations:
+    #         contactform:
+    #           email:
+    #             invalid: 'Die Email hat nicht das richtige Format'
+    #
+    #
+    # == Error message translation fallbacks
+    #
+    # In order to not translate every single content for every element
+    # you can provide default error messages per content name:
+    #
+    # === Example
+    #
+    #   en:
+    #     alchemy:
+    #       content_validations:
+    #         fields:
+    #           email:
+    #             invalid: E-Mail has wrong format
+    #             blank: E-Mail can't be blank
+    #
+    # And even further you can provide general field agnostic error messages:
+    #
+    # === Example
+    #
+    #   en:
+    #     alchemy:
+    #       content_validations:
+    #         errors:
+    #           invalid: %{field} has wrong format
+    #           blank: %{field} can't be blank
+    #
+    def essence_error_messages
+      messages = []
+      essence_errors.each do |content_name, errors|
+        errors.each do |error|
+          messages << I18n.t(
+            "#{name}.#{content_name}.#{error}",
+            scope: 'content_validations',
+            default: [
+              "fields.#{content_name}.#{error}".to_sym,
+              "errors.#{error}".to_sym
+            ],
+            field: Content.translated_label_for(content_name, name)
+          )
+        end
+      end
+      messages
+    end
+  end
+end


### PR DESCRIPTION
To clean up the code two new modules now hold methods concerning contents and essences for the element model.