### PR TITLE
Globally show the current locked pages tabs.

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.initializer.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.initializer.js.coffee
@@ -16,7 +16,7 @@ Alchemy.Initializer = ->
 
   # Add observer for please wait overlay.
   $('a.please_wait, #main_navi a.main_navi_entry, div.button_with_label form :submit, #sub_navigation .subnavi_tab a, .pagination a')
-    .not('*[data-alchemy-confirm], #subnav_additions .subnavi_tab button')
+    .not('*[data-alchemy-confirm], #locked_pages .subnavi_tab button')
     .click ->
       unless Alchemy.isPageDirty()
         Alchemy.pleaseWaitOverlay()

--- a/app/assets/stylesheets/alchemy/frame.scss
+++ b/app/assets/stylesheets/alchemy/frame.scss
@@ -273,7 +273,7 @@ div#user_info {
   }
 }
 
-#subnav_additions {
+#locked_pages {
   height: 25px;
   overflow: hidden;
 

--- a/app/controllers/alchemy/admin/base_controller.rb
+++ b/app/controllers/alchemy/admin/base_controller.rb
@@ -4,7 +4,8 @@ module Alchemy
       include Userstamp
       include Alchemy::Locale
 
-      before_filter { enforce_ssl if ssl_required? && !request.ssl? }
+      before_action { enforce_ssl if ssl_required? && !request.ssl? }
+      before_action :load_locked_pages
 
       helper_method :clipboard_empty?, :trash_empty?, :get_clipboard, :is_admin?
 
@@ -163,6 +164,9 @@ module Alchemy
         controller_path == 'alchemy/admin/pages' && action_name == 'show'
       end
 
+      def load_locked_pages
+        @locked_pages = Page.from_current_site.locked_by(current_alchemy_user)
+      end
     end
   end
 end

--- a/app/controllers/alchemy/admin/dashboard_controller.rb
+++ b/app/controllers/alchemy/admin/dashboard_controller.rb
@@ -8,7 +8,7 @@ module Alchemy
 
       def index
         @last_edited_pages = Page.from_current_site.all_last_edited_from(current_alchemy_user)
-        @locked_pages = Page.from_current_site.all_locked
+        @all_locked_pages = Page.from_current_site.locked
         if Alchemy.user_class.respond_to?(:logged_in)
           @online_users = Alchemy.user_class.logged_in.to_a - [current_alchemy_user]
         end

--- a/app/controllers/alchemy/admin/layoutpages_controller.rb
+++ b/app/controllers/alchemy/admin/layoutpages_controller.rb
@@ -4,7 +4,6 @@ module Alchemy
       authorize_resource class: :alchemy_admin_layoutpages
 
       def index
-        @locked_pages = Page.from_current_site.all_locked_by(current_alchemy_user)
         @layout_root = Page.find_or_create_layout_root_for(Language.current.id)
         @languages = Language.all
       end
@@ -13,7 +12,6 @@ module Alchemy
         @page = Page.find(params[:id])
         @page_layouts = PageLayout.layouts_with_own_for_select(@page.page_layout, Language.current.id, true)
       end
-
     end
   end
 end

--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -17,7 +17,6 @@ module Alchemy
       def index
         authorize! :index, :alchemy_admin_pages
 
-        @locked_pages = Page.from_current_site.all_locked_by(current_alchemy_user)
         @languages = Language.all
         if !@page_root
           @language = Language.current
@@ -67,7 +66,6 @@ module Alchemy
           redirect_to admin_pages_path
         else
           @page.lock_to!(current_alchemy_user)
-          @locked_pages = Page.from_current_site.all_locked_by(current_alchemy_user)
         end
         @layoutpage = @page.layoutpage?
       end
@@ -142,7 +140,7 @@ module Alchemy
         # fetching page via before filter
         @page.unlock!
         flash[:notice] = _t(:unlocked_page, :name => @page.name)
