### PR TITLE
Removes "available contents" feature.

### DIFF
--- a/app/controllers/alchemy/admin/contents_controller.rb
+++ b/app/controllers/alchemy/admin/contents_controller.rb
@@ -8,7 +8,6 @@ module Alchemy
       def new
         @element = Element.find(params[:element_id])
         @options = options_from_params
-        @contents = @element.available_contents
         @content = @element.contents.build
       end
 
@@ -70,7 +69,6 @@ module Alchemy
           html_options: @html_options.symbolize_keys
         }
       end
-
     end
   end
 end

--- a/app/models/alchemy/content/factory.rb
+++ b/app/models/alchemy/content/factory.rb
@@ -99,9 +99,7 @@ module Alchemy
 
       # Returns the content description hash from element.
       #
-      # It first uses the normal content description described in the +elements.yml+ +contents+ array.
-      #
-      # If the content description could not be found it tries to load it from +available_contents+ array.
+      # Content descriptions are described in the +elements.yml+ +contents+ array.
       #
       # @param [Alchemy::Element]
       #   The element instance the content is for
@@ -109,8 +107,7 @@ module Alchemy
       #   The name of the content
       #
       def content_description_from_element(element, name)
-        element.content_description_for(name) ||
-          element.available_content_description_for(name)
+        element.content_description_for(name)
       end
 
       # Returns all content descriptions from elements.yml

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -25,7 +25,6 @@ module Alchemy
 
     FORBIDDEN_DEFINITION_ATTRIBUTES = [
       "amount",
-      "available_contents",
       "nestable_elements",
       "contents",
       "hint",

--- a/app/models/alchemy/element/element_contents.rb
+++ b/app/models/alchemy/element/element_contents.rb
@@ -104,21 +104,7 @@ module Alchemy
     end
     alias_method :content_description_for, :content_definition_for
 
-    # Returns the definition for given content_name inside the available_contents
-    def available_content_definition_for(content_name)
-      return nil if available_contents.blank?
-      available_contents.detect { |d| d['name'] == content_name }
-    end
-    alias_method :available_content_description_for, :available_content_definition_for
-
-    # The collection of available essence_types that can be created for
-    # this element depending on its description in +elements.yml+.
-    def available_contents
-      definition['available_contents']
-    end
-
-    # Returns an array of ids from element's EssenceRichtext contents
-    # and element's all descendent elements EssenceRichtext contents.
+    # Returns an array of all EssenceRichtext contents ids from elements
     #
     # This is used to initialize the TinyMCE editor in the element editor.
     #

--- a/lib/alchemy/cache_digests/template_tracker.rb
+++ b/lib/alchemy/cache_digests/template_tracker.rb
@@ -52,14 +52,9 @@ module Alchemy
 
       def essence_types(name)
         element = element_description(name)
-        if element
-          (element.fetch('contents', []) +
-            element.fetch('available_contents', [])).collect { |c| c['type'] }
-        else
-          []
-        end
+        return [] unless element
+        element.fetch('contents', []).collect { |c| c['type'] }
       end
-
     end
   end
 end

--- a/lib/alchemy/upgrader/four_point_zero.rb
+++ b/lib/alchemy/upgrader/four_point_zero.rb
@@ -1,0 +1,65 @@
+module Alchemy
+  module Upgrader::FourPointZero
+    private
+
+    def alchemy_4_0_todos
+      notice = <<-NOTE
+
+Element's "available_contents" feature removed
+----------------------------------------------
+
+The `available_contents` feature of elements was removed and replaced by nestable elements.
+
+Please update your `config/alchemy/elements.yml` so that you define an element for each content
+in `available_contents` and put its name into the `nestable_elements` collection in the parent
+element's definition.
+
+## Example:
+
+    - name: link_list
+      contents:
+      - name: headline
+        type: EssenceText
+      available_contents:
+      - name: link
+        type: EssenceText
+        settings:
+          linkable: true
+
+becomes
+
+    - name: link_list
+      contents:
+      - name: headline
+        type: EssenceText
+      nestable_elements:
+      - link_list_link
+
+    - name: link_list_link
+      contents:
+      - name: link
+        type: EssenceText
+        settings:
+          linkable: true
+
+Also update your element view partials, so they use the `element.nested_elements` collection
+instead of the `element.contents.named` collection.
+
+## Example:
+
+    element.contents.named(['link', 'attachment']).each do |content|
+      render_essence(content)
+
+becomes
+
+    element.nested_elements.published.each do |element|
+      render_element(element)
+
+The code for the available contents button in the element editor partial can be removed
+without replacement. The nested elements editor partials render automatically.
+
+NOTE
+      todo notice, 'Alchemy v4.0 changes'
+    end
+  end
+end

--- a/lib/rails/generators/alchemy/elements/elements_generator.rb
+++ b/lib/rails/generators/alchemy/elements/elements_generator.rb
@@ -15,13 +15,7 @@ module Alchemy
         @elements = load_alchemy_yaml('elements.yml')
         @elements.each do |element|
           @element = element
-          contents = element["contents"] || []
-          if @element['available_contents']
-            @available_contents_names = @element['available_contents'].collect { |c| c['name'] }
-            @contents = contents.delete_if { |c| @available_contents_names.include?(c['name']) } or []
-          else
-            @contents = contents
-          end
+          @contents = element["contents"] || []
           if element["name"] =~ /\A[a-z0-9_-]+\z/
             @element_name = element["name"].underscore
           else

--- a/lib/rails/generators/alchemy/elements/templates/editor.html.erb
+++ b/lib/rails/generators/alchemy/elements/templates/editor.html.erb
@@ -6,12 +6,6 @@
 <%- @contents.each do |content| -%>
   <%%= el.edit :<%= content["name"] %> %>
 <%- end -%>
-<%- if @element['available_contents'] -%>
-  <%% element.contents.named(['<%= @available_contents_names.join("', '") %>']).each do |content| %>
-    <%%= render_essence_editor content %>
-  <%% end %>
-  <p><%%= render_new_content_link(element) %></p>
-<%- end -%>
 <%%- end -%>
 <%- else -%>
 <%%= element_editor_for(element) -%>

--- a/lib/rails/generators/alchemy/elements/templates/editor.html.haml
+++ b/lib/rails/generators/alchemy/elements/templates/editor.html.haml
@@ -6,12 +6,6 @@
 <%- @contents.each do |content| -%>
   = el.edit :<%= content["name"] %>
 <%- end -%>
-<%- if @element['available_contents'] -%>
-  - element.contents.named(['<%= @available_contents_names.join("', '") %>']).each do |content|
-    = render_essence_editor content
-  %p
-    = render_new_content_link(element)
-<%- end -%>
 <%- else -%>
 = element_editor_for(element)
 <%- end -%>

--- a/lib/rails/generators/alchemy/elements/templates/editor.html.slim
+++ b/lib/rails/generators/alchemy/elements/templates/editor.html.slim
@@ -6,11 +6,6 @@
 <%- @contents.each do |content| -%>
   = el.edit :<%= content["name"] %>
 <%- end -%>
-<%- if @element['available_contents'] -%>
-  - element.contents.named(['<%= @available_contents_names.join("', '") %>']).each do |content|
-    = render_essence_editor content
-  p = render_new_content_link(element)
-<%- end -%>
 <%- else -%>
 = element_editor_for(element)
 <%- end -%>

--- a/lib/rails/generators/alchemy/elements/templates/view.html.erb
+++ b/lib/rails/generators/alchemy/elements/templates/view.html.erb
@@ -18,11 +18,6 @@
     <%%= el.render :<%= content["name"] %> %>
     <%- end -%>
   <%- end -%>
-  <%- if @element['available_contents'] -%>
-    <%%- element.contents.named(['<%= @available_contents_names.join("', '") %>']).each do |content| -%>
-      <%%= render_essence_view(content) %>
-    <%%- end -%>
-  <%- end -%>
   <%- if @element['nestable_elements'].present? -%>
     <%% element.nested_elements.available.each do |nested_element| %>
       <%%= render_element(nested_element) %>

--- a/lib/rails/generators/alchemy/elements/templates/view.html.haml
+++ b/lib/rails/generators/alchemy/elements/templates/view.html.haml
@@ -14,10 +14,6 @@
     = el.render :<%= content["name"] %>
     <%- end -%>
   <%- end -%>
-  <%- if @element['available_contents'] -%>
-    - element.contents.named(['<%= @available_contents_names.join("', '") %>']).each do |content|
-      = render_essence_view(content)
-  <%- end -%>
   <%- if @element['nestable_elements'].present? -%>
     - element.nested_elements.available.each do |nested_element|
       = render_element(nested_element)

--- a/lib/rails/generators/alchemy/elements/templates/view.html.slim
+++ b/lib/rails/generators/alchemy/elements/templates/view.html.slim
@@ -14,10 +14,6 @@
     = el.render :<%= content["name"] %>
     <%- end -%>
   <%- end -%>
-  <%- if @element['available_contents'] -%>
-    - element.contents.named(['<%= @available_contents_names.join("', '") %>']).each do |content|
-      = render_essence_view(content)
-  <%- end -%>
   <%- if @element['nestable_elements'].present? -%>
     - element.nested_elements.available.each do |nested_element|
       = render_element(nested_element)

--- a/spec/dummy/config/alchemy/elements.yml
+++ b/spec/dummy/config/alchemy/elements.yml
@@ -24,11 +24,6 @@
     type: EssenceRichtext
     settings:
       deletable: true
-  available_contents:
-  - name: text
-    type: EssenceRichtext
-  - name: headline
-    type: EssenceText
 
 - name: text
   contents:
@@ -55,9 +50,6 @@
     type: EssenceFile
     settings:
       deletable: true
-  available_contents:
-  - name: file
-    type: EssenceFile
 
 - name: bild
   contents:

--- a/spec/libraries/template_tracker_spec.rb
+++ b/spec/libraries/template_tracker_spec.rb
@@ -60,14 +60,6 @@ module Alchemy
                 is_expected.to include('alchemy/essences/_essence_picture_view')
               end
             end
-
-            context 'and element has available_contents defined' do
-              let(:elements) { [{'name' => 'text', 'available_contents' => ['type' => 'EssenceFile']}] }
-
-              it "has these essences as template dependency" do
-                is_expected.to include('alchemy/essences/_essence_file_view')
-              end
-            end
           end
 
           context 'that has no description' do
@@ -88,7 +80,6 @@ module Alchemy
           end
         end
       end
-
     end
   end
 end

--- a/spec/models/content_spec.rb
+++ b/spec/models/content_spec.rb
@@ -150,11 +150,10 @@ module Alchemy
       context "with content description not found" do
         before {
           expect(element).to receive(:content_description_for).and_return(nil)
-          expect(element).to receive(:available_content_description_for).and_return(essence)
         }
 
-        it "returns the description hash from available contents" do
-          expect(Content.content_description(element, name: 'headline')).to eq(essence)
+        it "returns nil" do
+          expect(Content.content_description(element, name: 'headline')).to be_nil
         end
       end
     end


### PR DESCRIPTION
The "available contents" feature is replaced by the far better "nestable elements" feature 457d1aa687867c00077b797c4cb684db35245d4d.

Please update your `config/alchemy/elements.yml` so that you define an element for each content
in `available_contents` and put its name into the `nestable_elements` collection in the parent
element's definition.

## Example:

    - name: link_list
      contents:
      - name: headline
        type: EssenceText
      available_contents:
      - name: link
        type: EssenceText
        settings:
          linkable: true

becomes

    - name: link_list
      contents:
      - name: headline
        type: EssenceText
      nestable_elements:
      - link_list_link

    - name: link_list_link
      contents:
      - name: link
        type: EssenceText
        settings:
          linkable: true

Also update your element view partials, so they use the `element.nested_elements` collection
instead of the `element.contents.named` collection.

## Example:

    element.contents.named(['link', 'attachment']).each do |content|
      render_essence(content)

becomes

    element.nested_elements.published.each do |element|
      render_element(element)

The code for the available contents button in the element editor partial can be removed
without replacement. The nested elements editor partials render automatically.