### PR TITLE
Test robustness

### DIFF
--- a/lib/alchemy/auth_accessors.rb
+++ b/lib/alchemy/auth_accessors.rb
@@ -66,7 +66,7 @@ module Alchemy
       if @@user_class_name.is_a?(String)
         @@user_class_name.constantize
       else
-        raise 'Alchemy.user_class_name must be a String, not a Class.'
+        raise TypeError, 'Alchemy.user_class_name must be a String, not a Class.'
       end
     end
   rescue NameError => e

--- a/lib/alchemy/config.rb
+++ b/lib/alchemy/config.rb
@@ -15,12 +15,12 @@ module Alchemy
       alias_method :parameter, :get
 
       # Returns a merged configuration of the following files
-      # 
+      #
       # Alchemy´s default config: +gems/../alchemy_cms/config/alchemy/config.yml+
       # Your apps default config: +your_app/config/alchemy/config.yml+
       # Environment specific config: +your_app/config/alchemy/development.config.yml+
       #
-      # An environment specific config overwrites the settings of your apps default config, 
+      # An environment specific config overwrites the settings of your apps default config,
       # while your apps default config has precedence over Alchemy´s default config.
       #
       def show
@@ -53,15 +53,13 @@ module Alchemy
       end
 
       # Merges all given configs together
-      # 
+      #
       def merge_configs!(*config_files)
         raise LoadError, 'No Alchemy config file found!' if config_files.map(&:blank?).all?
         config = {}
         config_files.each {|h| config.merge!(h.stringify_keys!) }
         config
       end
-
     end
-
   end
 end

--- a/lib/alchemy/errors.rb
+++ b/lib/alchemy/errors.rb
@@ -17,6 +17,13 @@ module Alchemy
     end
   end
 
+  class DefaultLanguageNotDeletable < StandardError
+    # Raised if one tries to delete the default language.
+    def message
+      "Default language is not deletable!"
+    end
+  end
+
   class ElementDefinitionError < StandardError
     # Raised if element definition can not be found.
     def initialize(attributes)
@@ -37,6 +44,13 @@ module Alchemy
 
   class MissingImageFileError < StandardError
     # Raised if calling +image_file+ on a Picture object returns nil.
+  end
+
+  class NotMountedError < StandardError
+    # Raised if Alchemy is not properly mounted in the apps routes file.
+    def message
+      "Alchemy mount point not found! Please run `bin/rake alchemy:mount'"
+    end
   end
 
   class PictureInUseError < StandardError

--- a/lib/alchemy/modules.rb
+++ b/lib/alchemy/modules.rb
@@ -39,7 +39,7 @@ module Alchemy
           definition_from_subnavi(alchemy_module, name.symbolize_keys)
         end
       else
-        raise "Could not find module definition for #{name}"
+        raise ArgumentError, "Could not find module definition for #{name}"
       end
     end
 

--- a/lib/alchemy/mount_point.rb
+++ b/lib/alchemy/mount_point.rb
@@ -27,7 +27,7 @@ module Alchemy
       def path
         match = File.read(routes_file_path).match(MOUNT_POINT_REGEXP)
         if match.nil?
-          raise "Alchemy mount point not found! Please run `bin/rake alchemy:mount'"
+          raise NotMountedError
         else
           match[1]
         end

--- a/spec/controllers/alchemy/api/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/api/elements_controller_spec.rb
@@ -2,25 +2,24 @@ require 'spec_helper'
 
 module Alchemy
   describe Api::ElementsController do
-    # We need to be sure, that the timestamps are always the same,
-    # while comparing json objects
-    before do
-      allow_any_instance_of(Alchemy::Element).
-        to receive(:created_at).and_return(Time.now)
-      allow_any_instance_of(Alchemy::Element).
-        to receive(:updated_at).and_return(Time.now)
-    end
 
     describe '#index' do
-      let!(:page)    { create(:public_page) }
-      let!(:element) { create(:element, page: page) }
+      let(:page) { create(:public_page) }
+
+      before do
+        2.times { create(:element, page: page) }
+      end
 
       it "returns all public elements as json objects" do
         alchemy_get :index, format: :json
+
         expect(response.status).to eq(200)
         expect(response.content_type).to eq('application/json')
