### PR TITLE
Skip the default locale in urls

### DIFF
--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -113,7 +113,6 @@ module Alchemy
       end
 
       def link
-        @url_prefix = ""
         if configuration(:show_real_root)
           @page_root = Page.root
         else
@@ -121,13 +120,10 @@ module Alchemy
         end
         @area_name = params[:area_name]
         @content_id = params[:content_id]
-        @attachments = Attachment.all.collect { |f| [f.name, download_attachment_path(:id => f.id, :name => f.urlname)] }
-        if params[:link_urls_for] == "newsletter"
-          @url_prefix = current_server
-        end
-        if multi_language?
-          @url_prefix = "#{Language.current.code}/"
-        end
+        @attachments = Attachment.all.collect { |f|
+          [f.name, download_attachment_path(id: f.id, name: f.urlname)]
+        }
+        @url_prefix = prefix_locale? ? "#{Language.current.code}/" : ""
       end
 
       def fold
@@ -154,7 +150,10 @@ module Alchemy
 
       def visit
         @page.unlock!
-        redirect_to show_page_path(urlname: @page.urlname, locale: multi_language? ? @page.language_code : nil)
+        redirect_to show_page_path(
+          urlname: @page.urlname,
+          locale: prefix_locale? ? @page.language_code : nil
+        )
       end
 
       # Sets the page public and updates the published_at attribute that is used as cache_key

--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -1,6 +1,8 @@
 module Alchemy
   module Admin
     class PagesController < Alchemy::Admin::BaseController
+      include OnPageLayout::CallbacksRunner
+
       helper 'alchemy/pages'
 
       before_action :set_translation,
@@ -14,8 +16,9 @@ module Alchemy
 
       authorize_resource class: Alchemy::Page, except: :index
 
-      # Needs to be included after +before_action+ calls, to be sure the filters are appended.
-      include OnPageLayout::CallbacksRunner
+      before_action :run_on_page_layout_callbacks,
+        if: :run_on_page_layout_callbacks?,
+        only: [:show]
 
       def index
         authorize! :index, :alchemy_admin_pages

--- a/app/controllers/alchemy/messages_controller.rb
+++ b/app/controllers/alchemy/messages_controller.rb
@@ -47,7 +47,10 @@ module Alchemy
     helper 'alchemy/pages'
 
     def index #:nodoc:
-      redirect_to show_page_path(urlname: @page.urlname, locale: multi_language? ? @page.language_code : nil)
+      redirect_to show_page_path(
+        urlname: @page.urlname,
+        locale: prefix_locale? ? @page.language_code : nil
+      )
     end
 
     def new #:nodoc:
@@ -99,7 +102,10 @@ module Alchemy
       else
         urlname = Language.current_root_page.urlname
       end
-      redirect_to show_page_path(urlname: urlname, locale: multi_language? ? Language.current.code : nil)
+      redirect_to show_page_path(
+        urlname: urlname,
+        locale: prefix_locale? ? Language.current.code : nil
+      )
     end
 
     def get_page
@@ -109,6 +115,5 @@ module Alchemy
       end
       @root_page = @page.get_language_root
     end
-
   end
 end

--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -9,13 +9,14 @@ module Alchemy
     include SiteRedirects
     include LocaleRedirects
     include PageRedirects
+    include OnPageLayout::CallbacksRunner
 
     before_action :load_index_page, only: [:index]
     before_action :load_page, only: [:show]
     before_action :set_root_page, only: [:index, :show]
-
-    # Needs to be included after +before_action+ calls, to be sure the filters are appended.
-    include OnPageLayout::CallbacksRunner
+    before_action :run_on_page_layout_callbacks,
+      if: :run_on_page_layout_callbacks?,
+      only: [:index, :show]
 
     rescue_from ActionController::UnknownFormat, with: :page_not_found!
 

--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -1,8 +1,16 @@
 module Alchemy
   class PagesController < Alchemy::BaseController
+
+    # Redirects to signup path, if no admin user is present yet
+    before_action if: :signup_required? do
+      redirect_to Alchemy.signup_path
+    end
+
     before_action :enforce_primary_host_for_site
-    before_action :enforce_no_locale, only: [:index],
+
+    before_action :enforce_no_locale, only: [:index, :show],
       if: :default_locale_requested?
+
     before_action :render_page_or_redirect, only: [:show]
 
     # Needs to be included after +before_action+ calls, to be sure the filters are appended.
@@ -121,9 +129,7 @@ module Alchemy
     def render_page_or_redirect
       @page ||= load_page
 
-      if signup_required?
-        redirect_to Alchemy.signup_path
-      elsif (@page.nil? || request.format.nil?) && last_legacy_url
+      if (@page.nil? || request.format.nil?) && last_legacy_url
         @page = last_legacy_url.page
         # This drops the given query string.
         redirect_legacy_page

--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -13,6 +13,8 @@ module Alchemy
 
     before_action :render_page_or_redirect, only: [:show]
 
+    before_action :set_root_page, only: [:index, :show]
+
     # Needs to be included after +before_action+ calls, to be sure the filters are appended.
     include OnPageLayout::CallbacksRunner
 
@@ -114,6 +116,10 @@ module Alchemy
       )
     end
 
+    def set_root_page
+      @root_page = Language.current_root_page
+    end
+
     def enforce_primary_host_for_site
       if needs_redirect_to_primary_host?
         redirect_to url_for(host: current_alchemy_site.host), :status => 301
@@ -146,7 +152,6 @@ module Alchemy
       else
         # setting the language to page.language to be sure it's correct
         set_alchemy_language(@page.language)
-        @root_page = Language.current_root_page
       end
     end
 

--- a/app/controllers/concerns/alchemy/legacy_page_redirects.rb
+++ b/app/controllers/concerns/alchemy/legacy_page_redirects.rb
@@ -1,0 +1,57 @@
+module Alchemy
+
+  # Handles Legacy page redirects
+  #
+  # If the page could not be found via its urlname we try to find
+  # a legacy page url for requested url to redirect to.
+  #
+  module LegacyPageRedirects
+    extend ActiveSupport::Concern
+
+    included do
+      before_action :redirect_to_legacy_url,
+        if: :redirect_to_legacy_url?,
+        only: [:show]
+    end
+
+    private
+
+    def redirect_to_legacy_url
+      redirect_permanently_to legacy_page_redirect_url
+    end
+
+    def redirect_to_legacy_url?
+      (@page.nil? || request.format.nil?) && last_legacy_url
+    end
+
+    # Use the bare minimum to redirect to legacy page
+    #
+    # Don't use query string of legacy urlname.
+    # This drops the given query string.
+    #
+    def legacy_page_redirect_url
+      page = last_legacy_url.page
+      return unless page
+
+      alchemy.show_page_path(
+        locale: prefix_locale? ? page.language_code : nil,
+        urlname: page.urlname
+      )
+    end
+
+    def legacy_urls
+      # /slug/tree => slug/tree
+      urlname = (request.fullpath[1..-1] if request.fullpath[0] == '/') || request.fullpath
+      LegacyPageUrl.joins(:page).where(
+        urlname: urlname,
+        Page.table_name => {
+          language_id: Language.current.id
+        }
+      )
+    end
+
+    def last_legacy_url
+      @_last_legacy_url ||= legacy_urls.last
+    end
+  end
+end

--- a/app/controllers/concerns/alchemy/locale_redirects.rb
+++ b/app/controllers/concerns/alchemy/locale_redirects.rb
@@ -1,0 +1,39 @@
+module Alchemy
+
+  # Handles locale redirects
+  #
+  # If the current URL has a locale prefix, but should not have one it redirects
+  # to url without locale prefix.
+  #
+  # Situations we don't want a locale prefix:
+  #
+  # 1. If only one language is published
+  # 2. If the requested locale is the current default locale
+  #
+  module LocaleRedirects
+    extend ActiveSupport::Concern
+
+    included do
+      before_action :enforce_no_locale,
+        if: :locale_prefix_not_allowed?,
+        only: [:index, :show]
+    end
+
+    private
+
+    # Redirects to requested action without locale prefixed
+    def enforce_no_locale
+      redirect_permanently_to additional_params.merge(locale: nil)
+    end
+
+    # Is the requested locale allowed?
+    #
+    # If Alchemy is not in multi language mode or the requested locale is the default locale,
+    # then we want to redirect to a non prefixed url.
+    #
+    def locale_prefix_not_allowed?
+      params[:locale].present? && !multi_language? ||
+        params[:locale].presence == ::I18n.default_locale.to_s
+    end
+  end
+end

