### PR TITLE
Several search query param fixes.

### DIFF
--- a/app/controllers/alchemy/admin/attachments_controller.rb
+++ b/app/controllers/alchemy/admin/attachments_controller.rb
@@ -57,7 +57,11 @@ module Alchemy
         @attachment.update_attributes(attachment_attributes)
         render_errors_or_redirect(
           @attachment,
-          admin_attachments_path(page: params[:page], query: params[:query], per_page: params[:per_page]),
+          admin_attachments_path(
+            per_page: params[:per_page],
+            page: params[:page],
+            q: params[:q]
+          ),
           _t("File successfully updated")
         )
       end
@@ -68,7 +72,7 @@ module Alchemy
         @url = admin_attachments_url(
           per_page: params[:per_page],
           page: params[:page],
-          query: params[:query]
+          q: params[:q]
         )
         flash[:notice] = _t('File deleted successfully', name: name)
       end

--- a/app/controllers/alchemy/admin/pictures_controller.rb
+++ b/app/controllers/alchemy/admin/pictures_controller.rb
@@ -161,7 +161,7 @@ module Alchemy
         do_redirect_to admin_pictures_path(
           filter: params[:filter].presence,
           page: params[:page].presence,
-          query: params[:query].presence,
+          q: params[:q].presence,
           size: params[:size].presence,
           tagged_with: params[:tagged_with].presence
         )

--- a/app/views/alchemy/admin/attachments/_attachment.html.erb
+++ b/app/views/alchemy/admin/attachments/_attachment.html.erb
@@ -38,7 +38,7 @@
       _t(:confirm_to_delete_file),
       alchemy.admin_attachment_path(
         id: attachment,
-        query: params[:query],
+        q: params[:q],
         page: params[:page],
         per_page: params[:per_page]
       ),
@@ -50,7 +50,7 @@
   <% end %>
   <% if can?(:edit, attachment) %>
     <%= link_to_dialog("",
-      alchemy.edit_admin_attachment_path(attachment, query: params[:query], page: params[:page]),
+      alchemy.edit_admin_attachment_path(attachment, q: params[:q], page: params[:page]),
       {
         title: _t(:rename_file),
         size: '380x250'

--- a/app/views/alchemy/admin/attachments/_files_list.html.erb
+++ b/app/views/alchemy/admin/attachments/_files_list.html.erb
@@ -1,4 +1,4 @@
-<% if @attachments.blank? && params[:query].nil? %>
+<% if @attachments.blank? && params[:q].blank? %>
 <div class="info" id="no_files_notice">
   <%= render_icon('info') %>
   <%= _t(:no_files_in_archive) %>

--- a/app/views/alchemy/admin/attachments/edit.html.erb
+++ b/app/views/alchemy/admin/attachments/edit.html.erb
@@ -1,5 +1,5 @@
 <%= alchemy_form_for([:admin, @attachment],
-  url: {action: :update, query: params[:query], page: params[:page]}) do |f| -%>
+  url: {action: :update, q: params[:q], page: params[:page]}) do |f| -%>
   <%= f.input :name, input_html: {autofocus: true} %>
   <%= f.input :file_name, input_html: {autofocus: true}, hint: _t(:attachment_filename_notice) %>
   <div class="input string">

--- a/app/views/alchemy/admin/languages/_table.html.erb
+++ b/app/views/alchemy/admin/languages/_table.html.erb
@@ -30,7 +30,7 @@
     <%= render_resources %>
   </tbody>
 </table>
-<%- elsif params[:query] -%>
+<%- elsif params[:q].present? -%>
 <p><%= _t('Nothing found') %></p>
 <%- end -%>
 

--- a/app/views/alchemy/admin/partials/_remote_search_form.html.erb
+++ b/app/views/alchemy/admin/partials/_remote_search_form.html.erb
@@ -1,33 +1,27 @@
-<%= form_tag(
-  url_for({
+<%= search_form_for @query, url: url_for(
     action: 'index',
     options: @options.to_json,
     size: @size
-  }),
-  remote: true,
-  method: 'get'
-) do %>
+  ), remote: true do |f| %>
   <%= hidden_field_tag("element_id", @element.blank? ? "" : @element.id) %>
   <%= hidden_field_tag("content_id", @content.blank? ? "" : @content.id) %>
   <div class="search_field">
   <%= render_icon('search') %>
-    <%= text_field_tag :query,
-      params['query'],
-      class: 'thin_border',
+    <%= f.search_field resource_handler.search_field_name,
       id: 'search_input_field',
       placeholder: _t(:search) %>
-    <%= link_to '', url_for({
+    <%= link_to '', url_for(
         action: 'index',
         element_id: @element.blank? ? '' : @element.id,
         content_id: @content.blank? ? '' : @content.id,
         options: @options.to_json,
         size: @size,
         overlay: true
-      }),
+      ),
       remote: true,
       class: 'search_field_clear',
       id: 'search_field_clear',
       title: _t(:click_to_show_all),
-      style: params[:query].nil? ? 'display: none' : 'display: block' %>
+      style: params[:q].blank? ? 'display: none' : 'display: block' %>
   </div>
 <% end %>

--- a/app/views/alchemy/admin/pictures/_archive.html.erb
+++ b/app/views/alchemy/admin/pictures/_archive.html.erb
@@ -25,7 +25,7 @@
     <%= link_to(
       render_icon('delete-small') + _t("Clear selection"),
       admin_pictures_path(
-        :query => params[:query],
+        :q => params[:q],
         :tagged_with => params[:tagged_with],
         :size => params[:size],
         :filter => params[:filter]
@@ -35,7 +35,7 @@
     ) %>
   </div>
   <div id="pictures">
-  <% if @pictures.blank? and @recent_pictures.blank? and params[:query].nil? %>
+  <% if @pictures.blank? and @recent_pictures.blank? and params[:q].blank? %>
     <div class="info">
       <%= render_icon('info') %>
       <%= _t(:no_images_in_archive) %>

--- a/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
+++ b/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
@@ -31,8 +31,10 @@
           content_id: @content,
           element_id: @element,
           swap: @swap,
-          query: params[:query],
-          options: @options.to_json
+          q: params[:q],
+          options: @options.to_json,
+          filter: params[:filter],
+          tagged_with: params[:tagged_with]
         }),
         remote: true,
         title: _t(:small_thumbnails),