-        expect(response.body).to_not eq('{"elements:[]"}')
-        expect(response.body).to eq("{\"elements\":[#{ElementSerializer.new(element).to_json}]}")
+
+        result = JSON.parse(response.body)
+
+        expect(result).to have_key('elements')
+        expect(result['elements'].size).to eq(Alchemy::Element.count)
       end
 
       context 'with page_id param' do
@@ -29,19 +28,29 @@ module Alchemy
 
         it "returns only elements from this page" do
           alchemy_get :index, page_id: other_page.id, format: :json
+
           expect(response.status).to eq(200)
           expect(response.content_type).to eq('application/json')
-          expect(response.body).to eq("{\"elements\":[#{ElementSerializer.new(other_element).to_json}]}")
+
+          result = JSON.parse(response.body)
+
+          expect(result).to have_key('elements')
+          expect(result['elements'].size).to eq(1)
+          expect(result['elements'][0]['page_id']).to eq(other_page.id)
         end
       end
 
       context 'with empty page_id param' do
         it "returns all elements" do
           alchemy_get :index, page_id: '', format: :json
+
           expect(response.status).to eq(200)
           expect(response.content_type).to eq('application/json')
-          expect(response.body).to_not eq('{"elements:[]"}')
-          expect(response.body).to eq("{\"elements\":[#{ElementSerializer.new(element).to_json}]}")
+
+          result = JSON.parse(response.body)
+
+          expect(result).to have_key('elements')
+          expect(result['elements'].size).to eq(Alchemy::Element.count)
         end
       end
 
@@ -50,19 +59,29 @@ module Alchemy
 
         it "returns only elements named like this." do
           alchemy_get :index, named: 'news', format: :json
+
           expect(response.status).to eq(200)
           expect(response.content_type).to eq('application/json')
-          expect(response.body).to eq("{\"elements\":[#{ElementSerializer.new(other_element).to_json}]}")
+
+          result = JSON.parse(response.body)
+
+          expect(result).to have_key('elements')
+          expect(result['elements'].size).to eq(1)
+          expect(result['elements'][0]['name']).to eq('news')
         end
       end
 
       context 'with empty named param' do
         it "returns all elements" do
           alchemy_get :index, named: '', format: :json
+
           expect(response.status).to eq(200)
           expect(response.content_type).to eq('application/json')
-          expect(response.body).to_not eq('{"elements:[]"}')
-          expect(response.body).to eq("{\"elements\":[#{ElementSerializer.new(element).to_json}]}")
+
+          result = JSON.parse(response.body)
+
+          expect(result).to have_key('elements')
+          expect(result['elements'].size).to eq(Alchemy::Element.count)
         end
       end
     end
@@ -77,9 +96,13 @@ module Alchemy
 
       it "returns element as json" do
         alchemy_get :show, id: element.id, format: :json
+
         expect(response.status).to eq(200)
         expect(response.content_type).to eq('application/json')
-        expect(response.body).to eq(ElementSerializer.new(element).to_json)
+
+        result = JSON.parse(response.body)
+
+        expect(result['id']).to eq(element.id)
       end
 
       context 'requesting an restricted element' do
@@ -87,9 +110,14 @@ module Alchemy
 
         it "responds with 403" do
           alchemy_get :show, id: element.id, format: :json
-          expect(response.content_type).to eq('application/json')
+
           expect(response.status).to eq(403)
-          expect(response.body).to eq('{"error":"Not authorized"}')
+          expect(response.content_type).to eq('application/json')
+
+          result = JSON.parse(response.body)
+
+          expect(result).to have_key('error')
+          expect(result['error']).to eq("Not authorized")
         end
       end
     end

--- a/spec/controllers/alchemy/api/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/api/pages_controller_spec.rb
@@ -8,28 +8,43 @@ module Alchemy
 
       it "returns all public pages as json objects" do
         alchemy_get :index, format: :json
+
         expect(response.status).to eq(200)
         expect(response.content_type).to eq('application/json')
-        expect(response.body).to eq("{\"pages\":[#{PageSerializer.new(page.parent).to_json},#{PageSerializer.new(page).to_json}]}")
+
+        result = JSON.parse(response.body)
+
+        expect(result).to have_key('pages')
+        expect(result['pages'].size).to eq(2)
       end
 
       context 'with page_layout' do
         let!(:other_page) { create(:public_page, page_layout: 'news') }
 
-        it "returns only pages with this page layout" do
+        it "returns only page with this page layout" do
           alchemy_get :index, {page_layout: 'news', format: :json}
