### PR TITLE
Fix #853

### DIFF
--- a/app/helpers/alchemy/admin/essences_helper.rb
+++ b/app/helpers/alchemy/admin/essences_helper.rb
@@ -80,6 +80,15 @@ module Alchemy
         )
       end
 
+      # Size value for edit picture dialog
+      def edit_picture_dialog_size(content, options = {})
+        if content.settings_value(:caption_as_textarea, options)
+          content.settings_value(:sizes, options) ? '380x320' : '380x300'
+        else
+          content.settings_value(:sizes, options) ? '380x290' : '380x255'
+        end
+      end
+
       private
 
       # Returns an Array with page attributes for select options
@@ -114,7 +123,6 @@ module Alchemy
           page.name
         end
       end
-
     end
   end
 end

--- a/app/models/alchemy/essence_picture.rb
+++ b/app/models/alchemy/essence_picture.rb
@@ -84,6 +84,15 @@ module Alchemy
       picture_url(content.settings)
     end
 
+    # Show image cropping link for content and options?
+    def allow_image_cropping?(options = {})
+      content && content.settings_value(:crop, options) && picture &&
+        picture.can_be_cropped_to(
+          content.settings_value(:image_size, options),
+          content.settings_value(:upsample, options)
+        )
+    end
+
     private
 
     def fix_crop_values
@@ -146,6 +155,5 @@ module Alchemy
       secure_attributes += %w(name format sh)
       params.delete_if { |k, v| !secure_attributes.include?(k.to_s) || v.blank? }
     end
-
   end
 end

--- a/app/views/alchemy/essences/shared/_essence_picture_tools.html.erb
+++ b/app/views/alchemy/essences/shared/_essence_picture_tools.html.erb
@@ -1,10 +1,11 @@
-<% linkable = content.settings_value(:linkable, local_assigns.fetch(:options, {})) != false %>
+<% linkable = content.settings_value(:linkable, options) != false %>
 
-<% if options[:crop] &&
-    content.ingredient &&
-    content.ingredient.can_be_cropped_to(options[:image_size], options[:upsample]) %>
+<% if content.essence && content.essence.allow_image_cropping?(options) %>
   <%= link_to_dialog render_icon('crop'),
