### PR TITLE
fix Page.public_language_roots

### DIFF
--- a/app/models/alchemy/page/page_scopes.rb
+++ b/app/models/alchemy/page/page_scopes.rb
@@ -50,7 +50,7 @@ module Alchemy
       #
       scope :public_language_roots, -> {
         published.language_roots.where(
-          language_code: Language.published.pluck(:code)
+          language_code: Language.published.pluck(:language_code)
         )
       }
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -697,6 +697,13 @@ module Alchemy
       end
     end
 
+    describe '.public_language_roots' do
+      it "should return pages that public language roots" do
+        create(:public_page, name: 'First Public Child', parent_id: language_root.id, language: language)
+        expect(Page.public_language_roots.size).to eq(1)
+      end
+    end
+
     describe '.restricted' do
       it "should return 1 restricted page" do
         create(:public_page, name: 'First Public Child', restricted: true, parent_id: language_root.id, language: language)


### PR DESCRIPTION
Language has no column ```:code```. Obviously ```:language_code``` was meant.