### PR TITLE
Add `dependent: :destroy` to has_many relation for nested elements

### DIFF
--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -63,7 +63,8 @@ module Alchemy
     has_many :nested_elements,
       -> { order(:position).not_trashed },
       class_name: 'Alchemy::Element',
-      foreign_key: :parent_element_id
+      foreign_key: :parent_element_id,
+      dependent: :destroy
 
     belongs_to :cell
     belongs_to :page


### PR DESCRIPTION
To avoid orphaned elements, nested elements need to be destroyed when its parent is deleted.