+
           expect(response.status).to eq(200)
           expect(response.content_type).to eq('application/json')
-          expect(response.body).to eq("{\"pages\":[#{PageSerializer.new(other_page).to_json}]}")
+
+          result = JSON.parse(response.body)
+
+          expect(result).to have_key('pages')
+          expect(result['pages'].size).to eq(1)
         end
       end
 
       context 'with empty string as page_layout' do
         it "returns all pages" do
           alchemy_get :index, {page_layout: '', format: :json}
+
           expect(response.status).to eq(200)
           expect(response.content_type).to eq('application/json')
-          expect(response.body).to eq("{\"pages\":[#{PageSerializer.new(page.parent).to_json},#{PageSerializer.new(page).to_json}]}")
+
+          result = JSON.parse(response.body)
+
+          expect(result).to have_key('pages')
+          expect(result['pages'].size).to eq(2)
         end
       end
     end
@@ -44,9 +59,13 @@ module Alchemy
 
         it "returns page as json" do
           alchemy_get :show, {urlname: page.urlname, format: :json}
+
           expect(response.status).to eq(200)
           expect(response.content_type).to eq('application/json')
-          expect(response.body).to eq(PageSerializer.new(page).to_json)
+
+          result = JSON.parse(response.body)
+
+          expect(result['id']).to eq(page.id)
         end
 
         context 'requesting an restricted page' do
@@ -54,9 +73,14 @@ module Alchemy
 
           it "responds with 403" do
             alchemy_get :show, {urlname: page.urlname, format: :json}
-            expect(response.content_type).to eq('application/json')
+
             expect(response.status).to eq(403)
-            expect(response.body).to eq('{"error":"Not authorized"}')
+            expect(response.content_type).to eq('application/json')
+
+            result = JSON.parse(response.body)
+
+            expect(result).to have_key('error')
+            expect(result['error']).to eq("Not authorized")
           end
         end
 
@@ -65,9 +89,14 @@ module Alchemy
 
           it "responds with 403" do
             alchemy_get :show, {urlname: page.urlname, format: :json}
-            expect(response.content_type).to eq('application/json')
+
             expect(response.status).to eq(403)
-            expect(response.body).to eq('{"error":"Not authorized"}')
+            expect(response.content_type).to eq('application/json')
+
+            result = JSON.parse(response.body)
+
+            expect(result).to have_key('error')
+            expect(result['error']).to eq("Not authorized")
           end
         end
       end
@@ -75,9 +104,14 @@ module Alchemy
       context 'requesting an unknown page' do
         it "responds with 404" do
           alchemy_get :show, {urlname: 'not-existing', format: :json}
-          expect(response.content_type).to eq('application/json')
+
           expect(response.status).to eq(404)
-          expect(response.body).to eq('{"error":"Record not found"}')
+          expect(response.content_type).to eq('application/json')
+
+          result = JSON.parse(response.body)
+
+          expect(result).to have_key('error')
+          expect(result['error']).to eq("Record not found")
         end
       end
 
@@ -86,9 +120,13 @@ module Alchemy
 
         it "responds with json" do
           alchemy_get :show, {id: page.id, format: :json}
+
           expect(response.status).to eq(200)
           expect(response.content_type).to eq('application/json')
-          expect(response.body).to eq(PageSerializer.new(page).to_json)
+
+          result = JSON.parse(response.body)
+
+          expect(result['id']).to eq(page.id)
         end
       end
     end

--- a/spec/libraries/auth_accessors_spec.rb
+++ b/spec/libraries/auth_accessors_spec.rb
@@ -13,7 +13,9 @@ module Alchemy
 
       it "raises error if user_class_name is not a String" do
         Alchemy.user_class_name = MyCustomUser
-        expect {Alchemy.user_class }.to raise_error
+        expect {
+          Alchemy.user_class
+        }.to raise_error(TypeError)
       end
 
       after do

--- a/spec/libraries/config_spec.rb
+++ b/spec/libraries/config_spec.rb
@@ -96,7 +96,7 @@ module Alchemy
 
       context 'when all passed configs are empty' do
         it "should raise an error" do
-          expect { Config.send(:merge_configs!, {}) }.to raise_error
+          expect { Config.send(:merge_configs!, {}) }.to raise_error(LoadError)
         end
       end
 
@@ -108,7 +108,5 @@ module Alchemy
         end
       end
     end