--- a/app/controllers/concerns/alchemy/page_redirects.rb
+++ b/app/controllers/concerns/alchemy/page_redirects.rb
@@ -1,0 +1,100 @@
+module Alchemy
+  module PageRedirects
+
+    private
+
+    # = Page redirect url
+    #
+    # Lots of reasons exist to redirect to another url, then the requested one.
+    # These module holds the logic behind this needs.
+    #
+    # If no redirect is needed returns nil.
+    #
+    # @return String
+    # @return NilClass
+    #
+    def redirect_url
+      @_redirect_url ||= legacy_page_redirect_url || raise_page_not_found ||
+        public_child_redirect_url || controller_and_action_url || locale_prefixed_url || nil
+    end
+
+    # Use the bare minimum to redirect to page
+    # Don't use query string of legacy urlname
+    # This drops the given query string.
+    def legacy_page_redirect_url
+      return unless redirect_to_legacy_url?
+
+      page = last_legacy_url.page
+      return unless page
+
+      alchemy.show_page_path(
+        locale: prefix_locale? ? page.language_code : nil,
+        urlname: page.urlname
+      )
+    end
+
+    def raise_page_not_found
+      page_not_found! if @page.blank?
+    end
+
+    def locale_prefixed_url
+      return unless locale_prefix_missing?
+
+      page_redirect_url(locale: Language.current.code)
+    end
+
+    def public_child_redirect_url
+      return unless redirect_to_public_child?
+
+      @page = @page.self_and_descendants.published.not_restricted.first
+      @page ? page_redirect_url : page_not_found!
+    end
+
+    def controller_and_action_url
+      return unless @page.has_controller?
+
+      main_app.url_for(@page.controller_and_action)
+    end
+
+    # Page url with or without locale while keeping all additional params
+    def page_redirect_url(options = {})
+      options = {
+        locale: prefix_locale? ? @page.language_code : nil,
+        urlname: @page.urlname
+      }.merge(options)
+
+      alchemy.show_page_path additional_params.merge(options)
+    end
+
+    def legacy_urls
+      # /slug/tree => slug/tree
+      urlname = (request.fullpath[1..-1] if request.fullpath[0] == '/') || request.fullpath
+      LegacyPageUrl.joins(:page).where(
+        urlname: urlname,
+        Page.table_name => {
+          language_id: Language.current.id
+        }
+      )
+    end
+
+    def last_legacy_url
+      @_last_legacy_url ||= legacy_urls.last
+    end
+
+    def default_locale?
+      Language.current.code.to_sym == ::I18n.default_locale.to_sym
+    end
+
+    def locale_prefix_missing?
+      multi_language? && params[:locale].blank? && !default_locale?
+    end
+
+    def redirect_to_legacy_url?
+      (@page.nil? || request.format.nil?) && last_legacy_url
+    end
+
+    def redirect_to_public_child?
+      configuration(:redirect_to_public_child) && !@page.public?
+    end
+  end
+end

--- a/app/controllers/concerns/alchemy/site_redirects.rb
+++ b/app/controllers/concerns/alchemy/site_redirects.rb
@@ -1,0 +1,22 @@
+module Alchemy
+  module SiteRedirects
+    extend ActiveSupport::Concern
+
+    included do
+      before_action :enforce_primary_host_for_site,
+        if: :needs_redirect_to_primary_host?
+    end
+
+    private
+
+    def enforce_primary_host_for_site
+      redirect_to url_for(host: current_alchemy_site.host), status: :moved_permanently
+    end
+
+    def needs_redirect_to_primary_host?
+      current_alchemy_site.redirect_to_primary_host? &&
+        current_alchemy_site.host != '*' &&
+        current_alchemy_site.host != request.host
+    end
+  end
+end

--- a/app/helpers/alchemy/base_helper.rb
+++ b/app/helpers/alchemy/base_helper.rb
@@ -12,15 +12,15 @@ module Alchemy
     end
 
     def parse_sitemap_name(page)
-      if multi_language?
-        pathname = "/#{Language.current.code}/#{page.urlname}"
+      if prefix_locale?
+        "/#{Language.current.code}/#{page.urlname}"
       else
-        pathname = "/#{page.urlname}"
+        "/#{page.urlname}"
       end
-      pathname
     end
 
-    # Logs a message in the Rails logger (warn level) and optionally displays an error message to the user.
+    # Logs a message in the Rails logger (warn level)
+    # and optionally displays an error message to the user.
     def warning(message, text = nil)
       Logger.warn(message, caller.first)
       unless text.nil?

--- a/app/helpers/alchemy/url_helper.rb
+++ b/app/helpers/alchemy/url_helper.rb
@@ -6,12 +6,12 @@ module Alchemy
   module UrlHelper
 
     # Returns the path for rendering an alchemy page
-    def show_alchemy_page_path(page, optional_params={})
+    def show_alchemy_page_path(page, optional_params = {})
       alchemy.show_page_path(show_page_path_params(page, optional_params))
     end
 
     # Returns the url for rendering an alchemy page
-    def show_alchemy_page_url(page, optional_params={})
+    def show_alchemy_page_url(page, optional_params = {})
       alchemy.show_page_url(show_page_path_params(page, optional_params))
     end
 
@@ -21,9 +21,9 @@ module Alchemy
     #
     # Example:
     #
-    #   <%= image_tag show_alchemy_picture_path(picture, :size => '320x200', :format => :png) %>
+    #   <%= image_tag show_alchemy_picture_path(picture, size: '320x200', format: :png) %>
     #
-    def show_alchemy_picture_path(picture, optional_params={})
+    def show_alchemy_picture_path(picture, optional_params = {})
       alchemy.show_picture_path(show_picture_path_params(picture, optional_params))
     end
 
@@ -33,28 +33,28 @@ module Alchemy
     #
     # Example:
     #
-    #   <%= image_tag show_alchemy_picture_url(picture, :size => '320x200', :format => :png) %>
+    #   <%= image_tag show_alchemy_picture_url(picture, size: '320x200', format: :png) %>
     #
-    def show_alchemy_picture_url(picture, optional_params={})
+    def show_alchemy_picture_url(picture, optional_params = {})
       alchemy.show_picture_url(show_picture_path_params(picture, optional_params))
     end
 
     # Returns the correct params hash for passing to show_picture_path
-    def show_picture_path_params(picture, optional_params={})
+    def show_picture_path_params(picture, optional_params = {})
       url_params = {
-        :id => picture.id,
-        :name => picture.urlname,
-        :format => configuration(:image_output_format),
-        :sh => picture.security_token(optional_params)
+        id: picture.id,
+        name: picture.urlname,
+        format: configuration(:image_output_format),
+        sh: picture.security_token(optional_params)
       }
-      url_params.update(optional_params.update({:crop => optional_params[:crop] ? 'crop' : nil}))
+      url_params.update(optional_params.update(crop: optional_params[:crop] ? 'crop' : nil))
     end
 
     # Returns the correct params-hash for passing to show_page_path
-    def show_page_path_params(page, optional_params={})
+    def show_page_path_params(page, optional_params = {})
       raise ArgumentError, 'Page is nil' if page.nil?
       url_params = {urlname: page.urlname}.update(optional_params)
-      multi_language? ? url_params.update(locale: page.language_code) : url_params
+      prefix_locale? ? url_params.update(locale: page.language_code) : url_params
     end
 
     # Returns the path for downloading an alchemy attachment
@@ -71,6 +71,5 @@ module Alchemy
     def full_url_for_element(element)
       "#{current_server}/#{element.page.urlname}##{element_dom_id(element)}"
     end
-
   end
 end

--- a/app/views/alchemy/language_links/_language.html.erb
+++ b/app/views/alchemy/language_links/_language.html.erb
@@ -1,12 +1,18 @@
-<% css_classes = [language.code] %>
-<% css_classes << 'active' if Alchemy::Language.current.id == language.id %>
-<% css_classes << 'first' if languages.first == language %>
-<% css_classes << 'last' if languages.last == language %>
-<% link_title = options[:show_title] ? _t("#{language.code}.title", scope: 'language_links', default: language.name) : nil %>
-
 <%= link_to(
   content_tag(:span, language.label(options[:linkname])).html_safe,
-  show_alchemy_page_path(language.pages.language_roots.first, locale: language.code),
-  class: css_classes.join(" "),
-  title: link_title
+  show_alchemy_page_path(
+    language.pages.language_roots.first,
+    locale: prefix_locale?(language.code) ? language.code : nil
+  ),
+  class: [
+    language.code,
+    Alchemy::Language.current.id == language.id ? 'active' : nil,
+    languages.first == language ? 'first' : nil,
+    languages.last == language ? 'last' : nil
+  ].compact,
+  title: options[:show_title] ? _t(
+    "#{language.code}.title",
+    scope: 'language_links',
+    default: language.name
+  ) : nil
 ) %>