-        @pages_locked_by_user = Page.from_current_site.all_locked_by(current_alchemy_user)
+        @pages_locked_by_user = Page.from_current_site.locked_by(current_alchemy_user)
         respond_to do |format|
           format.js
           format.html {

--- a/app/models/alchemy/page/page_scopes.rb
+++ b/app/models/alchemy/page/page_scopes.rb
@@ -16,13 +16,13 @@ module Alchemy
 
       # All locked pages
       #
-      scope :all_locked, -> { where(locked: true) }
+      scope :locked, -> { where(locked: true) }
 
       # All pages locked by given user
       #
-      scope :all_locked_by, ->(user) {
+      scope :locked_by, ->(user) {
         if user.class.respond_to? :primary_key
-          all_locked.where(locked_by: user.send(user.class.primary_key))
+          locked.where(locked_by: user.send(user.class.primary_key))
         end
       }
 
@@ -68,7 +68,9 @@ module Alchemy
 
       # Returns all content pages.
       #
-      scope :contentpages, -> { where(layoutpage: [false, nil]).where(Page.arel_table[:parent_id].not_eq(nil)) }
+      scope :contentpages, -> {
+        where(layoutpage: [false, nil]).where(Page.arel_table[:parent_id].not_eq(nil))
+      }
 
       # Returns all public contentpages that are not locked.
       #
@@ -90,6 +92,5 @@ module Alchemy
       #
       scope :sitemap, -> { from_current_site.published.contentpages.where(sitemap: true) }
     end
-
   end
 end

--- a/app/views/alchemy/admin/dashboard/_locked_pages.html.erb
+++ b/app/views/alchemy/admin/dashboard/_locked_pages.html.erb
@@ -1,12 +1,12 @@
 <div class="widget">
   <h2><%= _t('Currently locked pages') %>:</h2>
   <table>
-  <% if @locked_pages.blank? %>
+  <% if @all_locked_pages.blank? %>
     <tr class="even">
       <td><%= _t('no pages') %></td>
     </tr>
   <% else %>
-    <% @locked_pages.each do |page| %>
+    <% @all_locked_pages.each do |page| %>
     <tr class="<%= cycle('even', 'odd', :name => 'locked_pages') %>">
       <% if current_alchemy_user.id == page.locked_by %>
       <td>

--- a/app/views/alchemy/admin/layoutpages/index.html.erb
+++ b/app/views/alchemy/admin/layoutpages/index.html.erb
@@ -1,10 +1,3 @@
-<% if @locked_pages.present? %>
-  <% content_for(:subnav_additions) do %>
-    <label><%= _t('Active Pages') %> &raquo;</label>
-    <%= render partial: 'alchemy/admin/pages/locked_page', collection: @locked_pages %>
-  <% end %>
-<% end %>
-
 <% content_for :toolbar do %>
 <div class="toolbar_buttons">
   <%= render partial: 'alchemy/admin/partials/language_tree_select' %>

--- a/app/views/alchemy/admin/pages/edit.html.erb
+++ b/app/views/alchemy/admin/pages/edit.html.erb
@@ -1,10 +1,5 @@
 <% content_for(:title) { @page.name } %>
 
-<% content_for(:subnav_additions) do %>
-  <label><%= _t('Active Pages') %> &raquo;</label>
-  <%= render partial: 'locked_page', collection: @locked_pages %>
-<% end %>
-
 <% content_for(:toolbar) do %>
 <div class="toolbar_buttons">
   <div class="button_with_label">

--- a/app/views/alchemy/admin/pages/index.html.erb
+++ b/app/views/alchemy/admin/pages/index.html.erb
@@ -1,10 +1,3 @@
-<% if @locked_pages.present? %>
-  <% content_for(:subnav_additions) do %>
-    <label><%= _t('Active Pages') %> &raquo;</label>
-    <%= render partial: 'locked_page', collection: @locked_pages %>
-  <% end %>
-<% end %>
-
 <% content_for :toolbar do %>
 <div class="toolbar_buttons">
   <%= render :partial => 'alchemy/admin/partials/language_tree_select' %>

--- a/app/views/alchemy/admin/pages/unlock.js.erb
+++ b/app/views/alchemy/admin/pages/unlock.js.erb
@@ -2,7 +2,7 @@
   $('#locked_page_<%= @page.id -%>').remove();
   $('#page_<%= @page.id -%> .sitemap_page').removeClass('locked');
   <%- if @pages_locked_by_user.blank? -%>
-  $('#subnav_additions label').hide();
+  $('#locked_pages label').hide();
   <%- end -%>
   Alchemy.growl('<%= flash[:notice] -%>');
 })(jQuery);

