### PR TITLE
Always pass on search parameters through resource controller actions

### DIFF
--- a/app/controllers/alchemy/admin/resources_controller.rb
+++ b/app/controllers/alchemy/admin/resources_controller.rb
@@ -49,7 +49,7 @@ module Alchemy
         resource_instance_variable.save
         render_errors_or_redirect(
           resource_instance_variable,
-          resources_path,
+          resources_path(resource_handler.resources_name, current_location_params),
           flash_notice_for_resource_action
         )
       end
@@ -58,7 +58,7 @@ module Alchemy
         resource_instance_variable.update_attributes(resource_params)
         render_errors_or_redirect(
           resource_instance_variable,
-          resources_path,
+          resources_path(resource_handler.resources_name, current_location_params),
           flash_notice_for_resource_action
         )
       end
@@ -66,7 +66,7 @@ module Alchemy
       def destroy
         resource_instance_variable.destroy
         flash_notice_for_resource_action
-        do_redirect_to resource_url_proxy.url_for(action: 'index')
+        do_redirect_to resource_url_proxy.url_for(current_location_params.merge(action: 'index'))
       end
 
       def resource_handler

--- a/app/views/alchemy/admin/resources/_form.html.erb
+++ b/app/views/alchemy/admin/resources/_form.html.erb
@@ -1,4 +1,4 @@
-<%= alchemy_form_for resource_instance_variable, url: resource_path(resource_instance_variable) do |f| %>
+<%= alchemy_form_for resource_instance_variable, url: resource_path(resource_instance_variable, current_location_params) do |f| %>
   <% resource_handler.editable_attributes.each do |attribute| %>
     <% if relation = attribute[:relation] %>
       <%= f.association relation[:name].to_sym,

--- a/app/views/alchemy/admin/resources/_resource.html.erb
+++ b/app/views/alchemy/admin/resources/_resource.html.erb
@@ -10,12 +10,12 @@
 <% end %>
   <td class="tools">
     <% if can?(:destroy, resource) %>
-    <%= delete_button resource_path(resource) %>
+    <%= delete_button resource_path(resource, current_location_params) %>
     <% end %>
     <% if can?(:edit, resource) %>
     <%= link_to_dialog(
       '',
-      edit_resource_path(resource),
+      edit_resource_path(resource, current_location_params),
       {
         title: _t('Edit'),
         size: resource_window_size

--- a/lib/alchemy/resource.rb
+++ b/lib/alchemy/resource.rb
@@ -1,5 +1,6 @@
-require 'active_support/inflector'
+require 'active_support'
 require 'active_support/core_ext'
+require 'active_support/inflector'
 
 module Alchemy
   # = Alchemy::Resource

--- a/lib/alchemy/resources_helper.rb
+++ b/lib/alchemy/resources_helper.rb
@@ -158,5 +158,15 @@ module Alchemy
     rescue ActionView::MissingTemplate
       render :partial => 'resource', :collection => resources_instance_variable
     end
+
+    # Returns all the params necessary to get you back from where you where
+    # before: the Ransack query and the current page.
+    #
+    def current_location_params
+      {
+        q: params[:q],
+        page: params[:page]
+      }
+    end
   end
 end

--- a/spec/controllers/admin/resources_controller_spec.rb
+++ b/spec/controllers/admin/resources_controller_spec.rb
@@ -49,4 +49,33 @@ describe Admin::EventsController do
       end
     end
   end
+
+  describe '#update' do
+    let(:params) { {q: 'some_query', page: 6} }
+    let!(:peter)  { Event.create(name: 'Peter') }
+
+    it 'redirects to index, keeping the current location parameters' do
+      post :update, {id: peter.id, event: {name: "Hans"}}.merge(params)
+      expect(response.redirect_url).to eq("http://test.host/admin/events?page=6&q=some_query")
+    end
+  end
+
+  describe '#create' do
+    let(:params) { {q: 'some_query', page: 6} }
+
+    it 'redirects to index, keeping the current location parameters' do
+      post :create, {event: {name: "Hans"}}.merge(params)
+      expect(response.redirect_url).to eq("http://test.host/admin/events?page=6&q=some_query")
+    end
+  end
+
+  describe '#destroy' do
+    let(:params) { {q: 'some_query', page: 6} }
+    let!(:peter)  { Event.create(name: 'Peter') }
+
+    it 'redirects to index, keeping the current location parameters' do
+      delete :destroy, {id: peter.id}.merge(params)
+      expect(response.redirect_url).to eq("http://test.host/admin/events?page=6&q=some_query")
+    end
+  end
 end

--- a/spec/libraries/resources_helper_spec.rb
+++ b/spec/libraries/resources_helper_spec.rb
@@ -175,4 +175,20 @@ describe Alchemy::ResourcesHelper do
       expect(controller.resource_name).to eq("my_resource")
     end
   end
+
+  describe '#current_location_params' do
+    let(:params) { {q: "some_query", page: 6, action: "some_action"} }
+
+    before do
+      allow(controller).to receive(:params) { params }
+    end
+
+    it 'returns the current location params' do
+      expect(controller.current_location_params).to eq({q: "some_query", page: 6})
+    end
+
+    it 'only includes the q and page parameters' do
+      expect(controller.current_location_params).not_to have_key(:action)
+    end
+  end
 end


### PR DESCRIPTION
My client has big resources through which they need to search, then
modify an entry, then continue with the search. This commit keeps the search
parameters constant during that kind of workflow.