--- a/app/views/alchemy/pages/show.rss.builder
+++ b/app/views/alchemy/pages/show.rss.builder
@@ -5,15 +5,17 @@ xml.rss version: "2.0" do
 
     xml.title @page.title
     xml.description @page.meta_description
-    xml.link show_page_url(urlname: @page.urlname, locale: multi_language? ? @page.language_code : nil)
+    xml.link show_alchemy_page_url(@page)
 
     @page.feed_elements.each do |element|
       xml.item do
         xml.title element.content_for_rss_title.try(:ingredient)
         xml.description element.content_for_rss_description.try(:ingredient)
-        xml.pubDate element.ingredient('date').to_s(:rfc822) if element.has_ingredient?('date')
-        xml.link show_page_url(urlname: @page.urlname, anchor: element_dom_id(element), locale: multi_language? ? @page.language_code : nil)
-        xml.guid show_page_url(urlname: @page.urlname, anchor: element_dom_id(element), locale: multi_language? ? @page.language_code : nil)
+        if element.has_ingredient?('date')
+          xml.pubDate element.ingredient('date').to_s(:rfc822)
+        end
+        xml.link show_alchemy_page_url(@page, anchor: element_dom_id(element))
+        xml.guid show_alchemy_page_url(@page, anchor: element_dom_id(element))
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 require 'alchemy/routing_constraints'
 
 Alchemy::Engine.routes.draw do
-  root :to => 'pages#show'
+  root to: 'pages#index'
 
   get '/sitemap.xml' => 'pages#sitemap', format: 'xml'
 
@@ -152,7 +152,7 @@ Alchemy::Engine.routes.draw do
     get '/admin/pages/:id(.:format)' => 'pages#show', as: 'preview_page'
   end
 
-  get '/:locale' => 'pages#show',
+  get '/:locale' => 'pages#index',
     constraints: {locale: Alchemy::RoutingConstraints::LOCALE_REGEXP},
     as: :show_language_root
 

--- a/lib/alchemy/configuration_methods.rb
+++ b/lib/alchemy/configuration_methods.rb
@@ -3,7 +3,7 @@ module Alchemy
     extend ActiveSupport::Concern
 
     included do
-      helper_method :configuration, :multi_language?, :multi_site?
+      helper_method :configuration, :multi_language?, :multi_site?, :prefix_locale?
     end
 
     # Returns the configuration value of given key.
@@ -18,6 +18,16 @@ module Alchemy
     #
     def multi_language?
       Language.published.count > 1
+    end
+
+    # Decides if the locale should be prefixed to urls
+    #
+    # If the current language's locale (or the optionally passed in locale)
+    # matches the current I18n.locale then the prefix os omitted.
+    # Also, if only one published language exists.
+    #
+    def prefix_locale?(locale = Language.current.code)
+      multi_language? && locale != ::I18n.default_locale.to_s
     end
 
     # Returns true if more than one site exists.

--- a/lib/alchemy/on_page_layout/callbacks_runner.rb
+++ b/lib/alchemy/on_page_layout/callbacks_runner.rb
@@ -8,14 +8,11 @@ module Alchemy
     # @see OnPageLayout in order to learn how to define +on_page_layout+ callbacks.
     #
     module CallbacksRunner
-      extend ActiveSupport::Concern
-
-      included do
-        before_action :run_on_page_layout_callbacks, only: :show,
-          if: -> { OnPageLayout.callbacks.present? }
-      end
-
       private
+
+      def run_on_page_layout_callbacks?
+        OnPageLayout.callbacks.present?
+      end
 
       def run_on_page_layout_callbacks
         OnPageLayout.callbacks.each do |page_layout, callbacks|

--- a/spec/controllers/base_controller_spec.rb
+++ b/spec/controllers/base_controller_spec.rb
@@ -47,5 +47,61 @@ module Alchemy
         end
       end
     end
+
+    describe "#prefix_locale?" do
+      subject(:prefix_locale?) { controller.prefix_locale? }
+
+      context "if multi_language? is true" do
+        before do
+          expect(controller).to receive(:multi_language?) { true }
+        end
+
+        context "and current language is not the default locale" do
+          before do
+            allow(Alchemy::Language).to receive(:current) { double(code: 'en') }
+            allow(::I18n).to receive(:default_locale) { :de }
+          end
+
+          it { expect(prefix_locale?).to be(true) }
+        end
+
+        context "and current language is the default locale" do
+          before do
+            allow(Alchemy::Language).to receive(:current) { double(code: 'de') }
+            allow(::I18n).to receive(:default_locale) { :de }
+          end
+
+          it { expect(prefix_locale?).to be(false) }
+        end
+
+        context "and passed in locale is not the default locale" do
+          subject(:prefix_locale?) { controller.prefix_locale?('en') }
+
+          before do
+            allow(::I18n).to receive(:default_locale) { :de }
+          end
+
+          it { expect(prefix_locale?).to be(true) }
+        end
+
+        context "and passed in locale is the default locale" do
+          subject(:prefix_locale?) { controller.prefix_locale?('de') }
+
+          before do
+            allow(::I18n).to receive(:default_locale) { :de }
+          end
+
+          it { expect(prefix_locale?).to be(false) }
+        end
+      end
+
+      context "if multi_language? is false" do
+        before do
+          expect(controller).to receive(:multi_language?) { false }
+        end
+
+        it { expect(prefix_locale?).to be(false) }
+      end
+    end
   end
 end

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -186,7 +186,7 @@ module Alchemy
                 end
 
                 it "should redirect to the language root page" do
-                  expect(Language).to receive(:current).and_return(language)
+                  allow(Language).to receive(:current).and_return(language)
                   expect(alchemy_post :create).to redirect_to(show_page_path(urlname: 'lang-root'))
                 end
               end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -27,6 +27,11 @@ module Alchemy
           expect(assigns(:page)).to eq(default_language_root)
         end
 
+        it 'sets @root_page to default language root' do
+          alchemy_get(:index)
+          expect(assigns(:root_page)).to eq(default_language_root)
+        end
+
         context 'and the root page is not public' do
           before do
             default_language_root.update!(public: false)
@@ -91,6 +96,11 @@ module Alchemy
         it 'loads the root page of that language' do
           alchemy_get :index, locale: 'de'
           expect(assigns(:page)).to eq(startseite)
+        end
+
+        it 'sets @root_page to root page of that language' do
+          alchemy_get :index, locale: 'de'
+          expect(assigns(:root_page)).to eq(startseite)
         end
       end
     end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -91,42 +91,6 @@ module Alchemy
       end
     end
 
-    describe '#redirect_to_public_child' do
-      let(:root_page)    { create(:alchemy_page, :language_root, public: false) }
-      let(:page)         { create(:alchemy_page, parent_id: root_page.id) }
-      let(:public_page)  { create(:alchemy_page, :public, parent_id: page.id) }
-
-      before { controller.instance_variable_set("@page", root_page) }
-
-      context 'as guest user' do
-        context "with unpublished and published pages in page tree" do
-          before do
-            public_page
-            root_page.reload
-          end
-
-          it "should redirect to first public child" do
-            expect(controller).to receive(:redirect_page)
-            controller.send(:redirect_to_public_child)
-            expect(controller.instance_variable_get('@page')).to eq(public_page)
-          end
-        end
-
-        context "with only unpublished pages in page tree" do
-          before do
-            page
-            root_page.reload
-          end
-
-          it "should raise not found error" do
-            expect {
-              controller.send(:redirect_to_public_child)
-            }.to raise_error(ActionController::RoutingError)
-          end
-        end
-      end
-    end
-
     describe 'Redirecting to legacy page urls' do
       context 'Request a page with legacy url' do
         let(:page)        { create(:alchemy_page, :public, name: 'New page name') }

--- a/spec/features/page_feature_spec.rb
+++ b/spec/features/page_feature_spec.rb
@@ -2,177 +2,43 @@ require 'spec_helper'
 
 module Alchemy
   describe 'Page' do
