### PR TITLE
4.0/skip the default locale in urls

### DIFF
--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -79,13 +79,13 @@ module Alchemy
         page_not_found!
       elsif multi_language? && params[:locale].blank? && !default_locale?
         redirect_page(locale: Language.current.code)
-      elsif multi_language? && params[:urlname].blank? && !params[:locale].blank? && configuration(:redirect_index)
+      elsif multi_language? && params[:urlname].blank? && params[:locale].present? && configuration(:redirect_index)
         redirect_page(locale: params[:locale])
       elsif configuration(:redirect_to_public_child) && !@page.public?
         redirect_to_public_child
       elsif params[:urlname].blank? && configuration(:redirect_index)
         redirect_page
-      elsif !multi_language? && !params[:locale].blank?
+      elsif !multi_language? && params[:locale].present?
         redirect_page
       elsif @page.has_controller?
         redirect_to main_app.url_for(@page.controller_and_action)

--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -77,7 +77,7 @@ module Alchemy
         redirect_legacy_page
       elsif @page.blank?
         page_not_found!
-      elsif multi_language? && params[:locale].blank?
+      elsif multi_language? && params[:locale].blank? && !default_locale?
         redirect_page(locale: Language.current.code)
       elsif multi_language? && params[:urlname].blank? && !params[:locale].blank? && configuration(:redirect_index)
         redirect_page(locale: params[:locale])
@@ -114,7 +114,7 @@ module Alchemy
     # Redirects page to given url with 301 status while keeping all additional params
     def redirect_page(options = {})
       options = {
-        locale: (multi_language? ? @page.language_code : nil),
+        locale: (multi_language? && !default_locale? ? @page.language_code : nil),
         urlname: @page.urlname
       }.merge(options)
 
@@ -206,6 +206,10 @@ module Alchemy
 
     def page_not_found!
       not_found_error!("Alchemy::Page not found \"#{request.fullpath}\"")
+    end
+
+    def default_locale?
+      Language.current.code.to_sym == ::I18n.default_locale.to_sym
     end
   end
 end

--- a/spec/features/page_feature_spec.rb
+++ b/spec/features/page_feature_spec.rb
@@ -18,10 +18,8 @@ module Alchemy
     end
 
     it "should show the navigation with all visible pages" do
-      pages = [
-        create(:public_page, :visible => true, :name => 'Page 1'),
-        create(:public_page, :visible => true, :name => 'Page 2')
-      ]
+      create(:public_page, visible: true, name: 'Page 1')
+      create(:public_page, visible: true, name: 'Page 2')
       visit '/'
       within('div#navigation ul') { expect(page).to have_selector('li a[href="/page-1"], li a[href="/page-2"]') }
     end

--- a/spec/features/page_feature_spec.rb
+++ b/spec/features/page_feature_spec.rb
@@ -67,12 +67,28 @@ module Alchemy
             visit "/not-public"
             expect(page.current_path).to eq("/public-child")
           end
+
+          context "if page.locale != then the default locale" do
+            it "prepends the public child path with it's locale" do
+              allow(::I18n).to receive(:default_locale).and_return(:de)
+              visit "/not-public"
+              expect(page.current_path).to eq("/en/public-child")
+            end
+          end
         end
 
         context "if requested url is the index url" do
           it "redirects to the url of the default language root page" do
             visit '/'
             expect(page.current_path).to eq("/home")
+          end
+
+          context "if page.locale != then the default locale" do
+            it "prepends the locale to the url" do
+              allow(::I18n).to receive(:default_locale).and_return(:de)
+              visit '/'
+              expect(page.current_path).to eq("/en/home")
+            end
           end
         end
 

--- a/spec/features/page_feature_spec.rb
+++ b/spec/features/page_feature_spec.rb
@@ -41,10 +41,18 @@ module Alchemy
           expect(uri.request_uri).to eq("/en/#{second_page.urlname}")
         end
 
-        context "if no language params are given" do
+        context "if no language params are given and page locale == default locale" do
           it "doesn't prepend the url with the locale string" do
             visit("/#{public_page_1.urlname}")
             expect(page.current_path).to eq("/#{public_page_1.urlname}")
+          end
+        end
+
+        context "if no language params are given and page locale != default locale" do
+          it "prepends the url with the locale string" do
+            allow(::I18n).to receive(:default_locale).and_return(:de)
+            visit("/#{public_page_1.urlname}")
+            expect(page.current_path).to eq("/en/#{public_page_1.urlname}")
           end
         end
 

--- a/spec/features/page_feature_spec.rb
+++ b/spec/features/page_feature_spec.rb
@@ -44,9 +44,9 @@ module Alchemy
         end
 
         context "if no language params are given" do
-          it "should redirect to url with nested language code" do
-            visit "/#{public_page_1.urlname}"
-            expect(page.current_path).to eq("/#{public_page_1.language_code}/#{public_page_1.urlname}")
+          it "doesn't prepend the url with the locale string" do
+            visit("/#{public_page_1.urlname}")
+            expect(page.current_path).to eq("/#{public_page_1.urlname}")
           end
         end
 

--- a/spec/features/page_feature_spec.rb
+++ b/spec/features/page_feature_spec.rb
@@ -56,22 +56,15 @@ module Alchemy
           end
 
           it "should redirect to public child" do
-            visit "/#{default_language.code}/not-public"
-            expect(page.current_path).to eq("/#{default_language.code}/public-child")
-          end
-
-          context "and url has no language code" do
-            it "should redirect to url of public child with language code of default language" do
-              visit '/not-public'
-              expect(page.current_path).to eq("/#{default_language.code}/public-child")
-            end
+            visit "/not-public"
+            expect(page.current_path).to eq("/public-child")
           end
         end
 
-        context "if requested url is index url" do
-          it "should redirect to pages url with default language" do
+        context "if requested url is the index url" do
+          it "redirects to the url of the default language root page" do
             visit '/'
-            expect(page.current_path).to eq("/#{default_language.code}/home")
+            expect(page.current_path).to eq("/home")
           end
         end
 
@@ -79,13 +72,6 @@ module Alchemy
           it "should redirect to pages url with default language" do
             visit "/#{default_language.code}"
             expect(page.current_path).to eq("/#{default_language.code}/home")
-          end
-        end
-
-        context "requested url is only the urlname" do
-          it "then it should redirect to pages url with nested language." do
-            visit '/home'
-            expect(page.current_path).to eq('/en/home')
           end
         end
 


### PR DESCRIPTION
## Don't prepend the default locale

On a multi language site, the default locale should not be included in the url. This can avoid seeing the locale twice (once in the tld and once in the locale)

For example a url that used to look like `exmample.de/de/index` now looks like this: `example.de/index`