### PR TITLE
Deprecate redirect_index configuration

### DIFF
--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -34,13 +34,12 @@ module Alchemy
     #
     # If no public page can be found it renders a 404 error.
     #
-    # If the configuration is set to :redirect_index, then the request gets redirected
-    # to that page, instead of displaying it.
-    #
     def index
       @page || page_not_found!
 
       if Alchemy::Config.get(:redirect_index)
+        ActiveSupport::Deprecation.warn("The configuration option `redirect_index` is deprecated and will be removed with the release of Alchemy v4.0")
+        raise "Remove deprecated `redirect_index` configuration!" if Alchemy.version == "4.0.0.rc1"
         redirect_permanently_to page_redirect_url
       else
         authorize! :index, @page

--- a/config/alchemy/config.yml
+++ b/config/alchemy/config.yml
@@ -19,10 +19,8 @@ auto_logout_time: 30
 
 # === Redirect Options
 #
-#   redirect_index            [Boolean]   # You can disable the redirect to first child page for not public pages.
 #   redirect_to_public_child  [Boolean]   # Alchemy redirects to the first public child page found, if a page is not visible.
 #
-redirect_index: true
 redirect_to_public_child: true
 
 # === Page caching


### PR DESCRIPTION
Also removes the option from newly generated apps configuration.