-    let(:default_language)      { Language.default }
-    let(:default_language_root) { create(:alchemy_page, :language_root, :language => default_language, :name => 'Home') }
-    let(:public_page_1)         { create(:alchemy_page, :public, :visible => true, :name => 'Page 1') }
-    let(:public_child)          { create(:alchemy_page, :public, :name => 'Public Child', :parent_id => public_page_1.id) }
+    let!(:default_language) { Language.default }
 
-    before { default_language_root }
+    let!(:default_language_root) do
+      create(:alchemy_page, :language_root, language: default_language, name: 'Home')
+    end
 
-    it "should include all its elements and contents" do
-      p = create(:alchemy_page, :public, :do_not_autogenerate => false)
-      article = p.elements.find_by_name('article')
-      article.content_by_name('intro').essence.update_attributes(:body => 'Welcome to Peters Petshop', :public => true)
-      visit "/#{p.urlname}"
-      within('div#content div.article div.intro') { expect(page).to have_content('Welcome to Peters Petshop') }
+    let(:public_page) do
+      create(:alchemy_page, :public, visible: true, name: 'Page 1')
+    end
+
+    let(:public_child) do
+      create(:alchemy_page, :public, name: 'Public Child', parent_id: public_page.id)
+    end
+
+    context 'rendered' do
+      let(:public_page) { create(:alchemy_page, :public, do_not_autogenerate: false) }
+      let(:article) { public_page.elements.find_by_name('article') }
+      let(:essence) { article.content_by_name('intro').essence }
+
+      before do
+        essence.update_attributes(body: 'Welcome to Peters Petshop', public: true)
+      end
+
+      it "should include all its elements and contents" do
+        visit "/#{public_page.urlname}"
+        within('div#content div.article div.intro') do
+          expect(page).to have_content('Welcome to Peters Petshop')
+        end
+      end
     end
 
     it "should show the navigation with all visible pages" do
-      pages = [
-        create(:alchemy_page, :public, :visible => true, :name => 'Page 1'),
-        create(:alchemy_page, :public, :visible => true, :name => 'Page 2')
-      ]
+      create(:alchemy_page, :public, visible: true, name: 'Page 1')
+      create(:alchemy_page, :public, visible: true, name: 'Page 2')
       visit '/'
-      within('div#navigation ul') { expect(page).to have_selector('li a[href="/page-1"], li a[href="/page-2"]') }
-    end
-
-    describe "redirecting" do
-      context "in multi language mode" do
-        before do
-          allow(Config).to receive(:get) { |arg| arg == :url_nesting ? true : Config.parameter(arg) }
-          allow_any_instance_of(PagesController).to receive(:multi_language?).and_return(true)
-        end
-
-        let(:second_page) { create(:alchemy_page, :public, name: 'Second Page') }
-        let(:legacy_url)  { LegacyPageUrl.create(urlname: 'index.php?option=com_content&view=article&id=48&Itemid=69', page: second_page) }
-
-        it "should redirect legacy url with unknown format & query string" do
-          visit "/#{legacy_url.urlname}"
-          uri = URI.parse(page.current_url)
-          expect(uri.query).to be_nil
-          expect(uri.request_uri).to eq("/en/#{second_page.urlname}")
-        end
-
-        context "if no language params are given and page locale == default locale" do
-          it "doesn't prepend the url with the locale string" do
-            visit("/#{public_page_1.urlname}")
-            expect(page.current_path).to eq("/#{public_page_1.urlname}")
-          end
-        end
-
-        context "if no language params are given and page locale != default locale" do
-          it "prepends the url with the locale string" do
-            allow(::I18n).to receive(:default_locale).and_return(:de)
-            visit("/#{public_page_1.urlname}")
-            expect(page.current_path).to eq("/en/#{public_page_1.urlname}")
-          end
-        end
-
-        context "if requested page is unpublished" do
-          before do
-            allow(Config).to receive(:get) { |arg| arg == :url_nesting ? false : Config.parameter(arg) }
-            public_page_1.update_attributes(:public => false, :name => 'Not Public', :urlname => '')
-            public_child
-          end
-
-          it "should redirect to public child" do
-            visit "/not-public"
-            expect(page.current_path).to eq("/public-child")
-          end
-
-          context "if page.locale != then the default locale" do
-            it "prepends the public child path with it's locale" do
-              allow(::I18n).to receive(:default_locale).and_return(:de)
-              visit "/not-public"
-              expect(page.current_path).to eq("/en/public-child")
-            end
-          end
-        end
-
-        context "if requested url is the index url" do
-          it "redirects to the url of the default language root page" do
-            visit '/'
-            expect(page.current_path).to eq("/home")
-          end
-
-          context "if page.locale != then the default locale" do
-            it "prepends the locale to the url" do
-              allow(::I18n).to receive(:default_locale).and_return(:de)
-              visit '/'
-              expect(page.current_path).to eq("/en/home")
-            end
-          end
-        end
-
-        context "if requested url is only the language code" do
-          it "should redirect to pages url with default language" do
-            visit "/#{default_language.code}"
-            expect(page.current_path).to eq("/#{default_language.code}/home")
-          end
-        end
-
-        it "should keep additional params" do
-          visit "/#{public_page_1.urlname}?query=Peter"
-          expect(page.current_url).to match(/\?query=Peter/)
-        end
-
-        context "wrong language requested" do
-          before { allow(Alchemy.user_class).to receive(:admins).and_return([1, 2]) }
-
-          it "should render 404 if urlname and lang parameter do not belong to same page" do
-            create(:alchemy_language, :klingonian)
-            expect {
-              visit "/kl/#{public_page_1.urlname}"
-            }.to raise_error(ActionController::RoutingError)
-          end
-
-          it "should render 404 if requested language does not exist" do
-            public_page_1
-            LegacyPageUrl.delete_all
-            expect {
-              visit "/fo/#{public_page_1.urlname}"
-            }.to raise_error(ActionController::RoutingError)
-          end
-        end
-      end
-
-      context "not in multi language mode" do
-        before do
-          allow_any_instance_of(PagesController).to receive(:multi_language?).and_return(false)
-          allow(Config).to receive(:get) { |arg| arg == :url_nesting ? false : Config.parameter(arg) }
-        end
-
-        let(:second_page) { create(:alchemy_page, :public, name: 'Second Page') }
-        let(:legacy_url) { LegacyPageUrl.create(urlname: 'index.php?option=com_content&view=article&id=48&Itemid=69', page: second_page) }
-
-        it "should redirect legacy url with unknown format & query string" do
-          visit "/#{legacy_url.urlname}"
-          uri = URI.parse(page.current_url)
-          expect(uri.query).to be_nil
-          expect(uri.request_uri).to eq("/#{second_page.urlname}")
-        end
-
-        it "should redirect from nested language code url to normal url" do
-          visit "/en/#{public_page_1.urlname}"
-          expect(page.current_path).to eq("/#{public_page_1.urlname}")
-        end
-
-        context "should redirect to public child" do
-          before do
-            public_page_1.update_attributes(:public => false, :name => 'Not Public', :urlname => '')
-            public_child
-          end
-
-          it "if requested page is unpublished" do
-            visit '/not-public'
-            expect(page.current_path).to eq('/public-child')
-          end
-
-          it "with normal url, if requested url has nested language code and is not public" do
-            visit '/en/not-public'
-            expect(page.current_path).to eq('/public-child')
-          end
-        end
-
-        it "should redirect to pages url, if requested url is index url" do
-          visit '/'
-          expect(page.current_path).to eq('/home')
-        end
-
-        it "should keep additional params" do
-          visit "/en/#{public_page_1.urlname}?query=Peter"
-          expect(page.current_url).to match(/\?query=Peter/)
-        end
+      within('div#navigation ul') do
+        expect(page).to have_selector('li a[href="/page-1"], li a[href="/page-2"]')
       end
     end
 
@@ -198,7 +64,7 @@ module Alchemy
     describe "menubar" do
       context "rendering for guest users" do
         it "is prohibited" do
-          visit "/#{public_page_1.urlname}"
+          visit "/#{public_page.urlname}"
           within('body') { expect(page).not_to have_selector('#alchemy_menubar') }
         end
       end
@@ -206,7 +72,7 @@ module Alchemy
       context "rendering for members" do
         it "is prohibited" do
           authorize_user(build(:alchemy_dummy_user))
