### PR TITLE
New option linkable: false for EssencePicture

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.base.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.base.js.coffee
@@ -58,6 +58,7 @@ $.extend Alchemy,
           spinner.stop()
           $parent.html('<span class="icon warn"/>')
 
+  # Removes the picture from essence picture thumbnail
   removePicture: (selector) ->
     $form_field = $(selector)
     $element = $form_field.closest(".element-editor")
@@ -66,14 +67,14 @@ $.extend Alchemy,
       $form_field.prev().remove()
       $form_field.parent().addClass "missing"
       Alchemy.setElementDirty $element
-    return
+    false
 
   # Sets the element to saved state
   setElementSaved: (selector) ->
     $element = $(selector)
     Alchemy.setElementClean selector
     Alchemy.Buttons.enable $element
-    return true
+    true
 
   # Initializes all select tag with .alchemy_selectbox class as selectBoxIt instance
   # Pass a jQuery scope to only init a subset of selectboxes.

--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -364,12 +364,15 @@
   bottom: 2px;
   width: 111px;
 
-  a {
+  > a, > span.icon {
     float: left;
     margin-left: 2px;
     margin-right: 2px;
     width: 18px;
     height: 18px;
+  }
+
+  a {
 
     &.linked {
       position: relative;
@@ -384,11 +387,11 @@
 
       .icon { margin-left: 1px }
     }
+  }
 
-    &.disabled {
-      @include opacity(0.3);
-      cursor: default;
-    }
+  a.disabled, > span.icon {
+    @include opacity(0.3);
+    cursor: default;
   }
 }
 

--- a/app/views/alchemy/essences/_essence_picture_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_picture_editor.html.erb
@@ -1,59 +1,54 @@
 <% cache(content) do %>
-<div id="<%= content.dom_id %>" class="essence_picture_editor<%= ' dragable_picture' if options[:dragable] %><%= ' content_editor' unless options[:grouped] %>" data-content-id="<%= content.id %>">
-  <% unless options[:grouped] %>
-  <%= content_label(content) %>
-  <% end %>
-  <div class="picture_thumbnail">
-    <span class="picture_tool delete">
-      <% if options[:grouped] %>
-      <%= link_to_confirm_dialog(
-        "",
-        _t(:confirm_to_delete_image),
-        alchemy.admin_essence_picture_path(
-          id: content,
-          options: options
-        ),
-        {
-          title: _t(:delete_image)
-        }
-      ) -%>
-      <% else %>
-      <%= link_to(
-        '',
-        '#',
-        onclick: "Alchemy.removePicture('##{content.form_field_id(:picture_id)}'); return false"
-      ) %>
-      <% end %>
-    </span>
-    <%- if content.ingredient -%>
-    <div class="picture_handle" title="<%= _t(:drag_to_sort) if options[:dragable] %>"></div>
-    <%- end -%>
-    <div class="picture_image">
-      <div class="thumbnail_background<%= ' missing' if content.ingredient.nil? %>">
-        <%- if content.ingredient -%>
-        <%= essence_picture_thumbnail(content, options) %>
-        <%= hidden_field_tag content.form_field_name(:picture_id), content.ingredient.id %>
+  <%= content_tag :div, id: content.dom_id, data: {"content-id" => content.id}, class: [
+      "essence_picture_editor",
+      options[:dragable] ? "dragable_picture" : nil,
+      options[:grouped] ? nil : "content_editor"
+    ].compact.join(" ") do %>
+    <% unless options[:grouped] %><%= content_label(content) %><% end %>
+    <div class="picture_thumbnail">
+      <span class="picture_tool delete">
+        <% if options[:grouped] %>
+          <%= link_to_confirm_dialog "", _t(:confirm_to_delete_image),
+            alchemy.admin_essence_picture_path(
+              id: content,
+              options: options
+            ), {title: _t(:delete_image)} %>
+        <% else %>
+          <%= link_to '', '#',
+            onclick: "return Alchemy.removePicture('##{content.form_field_id(:picture_id)}');" %>
         <% end %>
