### PR TITLE
WIP: Adds locale select to languages admin form.

### DIFF
--- a/app/controllers/alchemy/base_controller.rb
+++ b/app/controllers/alchemy/base_controller.rb
@@ -23,7 +23,7 @@ module Alchemy
     # Sets +I18n.locale+ to current Alchemy language.
     #
     def set_locale
-      ::I18n.locale = Language.current.code
+      ::I18n.locale = Language.current.locale || Language.current.code
     end
 
     def not_found_error!(msg = "Not found \"#{request.fullpath}\"")

--- a/app/models/alchemy/language.rb
+++ b/app/models/alchemy/language.rb
@@ -26,6 +26,7 @@ module Alchemy
     validates_presence_of :language_code
     validates_presence_of :page_layout
     validates_presence_of :frontpage_name
+    validates_presence_of :locale, if: -> { Alchemy::I18n.app_locales.present? }
     validates_uniqueness_of :language_code, scope: [:site_id, :country_code]
     validate :presence_of_default_language
     validate :publicity_of_default_language

--- a/app/views/alchemy/admin/languages/_form.html.erb
+++ b/app/views/alchemy/admin/languages/_form.html.erb
@@ -1,7 +1,17 @@
 <%= alchemy_form_for [alchemy, :admin, @language] do |f| %>
   <%= f.input :name, autofocus: true %>
   <%= f.input :language_code, placeholder: _t(:language_code_placeholder) %>
-  <%= f.input :country_code, as: 'string', placeholder: _t(:country_code_placeholder), hint: _t(:country_code_foot_note) %>
+  <%= f.input :country_code,
+    as: 'string',
+    placeholder: _t(:country_code_placeholder),
+    hint: _t(:country_code_foot_note) %>
+  <% if Alchemy::I18n.app_locales.present? %>
+    <%= f.input :locale,
+      collection: Alchemy::I18n.app_locales,
+      selected: @language.language_code,
+      hint: _t(:language_locale_notice),
+      input_html: {class: 'alchemy_selectbox'} %>
+  <% end %>
   <%= f.input :frontpage_name %>
   <%= f.input :page_layout,
     collection: Alchemy::PageLayout.all,

--- a/config/locales/alchemy.de.yml
+++ b/config/locales/alchemy.de.yml
@@ -418,6 +418,7 @@ de:
     javascript_disabled_text: "Alchemy funktioniert nur einwandfrei mit aktiviertem Javascript. Bitte aktivieren Sie es in Ihrem Browser."
     language_code_placeholder: 'z.B. de'
     language_does_not_exist: "Dieser Sprachbaum existiert noch nicht"
+    language_locale_notice: "Bitte wählen Sie die Übersetzungsdatei die sie dieser Sprache zuweisen wollen. Üblicherweise ist dies die, die dem Sprachkürzel entspricht."
     language_pages_copied: "Der Sprachbaum wurde kopiert"
     last_upload_only: "Zuletzt hochgeladene"
     left: "links"

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -418,6 +418,7 @@ en:
     javascript_disabled_text: "Alchemy needs Javascript to run smoothly. Please enable it in your browser settings."
     language_code_placeholder: 'i.e. en'
     language_does_not_exist: "This language tree does not exist"
+    language_locale_notice: "Please choose the translation file you want this language to be assigned to. Typically this is the one matching the language code."
     language_pages_copied: "Language tree successfully copied."
     last_upload_only: "Last upload only"
     left: "left"

--- a/config/locales/alchemy.es.yml
+++ b/config/locales/alchemy.es.yml
@@ -419,6 +419,7 @@ es:
     javascript_disabled_text: "Alchemy necesita Javascript para funcionar correctamente. Por favor habilítalo en las opciones de tu navegador."
     language_code_placeholder: 'i.e. es'
     language_does_not_exist: "Este árbol de idioma no existe"
+    language_locale_notice: "Please choose the translation file you want this language to be assigned to. Typically this is the one matching the language code."
     language_pages_copied: "El árbol de idioma fue copiado correctamente."
     last_upload_only: "Solo última subida"
     left: "Izquierda"

--- a/config/locales/alchemy.fr.yml
+++ b/config/locales/alchemy.fr.yml
@@ -439,6 +439,7 @@ fr:
     javascript_disabled_text: "Alchimie ne fonctionne correctement qu'avec Javascript. S'il vous plaît activer dans votre navigateur."
     language_code_placeholder: 'par exemple. de'
     language_does_not_exist: "l'arbre de langue n´existe pas encore"
+    language_locale_notice: "Please choose the translation file you want this language to be assigned to. Typically this is the one matching the language code."
     language_pages_copied: "L'arbre de la langue a été copié"
     last_upload_only: "Dernière téléchargées"
     left: "Gauche"