-          visit "/#{public_page_1.urlname}"
+          visit "/#{public_page.urlname}"
           within('body') { expect(page).not_to have_selector('#alchemy_menubar') }
         end
       end
@@ -214,7 +80,7 @@ module Alchemy
       context "rendering for authors" do
         it "is allowed" do
           authorize_user(:as_author)
-          visit "/#{public_page_1.urlname}"
+          visit "/#{public_page.urlname}"
           within('body') { expect(page).to have_selector('#alchemy_menubar') }
         end
       end
@@ -222,7 +88,7 @@ module Alchemy
       context "rendering for editors" do
         it "is allowed" do
           authorize_user(:as_editor)
-          visit "/#{public_page_1.urlname}"
+          visit "/#{public_page.urlname}"
           within('body') { expect(page).to have_selector('#alchemy_menubar') }
         end
       end
@@ -230,7 +96,7 @@ module Alchemy
       context "rendering for admins" do
         it "is allowed" do
           authorize_user(:as_admin)
-          visit "/#{public_page_1.urlname}"
+          visit "/#{public_page.urlname}"
           within('body') { expect(page).to have_selector('#alchemy_menubar') }
         end
       end
@@ -238,7 +104,7 @@ module Alchemy
       context "contains" do
         before do
           authorize_user(:as_admin)
-          visit "/#{public_page_1.urlname}"
+          visit "/#{public_page.urlname}"
         end
 
         it "a link to the admin area" do
@@ -249,13 +115,15 @@ module Alchemy
 
         it "a link to edit the current page" do
           within('#alchemy_menubar') do
-            expect(page).to have_selector("li a[href='#{alchemy.edit_admin_page_url(public_page_1)}']")
+            expect(page).to \
+              have_selector("li a[href='#{alchemy.edit_admin_page_url(public_page)}']")
           end
         end
 
         it "a form and button to logout of alchemy" do
           within('#alchemy_menubar') do
-            expect(page).to have_selector("li form[action='#{Alchemy.logout_path}'], li button[type='submit']")
+            expect(page).to \
+              have_selector("li form[action='#{Alchemy.logout_path}'], li button[type='submit']")
           end
         end
       end
@@ -263,10 +131,12 @@ module Alchemy
 
     describe 'navigation rendering' do
       context 'with page having an external url without protocol' do
-        let!(:external_page) { create(:alchemy_page, urlname: 'google.com', page_layout: 'external', visible: true) }
+        let!(:external_page) do
+          create(:alchemy_page, urlname: 'google.com', page_layout: 'external', visible: true)
+        end
 
         it "adds an prefix to url" do
-          visit "/#{public_page_1.urlname}"
+          visit "/#{public_page.urlname}"
           within '#navigation' do
             expect(page.body).to match('http://google.com')
           end
@@ -285,7 +155,9 @@ module Alchemy
       end
 
       context 'as a member user' do
-        before { authorize_user(create(:alchemy_dummy_user)) }
+        before do
+          authorize_user(create(:alchemy_dummy_user))
+        end
 
         it "I am able to visit the page" do
           visit restricted_page.urlname

--- a/spec/features/page_feature_spec.rb
+++ b/spec/features/page_feature_spec.rb
@@ -43,10 +43,18 @@ module Alchemy
           expect(uri.request_uri).to eq("/en/#{second_page.urlname}")
         end
 
-        context "if no language params are given" do
-          it "should redirect to url with nested language code" do
-            visit "/#{public_page_1.urlname}"
-            expect(page.current_path).to eq("/#{public_page_1.language_code}/#{public_page_1.urlname}")
+        context "if no language params are given and page locale == default locale" do
+          it "doesn't prepend the url with the locale string" do
+            visit("/#{public_page_1.urlname}")
+            expect(page.current_path).to eq("/#{public_page_1.urlname}")
+          end
+        end
+
+        context "if no language params are given and page locale != default locale" do
+          it "prepends the url with the locale string" do
+            allow(::I18n).to receive(:default_locale).and_return(:de)
+            visit("/#{public_page_1.urlname}")
+            expect(page.current_path).to eq("/en/#{public_page_1.urlname}")
           end
         end
 
@@ -58,22 +66,31 @@ module Alchemy
           end
 
           it "should redirect to public child" do
-            visit "/#{default_language.code}/not-public"
-            expect(page.current_path).to eq("/#{default_language.code}/public-child")
+            visit "/not-public"
+            expect(page.current_path).to eq("/public-child")
           end
 
-          context "and url has no language code" do
-            it "should redirect to url of public child with language code of default language" do
-              visit '/not-public'
-              expect(page.current_path).to eq("/#{default_language.code}/public-child")
+          context "if page.locale != then the default locale" do
+            it "prepends the public child path with it's locale" do
+              allow(::I18n).to receive(:default_locale).and_return(:de)
+              visit "/not-public"
+              expect(page.current_path).to eq("/en/public-child")
             end
           end
         end
 
-        context "if requested url is index url" do
-          it "should redirect to pages url with default language" do
+        context "if requested url is the index url" do
+          it "redirects to the url of the default language root page" do
             visit '/'
-            expect(page.current_path).to eq("/#{default_language.code}/home")
+            expect(page.current_path).to eq("/home")
+          end
+
+          context "if page.locale != then the default locale" do
+            it "prepends the locale to the url" do
+              allow(::I18n).to receive(:default_locale).and_return(:de)
+              visit '/'
+              expect(page.current_path).to eq("/en/home")
+            end
           end
         end
 
@@ -81,13 +98,6 @@ module Alchemy
           it "should redirect to pages url with default language" do
             visit "/#{default_language.code}"
             expect(page.current_path).to eq("/#{default_language.code}/home")
-          end
-        end
-
-        context "requested url is only the urlname" do
-          it "then it should redirect to pages url with nested language." do
-            visit '/home'
-            expect(page.current_path).to eq('/en/home')
           end
         end
 

--- a/spec/features/page_redirects_spec.rb
+++ b/spec/features/page_redirects_spec.rb
@@ -95,7 +95,7 @@ module Alchemy
           public_child
         end
 
-        it "should redirect to public child" do
+        it "redirects to public child" do
           visit "/not-public"
           expect(page.current_path).to eq("/public-child")
         end
@@ -173,14 +173,6 @@ module Alchemy
             visit '/'
             expect(page.current_path).to eq('/')
           end
-
-          context "if page.locale != then the default locale" do
-            it "redirects to the default language locale" do
-              allow(::I18n).to receive(:default_locale).and_return(:de)
-              visit '/'
-              expect(page.current_path).to eq('/en')
-            end
-          end
         end
       end
 
@@ -192,13 +184,15 @@ module Alchemy
             end
           end
 
-          it "should redirect to pages url with default language" do
-            visit "/#{default_language.code}"
-            expect(page.current_path).to eq("/#{default_language.code}/home")
+          context "if page locale is the default locale" do
+            it "redirects to pages url without locale prefixed" do
+              visit "/#{default_language.code}"
+              expect(page.current_path).to eq("/home")
+            end
           end
 
-          context "if page.locale != then the default locale" do
-            it "redirects to the default language root page's url with prefixed locale" do
+          context "if page locale is not the default locale" do
+            it "redirects to the default language root url with prefixed locale" do
               allow(::I18n).to receive(:default_locale).and_return(:de)
               visit "/#{default_language.code}"
               expect(page.current_path).to eq('/en/home')
@@ -224,7 +218,7 @@ module Alchemy
             end
           end
 
-          context "if page.locale != then the default locale" do
+          context "if page locale is not the default locale" do
             it "does not redirect" do
               visit "/#{default_language.code}"
               expect(page.current_path).to eq("/#{default_language.code}")
@@ -277,19 +271,19 @@ module Alchemy
         end
       end
 
-      it "should redirect legacy url with unknown format & query string" do
+      it "redirects legacy url with unknown format & query string" do
         visit "/#{legacy_url.urlname}"
         uri = URI.parse(page.current_url)
         expect(uri.query).to be_nil
         expect(uri.request_uri).to eq("/#{second_page.urlname}")
       end
 
-      it "should redirect from nested language code url to normal url" do
+      it "redirects from nested language code url to normal url" do
         visit "/en/#{public_page.urlname}"
         expect(page.current_path).to eq("/#{public_page.urlname}")
       end
 
-      context "should redirect to public child" do
+      context "redirects to public child" do
         before do
           public_page.update_attributes(public: false, name: 'Not Public', urlname: '')
           public_child
@@ -306,7 +300,7 @@ module Alchemy
         end
       end
 