+      </span>
+      <%- if content.ingredient -%>
+        <div class="picture_handle" title="<%= _t(:drag_to_sort) if options[:dragable] %>"></div>
+      <%- end -%>
+      <div class="picture_image">
+        <div class="thumbnail_background<%= ' missing' if content.ingredient.nil? %>">
+          <%- if content.ingredient -%>
+          <%= essence_picture_thumbnail(content, options) %>
+          <%= hidden_field_tag content.form_field_name(:picture_id), content.ingredient.id %>
+          <% end %>
+        </div>
       </div>
-    </div>
-    <%- if content.essence.css_class.present? -%>
-    <div class="essence_picture_css_class">
-      <%= _t("alchemy.essence_pictures.css_classes.#{content.essence.css_class}", default: content.essence.css_class.camelcase) %>
-    </div>
-    <%- end -%>
-    <div class="edit_images_bottom">
-      <%= render(
-        partial: 'alchemy/essences/shared/essence_picture_tools',
-        locals: {
+      <%- if content.essence.css_class.present? -%>
+        <div class="essence_picture_css_class">
+          <%= _t("alchemy.essence_pictures.css_classes.#{content.essence.css_class}",
+            default: content.essence.css_class.camelcase) %>
+        </div>
+      <%- end -%>
+      <div class="edit_images_bottom">
+        <%= render 'alchemy/essences/shared/essence_picture_tools', {
           content: content,
           options: options
-        }
-      ) %>
+        } %>
+      </div>
     </div>
-  </div>
-  <%= hidden_field_tag content.form_field_name(:link), content.essence.link %>
-  <%= hidden_field_tag content.form_field_name(:link_title), content.essence.link_title %>
-  <%= hidden_field_tag content.form_field_name(:link_class_name), content.essence.link_class_name %>
-  <%= hidden_field_tag content.form_field_name(:link_target), content.essence.link_target %>
-</div>
+    <%= hidden_field_tag content.form_field_name(:link),
+      content.essence.link %>
+    <%= hidden_field_tag content.form_field_name(:link_title),
+      content.essence.link_title %>
+    <%= hidden_field_tag content.form_field_name(:link_class_name),
+      content.essence.link_class_name %>
+    <%= hidden_field_tag content.form_field_name(:link_target),
+      content.essence.link_target %>
+  <% end %>
 <% end %>

--- a/app/views/alchemy/essences/shared/_essence_picture_tools.html.erb
+++ b/app/views/alchemy/essences/shared/_essence_picture_tools.html.erb
@@ -1,23 +1,23 @@
-<% if options[:crop] && content.ingredient && content.ingredient.can_be_cropped_to(options[:image_size], options[:upsample]) %>
-<%= link_to_dialog(
-  render_icon('crop'),
-  alchemy.crop_admin_essence_picture_path(content.essence, options: options.to_json),
-  {
-    size: "1000x615",
-    title: _t('Edit Picturemask'),
-    image_loader: false,
-    padding: false
-  },
-  {
-    title: _t('Edit Picturemask')
-  }
-) %>
+<% linkable = content_settings_value(
+    content, :linkable,
+    local_assigns.fetch(:options, {})
+  ) != false %>
+
+<% if options[:crop] &&
+    content.ingredient &&
+    content.ingredient.can_be_cropped_to(options[:image_size], options[:upsample]) %>
+  <%= link_to_dialog render_icon('crop'),
+    alchemy.crop_admin_essence_picture_path(content.essence, options: options.to_json), {
+      size: "1000x615",
+      title: _t('Edit Picturemask'),
+      image_loader: false,
+      padding: false
+    }, {title: _t('Edit Picturemask')} %>
 <%- else -%>
-<a href="#" class="disabled"><%= render_icon('crop') %></a>
+  <a href="#" class="disabled"><%= render_icon('crop') %></a>
 <%- end -%>
 
