### PR TITLE
Use `send_file` instead of `send_data`

### DIFF
--- a/app/controllers/alchemy/admin/attachments_controller.rb
+++ b/app/controllers/alchemy/admin/attachments_controller.rb
@@ -75,7 +75,7 @@ module Alchemy
 
       def download
         @attachment = Attachment.find(params[:id])
-        send_data @attachment.file.data, {
+        send_file @attachment.file.path, {
           filename: @attachment.file_name,
           type: @attachment.file_mime_type
         }

--- a/app/controllers/alchemy/attachments_controller.rb
+++ b/app/controllers/alchemy/attachments_controller.rb
@@ -5,8 +5,8 @@ module Alchemy
 
     # sends file inline. i.e. for viewing pdfs/movies in browser
     def show
-      send_data(
-        @attachment.file.data,
+      send_file(
+        @attachment.file.path,
         {
           filename: @attachment.file_name,
           type: @attachment.file_mime_type,
@@ -17,8 +17,8 @@ module Alchemy
 
     # sends file as attachment. aka download
     def download
-      send_data(
-        @attachment.file.data, {
+      send_file(
+        @attachment.file.path, {
           filename: @attachment.file_name,
           type: @attachment.file_mime_type
         }

--- a/spec/controllers/admin/attachments_controller_spec.rb
+++ b/spec/controllers/admin/attachments_controller_spec.rb
@@ -203,7 +203,7 @@ module Alchemy
       end
 
       it "should send the data to the browser" do
-        expect(controller).to receive(:send_data)
+        expect(controller).to receive(:send_file)
         alchemy_get :download, id: attachment.id
       end
     end


### PR DESCRIPTION
Using `send_file` allows the use of X-Sendfile/X-Accel-Redirect with
Apache/Nginx to bypass rails for sending attachments to the client.