-      it "should redirect to pages url, if requested url is index url" do
+      it "redirects to pages url, if requested url is index url" do
         visit '/'
         expect(page.current_path).to eq('/home')
       end

--- a/spec/features/page_redirects_spec.rb
+++ b/spec/features/page_redirects_spec.rb
@@ -33,7 +33,7 @@ module Alchemy
       context 'if language params are given' do
         context "and page locale is default locale" do
           it "redirects to unprefixed locale url" do
-            allow(::I18n).to receive(:default_locale).and_return(public_page.language_code)
+            allow(::I18n).to receive(:default_locale) { public_page.language_code.to_sym }
             visit("/#{public_page.language_code}/#{public_page.urlname}")
             expect(page.current_path).to eq("/#{public_page.urlname}")
           end
@@ -51,13 +51,13 @@ module Alchemy
       context 'if no language params are given' do
         context "and page locale is default locale" do
           it "doesn't prepend the url with the locale string" do
-            allow(::I18n).to receive(:default_locale).and_return(public_page.language_code)
+            allow(::I18n).to receive(:default_locale) { public_page.language_code.to_sym }
             visit("/#{public_page.urlname}")
             expect(page.current_path).to eq("/#{public_page.urlname}")
           end
 
           it "redirects legacy url with unknown format & query string without locale prefix" do
-            allow(::I18n).to receive(:default_locale).and_return(second_page.language_code)
+            allow(::I18n).to receive(:default_locale) { second_page.language_code.to_sym }
             visit "/#{legacy_url.urlname}"
             uri = URI.parse(page.current_url)
             expect(uri.query).to be_nil
@@ -70,7 +70,7 @@ module Alchemy
             allow(::I18n).to receive(:default_locale).and_return(:de)
           end
 
-          it "prepends the url with the locale string" do
+          it "redirects to url with the locale prefixed" do
             visit("/#{public_page.urlname}")
             expect(page.current_path).to eq("/en/#{public_page.urlname}")
           end
@@ -219,6 +219,10 @@ module Alchemy
           end
 
           context "if page locale is not the default locale" do
+            before do
+              allow(::I18n).to receive(:default_locale) { :de }
+            end
+
             it "does not redirect" do
               visit "/#{default_language.code}"
               expect(page.current_path).to eq("/#{default_language.code}")

--- a/spec/features/page_redirects_spec.rb
+++ b/spec/features/page_redirects_spec.rb
@@ -1,0 +1,320 @@
+require 'spec_helper'
+
+module Alchemy
+  describe 'Requesting a page' do
+    let!(:default_language) { Language.default }
+
+    let!(:default_language_root) do
+      create(:alchemy_page, :language_root, language: default_language, name: 'Home')
+    end
+
+    let(:public_page) do
+      create(:alchemy_page, :public, visible: true, name: 'Page 1')
+    end
+
+    let(:public_child) do
+      create(:alchemy_page, :public, name: 'Public Child', parent_id: public_page.id)
+    end
+
+    context "in multi language mode" do
+      let(:second_page) { create(:alchemy_page, :public, name: 'Second Page') }
+
+      let(:legacy_url) do
+        LegacyPageUrl.create(
+          urlname: 'index.php?option=com_content&view=article&id=48&Itemid=69',
+          page: second_page
+        )
+      end
+
+      before do
+        allow_any_instance_of(PagesController).to receive(:multi_language?).and_return(true)
+      end
+
+      context 'if language params are given' do
+        context "and page locale is default locale" do
+          it "redirects to unprefixed locale url" do
+            allow(::I18n).to receive(:default_locale).and_return(public_page.language_code)
+            visit("/#{public_page.language_code}/#{public_page.urlname}")
+            expect(page.current_path).to eq("/#{public_page.urlname}")
+          end
+        end
+
+        context "and page locale is not default locale" do
+          it "does not redirect" do
+            allow(::I18n).to receive(:default_locale).and_return(:de)
+            visit("/#{public_page.language_code}/#{public_page.urlname}")
+            expect(page.current_path).to eq("/#{public_page.language_code}/#{public_page.urlname}")
+          end
+        end
+      end
+
+      context 'if no language params are given' do
+        context "and page locale is default locale" do
+          it "doesn't prepend the url with the locale string" do
+            allow(::I18n).to receive(:default_locale).and_return(public_page.language_code)
+            visit("/#{public_page.urlname}")
+            expect(page.current_path).to eq("/#{public_page.urlname}")
+          end
+
+          it "redirects legacy url with unknown format & query string without locale prefix" do
+            allow(::I18n).to receive(:default_locale).and_return(second_page.language_code)
+            visit "/#{legacy_url.urlname}"
+            uri = URI.parse(page.current_url)
+            expect(uri.query).to be_nil
+            expect(uri.request_uri).to eq("/#{second_page.urlname}")
+          end
+        end
+
+        context "and page locale is not default locale" do
+          before do
+            allow(::I18n).to receive(:default_locale).and_return(:de)
+          end
+
+          it "prepends the url with the locale string" do
+            visit("/#{public_page.urlname}")
+            expect(page.current_path).to eq("/en/#{public_page.urlname}")
+          end
+
+          it "redirects legacy url with unknown format & query string with locale prefix" do
+            visit "/#{legacy_url.urlname}"
+            uri = URI.parse(page.current_url)
+            expect(uri.query).to be_nil
+            expect(uri.request_uri).to eq("/en/#{second_page.urlname}")
+          end
+        end
+      end
+
+      context "if requested page is unpublished" do
+        before do
+          public_page.update_attributes(
+            public: false,
+            visible: false,
+            name: 'Not Public',
+            urlname: ''
+          )
+          public_child
+        end
+
+        it "should redirect to public child" do
+          visit "/not-public"
+          expect(page.current_path).to eq("/public-child")
+        end
+
+        context "with only unpublished pages in page tree" do
+          before do
+            public_child.update_attributes(public: false)
+          end
+
+          it "should raise not found error" do
+            expect {
+              visit "/not-public"
+            }.to raise_error(ActionController::RoutingError)
+          end
+        end
+
+        context "if page locale is the default locale" do
+          it "redirects to public child with prefixed locale" do
+            allow(::I18n).to receive(:default_locale).and_return(:de)
+            visit "/not-public"
+            expect(page.current_path).to eq("/en/public-child")
+          end
+        end
+      end
+
+      context "if requested url is the index url" do
+        context 'and redirect_index is set to true' do
+          before do
+            allow(Config).to receive(:get) do |arg|
+              arg == :redirect_index ? true : Config.parameter(arg)
+            end
+          end
+
+          context "and if page locale is the default locale" do
+            it "redirects to the default language root page without prefixed locale" do
+              visit '/'
+              expect(page.current_path).to eq('/home')
+            end
+
+            context "having additional parameter" do
+              it "redirects to the default language root page with prefixed locale while keeping the additional params" do
+                visit '/?search=kitten'
+                expect(page.current_url).to eq('http://www.example.com/home?search=kitten')
+              end
+            end
+          end
+
+          context "and if page locale is not the default locale" do
+            before do
+              allow(::I18n).to receive(:default_locale).and_return(:de)
+            end
+
+            it "redirects to the default language root page with prefixed locale" do
+              visit '/'
+              expect(page.current_path).to eq('/en/home')
+            end
+
+            context "having additional parameter" do
+              it "redirects to the default language root page with prefixed locale while keeping the additional params" do
+                visit '/?search=kitten'
+                expect(page.current_url).to eq('http://www.example.com/en/home?search=kitten')
+              end
+            end
+          end
+        end
+
+        context 'and redirect_index is set to false' do
+          before do
+            allow(Config).to receive(:get) do |arg|
+              arg == :redirect_index ? false : Config.parameter(arg)
+            end
+          end
+
+          it "does not redirect" do
+            visit '/'
+            expect(page.current_path).to eq('/')
+          end
+
+          context "if page.locale != then the default locale" do
+            it "redirects to the default language locale" do
+              allow(::I18n).to receive(:default_locale).and_return(:de)
+              visit '/'
+              expect(page.current_path).to eq('/en')
+            end
+          end
+        end
+      end
+
+      context "if requested url is only the language code" do
+        context 'and redirect_index is set to true' do
+          before do
+            allow(Config).to receive(:get) do |arg|
+              arg == :redirect_index ? true : Config.parameter(arg)
+            end
+          end
+
+          it "should redirect to pages url with default language" do
+            visit "/#{default_language.code}"
+            expect(page.current_path).to eq("/#{default_language.code}/home")
+          end
+
+          context "if page.locale != then the default locale" do
+            it "redirects to the default language root page's url with prefixed locale" do
+              allow(::I18n).to receive(:default_locale).and_return(:de)
+              visit "/#{default_language.code}"
+              expect(page.current_path).to eq('/en/home')
+            end
+          end
+        end
+
+        context 'and redirect_index is set to false' do
+          before do
+            allow(Config).to receive(:get) do |arg|
+              arg == :redirect_index ? false : Config.parameter(arg)
+            end
+          end
+
+          context "if requested locale is the default locale" do
+            before do
+              allow(::I18n).to receive(:default_locale) { default_language.code }
+            end
+
+            it "redirects to '/'" do
+              visit "/#{default_language.code}"
+              expect(page.current_path).to eq('/')
+            end
+          end
+
+          context "if page.locale != then the default locale" do
+            it "does not redirect" do
+              visit "/#{default_language.code}"
+              expect(page.current_path).to eq("/#{default_language.code}")
+            end
+          end
+        end
+      end
+
+      it "should keep additional params" do
+        visit "/#{public_page.urlname}?query=Peter"
+        expect(page.current_url).to match(/\?query=Peter/)
+      end
+
+      context "wrong language requested" do
+        before do
+          allow(Alchemy.user_class).to receive(:admins).and_return([1, 2])
+        end
+
+        it "should render 404 if urlname and lang parameter do not belong to same page" do
+          create(:alchemy_language, :klingonian)
+          expect {
+            visit "/kl/#{public_page.urlname}"
+          }.to raise_error(ActionController::RoutingError)
+        end
+
+        it "should render 404 if requested language does not exist" do
+          public_page
+          LegacyPageUrl.delete_all
+          expect {
+            visit "/fo/#{public_page.urlname}"
+          }.to raise_error(ActionController::RoutingError)
+        end
+      end
+    end
+
+    context "not in multi language mode" do
+      let(:second_page) { create(:alchemy_page, :public, name: 'Second Page') }
+
+      let(:legacy_url) do
+        LegacyPageUrl.create(
+          urlname: 'index.php?option=com_content&view=article&id=48&Itemid=69',
+          page: second_page
+        )
+      end
+
+      before do
+        allow_any_instance_of(PagesController).to receive(:multi_language?).and_return(false)
+        allow(Config).to receive(:get) do |arg|
+          arg == :url_nesting ? false : Config.parameter(arg)
+        end
+      end
+
+      it "should redirect legacy url with unknown format & query string" do
+        visit "/#{legacy_url.urlname}"
+        uri = URI.parse(page.current_url)
+        expect(uri.query).to be_nil
+        expect(uri.request_uri).to eq("/#{second_page.urlname}")
+      end
+
+      it "should redirect from nested language code url to normal url" do
+        visit "/en/#{public_page.urlname}"
+        expect(page.current_path).to eq("/#{public_page.urlname}")
+      end
+
+      context "should redirect to public child" do
+        before do
+          public_page.update_attributes(public: false, name: 'Not Public', urlname: '')
+          public_child
+        end
+
+        it "if requested page is unpublished" do
+          visit '/not-public'
+          expect(page.current_path).to eq('/public-child')
+        end
+
+        it "with normal url, if requested url has nested language code and is not public" do
+          visit '/en/not-public'
+          expect(page.current_path).to eq('/public-child')
+        end
+      end
+
+      it "should redirect to pages url, if requested url is index url" do
+        visit '/'
+        expect(page.current_path).to eq('/home')
+      end
+
+      it "should keep additional params" do
+        visit "/en/#{public_page.urlname}?query=Peter"
+        expect(page.current_url).to match(/\?query=Peter/)
+      end
+    end
+  end
+end

