### PR TITLE
Allow custom routing for admin backend

### DIFF
--- a/app/views/alchemy/_menubar.html.erb
+++ b/app/views/alchemy/_menubar.html.erb
@@ -1,8 +1,8 @@
 <% if !@preview_mode && can?(:edit_content, @page) %>
   <div id="alchemy_menubar" style="display: none">
     <ul>
-      <li><%= link_to _t(:to_alchemy), alchemy.admin_dashboard_path %></li>
-      <li><%= link_to _t(:edit_page), alchemy.edit_admin_page_path(@page) %></li>
+      <li><%= link_to _t(:to_alchemy), alchemy.admin_dashboard_url %></li>
+      <li><%= link_to _t(:edit_page), alchemy.edit_admin_page_url(@page) %></li>
       <li>
         <%= form_tag Alchemy.logout_path, method: 'delete' do %>
           <%= button_tag _t(:logout) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Alchemy::Engine.routes.draw do
   get '/sitemap.xml' => 'pages#sitemap', format: 'xml'
 
   scope Alchemy.admin_path, { constraints: Alchemy.admin_constraints } do
-    get '/' => redirect('admin/dashboard'), as: :admin
+    get '/' => redirect("#{Alchemy.admin_path}/dashboard"), as: :admin
     get '/dashboard' => 'admin/dashboard#index', as: :admin_dashboard
     get '/dashboard/info' => 'admin/dashboard#info', as: :dashboard_info
     get '/help' => 'admin/dashboard#help', as: :help

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,52 +5,16 @@ Alchemy::Engine.routes.draw do
 
   get '/sitemap.xml' => 'pages#sitemap', format: 'xml'
 
-  get '/admin' => redirect('admin/dashboard')
-  get '/admin/dashboard' => 'admin/dashboard#index',
-        :as => :admin_dashboard
-  get '/admin/dashboard/info' => 'admin/dashboard#info',
-        :as => :dashboard_info
-  get '/admin/help' => 'admin/dashboard#help',
-        :as => :help
-  get '/admin/dashboard/update_check' => 'admin/dashboard#update_check',
-        :as => :update_check
-
-  get '/attachment/:id/download(/:name)' => 'attachments#download',
-        :as => :download_attachment
-  get '/attachment/:id/show' => 'attachments#show',
-        :as => :show_attachment
-
-  # Picture urls
-  get "/pictures/:id/show(/:size)(/:crop)(/:crop_from/:crop_size)(/:quality)/:name.:format" => 'pictures#show',
-        :as => :show_picture
-  get '/pictures/:id/zoom/:name.:format' => 'pictures#zoom',
-        :as => :zoom_picture
-  get "/pictures/:id/thumbnails(/:size)(/:crop)(/:crop_from/:crop_size)/:name.:format" => 'pictures#thumbnail',
-        :as => :thumbnail, :defaults => {:format => 'png', :name => "thumbnail"}
-
-  get '/admin/leave' => 'admin/base#leave', :as => :leave_admin
-
-  resources :messages, :only => [:index, :new, :create]
-  resources :elements, :only => :show
-
-  namespace :api, defaults: {format: 'json'} do
-    resources :contents, only: [:index, :show]
-
-    resources :elements, only: [:index, :show] do
-      get '/contents' => 'contents#index', as: 'contents'
-      get '/contents/:name' => 'contents#show', as: 'content'
-    end
-
-    resources :pages, only: [:index] do
-      get 'elements' => 'elements#index', as: 'elements'
-      get 'elements/:named' => 'elements#index', as: 'named_elements'
-    end
-
-    get '/pages/*urlname(.:format)' => 'pages#show', as: 'page'
-    get '/admin/pages/:id(.:format)' => 'pages#show', as: 'preview_page'
+  scope Alchemy.admin_path, { constraints: Alchemy.admin_constraints } do
+    get '/' => redirect('admin/dashboard'), as: :admin
+    get '/dashboard' => 'admin/dashboard#index', as: :admin_dashboard
+    get '/dashboard/info' => 'admin/dashboard#info', as: :dashboard_info
+    get '/help' => 'admin/dashboard#help', as: :help
+    get '/dashboard/update_check' => 'admin/dashboard#update_check', as: :update_check
+    get '/leave' => 'admin/base#leave', as: :leave_admin
   end
 
