### PR TITLE
Rename the admin body class method.

### DIFF
--- a/app/helpers/alchemy/admin/base_helper.rb
+++ b/app/helpers/alchemy/admin/base_helper.rb
@@ -403,7 +403,7 @@ module Alchemy
       end
 
       # Appends the current controller and action to body as css class.
-      def body_class
+      def alchemy_body_class
         "#{controller_name} #{action_name}"
       end
 

--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -37,7 +37,7 @@
     <%= javascript_include_tag('alchemy/alchemy', "data-turbolinks-track" => true) %>
     <%= yield :javascript_includes %>
   </head>
-  <body id="alchemy" class="<%= body_class %>">
+  <body id="alchemy" class="<%= alchemy_body_class %>">
     <noscript>
       <h1><%= _t(:javascript_disabled_headline) %></h1>
       <p><%= _t(:javascript_disabled_text) %></p>

--- a/spec/features/admin/admin_layout_spec.rb
+++ b/spec/features/admin/admin_layout_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.feature 'Admin layout' do
+  let(:user) { create(:alchemy_dummy_user, :as_admin, name: "Joe User") }
+
+  before do
+    authorize_user(user)
+  end
+
+  it 'has controller and action name as body class' do
+    visit admin_path
+    expect(page).to have_selector('body.dashboard.index')
+  end
+end


### PR DESCRIPTION
The former name of the helper `body_class` was too generic and can potentially conflict with existing helpers.