### PR TITLE
EssenceFile and Attachment refactoring.

### DIFF
--- a/app/controllers/alchemy/admin/essence_files_controller.rb
+++ b/app/controllers/alchemy/admin/essence_files_controller.rb
@@ -36,7 +36,7 @@ module Alchemy
       private
 
       def essence_file_params
-        params.require(:essence_file).permit(:title, :css_class)
+        params.require(:essence_file).permit(:title, :css_class, :link_text)
       end
 
       def load_essence_file

--- a/app/models/alchemy/attachment.rb
+++ b/app/models/alchemy/attachment.rb
@@ -45,7 +45,6 @@ module Alchemy
 
     before_create do
       write_attribute(:name, convert_to_humanized_name(self.file_name, self.file.ext))
-      write_attribute(:file_name, sanitized_filename)
     end
 
     after_update :touch_contents
@@ -60,8 +59,9 @@ module Alchemy
       }
     end
 
+    # An url save filename without format suffix
     def urlname
-      read_attribute :file_name
+      CGI.escape(file_name.gsub(/\.#{extension}$/, '').gsub(/\./, ' '))
     end
 
     # Checks if the attachment is restricted, because it is attached on restricted pages only
@@ -69,6 +69,7 @@ module Alchemy
       pages.any? && pages.not_restricted.blank?
     end
 
+    # File format suffix
     def extension
       file_name.split(".").last
     end
@@ -105,13 +106,5 @@ module Alchemy
         else "file"
       end
     end
-
-    def sanitized_filename
-      parts = self.file_name.split('.')
-      sfx = parts.pop
-      name = convert_to_urlname(parts.join('-'))
-      "#{name}.#{sfx}"
-    end
-
   end
 end

--- a/app/models/alchemy/essence_file.rb
+++ b/app/models/alchemy/essence_file.rb
@@ -4,23 +4,19 @@
 #
 #  id            :integer          not null, primary key
 #  attachment_id :integer
-#  title         :string(255)
-#  css_class     :string(255)
+#  title         :string
+#  css_class     :string
 #  creator_id    :integer
 #  updater_id    :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  link_text     :string
 #
 
 module Alchemy
   class EssenceFile < ActiveRecord::Base
     belongs_to :attachment
     acts_as_essence ingredient_column: 'attachment'
-
-    def attachment_url
-      return if attachment.nil?
-      routes.download_attachment_path(id: attachment.id, name: attachment.file_name)
-    end
 
     def preview_text(max=30)
       return "" if attachment.blank?
@@ -31,12 +27,5 @@ module Alchemy
     def serialized_ingredient
       attachment_url
     end
-
-    private
-
-    def routes
-      @routes ||= Engine.routes.url_helpers
-    end
-
   end
 end

--- a/app/views/alchemy/admin/essence_files/edit.html.erb
+++ b/app/views/alchemy/admin/essence_files/edit.html.erb
@@ -1,11 +1,17 @@
+<% css_classes = content_settings_value(
+  @content,
+  :css_classes, local_assigns.fetch(:options, {})
+) %>
+
 <%= alchemy_form_for [:admin, @essence_file] do |f| %>
+  <%= f.input :link_text %>
   <%= f.input :title %>
-    <%- if @options[:css_classes].present? -%>
-      <%= f.input :css_class,
-        collection: @options[:css_classes],
-        include_blank: _t('None'),
-        input_html: {class: 'alchemy_selectbox'} %>
-    <%- else -%>
+  <%- if css_classes.present? -%>
+    <%= f.input :css_class,
+      collection: css_classes,
+      include_blank: _t('None'),
+      input_html: {class: 'alchemy_selectbox'} %>
+  <%- else -%>
     <%= f.input :css_class,
       label: _t(:position_in_text),
       collection: [
@@ -13,6 +19,6 @@
         [_t(:left), "left"],
         [_t(:right), "right"]
       ], include_blank: _t('Layout default'), input_html: {class: 'alchemy_selectbox'} %>
-    <%- end -%>
+  <%- end -%>
   <%= f.submit _t(:save) %>
 <% end %>

--- a/app/views/alchemy/essences/_essence_file_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_file_editor.html.erb
@@ -43,7 +43,7 @@
         ),
         {
           title: _t(:edit_file_properties),
-          size: '400x165'
+          size: '400x215'
         },
         class: 'edit_file',
         title: _t(:edit_file_properties) %>

--- a/app/views/alchemy/essences/_essence_file_view.html.erb
+++ b/app/views/alchemy/essences/_essence_file_view.html.erb
@@ -1,10 +1,16 @@
 <%- cache(content) do -%>
 <%- if attachment = content.ingredient -%>
 <%= link_to(
-  h(attachment.name),
-  alchemy.download_attachment_path(attachment),
-  class: "file_link #{content.essence.css_class.blank? ? "" : content.essence.css_class}",
-  title: "#{content.essence.title.blank? ? attachment.file_name : content.essence.title}"
+  content.essence.link_text.presence ||
+    content_settings_value(content, :link_text, local_assigns.fetch(:options, {})) ||
+    attachment.name,
+  alchemy.download_attachment_path(
+    attachment,
+    name: attachment.urlname,
+    format: attachment.suffix
+  ),
+  class: content.essence.css_class.presence,
+  title: content.essence.title.presence
 ) -%>
 <%- end -%>
 <%- end -%>

--- a/config/locales/alchemy.de.yml
+++ b/config/locales/alchemy.de.yml
@@ -846,6 +846,8 @@ de:
 
       alchemy/essence_file:
         css_class: Stil
+        link_text: Link-Text
+        title: Titel
 
       alchemy/essence_picture:
         caption: "Untertitel"

--- a/db/migrate/20150729151825_add_link_text_to_alchemy_essence_files.rb
+++ b/db/migrate/20150729151825_add_link_text_to_alchemy_essence_files.rb
@@ -1,0 +1,5 @@
+class AddLinkTextToAlchemyEssenceFiles < ActiveRecord::Migration
+  def change
+    add_column :alchemy_essence_files, :link_text, :string
+  end
+end

--- a/spec/controllers/admin/essence_files_controller_spec.rb
+++ b/spec/controllers/admin/essence_files_controller_spec.rb
@@ -36,9 +36,14 @@ module Alchemy
       end
 
       it "should update the attributes of essence_file" do
-        alchemy_xhr :put, :update, id: essence_file.id, essence_file: {title: 'new title', css_class: 'left'}
+        alchemy_xhr :put, :update, id: essence_file.id, essence_file: {
+          title: 'new title',
+          css_class: 'left',
+          link_text: 'Download this file'
+        }
         expect(essence_file.title).to eq 'new title'
         expect(essence_file.css_class).to eq 'left'
+        expect(essence_file.link_text).to eq 'Download this file'
       end
     end
 

--- a/spec/dummy/db/migrate/20150729151825_add_link_text_to_alchemy_essence_files.rb
+++ b/spec/dummy/db/migrate/20150729151825_add_link_text_to_alchemy_essence_files.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20150729151825_add_link_text_to_alchemy_essence_files.rb

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150608204610) do
+ActiveRecord::Schema.define(version: 20150729151825) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string   "name"
@@ -99,6 +99,7 @@ ActiveRecord::Schema.define(version: 20150608204610) do
     t.integer  "updater_id"
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
+    t.string   "link_text"
   end
 
   create_table "alchemy_essence_htmls", force: :cascade do |t|

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -20,33 +20,29 @@ module Alchemy
         expect(attachment.name).to eq("image with spaces")
       end
 
