### PR TITLE
Fix tag list display on load

### DIFF
--- a/app/views/alchemy/admin/partials/_autocomplete_tag_list.html.erb
+++ b/app/views/alchemy/admin/partials/_autocomplete_tag_list.html.erb
@@ -1,1 +1,1 @@
-<%= f.text_field :tag_list, data: {autocomplete: alchemy.autocomplete_admin_tags_path} %>
+<%= f.text_field :tag_list, value: f.object.tag_list.join(","), data: {autocomplete: alchemy.autocomplete_admin_tags_path} %>

--- a/spec/views/admin/pictures/show_spec.rb
+++ b/spec/views/admin/pictures/show_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 
 describe "alchemy/admin/pictures/show.html.erb" do
+
   let(:image) do
     fixture_file_upload(
       File.expand_path('../../../../fixtures/animated.gif', __FILE__),
@@ -17,9 +18,10 @@ describe "alchemy/admin/pictures/show.html.erb" do
   end
 
   before do
-    allow(view).to receive(:alchemy_form_for) {}
+    allow(view).to receive(:admin_picture_path).and_return("/path")
     allow(view).to receive(:_t) {}
     allow(view).to receive(:render_message) {}
+    view.extend Alchemy::Admin::FormHelper
   end
 
   it "displays picture in original format" do
@@ -29,5 +31,15 @@ describe "alchemy/admin/pictures/show.html.erb" do
     render
 
     expect(rendered).to have_selector('img[src*="gif"]')
+  end
+
+  it "separates the tags with a comma" do
+    allow(picture).to receive(:tag_list).and_return(["one", "two", "three"])
+    assign(:picture, picture)
+    assign(:pages, [])
+
+    render
+
+    expect(rendered).to have_selector('input[value*="one,two,three"]')
   end
 end


### PR DESCRIPTION
The edit picture form has a tags list field that was not displaying the tags as a list. Instead it would display them as one tag.

Resolves: #849