### PR TITLE
Transmit content length for attachments

### DIFF
--- a/app/controllers/alchemy/attachments_controller.rb
+++ b/app/controllers/alchemy/attachments_controller.rb
@@ -5,6 +5,7 @@ module Alchemy
 
     # sends file inline. i.e. for viewing pdfs/movies in browser
     def show
+      response.headers['Content-Length'] = @attachment.file.size.to_s
       send_file(
         @attachment.file.path,
         {
@@ -17,6 +18,7 @@ module Alchemy
 
     # sends file as attachment. aka download
     def download
+      response.headers['Content-Length'] = @attachment.file.size.to_s
       send_file(
         @attachment.file.path, {
           filename: @attachment.file_name,

--- a/spec/controllers/alchemy/attachments_controller_spec.rb
+++ b/spec/controllers/alchemy/attachments_controller_spec.rb
@@ -24,6 +24,18 @@ module Alchemy
         expect(response.status).to eq(200)
         expect(response.headers['Content-Disposition']).to match(/inline/)
       end
+
+      context "adds Content-Length to header" do
+        it "when downloading attachment" do
+          alchemy_get :download, id: attachment.id
+          expect(response.headers['Content-Length']).to eq(attachment.file_size.to_s)
+        end
+
+        it "when showing attachment" do
+          alchemy_get :show, id: attachment.id
+          expect(response.headers['Content-Length']).to eq(attachment.file_size.to_s)
+        end
+      end
     end
 
     context 'with restricted attachment' do


### PR DESCRIPTION
Due to some issues with the duration / size of attachments in the context of HTML media elements such as `<audio>` or `<video>`, I've recognized that no `Content-Length` was transmitted in the Response Header. 
In case of a missing `Content-Length`, e.g. the MediaElement.js Library displays `NaN:NaN` instead of the duration. 

Therefore this PR explicitly adds the `Content-Length` based on the size of the file.
