### PR TITLE
Change implementation of on_page_layout callbacks

### DIFF
--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -4,6 +4,9 @@ module Alchemy
     before_action :enforce_primary_host_for_site
     before_action :render_page_or_redirect, only: [:show]
 
+    before_action :run_on_page_layout_callbacks, only: :show,
+      if: -> { OnPageLayout.callbacks.present? }
+
     # Showing page from params[:urlname]
     #
     def show
@@ -206,6 +209,23 @@ module Alchemy
 
     def page_not_found!
       not_found_error!("Alchemy::Page not found \"#{request.fullpath}\"")
+    end
+
+    def run_on_page_layout_callbacks
+      OnPageLayout.callbacks.each do |page_layout, callbacks|
+        next unless call_page_layout_callback_for?(page_layout)
+        callbacks.each do |callback|
+          if callback.respond_to?(:call)
+            instance_eval(&callback)
+          else
+            send(callback)
+          end
+        end
+      end
+    end
+
+    def call_page_layout_callback_for?(page_layout)
+      page_layout.to_sym == :all || @page.page_layout.to_sym == page_layout.to_sym
     end
   end
 end

--- a/lib/alchemy/on_page_layout.rb
+++ b/lib/alchemy/on_page_layout.rb
@@ -33,25 +33,17 @@ module Alchemy
   #     end
   #
   module OnPageLayout
+    mattr_accessor :callbacks
 
-    def on_page_layout(page_layout, callback = nil)
-      Alchemy::PagesController.class_eval do
-
-        append_before_action only: :show, if: -> { call_page_layout_callback_for?(page_layout) } do
-          if block_given?
-            instance_eval(&Proc.new)
-          elsif callback
-            self.send(callback)
-          else
-            raise "You need to either pass a block or method name as callback for `on_page_layout`"
-          end
-        end
-
-        private
-
-        def call_page_layout_callback_for?(page_layout)
-          page_layout.to_sym == :all || @page.page_layout.to_sym == page_layout.to_sym
-        end
+    def on_page_layout(page_layout, callback = nil, &block)
+      @@callbacks = {}
+      @@callbacks[page_layout] = []
+      if block_given?
+        @@callbacks[page_layout] << block
+      elsif callback
+        @@callbacks[page_layout] << callback
+      else
+        raise "You need to either pass a block or method name as callback for `on_page_layout`"
       end
     end
   end


### PR DESCRIPTION
Before we used a hackish way to `class_eval` a `before_action` into the `PagesController`. 

This is now changed to a **real** `before_action` in the `PagesController` ;)

The specs didn't change and still pass, because the tested feature is the same \o/