### PR TITLE
Allow editors to visit languages page in admin area, fixes #841

### DIFF
--- a/lib/alchemy/permissions.rb
+++ b/lib/alchemy/permissions.rb
@@ -153,6 +153,7 @@ module Alchemy
         can :manage, Alchemy::Attachment
         can :read,   Alchemy.user_class
         can :manage, Alchemy::Tag
+        can :index,  Alchemy::Language
       end
     end
 

--- a/spec/controllers/admin/languages_controller_spec.rb
+++ b/spec/controllers/admin/languages_controller_spec.rb
@@ -58,4 +58,17 @@ describe Alchemy::Admin::LanguagesController do
       end
     end
   end
+
+  describe "#index" do
+    context "editor users" do
+      before do
+        authorize_user(:as_editor)
+      end
+
+      it "should be able to index language" do
+        alchemy_get :index
+        expect(response).to render_template(:index)
+      end
+    end
+  end
 end

--- a/spec/features/admin/navigation_feature_spec.rb
+++ b/spec/features/admin/navigation_feature_spec.rb
@@ -10,4 +10,14 @@ describe 'Admin navigation feature' do
       expect(page).to have_content('You are about to leave Alchemy')
     end
   end
+
+  context 'editor users' do
+    before { authorize_user(:as_editor) }
+
+    it "can access the languages page" do
+      visit '/admin'
+      click_on 'Languages'
+      expect(current_path).to eq('/admin/languages')
+    end
+  end
 end


### PR DESCRIPTION
As discussed in Slack, editors should be able to see the languages but not manage them.