### PR TITLE
Remove invalid locale attribute from a tag in navigation

### DIFF
--- a/app/views/alchemy/navigation/_link.html.erb
+++ b/app/views/alchemy/navigation/_link.html.erb
@@ -13,7 +13,6 @@
     {
       class: (page_active?(page) ? 'active' : nil),
       title: (options[:show_title] ? page.title : nil),
-      locale: page.language_code,
       data: {'page-id' => page.id}
     }
   ) %>


### PR DESCRIPTION
As discussed in slack the invalid locale attribute should be removed from the a tag in the navigation.
A language attribute is not needed at all in this case, as the navigation is always for one specific language tree.