### PR TITLE
[feature] load pages asynchronously in link editor

### DIFF
--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -130,6 +130,16 @@ module Alchemy
         end
       end
 
+      def page_for_link
+        @page = Page.find(params[:id])
+        @area_name = params[:area_name]
+        @url_prefix = ''
+        render partial: 'page_for_links',
+                object: @page,
+                locals: {area_name: @area_name},
+                layout: false
+      end
+
       def fold
         # @page is fetched via before filter
         @page.fold!(current_alchemy_user.id, !@page.folded?(current_alchemy_user.id))

--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -5,11 +5,14 @@ module Alchemy
     # Returns all pages as json object
     #
     def index
-      @pages = Page.accessible_by(current_ability, :index)
+      @pages = Page.searchables
       if params[:page_layout].present?
         @pages = @pages.where(page_layout: params[:page_layout])
+      elsif params[:q].present?
+        @pages = @pages.where(["urlname like :q", q: "%#{params[:q]}%"])
       end
-      respond_with @pages
+      page = [params[:page].to_i, 1].min
+      respond_with @pages.page(page).per(25), meta: {total: @pages.count}
     end
 
     # Returns a json object for page

--- a/app/views/alchemy/admin/pages/_internal_link.html.erb
+++ b/app/views/alchemy/admin/pages/_internal_link.html.erb
@@ -6,8 +6,13 @@
   <% end %>
   <div id="page_selector_container">
     <% if @page_root %>
+    <div class="alchemy_selectbox">
+      <%= text_field_tag :internal_urlname,
+        '',
+        placeholder: _t(:internal_urlname),
+        autofocus: true %>
+    </div>
     <ul id="sitemap">
-      <%= render partial: 'page_for_links', object: @page_root, locals: {area_name: @area_name} %>
     </ul>
     <% end %>
   </div>

--- a/app/views/alchemy/admin/pages/_page_for_links.html.erb
+++ b/app/views/alchemy/admin/pages/_page_for_links.html.erb
@@ -37,9 +37,4 @@
       <% end %>
     </div>
   </div>
-  <% if page_for_links.children.present? %>
-    <ul id="page_<%= page_for_links.id %>_children">
-      <%= render partial: 'page_for_links', collection: page_for_links.children, locals: {area_name: @area_name} %>
-    </ul>
-  <% end %>
 </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,7 @@ Alchemy::Engine.routes.draw do
         get :configure
         get :preview
         get :info
+        get :page_for_link
       end
     end
 

--- a/lib/alchemy/permissions.rb
+++ b/lib/alchemy/permissions.rb
@@ -144,6 +144,7 @@ module Alchemy
           :destroy,
           :flush,
           :order,
+          :page_for_link,
           :publish,
           :sort,
           :switch_language

--- a/spec/features/admin/link_overlay_spec.rb
+++ b/spec/features/admin/link_overlay_spec.rb
@@ -38,7 +38,7 @@ describe "Link overlay" do
 
     it "should have a tree of internal pages" do
       visit link_admin_pages_path
-      expect(page).to have_selector('ul#sitemap li a')
+      expect(page).to have_selector('ul#sitemap')
     end
 
     it "should not have a link for pages that redirect to external" do


### PR DESCRIPTION
See #836 for a diskussion of the broad topic.

This is a first step into the direction of making alchemy support thousands of pages by not rendering them all the time. I've updated the link editor to work asynchronously using select2 with ajax requests to find pages by `urlname`. Apart from that no changes in functionality.

Things to do:

- [ ] unit & acceptance tests 
- [ ] tests for the modified JS, if we have any.

Maybe I can also refactor the JS to use the select2 wrapper alchemy already uses.