--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -74,9 +74,12 @@
     <div id="top_menu">
       <div id="sub_navigation">
         <%= admin_subnavigation %>
-        <div id="subnav_additions">
-          <%= yield(:subnav_additions) %>
-        </div>
+        <% if @locked_pages.present? %>
+          <div id="locked_pages">
+            <label><%= _t(:locked_pages) %> &raquo;</label>
+            <%= render partial: 'alchemy/admin/pages/locked_page', collection: @locked_pages %>
+          </div>
+        <% end %>
       </div>
       <div id="toolbar">
         <%= yield(:toolbar) %>

--- a/config/locales/alchemy.de.yml
+++ b/config/locales/alchemy.de.yml
@@ -159,7 +159,7 @@ de:
     anchor: 'Sprungmarke'
     back: 'zurück'
     create_tree_as_new_language: "%{language} als neuen Sprachbaum anlegen"
-    "Active Pages": "Aktive Seiten"
+    locked_pages: "Aktive Seiten"
     "Add global page": "Neue globale Seite"
     "Add page link": "Verweis hinzufügen"
     "Adobe Website": "Adobe Webseite"

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -159,7 +159,7 @@ en:
     anchor: 'Anchor'
     back: 'back'
     create_tree_as_new_language: "Create %{language} as a new language tree"
-    "Active Pages": "Active pages"
+    locked_pages: "Active pages"
     "Add global page": "Add global page"
     "Add page link": "Add page link"
     "Adobe Website": "Adobe Website"

--- a/config/locales/alchemy.es.yml
+++ b/config/locales/alchemy.es.yml
@@ -160,7 +160,7 @@ es:
     anchor: 'Ancla'
     back: 'Atras'
     create_tree_as_new_language: "Crear %{language} como nuevo árbol de idioma"
-    "Active Pages": "Páginas activas"
+    locked_pages: "Páginas activas"
     "Add global page": "Añadir página global"
     "Add page link": "Añadir redirección"
     "Adobe Website": "Sitio web de Adobe"

--- a/config/locales/alchemy.fr.yml
+++ b/config/locales/alchemy.fr.yml
@@ -175,7 +175,7 @@ fr:
     back: 'arrière'
     create_tree_as_new_language: "%{language} Création d'un nouvel arbre de la langue"
     "<a href=\"http://get.adobe.com/flashplayer\" target=\"_blank\">%{value}</a>": ""
-    "Active Pages": "sites actifs"
+    locked_pages: "sites actifs"
     "Add global page": "Nouvelle page globale"
     "Add page link": "Add Reference"
     "Adobe Website": "site Web d'Adobe"

--- a/config/locales/alchemy.nl.yml
+++ b/config/locales/alchemy.nl.yml
@@ -159,7 +159,7 @@ nl:
     anchor: 'Anchor'
     back: 'back'
     create_tree_as_new_language: "%{language} aanmaken als nieuwe boomstructuur"
-    "Active Pages": "Actieve pagina's"
+    locked_pages: "Actieve pagina's"
     "Add global page": "Nieuwe globale pagina"
     "Add page link": "Voeg pagina link toe"
     "Adobe Website": "Adobe Website"

--- a/config/locales/alchemy.ru.yml
+++ b/config/locales/alchemy.ru.yml
@@ -160,7 +160,7 @@ ru:
     anchor: 'Анкор'
     back: 'назад'
     create_tree_as_new_language: "Создать дерево языка %{language}"
-    "Active Pages": "Активные страницы"
+    locked_pages: "Активные страницы"
     "Add global page": "Добавить часть макета"
     "Add page link": "Добавить ссылку на страницу"
     "Adobe Website": "Adobe Website"

--- a/spec/controllers/admin/base_controller_spec.rb
+++ b/spec/controllers/admin/base_controller_spec.rb
@@ -71,4 +71,18 @@ describe Alchemy::Admin::BaseController do
     end
   end
 
