### PR TITLE
Fix/essence select grouped options tags

### DIFF
--- a/app/views/alchemy/essences/_essence_select_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_select_editor.html.erb
@@ -1,22 +1,33 @@
 <% cache(content) do %>
-  <%- select_values = content.settings_value(:select_values, local_assigns.fetch(:options, {})) -%>
+  <% select_values = content.settings_value(:select_values, local_assigns.fetch(:options, {})) %>
+  <% inline = content.settings_value(:display_inline, local_assigns.fetch(:options, {})) %>
 
-  <div class="content_editor essence_select<%= options[:display_inline].to_s == 'true' ? ' display_inline' : '' %>" id="<%= content.dom_id %>" data-content-id="<%= content.id %>">
+  <%= content_tag :div,
+    id: content.dom_id,
+    class: [
+      "content_editor",
+      "essence_select",
+      inline ? 'display_inline' : nil
+    ].compact, data: {content_id: content.id} do %>
     <%= content_label(content) %>
 
     <% if select_values.nil? %>
-      <%= warning(':select_values is nil', "<strong>No select values given.</strong><br>Please provide :<code>select_values</code> either as argument to <code>render_essence_editor</code> helper or as setting on the content definition in <code>elements.yml</code>.".html_safe) %>
+      <%== warning(':select_values is nil',
+      "<strong>No select values given.</strong>
+      <br>Please provide :<code>select_values</code> either as argument to
+      <code>render_essence_editor</code> helper or as setting on the content definition in
+      <code>elements.yml</code>.") %>
     <% else %>
-      <%  if select_values.is_a?(Hash)
-            options_tags = grouped_options_for_select(select_values, content.ingredient)
-          else
-            options_tags = options_for_select(select_values, content.ingredient)
-          end %>
-
+      <%
+      if select_values.is_a?(Hash)
+        options_tags = grouped_options_for_select(select_values, content.ingredient)
+      else
+        options_tags = options_for_select(select_values, content.ingredient)
+      end %>
       <%= select_tag content.form_field_name, options_tags, {
-        class: ["alchemy_selectbox", "essence_editor_select", html_options[:class]].join(' '),
+        class: ["alchemy_selectbox", "essence_editor_select", html_options[:class]].compact,
         style: html_options[:style]
       } %>
     <% end %>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/alchemy/essences/_essence_select_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_select_editor.html.erb
@@ -8,11 +8,9 @@
       <%= warning(':select_values is nil', "<strong>No select values given.</strong><br>Please provide :<code>select_values</code> either as argument to <code>render_essence_editor</code> helper or as setting on the content definition in <code>elements.yml</code>.".html_safe) %>
     <% else %>
       <%  if select_values.is_a?(Hash)
-            options_tags = grouped_options_for_select select_values,
-              content.ingredient, ''
+            options_tags = grouped_options_for_select(select_values, content.ingredient)
           else
-            options_tags = options_for_select select_values,
-              content.ingredient
+            options_tags = options_for_select(select_values, content.ingredient)
           end %>
 
       <%= select_tag content.form_field_name, options_tags, {


### PR DESCRIPTION
If EssenceSelect select_values where passed as Hash we get an syntax error.

Removing the last parameter to grouped_options_for_select helper fixes this.

Also refactors the partial layout in a second commit.