-
   end
-
 end

--- a/spec/libraries/modules_spec.rb
+++ b/spec/libraries/modules_spec.rb
@@ -42,7 +42,7 @@ module Alchemy
       context 'with nil given as name' do
         let(:name) { nil }
         it 'raises an error' do
-          expect { subject }.to raise_error('Could not find module definition for ')
+          expect { subject }.to raise_error(ArgumentError)
         end
       end
     end

--- a/spec/libraries/mount_point_spec.rb
+++ b/spec/libraries/mount_point_spec.rb
@@ -58,7 +58,7 @@ describe Alchemy::MountPoint do
       it "raises an exception" do
         expect {
           Alchemy::MountPoint.path
-        }.to raise_error
+        }.to raise_error(Alchemy::NotMountedError)
       end
     end
 

--- a/spec/models/content_spec.rb
+++ b/spec/models/content_spec.rb
@@ -85,7 +85,7 @@ module Alchemy
         end
 
         it "should raise error" do
-          expect { subject }.to raise_error
+          expect { subject }.to raise_error(EssenceMissingError)
         end
       end
     end
@@ -217,7 +217,7 @@ module Alchemy
 
         it "should raise error" do
           c = Content.create(:element_id => element.id, name: 'headline')
-          expect { c.ingredient = "Welcome" }.to raise_error
+          expect { c.ingredient = "Welcome" }.to raise_error(EssenceMissingError)
         end
       end
     end

--- a/spec/models/element_spec.rb
+++ b/spec/models/element_spec.rb
@@ -8,6 +8,34 @@ module Alchemy
 
     # ClassMethods
 
+    describe '.new_from_scratch' do
+      it "should initialize an element by name from scratch" do
+        el = Element.new_from_scratch(name: 'article')
+        expect(el).to be_valid
+      end
+
+      it "should raise an error if the given name is not defined in the elements.yml" do
+        expect {
+          Element.new_from_scratch(name: 'foobar')
+        }.to raise_error(ElementDefinitionError)
+      end
+
+      it "should take the first part of an given name containing a hash (#)" do
+        el = Element.new_from_scratch(name: 'article#header')
+        expect(el.name).to eq("article")
+      end
+
+      it "should merge given attributes into defined ones" do
+        el = Element.new_from_scratch(name: 'article', page_id: 1)
+        expect(el.page_id).to eq(1)
+      end
+
+      it "should not have forbidden attributes from definition" do
+        el = Element.new_from_scratch(name: 'article')
+        expect(el.contents).to eq([])
+      end
+    end
+
     describe '.copy' do
       let(:element) { FactoryGirl.create(:element, :create_contents_after_create => true, :tag_list => 'red, yellow') }
 
@@ -283,32 +311,6 @@ module Alchemy
 
       it "returns an string from element name and id" do
         expect(element.dom_id).to eq("#{element.name}_#{element.id}")
-      end
-    end
-
-    describe '#new_from_scratch' do
-      it "should initialize an element by name from scratch" do
-        el = Element.new_from_scratch({:name => 'article'})
-        expect(el).to be_valid
-      end
-
-      it "should raise an error if the given name is not defined in the elements.yml" do
-        expect { Element.new_from_scratch({:name => 'foobar'}) }.to raise_error
-      end
-
-      it "should take the first part of an given name containing a hash (#)" do
-        el = Element.new_from_scratch({:name => 'article#header'})
-        expect(el.name).to eq("article")
-      end
-
-      it "should merge given attributes into defined ones" do
-        el = Element.new_from_scratch({:name => 'article', :page_id => 1})
-        expect(el.page_id).to eq(1)
-      end
-
-      it "should not have forbidden attributes from definition" do
-        el = Element.new_from_scratch({:name => 'article'})
-        expect(el.contents).to eq([])
       end
     end
 

--- a/spec/models/language_spec.rb
+++ b/spec/models/language_spec.rb
@@ -48,7 +48,9 @@ module Alchemy
     end
 
     it "should not be deletable if it is the default language" do
-      expect { default_language.destroy }.to raise_error
+      expect {
+        default_language.destroy
+      }.to raise_error(DefaultLanguageNotDeletable)
     end
 
     describe "before save" do


### PR DESCRIPTION
This should prevent the API tests from failing every once a while on Travis CI.

Also removes the RSpec warning about not explicitly expecting error type.