--- a/config/locales/alchemy.nl.yml
+++ b/config/locales/alchemy.nl.yml
@@ -415,6 +415,7 @@ nl:
     javascript_disabled_text: "Javascript is nodig voor een juiste werking van Alchemy. Gebruik de browserinstellingen om Javascript in te schakelen."
     language_code_placeholder: 'bijv. en'
     language_does_not_exist: "Deze boomstructuur bestaat niet."
+    language_locale_notice: "Please choose the translation file you want this language to be assigned to. Typically this is the one matching the language code."
     language_pages_copied: "Boomstructuur gekopieerd."
     last_upload_only: "Alleen de laatste upload"
     left: "links"

--- a/config/locales/alchemy.ru.yml
+++ b/config/locales/alchemy.ru.yml
@@ -419,6 +419,7 @@ ru:
     javascript_disabled_text: "Для работы Alchemy необходимо включить JavaScript."
     language_code_placeholder: 'например, ru'
     language_does_not_exist: "Дерево языка не существует"
+    language_locale_notice: "Please choose the translation file you want this language to be assigned to. Typically this is the one matching the language code."
     language_pages_copied: "Дерево языка успешно скопировано."
     last_upload_only: "Из последней загрузки"
     left: "слева"

--- a/db/migrate/20150906195818_add_locale_to_alchemy_languages.rb
+++ b/db/migrate/20150906195818_add_locale_to_alchemy_languages.rb
@@ -1,0 +1,5 @@
+class AddLocaleToAlchemyLanguages < ActiveRecord::Migration
+  def change
+    add_column :alchemy_languages, :locale, :string
+  end
+end

--- a/lib/alchemy/i18n.rb
+++ b/lib/alchemy/i18n.rb
@@ -41,12 +41,13 @@ module Alchemy
       when "Symbol"
         scope << options[:scope] unless options[:scope] == :alchemy
       end
-      ::I18n.t(msg, options.merge(:scope => scope))
+      ::I18n.t(msg, options.merge(scope: scope))
     end
 
     def self.available_locales
-      @@available_locales ||= nil
-      @@available_locales || translation_files.collect { |f| f.match(/.{2}\.yml$/).to_s.gsub(/\.yml/, '').to_sym }
+      @@available_locales ||= translation_files.collect do |f|
+        f.match(/.{2}\.yml$/).to_s.gsub(/\.yml/, '').to_sym
+      end
     end
 
     def self.available_locales=(locales)
@@ -58,7 +59,15 @@ module Alchemy
       Dir.glob(File.join(File.dirname(__FILE__), '../../config/locales/alchemy.*.yml'))
     end
 
-  private
+    def self.app_locales
+      @_app_locales ||= begin
+        app_locale_files.collect do |f|
+          f.match(/.{2}\.yml$/).to_s.gsub(/\.yml/, '')
+        end.uniq
+      end
+    end
+
+    private
 
     def self.humanize_default_string!(msg, options)
       if options[:default].blank?
@@ -66,5 +75,8 @@ module Alchemy
       end
     end
 
+    def self.app_locale_files
+      @_app_locale_files ||= Dir.glob(Rails.root.join('config/locales/*.yml'))
+    end
   end
 end

--- a/spec/dummy/app/views/alchemy/page_layouts/_standard.html.erb
+++ b/spec/dummy/app/views/alchemy/page_layouts/_standard.html.erb
@@ -10,5 +10,6 @@
   <%- end -%>
 </div>
 <div id="content">
+  <h1><%= t(:hello) %></h1>
   <%= render_elements :except => ["claim", "header"] %>
 </div>

--- a/spec/dummy/db/migrate/20150906195818_add_locale_to_alchemy_languages.rb
+++ b/spec/dummy/db/migrate/20150906195818_add_locale_to_alchemy_languages.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20150906195818_add_locale_to_alchemy_languages.rb

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150729151825) do
+ActiveRecord::Schema.define(version: 20150906195818) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string   "name"
@@ -192,6 +192,7 @@ ActiveRecord::Schema.define(version: 20150729151825) do
     t.boolean  "default",        default: false
     t.string   "country_code",   default: "",      null: false
     t.integer  "site_id"
+    t.string   "locale"
   end
 
   add_index "alchemy_languages", ["language_code", "country_code"], name: "index_alchemy_languages_on_language_code_and_country_code"


### PR DESCRIPTION
In order to fix issues like #831 we add a locale field to languages.
So that users are able to assign locale files to alchemy languages to
avoid errors with `config.enforce_available_locales = true`.

TODO: Use all `I18n.available_locales` instead of only the files present
in the local app.