-      it "should have a valid file_name" do
-        expect(attachment.file_name).to eq("image-with-spaces.png")
-      end
-
       after { attachment.destroy }
     end
 
     describe 'urlname sanitizing' do
-      it "should sanitize url characters in the filename" do
+      it "escapes unsafe url characters" do
         attachment.file_name = 'f#%&cking cute kitten pic.png'
-        attachment.save!
-        expect(attachment.urlname).to eq('f-cking-cute-kitten-pic.png')
+        expect(attachment.urlname).to eq('f%23%25%26cking+cute+kitten+pic')
       end
 
-      it "should sanitize lot of dots in the name" do
+      it "removes format suffix from end of file name" do
+        attachment.file_name = 'pic.png.png'
+        expect(attachment.urlname).to eq('pic+png')
+      end
+
+      it "converts dots into escaped spaces" do
         attachment.file_name = 'cute.kitten.pic.png'
-        attachment.save!
-        expect(attachment.urlname).to eq('cute-kitten-pic.png')
+        expect(attachment.urlname).to eq('cute+kitten+pic')
       end
 
-      it "should sanitize umlauts in the name" do
+      it "escapes umlauts in the name" do
         attachment.file_name = 'süßes katzenbild.png'
-        attachment.save!
-        expect(attachment.urlname).to eq('suesses-katzenbild.png')
+        expect(attachment.urlname).to eq('s%C3%BC%C3%9Fes+katzenbild')
       end