--- a/spec/helpers/url_helper_spec.rb
+++ b/spec/helpers/url_helper_spec.rb
@@ -12,45 +12,59 @@ module Alchemy
 
     context 'page path helpers' do
       describe "#show_page_path_params" do
-        context "when multi_language" do
+        subject(:show_page_path_params) { helper.show_page_path_params(page) }
 
+        context "if prefix_locale? is false" do
           before do
-            allow(helper).to receive(:multi_language?).and_return(true)
+            expect(helper).to receive(:prefix_locale?) { false }
           end
 
-          it "should return a Hash with urlname and language_id parameter" do
-            allow(helper).to receive(:multi_language?).and_return(true)
-            expect(helper.show_page_path_params(page)).to include(urlname: 'testpage', locale: 'en')
+          it "returns a Hash with urlname and no locale parameter" do
+            expect(show_page_path_params).to include(urlname: 'testpage')
+            expect(show_page_path_params).to_not include(locale: 'en')
           end
 
-          it "should return a Hash with urlname, language_id and query parameter" do
-            allow(helper).to receive(:multi_language?).and_return(true)
-            expect(helper.show_page_path_params(page, {query: 'test'})).to include(urlname: 'testpage', locale: 'en', query: 'test')
+          context "with addiitonal parameters" do
+            subject(:show_page_path_params) do
+              helper.show_page_path_params(page, {query: 'test'})
+            end
+
+            it "returns a Hash with urlname, no locale and query parameter" do
+              expect(show_page_path_params).to \
+                include(urlname: 'testpage', query: 'test')
+              expect(show_page_path_params).to_not \
+                include(locale: 'en')
+            end
           end
         end
 
-        context "not multi_language" do
+        context "if prefix_locale? is false" do
           before do
-            allow(helper).to receive(:multi_language?).and_return(false)
+            expect(helper).to receive(:prefix_locale?) { true }
           end
 
-          it "should return a Hash with the urlname but without language_id parameter" do
-            expect(helper.show_page_path_params(page)).to include(urlname: 'testpage')
-            expect(helper.show_page_path_params(page)).not_to include(locale: 'en')
+          it "returns a Hash with urlname and locale parameter" do
+            expect(show_page_path_params).to \
+              include(urlname: 'testpage', locale: 'en')
           end
 
-          it "should return a Hash with urlname and query parameter" do
-            expect(helper.show_page_path_params(page, {query: 'test'})).to include(urlname: 'testpage', query: 'test')
-            expect(helper.show_page_path_params(page)).not_to include(locale: 'en')
+          context "with additional parameters" do
+            subject(:show_page_path_params) do
+              helper.show_page_path_params(page, {query: 'test'})
+            end
+
+            it "returns a Hash with urlname, locale and query parameter" do
+              expect(show_page_path_params).to \
+                include(urlname: 'testpage', locale: 'en', query: 'test')
+            end
           end
         end
       end
 
       describe "#show_alchemy_page_path" do
-        context "when multi_language" do
-
+        context "when prefix_locale? set to true" do
           before do
-            allow(helper).to receive(:multi_language?).and_return(true)
+            expect(helper).to receive(:prefix_locale?) { true }
           end
 
           it "should return the correct relative path string" do
@@ -58,13 +72,14 @@ module Alchemy
           end
 
           it "should return the correct relative path string with additional parameters" do
-            expect(helper.show_alchemy_page_path(page, {query: 'test'})).to eq("/#{page.language_code}/testpage?query=test")
+            expect(helper.show_alchemy_page_path(page, {query: 'test'})).to \
+              eq("/#{page.language_code}/testpage?query=test")
           end
         end
 
-        context "not multi_language" do
+        context "when prefix_locale? set to false" do
           before do
-            allow(helper).to receive(:multi_language?).and_return(false)
+            expect(helper).to receive(:prefix_locale?) { false }
           end
 
           it "should return the correct relative path string" do
@@ -72,38 +87,42 @@ module Alchemy
           end
 
           it "should return the correct relative path string with additional parameter" do
-            expect(helper.show_alchemy_page_path(page, {query: 'test'})).to eq("/testpage?query=test")
+            expect(helper.show_alchemy_page_path(page, {query: 'test'})).to \
+              eq("/testpage?query=test")
           end
         end
       end
 
       describe "#show_alchemy_page_url" do
-        context "when multi_language" do
-
+        context "when prefix_locale? set to true" do
           before do
-            allow(helper).to receive(:multi_language?).and_return(true)
+            expect(helper).to receive(:prefix_locale?) { true }
           end
 
           it "should return the correct url string" do
