### PR TITLE
A Select shouldn't be too wide

### DIFF
--- a/app/assets/stylesheets/alchemy/selects.scss
+++ b/app/assets/stylesheets/alchemy/selects.scss
@@ -2,6 +2,7 @@ select {
   @include button-defaults;
   height: 29px;
   padding: 0.4em 0.6em;
+  max-width: 100%;
 }
 
 .select2-container {


### PR DESCRIPTION
Super Mini Fix: Without this, backend select boxes are often wider than their container. 