### PR TITLE
Use event delegation for several element events.

### DIFF
--- a/app/views/alchemy/admin/elements/create.js.erb
+++ b/app/views/alchemy/admin/elements/create.js.erb
@@ -35,7 +35,9 @@
   Alchemy.growl('<%= _t(:successfully_added_element) %>');
   Alchemy.closeCurrentDialog();
   Alchemy.Tinymce.init(<%= @element.richtext_contents_ids.to_json %>);
-  Alchemy.PreviewWindow.refresh();
+  Alchemy.PreviewWindow.refresh(function() {
+    Alchemy.ElementEditors.selectElementInPreview(<%= @element.id %>);
+  });
 
   $el = $('#element_<%= @element.id %>');
   $el.trigger('FocusElementEditor.Alchemy');

--- a/app/views/alchemy/admin/elements/create.js.erb
+++ b/app/views/alchemy/admin/elements/create.js.erb
@@ -36,7 +36,6 @@
   Alchemy.closeCurrentDialog();
   Alchemy.Tinymce.init(<%= @element.richtext_contents_ids.to_json %>);
   Alchemy.PreviewWindow.refresh();
-  Alchemy.ElementEditors.init();
 
   $el = $('#element_<%= @element.id %>');
   $el.trigger('FocusElementEditor.Alchemy');

--- a/app/views/alchemy/admin/elements/fold.js.erb
+++ b/app/views/alchemy/admin/elements/fold.js.erb
@@ -11,7 +11,6 @@
   $el.replaceWith('<%= j render(partial: "element", object: @element) %>');
   $el = $('#element_<%= @element.id %>');
   $('#element_area .sortable_cell').sortable('refresh');
-  Alchemy.ElementEditors.reinit($el);
 
   <% if @element.folded? -%>
 

--- a/app/views/alchemy/admin/elements/order.js.erb
+++ b/app/views/alchemy/admin/elements/order.js.erb
@@ -8,7 +8,6 @@ Alchemy.growl('<%= _t(:successfully_restored_element) -%>');
 <% @trashed_element_ids.each do |id| %>
 $('<%= element_ids %>').each(function() { this.id = 'element_' + <%= id %> });
 <% end %>
-Alchemy.ElementEditors.reinit('<%= element_ids %>');
 <% else %>
 Alchemy.growl('<%= _t(:successfully_saved_element_position) -%>');
 <% end %>

--- a/app/views/alchemy/admin/elements/update.js.erb
+++ b/app/views/alchemy/admin/elements/update.js.erb
@@ -6,7 +6,6 @@
 <%- if @element_validated -%>
 
   $el.find('> .element-header').replaceWith('<%= j render("element_header", element: @element) %>');
-  Alchemy.ElementEditors.reinit($el);
   $errors.hide();
   Alchemy.setElementSaved($el);
   Alchemy.growl('<%= _t(:element_saved) %>');


### PR DESCRIPTION
Instead of rebinding the events on every created, updated, ordered and folded element over and over again, we use [jQuery event delegation](http://learn.jquery.com/events/event-delegation/).

This helps to avoid a lot of double event bindings and/or missing events, etc.