-    alchemy.crop_admin_essence_picture_path(content.essence, options: options.to_json), {
+    alchemy.crop_admin_essence_picture_path(
+      content.essence,
+      options: content.settings.update(options).to_json
+    ), {
       size: "1000x615",
       title: _t('Edit Picturemask'),
       image_loader: false,
@@ -49,5 +50,5 @@
     options: options.to_json
   ), {
     title: _t(:edit_image_properties),
-    size: (options[:caption_as_textarea] ? (options[:sizes] ? '380x320' : '380x300') : (options[:sizes] ? '380x290' : '380x255'))
+    size: edit_picture_dialog_size(content, options)
   }, title: _t(:edit_image_properties) %>

--- a/spec/helpers/admin/essences_helper_spec.rb
+++ b/spec/helpers/admin/essences_helper_spec.rb
@@ -3,7 +3,9 @@ require 'spec_helper'
 describe Alchemy::Admin::EssencesHelper do
   include Alchemy::Admin::ElementsHelper
 
-  let(:element) { FactoryGirl.create(:element, :name => 'article', :create_contents_after_create => true) }
+  let(:element) do
+    create(:element, name: 'article', create_contents_after_create: true)
+  end
 
   describe 'essence rendering' do
     before do
@@ -15,7 +17,8 @@ describe Alchemy::Admin::EssencesHelper do
     describe '#render_essence_editor' do
       it "should render an essence editor" do
         content = element.content_by_name('intro')
-        expect(helper.render_essence_editor(content)).to match(/input.+type="text".+value="hello!/)
+        expect(helper.render_essence_editor(content)).
+          to match(/input.+type="text".+value="hello!/)
       end
     end
 
@@ -48,10 +51,13 @@ describe Alchemy::Admin::EssencesHelper do
   end
 
   describe '#pages_for_select' do
-    let(:contact_form) { FactoryGirl.create(:element, :name => 'contactform', :create_contents_after_create => true) }
-    let(:page_a) { FactoryGirl.create(:public_page, :name => 'Page A') }
-    let(:page_b) { FactoryGirl.create(:public_page, :name => 'Page B') }
-    let(:page_c) { FactoryGirl.create(:public_page, :name => 'Page C', :parent_id => page_b.id) }
+    let(:contact_form) do
+      create(:element, name: 'contactform', create_contents_after_create: true)
+    end
+
+    let(:page_a) { create(:public_page, name: 'Page A') }
+    let(:page_b) { create(:public_page, name: 'Page B') }
+    let(:page_c) { create(:public_page, name: 'Page C', parent_id: page_b.id) }
 
     before do
       # to be shure the ordering is alphabetic
@@ -75,7 +81,7 @@ describe Alchemy::Admin::EssencesHelper do
     context "with pages passed in" do
       before do
         @pages = []
-        3.times { @pages << FactoryGirl.create(:public_page) }
+        3.times { @pages << create(:public_page) }
       end
 
       it "should return options for select with only these pages" do
@@ -137,4 +143,59 @@ describe Alchemy::Admin::EssencesHelper do
     end
   end
 
+  describe "#edit_picture_dialog_size" do
+    let(:content) { build_stubbed(:content) }
+
+    subject { edit_picture_dialog_size(content) }
+
+    context "with content having setting caption_as_textarea being true and sizes set" do
+      before do
+        allow(content).to receive(:settings) do
+          {
+            caption_as_textarea: true,
+            sizes: ['100x100', '200x200']
+          }
+        end
+
+        it { is_expected.to eq("380x320") }
+      end
+    end
+
+    context "with content having setting caption_as_textarea being true and no sizes set" do
+      before do
+        allow(content).to receive(:settings) do
+          {
+            caption_as_textarea: true
+          }
+        end
+
+        it { is_expected.to eq("380x300") }
+      end
+    end
+
+    context "with content having setting caption_as_textarea being false and sizes set" do
+      before do
+        allow(content).to receive(:settings) do
+          {
+            caption_as_textarea: false,
+            sizes: ['100x100', '200x200']
+          }
+        end
+
+        it { is_expected.to eq("380x290") }
+      end
+    end
+
+    context "with content having setting caption_as_textarea being false and no sizes set" do
+      before do
+        allow(content).to receive(:settings) do
+          {
+            caption_as_textarea: false
+          }
+        end
+
+        it { is_expected.to eq("380x255") }
+      end
+    end
+  end
 end

--- a/spec/models/essence_picture_spec.rb
+++ b/spec/models/essence_picture_spec.rb
@@ -179,5 +179,61 @@ module Alchemy
       end
     end
 
+    describe "#allow_image_cropping?" do
+      let(:essence_picture) do
+        stub_model(
+          Alchemy::EssencePicture,
+          picture: picture,
+          caption: 'This is a cute cat'
+        )
+      end
+
+      let(:content) do
+        stub_model(
+          Alchemy::Content,
+          name: 'image',
+          essence_type: 'EssencePicture',
+          essence: essence_picture
+        )
+      end
+
+      let(:picture) { stub_model(Alchemy::Picture) }
+
+      subject { essence_picture.allow_image_cropping? }
+
+      it { is_expected.to be_falsy }
+
+      context "with content existing?" do
+        before do
+          allow(essence_picture).to receive(:content) { content }
+        end
+
+        it { is_expected.to be_falsy }
+
+        context "with picture assigned" do
+          before do
+            allow(content).to receive(:ingredient) { picture }
+          end
+
+          it { is_expected.to be_falsy }
+
+          context "and with image larger than crop size" do
+            before do
+              allow(picture).to receive(:can_be_cropped_to) { true }
+            end
+
+            it { is_expected.to be_falsy }
+
+            context "with crop set to true" do
+              before do
+                allow(content).to receive(:settings_value) { true }
+              end
+
+              it { is_expected.to be(true) }
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/views/essences/essence_picture_editor_spec.rb
+++ b/spec/views/essences/essence_picture_editor_spec.rb
@@ -1,10 +1,12 @@
 require 'spec_helper'
 
 describe "essences/_essence_picture_editor" do
+  let(:picture) { stub_model(Alchemy::Picture) }
+
   let(:essence_picture) do
     stub_model(
       Alchemy::EssencePicture,
-      picture: stub_model(Alchemy::Picture),
+      picture: picture,
       caption: 'This is a cute cat'
     )
   end
@@ -21,19 +23,22 @@ describe "essences/_essence_picture_editor" do
   let(:options) { Hash.new }
 
   before do
-    view.class.send(:include, Alchemy::BaseHelper)
-    view.class.send(:include, Alchemy::EssencesHelper)
+    view.class.send(:include, Alchemy::Admin::BaseHelper)
+    view.class.send(:include, Alchemy::Admin::EssencesHelper)
     allow(view).to receive(:content_label).and_return('')
     allow(view).to receive(:essence_picture_thumbnail).and_return('')
-    allow(view).to receive(:link_to_dialog).and_return('')
+  end
+
+  subject do
     render partial: "alchemy/essences/essence_picture_editor",
       locals: {content: content, options: options}
+    rendered
   end
 
   context "with settings[:deletable] being nil" do
     it 'should not render a button to link and unlink the picture' do
-      expect(rendered).to have_selector("a .icon.link")
-      expect(rendered).to have_selector("a .icon.unlink")
+      is_expected.to have_selector("a .icon.link")
+      is_expected.to have_selector("a .icon.unlink")
     end
   end
 
@@ -43,13 +48,33 @@ describe "essences/_essence_picture_editor" do
     end
 
     it 'should not render a button to link and unlink the picture' do
-      expect(rendered).to_not have_selector("a .icon.link")
-      expect(rendered).to_not have_selector("a .icon.unlink")
+      is_expected.to_not have_selector("a .icon.link")
+      is_expected.to_not have_selector("a .icon.unlink")
     end
 
     it 'but renders the disabled link and unlink icons' do
-      expect(rendered).to have_selector(".icon.link")
-      expect(rendered).to have_selector(".icon.unlink")
+      is_expected.to have_selector(".icon.link")
+      is_expected.to have_selector(".icon.unlink")
+    end
+  end
+
+  context 'with allow_image_cropping? true' do
+    before do
+      allow(essence_picture).to receive(:allow_image_cropping?) { true }
+    end
+
+    it 'shows cropping link' do
+      is_expected.to have_selector('a[href*="crop"]')
+    end
+  end
+
+  context 'with allow_image_cropping? false' do
+    before do
+      allow(essence_picture).to receive(:allow_image_cropping?) { false }
+    end
+
+    it 'shows disabled cropping link' do
+      is_expected.to have_selector('a.disabled .icon.crop')
     end
   end
 end


### PR DESCRIPTION
Former only the local options where used. This fixes #853
and adds some more refactorings to the essence picture editor view.