-
-      after { attachment.destroy }
     end
 
     describe 'validations' do

--- a/spec/models/essence_file_spec.rb
+++ b/spec/models/essence_file_spec.rb
@@ -11,20 +11,6 @@ module Alchemy
       let(:ingredient_value) { attachment }
     end
 
-    describe '#attachment_url' do
-      subject { essence.attachment_url }
-
-      it "returns the download attachment url." do
-        is_expected.to match(/\/attachment\/#{attachment.id}\/download\/#{attachment.file_name}/)
-      end
-
-      context 'without attachment assigned' do
-        let(:attachment) { nil }
-
-        it { is_expected.to be_nil }
-      end
-    end
-
     describe '#preview_text' do
 
       it "returns the attachment's name as preview text" do
@@ -38,6 +24,5 @@ module Alchemy
         end
       end
     end
-
   end
 end

--- a/spec/views/essences/essence_file_view_spec.rb
+++ b/spec/views/essences/essence_file_view_spec.rb
@@ -1,8 +1,12 @@
 require 'spec_helper'
 
 describe 'alchemy/essences/_essence_file_view' do
-  let(:file)       { File.new(File.expand_path('../../../fixtures/image with spaces.png', __FILE__)) }
-  let(:attachment) { mock_model('Attachment', file: file, name: 'image', file_name: 'Image') }
+  let(:file) do
+    File.new(File.expand_path('../../../fixtures/image with spaces.png', __FILE__))
+  end
+  let(:attachment) do
+    build_stubbed(:attachment, file: file, name: 'an image', file_name: 'image with spaces.png')
+  end
   let(:essence)    { Alchemy::EssenceFile.new(attachment: attachment) }
   let(:content)    { Alchemy::Content.new(essence: essence) }
 
@@ -18,7 +22,56 @@ describe 'alchemy/essences/_essence_file_view' do
   context 'with attachment' do
     it "renders a link to download the attachment" do
       render content, content: content
-      expect(rendered).to have_selector("a.file_link[href='/attachment/#{attachment.id}/download']")
+      expect(rendered).to have_selector(
+        "a[href='/attachment/#{attachment.id}/download/#{attachment.urlname}.#{attachment.suffix}']"
+      )
+    end
+
+    context 'with no link_text set' do
+      it "has this attachments name as link text" do
+        render content, content: content
+        expect(rendered).to have_selector("a:contains('#{attachment.name}')")
+      end
+    end
+
+    context 'with link_text set in the local options' do
+      it "has this value as link text" do
+        render content, content: content, options: {link_text: 'Download this file'}
+        expect(rendered).to have_selector("a:contains('Download this file')")
+      end
+    end
+
+    context 'with link_text set in the content settings' do
+      before do
+        allow(content).to receive(:settings) { {link_text: 'Download this file'} }
+      end
+
+      it "has this value as link text" do
+        render content, content: content
+        expect(rendered).to have_selector("a:contains('Download this file')")
+      end
+    end
+
+    context 'with link_text stored in the essence attribute' do
+      before do
+        allow(essence).to receive(:link_text) { 'Download this file' }
+      end
+
+      it "has this value as link text" do
+        render content, content: content
+        expect(rendered).to have_selector("a:contains('Download this file')")
+      end
+    end
+  end
+
+  context "with css_class set" do
+    before do
+      allow(essence).to receive(:css_class) { 'file-download' }
+    end
+
+    it "has this class at the link" do
+      render content, content: content
+      expect(rendered).to have_selector("a.file-download")
     end
   end
 end


### PR DESCRIPTION
`Alchemy::EssenceFile` now has a `link_text` attribute, so the editor is able to change the linked text of the download link.

`Alchemy::Attachment#urlname` now returns always an escaped urlname w/o format suffix and does not convert the `file_name` once on create anymore.

Also removes an unused method (`attachment_url`) from the `Alchemy::Attachment` model, that has some weird hack including the routes into the model :scream: 