@@ -47,8 +49,10 @@
           content_id: @content,
           element_id: @element,
           swap: @swap,
-          query: params[:query],
-          options: @options.to_json
+          q: params[:q],
+          options: @options.to_json,
+          filter: params[:filter],
+          tagged_with: params[:tagged_with]
         }),
         remote: true,
         title: _t(:medium_thumbnails),
@@ -63,8 +67,10 @@
           content_id: @content,
           element_id: @element,
           swap: @swap,
-          query: params[:query],
-          options: @options.to_json
+          q: params[:q],
+          options: @options.to_json,
+          filter: params[:filter],
+          tagged_with: params[:tagged_with]
         }),
         remote: true,
         title: _t(:big_thumbnails),

--- a/app/views/alchemy/admin/pictures/_form.html.erb
+++ b/app/views/alchemy/admin/pictures/_form.html.erb
@@ -6,7 +6,7 @@
     <%= render 'alchemy/admin/partials/autocomplete_tag_list', f: f %>
     <small class="hint"><%= _t('Please seperate the tags with commata') %></small>
   </div>
-  <%= hidden_field_tag :query, params[:query] %>
+  <%= hidden_field_tag :q, params[:q] %>
   <%= hidden_field_tag :size, params[:size] %>
   <%= hidden_field_tag :tagged_with, params[:tagged_with] %>
   <%= hidden_field_tag :filter, params[:filter] %>

--- a/app/views/alchemy/admin/pictures/edit_multiple.html.erb
+++ b/app/views/alchemy/admin/pictures/edit_multiple.html.erb
@@ -1,5 +1,5 @@
 <%= form_tag update_multiple_admin_pictures_path do %>
-  <%= hidden_field_tag :query, params[:query] %>
+  <%= hidden_field_tag :q, params[:q] %>
   <%= hidden_field_tag :size, params[:size] %>
   <%= hidden_field_tag :tagged_with, params[:tagged_with] %>
   <%= hidden_field_tag :filter, params[:filter] %>

--- a/app/views/alchemy/admin/pictures/index.html.erb
+++ b/app/views/alchemy/admin/pictures/index.html.erb
@@ -20,10 +20,7 @@
       <div class="button_with_label">
         <%= link_to(
           render_icon('zoom-out'),
-          alchemy.admin_pictures_path({
-            size: "small",
-            query: params[:query]
-          }),
+          alchemy.admin_pictures_path(size: "small", q: params[:q]),
           title: _t(:small_thumbnails),
           class: "icon_button please_wait"
         ) %>
@@ -31,10 +28,7 @@
       <div class="button_with_label">
         <%= link_to(
           render_icon('zoom-equal'),
-          alchemy.admin_pictures_path({
-            size: "medium",
-            query: params[:query]
-          }),
+          alchemy.admin_pictures_path(size: "medium", q: params[:q]),
           title: _t(:medium_thumbnails),
           class: "icon_button please_wait"
         ) %>
@@ -42,10 +36,7 @@
       <div class="button_with_label">
         <%= link_to(
           render_icon('zoom-in'),
-          alchemy.admin_pictures_path({
-            size: "large",
-            query: params[:query]
-          }),
+          alchemy.admin_pictures_path(size: "large", q: params[:q]),
           title: _t(:big_thumbnails),
           class: "icon_button please_wait"
         ) %>

--- a/app/views/alchemy/admin/resources/_table.html.erb
+++ b/app/views/alchemy/admin/resources/_table.html.erb
@@ -17,7 +17,7 @@
     <%= render_resources %>
   </tbody>
 </table>
-<% elsif params[:query] %>
+<% elsif params[:q].present? %>
 <p><%= _t('Nothing found') %></p>
 <% end %>
 

--- a/app/views/alchemy/admin/tags/index.html.erb
+++ b/app/views/alchemy/admin/tags/index.html.erb
@@ -43,7 +43,7 @@
 
   <%= render_message do %>
     <h2><%= _t('No Tags found') %></h2>
-    <% if params[:query].blank? %>
+    <% if params[:q].blank? %>
       <p><%= _t(:tags_get_created_if_used_the_first_time) %></p>
     <% end %>
   <% end %>

--- a/spec/controllers/admin/attachments_controller_spec.rb
+++ b/spec/controllers/admin/attachments_controller_spec.rb
@@ -161,6 +161,24 @@ module Alchemy
         it "redirects to index path" do
           is_expected.to redirect_to admin_attachments_path
         end
+
+        context 'with search params' do
+          let(:search_params) do
+            {
+              q: {name_cont: 'kitten'},
+              per_page: 20,
+              page: 2
+            }
+          end
+
+          subject do
+            alchemy_put :update, {id: 1, attachment: {name: ''}}.merge(search_params)
+          end
+
+          it "passes them along" do
+            is_expected.to redirect_to admin_attachments_path(search_params)
+          end
+        end
       end
 
       context 'with failing validations' do


### PR DESCRIPTION
Since the recently switch to ransack as search, several occurrences of `params[:query]` where left in the code. This pr renames them to `params[:q]`. 

Also fixes the remote search form, that is used, amongst others, in the picture and attachment assignment overlay.

Fixes #897 