-            expect(helper.show_alchemy_page_url(page)).to eq("http://#{helper.request.host}/#{page.language_code}/testpage")
+            expect(helper.show_alchemy_page_url(page)).to \
+              eq("http://#{helper.request.host}/#{page.language_code}/testpage")
           end
 
           it "should return the correct url string with additional parameters" do
-            expect(helper.show_alchemy_page_url(page, {query: 'test'})).to eq("http://#{helper.request.host}/#{page.language_code}/testpage?query=test")
+            expect(helper.show_alchemy_page_url(page, {query: 'test'})).to \
+              eq("http://#{helper.request.host}/#{page.language_code}/testpage?query=test")
           end
         end
 
-        context "not multi_language" do
+        context "when prefix_locale? set to false" do
           before do
-            allow(helper).to receive(:multi_language?).and_return(false)
+            expect(helper).to receive(:prefix_locale?) { false }
           end
 
           it "should return the correct url string" do
-            expect(helper.show_alchemy_page_url(page)).to eq("http://#{helper.request.host}/testpage")
+            expect(helper.show_alchemy_page_url(page)).to \
+              eq("http://#{helper.request.host}/testpage")
           end
 
           it "should return the correct url string with additional parameter" do
-            expect(helper.show_alchemy_page_url(page, {query: 'test'})).to eq("http://#{helper.request.host}/testpage?query=test")
+            expect(helper.show_alchemy_page_url(page, {query: 'test'})).to \
+              eq("http://#{helper.request.host}/testpage?query=test")
           end
         end
       end
@@ -114,19 +133,22 @@ module Alchemy
 
       describe '#show_alchemy_picture_path' do
         it "should return the correct relative path string" do
-          expect(helper.show_alchemy_picture_path(picture)).to match(Regexp.new("/pictures/42/show/cute_kitten.jpg"))
+          expect(helper.show_alchemy_picture_path(picture)).to \
+            match(Regexp.new("/pictures/42/show/cute_kitten.jpg"))
         end
       end
 
       describe '#show_alchemy_picture_url' do
         it "should return the correct url string" do
-          expect(helper.show_alchemy_picture_url(picture)).to match(Regexp.new("http://#{helper.request.host}/pictures/42/show/cute_kitten.jpg"))
+          expect(helper.show_alchemy_picture_url(picture)).to \
+            match(Regexp.new("http://#{helper.request.host}/pictures/42/show/cute_kitten.jpg"))
         end
       end
 
       describe '#show_picture_path_params' do
         it "should return the correct params for rendering a picture" do
-          expect(helper.show_picture_path_params(picture)).to include(name: 'cute_kitten', format: 'jpg')
+          expect(helper.show_picture_path_params(picture)).to \
+            include(name: 'cute_kitten', format: 'jpg')
         end
 
         it "should include the secure hash parameter" do
@@ -136,13 +158,15 @@ module Alchemy
 
         context "with additional params" do
           it "should include these params" do
-            expect(helper.show_picture_path_params(picture, {format: 'png'})).to include(name: 'cute_kitten', format: 'png')
+            expect(helper.show_picture_path_params(picture, {format: 'png'})).to \
+              include(name: 'cute_kitten', format: 'png')
           end
         end
 
         context "with additional params crop set to true" do
           it "should include crop as parameter" do
-            expect(helper.show_picture_path_params(picture, {crop: true})).to include(name: 'cute_kitten', crop: 'crop')
+            expect(helper.show_picture_path_params(picture, {crop: true})).to \
+              include(name: 'cute_kitten', crop: 'crop')
           end
         end
       end
@@ -152,11 +176,13 @@ module Alchemy
       let(:attachment) { mock_model(Attachment, urlname: 'test-attachment.pdf') }
 
       it 'should return the correct relative path to download an attachment' do
-        expect(helper.download_alchemy_attachment_path(attachment)).to eq("/attachment/#{attachment.id}/download/#{attachment.urlname}")
+        expect(helper.download_alchemy_attachment_path(attachment)).to \
+          eq("/attachment/#{attachment.id}/download/#{attachment.urlname}")
       end
 
       it 'should return the correct url to download an attachment' do
-        expect(helper.download_alchemy_attachment_url(attachment)).to eq("http://#{helper.request.host}/attachment/#{attachment.id}/download/#{attachment.urlname}")
+        expect(helper.download_alchemy_attachment_url(attachment)).to \
+          eq("http://#{helper.request.host}/attachment/#{attachment.id}/download/#{attachment.urlname}")
       end
     end
 

--- a/spec/requests/alchemy/sitemap_spec.rb
+++ b/spec/requests/alchemy/sitemap_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+RSpec.describe 'Requests for PagesController#sitemap' do
+  let!(:page) { create(:alchemy_page, :public, sitemap: true) }
+
+  it 'renders valid xml sitemap' do
+    get '/sitemap.xml'
+    expect(response.content_type).to eq(:xml)
+    xml_doc = Nokogiri::XML(response.body)
+    expect(xml_doc.namespaces).to have_key('xmlns')
+    expect(xml_doc.namespaces['xmlns']).to eq('http://www.sitemaps.org/schemas/sitemap/0.9')
+    expect(xml_doc.css('urlset url loc').length).to eq(2)
+  end
+
+  it 'lastmod dates are ISO 8601 timestamps' do
+    get '/sitemap.xml'
+    expect(response.content_type).to eq(:xml)
+    xml_doc = Nokogiri::XML(response.body)
+    xml_doc.css('urlset url lastmod').each do |timestamps|
+      expect(timestamps.text).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/)
+    end
+  end
+
+  context 'in multi language mode' do
+    let!(:root) { page.parent }
+    let!(:pages) { [root, page] }
+
+    before do
+      allow_any_instance_of(Alchemy::BaseController).to receive('prefix_locale?') { true }
+    end
+
+    it 'links in sitemap has locale code included' do
+      get '/sitemap.xml'
+      xml_doc = Nokogiri::XML(response.body)
+      xml_doc.css('urlset url').each_with_index do |node, i|
+        page = pages[i]
+        expect(node.css('loc').text).to match(/\/#{page.language_code}\//)
+      end
+    end
+
+    context 'if the default locale is the page locale' do
+      before do
+        allow_any_instance_of(Alchemy::BaseController).to receive('prefix_locale?') { false }
+      end
+
+      it 'links in sitemap has no locale code included' do
+        get '/sitemap.xml'
+        xml_doc = Nokogiri::XML(response.body)
+        xml_doc.css('urlset url').each_with_index do |node, i|
+          page = pages[i]
+          expect(node.css('loc').text).to_not match(/\/#{page.language_code}\//)
+        end
+      end
+    end
+  end
+end

--- a/spec/routing/routing_spec.rb
+++ b/spec/routing/routing_spec.rb
@@ -3,6 +3,29 @@ require 'spec_helper'
 describe "The Routing" do
   routes { Alchemy::Engine.routes }
 
+  describe "root url" do
+    it "routes to pages_controller#index" do
+      expect({
+        get: "/"
+      }).to route_to(
+        controller: "alchemy/pages",
+        action: "index"
+      )
+    end
+
+    context 'with locale parameter' do
+      it 'routes to pages_controller#index' do
+        expect({
+          get: '/en'
+        }).to route_to(
+          controller: 'alchemy/pages',
+          action: 'index',
+          locale: 'en'
+        )
+      end
+    end
+  end
+
   context "for downloads" do
     it "should have a named route" do
       expect({


### PR DESCRIPTION
Follow up to #811 

## Don't prepend the default locale

On a multi language site, the default locale should not be included in the url. This can avoid seeing the locale twice (once in the tld and once in the locale)

For example a url that used to look like `example.de/de/index` now looks like this: `example.de/index`

## TODO

1. [x] The navigation renderer must not link to urls with locale in them, if the locale is the default locale
2. [x] If someone requests an url of a page from the default locale with locale in it, we need to redirect to the unprefixed variant of the url to prevent duplicated content (ie: `/de/home` should redirect to `/home` if `de` is the default locale)
3. [x] The urls generated by the link overlay, that opens from the TinyMCE editor and linkable essences (EssenceText, EssenceLink, EssencePicture), should not include the default locale
4. [x] The visit page button inside the page edit mode should not redirect to urls with the default locale in them
5. [x] The sitemap should include the correct prefixed and unprefixed urls
6. [x] The RSS feed should include the correct prefixed and unprefixed urls
7. [x] If someone requests the root route, then the default locale should be used and it's root page displayed. No redirection should happen to the current language in session. Therefore we need to remove the redirect to index page's urlname completely. Nobody wants that anyway.
