### PR TITLE
Allow filenames for attachments with special characters

### DIFF
--- a/app/models/alchemy/attachment.rb
+++ b/app/models/alchemy/attachment.rb
@@ -35,7 +35,7 @@ module Alchemy
     has_many :pages, :through => :elements
 
     validates_presence_of :file
-    validates_format_of :file_name, with: /\A[A-Za-z0-9\.\-_]+\z/, on: :update
+    validates_format_of :file_name, with: /\A[A-Za-z0-9\. \-_äÄöÖüÜß]+\z/, on: :update
     validates_size_of :file, maximum: Config.get(:uploader)['file_size_limit'].megabytes
     validates_property :ext, of: :file,
       in: Config.get(:uploader)['allowed_filetypes']['attachments'],

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -63,6 +63,28 @@ module Alchemy
         end
       end
 
+      context "having a filename with special characters" do
+        before do
+           attachment.file_name = 'my FileNämü.pdf'
+           attachment.save
+         end
+
+        it "should be valid" do
+          expect(attachment).to be_valid
+        end
+      end
+
+      context "having a filename with unallowed character" do
+        before do
+          attachment.file_name = 'my FileNämü?!.pdf'
+          attachment.save
+        end
+
+        it "should not be valid" do
+          expect(attachment).not_to be_valid
+        end
+      end
+
     end
 
     context 'PNG image' do


### PR DESCRIPTION
This PR closes #839 for attached files. 
Special characters such as mutated vowels as well as spaces are allowed.