+  context 'when current_alchemy_user is present' do
+    let!(:page) { create(:page) }
+    let!(:user) { create(:alchemy_dummy_user, :as_admin) }
+
+    before do
+      allow(controller).to receive(:current_alchemy_user) { user }
+      page.lock_to!(user)
+    end
+
+    it 'loads locked pages' do
+      controller.send(:load_locked_pages)
+      expect(assigns(:locked_pages)).to include(page)
+    end
+  end
 end

--- a/spec/controllers/admin/dashboard_controller_spec.rb
+++ b/spec/controllers/admin/dashboard_controller_spec.rb
@@ -2,14 +2,19 @@ require 'spec_helper'
 
 module Alchemy
   describe Admin::DashboardController do
-    let(:user) { build(:alchemy_dummy_user, :as_admin) }
+    let(:user) { build_stubbed(:alchemy_dummy_user, :as_admin) }
 
     before { authorize_user(user) }
 
     describe '#index' do
       before do
-        expect(Page).to receive(:from_current_site).and_return(double(all_last_edited_from: []))
-        expect(Page).to receive(:from_current_site).and_return(double(all_locked: []))
+        allow(Page).to receive(:from_current_site).and_return(
+          double(
+            all_last_edited_from: [],
+            locked_by: [],
+            locked: []
+          )
+        )
       end
 
       it "assigns @last_edited_pages" do
@@ -17,9 +22,9 @@ module Alchemy
         expect(assigns(:last_edited_pages)).to eq([])
       end
 
-      it "assigns @locked_pages" do
+      it "assigns @all_locked_pages" do
         alchemy_get :index
-        expect(assigns(:locked_pages)).to eq([])
+        expect(assigns(:all_locked_pages)).to eq([])
       end
 
       context 'with user class having logged_in scope' do

--- a/spec/controllers/admin/layoutpages_controller_spec.rb
+++ b/spec/controllers/admin/layoutpages_controller_spec.rb
@@ -8,11 +8,6 @@ module Alchemy
     end
 
     describe "#index" do
-      it "should assign @locked_pages" do
-        alchemy_get :index
-        expect(assigns(:locked_pages)).to eq([])
-      end
-
       it "should assign @layout_root" do
         alchemy_get :index
         expect(assigns(:layout_root)).to be_a(Page)

--- a/spec/controllers/admin/pages_controller_spec.rb
+++ b/spec/controllers/admin/pages_controller_spec.rb
@@ -501,7 +501,7 @@ module Alchemy
 
         before do
           allow(Page).to receive(:find).with("#{page.id}").and_return(page)
-          allow(Page).to receive(:from_current_site).and_return(double(all_locked_by: nil))
+          allow(Page).to receive(:from_current_site).and_return(double(locked_by: nil))
           expect(page).to receive(:unlock!).and_return(true)
         end
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -398,14 +398,14 @@ module Alchemy
       end
     end
 
-    describe '.all_locked' do
+    describe '.locked' do
       it "should return 1 page that is blocked by a user at the moment" do
         create(:public_page, locked: true, name: 'First Public Child', parent_id: language_root.id, language: language)
-        expect(Page.all_locked.size).to eq(1)
+        expect(Page.locked.size).to eq(1)
       end
     end
 
-    describe '.all_locked_by' do
+    describe '.locked_by' do
       let(:user) { double(:user, id: 1, class: DummyUser) }
 
       before do
@@ -417,7 +417,7 @@ module Alchemy
 
       it "should return the correct page collection blocked by a certain user" do
         page = create(:public_page, locked: true, locked_by: 1)
-        expect(Page.all_locked_by(user).pluck(:id)).to eq([page.id])
+        expect(Page.locked_by(user).pluck(:id)).to eq([page.id])
       end
 
       context 'with user class having a different primary key' do
@@ -431,7 +431,7 @@ module Alchemy
 
         it "should return the correct page collection blocked by a certain user" do
           page = create(:public_page, locked: true, locked_by: 123)
-          expect(Page.all_locked_by(user).pluck(:id)).to eq([page.id])
+          expect(Page.locked_by(user).pluck(:id)).to eq([page.id])
         end
       end
     end


### PR DESCRIPTION
Before the locked pages tabs where shown in pages index and edit mode only.
Now we always show them globally in every admin view.