-  namespace :admin do
+  namespace :admin, { path: Alchemy.admin_path, constraints: Alchemy.admin_constraints } do
     resources :contents do
       collection do
         post :order
@@ -152,6 +116,40 @@ Alchemy::Engine.routes.draw do
     end
 
     resources :sites
+  end
+
+  get '/attachment/:id/download(/:name)' => 'attachments#download',
+        :as => :download_attachment
+  get '/attachment/:id/show' => 'attachments#show',
+        :as => :show_attachment
+
+  # Picture urls
+  get "/pictures/:id/show(/:size)(/:crop)(/:crop_from/:crop_size)(/:quality)/:name.:format" => 'pictures#show',
+        :as => :show_picture
+  get '/pictures/:id/zoom/:name.:format' => 'pictures#zoom',
+        :as => :zoom_picture
+  get "/pictures/:id/thumbnails/:size(/:crop)(/:crop_from/:crop_size)/:name.:format" => 'pictures#thumbnail',
+        :as => :thumbnail, :defaults => {:format => 'png', :name => "thumbnail"}
+
+  resources :messages, :only => [:index, :new, :create]
+  resources :elements, :only => :show
+  resources :contents, :only => :show
+
+  namespace :api, defaults: {format: 'json'} do
+    resources :contents, only: [:index, :show]
+
+    resources :elements, only: [:index, :show] do
+      get '/contents' => 'contents#index', as: 'contents'
+      get '/contents/:name' => 'contents#show', as: 'content'
+    end
+
+    resources :pages, only: [:index] do
+      get 'elements' => 'elements#index', as: 'elements'
+      get 'elements/:named' => 'elements#index', as: 'named_elements'
+    end
+
+    get '/pages/*urlname(.:format)' => 'pages#show', as: 'page'
+    get '/admin/pages/:id(.:format)' => 'pages#show', as: 'preview_page'
   end
 
   get '/:locale' => 'pages#show',

--- a/lib/alchemy/auth_accessors.rb
+++ b/lib/alchemy/auth_accessors.rb
@@ -40,7 +40,9 @@ module Alchemy
     :current_user_method,
     :signup_path,
     :login_path,
-    :logout_path
+    :logout_path,
+    :admin_path,
+    :admin_constraints
 
   # Defaults
   #
@@ -49,6 +51,8 @@ module Alchemy
   @@signup_path = '/signup'
   @@login_path = '/login'
   @@logout_path = '/logout'
+  @@admin_path = '/admin'
+  @@admin_constraints = {}
 
   # Returns the user class
   #

--- a/spec/features/page_feature_spec.rb
+++ b/spec/features/page_feature_spec.rb
@@ -233,13 +233,13 @@ module Alchemy
 
         it "a link to the admin area" do
           within('#alchemy_menubar') do
-            expect(page).to have_selector("li a[href='#{alchemy.admin_dashboard_path}']")
+            expect(page).to have_selector("li a[href='#{alchemy.admin_dashboard_url}']")
           end
         end
 
         it "a link to edit the current page" do
           within('#alchemy_menubar') do
-            expect(page).to have_selector("li a[href='#{alchemy.edit_admin_page_path(public_page_1)}']")
+            expect(page).to have_selector("li a[href='#{alchemy.edit_admin_page_url(public_page_1)}']")
           end
         end
 


### PR DESCRIPTION
This PR allows custom admin interface routing, that is, instead of default `example.com/admin/` it is possible to use e.g. `hidden.example.com/backend/`.

Configuration is done via `Alchemy.admin_path` and `Alchemy.admin_constraints` in an initializer. CAUTION: If the `admin_path` is set to `''`, route name clashes are possible and you need to know what you are doing!

This PR is not intended to be merged as it's based on `3.2-stable` which we are currently using. If the idea of customizable admin routes is accepted, I will prepare a new PR based on the current `master`.