-<%= link_to_dialog(
-  render_icon('swap_picture'),
+<%= link_to_dialog render_icon('swap_picture'),
   alchemy.admin_pictures_path(
     element_id: content.element,
     content_id: content.id,
@@ -29,33 +29,28 @@
     size: '780x580',
     padding: false
   },
-  title: (content.ingredient ? _t(:swap_image) : _t(:insert_image))
-) %>
+  title: (content.ingredient ? _t(:swap_image) : _t(:insert_image)) %>
 
-<%= link_to(render_icon(:link), '', {
+<%= link_to_if linkable, render_icon(:link), '', {
   onclick: 'd = new Alchemy.LinkDialog(this); d.open(); return false;',
   class: content.linked? ? 'linked' : nil,
   title: _t(:link_image),
   'data-content-id' => content.id,
   id: "edit_link_#{content.id}"
-}) %>
+} %>
 
-<%= link_to(render_icon('unlink'), '', {
+<%= link_to_if linkable, render_icon('unlink'), '', {
   onclick: "return Alchemy.LinkDialog.removeLink(this, #{content.id})",
   class: content.linked? ? 'linked' : 'disabled',
   title: _t(:unlink)
-}) %>
+} %>
 
-<%= link_to_dialog(
-  render_icon('edit'),
+<%= link_to_dialog render_icon('edit'),
   alchemy.edit_admin_essence_picture_path(
     id: content.essence.id,
     content_id: content.id,
     options: options.to_json
-  ),
-  {
+  ), {
     title: _t(:edit_image_properties),
     size: (options[:caption_as_textarea] ? (options[:sizes] ? '380x320' : '380x300') : (options[:sizes] ? '380x290' : '380x255'))
-  },
-  title: _t(:edit_image_properties)
-) %>
+  }, title: _t(:edit_image_properties) %>

--- a/spec/views/essences/essence_picture_editor_spec.rb
+++ b/spec/views/essences/essence_picture_editor_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe "essences/_essence_picture_editor" do
+  let(:essence_picture) do
+    stub_model(
+      Alchemy::EssencePicture,
+      picture: stub_model(Alchemy::Picture),
+      caption: 'This is a cute cat'
+    )
+  end
+
+  let(:content) do
+    stub_model(
+      Alchemy::Content,
+      name: 'image',
+      essence_type: 'EssencePicture',
+      essence: essence_picture
+    )
+  end
+
+  let(:options) { Hash.new }
+
+  before do
+    view.class.send(:include, Alchemy::BaseHelper)
+    view.class.send(:include, Alchemy::EssencesHelper)
+    allow(view).to receive(:content_label).and_return('')
+    allow(view).to receive(:essence_picture_thumbnail).and_return('')
+    allow(view).to receive(:link_to_dialog).and_return('')
+    render partial: "alchemy/essences/essence_picture_editor",
+      locals: {content: content, options: options}
+  end
+
+  context "with settings[:deletable] being nil" do
+    it 'should not render a button to link and unlink the picture' do
+      expect(rendered).to have_selector("a .icon.link")
+      expect(rendered).to have_selector("a .icon.unlink")
+    end
+  end
+
+  context "with settings[:deletable] being false" do
+    let(:options) do
+      {linkable: false}
+    end
+
+    it 'should not render a button to link and unlink the picture' do
+      expect(rendered).to_not have_selector("a .icon.link")
+      expect(rendered).to_not have_selector("a .icon.unlink")
+    end
+
+    it 'but renders the disabled link and unlink icons' do
+      expect(rendered).to have_selector(".icon.link")
+      expect(rendered).to have_selector(".icon.unlink")
+    end
+  end
+end


### PR DESCRIPTION
You can now disable the link option in the EssencePicture editor partial.

Just pass `linkable: false` to your element's definition.

## Example:

    # elements.yml
    - name: background_image
      contents:
      - name: image
        type: EssencePicture
        settings:
          linkable: false