### PR TITLE
Use rails tag helpers instead of plain HTML

### DIFF
--- a/app/helpers/alchemy/pages_helper.rb
+++ b/app/helpers/alchemy/pages_helper.rb
@@ -283,7 +283,7 @@ module Alchemy
       else
         title_parts << response.status
       end
-      title_parts.join(options[:separator])
+      title_parts.join(options[:separator]).html_safe
     end
 
     # Returns a complete html <title> tag for the <head> part of the html document.
@@ -299,7 +299,7 @@ module Alchemy
         separator: ""
       }
       options = default_options.merge(options)
-      %(<title>#{render_page_title(options)}</title>).html_safe
+      content_tag(:title, render_page_title(options))
     end
 
     # Renders a html <meta> tag for name: "" and content: ""
@@ -317,7 +317,7 @@ module Alchemy
       }
       options = default_options.merge(options)
       lang = (@page.language.blank? ? options[:default_language] : @page.language.code)
-      %(<meta name="#{options[:name]}" content="#{options[:content]}" lang="#{lang}">).html_safe
+      tag(:meta, name: options[:name], content: options[:content], lang: lang)
     end
 
     # This helper takes care of all important meta tags for your page.
@@ -332,7 +332,7 @@ module Alchemy
     #
     # Then placing +render_meta_data(title_prefix: "Company", title_separator: "-")+ into the <head> part of the +pages.html.erb+ layout produces:
     #
-    #   <meta charset="UTF-8">
+    #   <meta charset="utf-8">
     #   <title>Company - #{@page.title}</title>
     #   <meta name="description" content="Your page description">
     #   <meta name="keywords" content="cms, ruby, rubyonrails, rails, software, development, html, javascript, ajax">
@@ -364,16 +364,24 @@ module Alchemy
       end
       robot = "#{@page.robot_index? ? '' : 'no'}index, #{@page.robot_follow? ? '' : 'no'}follow"
       meta_string = %(
-        <meta charset="UTF-8">
+        #{tag(:meta, charset: 'utf-8')}
         #{render_title_tag(prefix: options[:title_prefix], separator: options[:title_separator])}
-        #{render_meta_tag(name: 'description', content: description)}
-        #{render_meta_tag(name: 'keywords', content: keywords)}
-        <meta name="created" content="#{@page.updated_at}">
-        <meta name="robots" content="#{robot}">
+        #{render_meta_tag(name: 'created', content: @page.updated_at)}
+        #{render_meta_tag(name: 'robots', content: robot)}
       )
+      if description.present?
+        meta_string += %(
+          #{render_meta_tag(name: 'description', content: description.html_safe)}
+        )
+      end
+      if keywords.present?
+        meta_string += %(
+          #{render_meta_tag(name: 'keywords', content: keywords.html_safe)}
+        )
+      end
       if @page.contains_feed?
         meta_string += %(
-          <link rel="alternate" type="application/rss+xml" title="RSS" href="#{show_alchemy_page_url(@page, format: :rss)}">
+          #{auto_discovery_link_tag(:rss, show_alchemy_page_url(@page, format: :rss))}
         )
       end
       meta_string.html_safe

--- a/spec/helpers/alchemy/pages_helper_spec.rb
+++ b/spec/helpers/alchemy/pages_helper_spec.rb
@@ -339,8 +339,8 @@ module Alchemy
           is_expected.to match /meta name="description" content="root page's description"/
         end
 
-        it "should set it to empty when language root's page is also missing one" do
-          is_expected.to match /meta name="description" content=""/
+        it "should not be set when language root's page is also missing one" do
+          is_expected.not_to match /meta name="description"/
         end
       end
 
@@ -352,8 +352,8 @@ module Alchemy
           is_expected.to match /meta name="keywords" content="root page's keywords"/
         end
 
-        it "should set it to empty when language root's page is also missing one" do
-          is_expected.to match /meta name="keywords" content=""/
+        it "should not be set when language root's page is also missing one" do
+          is_expected.not_to match /meta name="keywords"/
         end
       end
     end


### PR DESCRIPTION
Using rails built-in tag helpers generates XHTML compliant tags.

Description and Keywords should only be generated if they are not empty.