### PR TITLE
Execute bundle install right before alchemy:install is called

### DIFF
--- a/bin/alchemy
+++ b/bin/alchemy
@@ -30,6 +30,7 @@ class AlchemyInstaller < Thor
     if options[:database] == 'mysql' || options[:database] == 'postgresql'
       create_database_yml(options[:database])
     end
+    system("cd #{@application} && bundle install")
     system("#{rake_cmd} alchemy:install from_binary=true") || exit!(1)
     say "\nStep 3: Installing Alchemy User into Rails app", :yellow
     say "Please wait...", :yellow


### PR DESCRIPTION
Without a `bundle install` the installation will fail with
> The git source git://github.com/AlchemyCMS/alchemy_cms.git is not yet checked out. Please run `bundle install` before trying to start your application