### PR TITLE
Eliminate an SQL lookup on frontend cached element partials

### DIFF
--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -179,38 +179,6 @@ module Alchemy
       end
     end
 
-    # Returns true if the page cache control headers should be set.
-    #
-    # == Disable Alchemy's page caching globally
-    #
-    #     # config/alchemy/config.yml
-    #     ...
-    #     cache_pages: false
-    #
-    # == Disable caching on page layout level
-    #
-    #     # config/alchemy/page_layouts.yml
-    #     - name: contact
-    #       cache: false
-    #
-    # == Note:
-    #
-    # This only sets the cache control headers and skips rendering of the page body,
-    # if the cache is fresh.
-    # This does not disable the fragment caching in the views.
-    # So if you don't want a page and it's elements to be cached,
-    # then be sure to not use <% cache element %> in the views.
-    #
-    # @returns Boolean
-    #
-    def cache_page?
-      return false if @page.nil? ||
-        !Rails.application.config.action_controller.perform_caching ||
-        !Alchemy::Config.get(:cache_pages)
-      page_layout = PageLayout.get(@page.page_layout)
-      page_layout['cache'] != false && page_layout['searchresults'] != true
-    end
-
     # Returns the etag used for response headers.
     #
     # If a user is logged in, we append theirs etag to prevent caching of user related content.
@@ -229,7 +197,7 @@ module Alchemy
     # or the cache is stale, because it's been republished by the user.
     #
     def render_fresh_page?
-      !cache_page? || stale?(etag: page_etag,
+      !@page.cache_page? || stale?(etag: page_etag,
         last_modified: @page.published_at,
         public: !@page.restricted)
     end

--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -159,7 +159,10 @@ module Alchemy
         locals: options.delete(:locals) || {}
       }
 
-      element.store_page(@page) if part.to_sym == :view
+      if part.to_sym == :view && @page.cache_page?
+        element.store_page(@page)
+      end
+
       render "alchemy/elements/#{element.name}_#{part}", options
     rescue ActionView::MissingTemplate => e
       warning(%(

--- a/app/models/alchemy/page/page_natures.rb
+++ b/app/models/alchemy/page/page_natures.rb
@@ -109,5 +109,42 @@ module Alchemy
       read_attribute(:published_at) || updated_at
     end
 
+    # Returns true if the page cache control headers should be set.
+    #
+    # == Disable Alchemy's page caching globally
+    #
+    #     # config/alchemy/config.yml
+    #     ...
+    #     cache_pages: false
+    #
+    # == Disable caching on page layout level
+    #
+    #     # config/alchemy/page_layouts.yml
+    #     - name: contact
+    #       cache: false
+    #
+    # == Note:
+    #
+    # This only sets the cache control headers and skips rendering of the page body,
+    # if the cache is fresh.
+    # This does not disable the fragment caching in the views.
+    # So if you don't want a page and it's elements to be cached,
+    # then be sure to not use <% cache element %> in the views.
+    #
+    # @returns Boolean
+    #
+    def cache_page?
+      return false unless caching_enabled?
+      page_layout = PageLayout.get(self.page_layout)
+      page_layout['cache'] != false && page_layout['searchresults'] != true
+    end
+
+    private
+
+    def caching_enabled?
+      Alchemy::Config.get(:cache_pages) &&
+        Rails.application.config.action_controller.perform_caching
+    end
+
   end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -302,46 +302,5 @@ module Alchemy
       end
     end
 
-    describe '#cache_page?' do
-      subject { controller.send(:cache_page?) }
-
-      before do
-        Rails.application.config.action_controller.perform_caching = true
-        controller.instance_variable_set('@page', page)
-      end
-
-      it 'returns true when everthing is alright' do
-        expect(subject).to be true
-      end
-
-      it 'returns false when the Rails app does not perform caching' do
-        Rails.application.config.action_controller.perform_caching = false
-        expect(subject).to be false
-      end
-
-      it 'returns false when there is no page' do
-        controller.instance_variable_set('@page', nil)
-        expect(subject).to be false
-      end
-
-      it 'returns false when caching is deactivated in the Alchemy config' do
-        allow(Alchemy::Config).to receive(:get).with(:cache_pages).and_return(false)
-        expect(subject).to be false
-      end
-
-      it 'returns false when the page layout is set to cache = false' do
-        page_layout = PageLayout.get('news')
-        page_layout['cache'] = false
-        allow(PageLayout).to receive(:get).with('news').and_return(page_layout)
-        expect(subject).to be false
-      end
-
-      it 'returns false when the page layout is set to searchresults = true' do
-        page_layout = PageLayout.get('news')
-        page_layout['searchresults'] = true
-        allow(PageLayout).to receive(:get).with('news').and_return(page_layout)
-        expect(subject).to be false
-      end
-    end
   end
 end

--- a/spec/helpers/elements_helper_spec.rb
+++ b/spec/helpers/elements_helper_spec.rb
@@ -12,7 +12,7 @@ module Alchemy
     end
 
     describe '#render_element' do
-      subject { render_element(element, part) }
+      subject { helper.render_element(element, part) }
 
       context 'with nil element' do
         let(:element) { nil }
@@ -25,6 +25,22 @@ module Alchemy
 
         it "renders the element's view partial" do
           is_expected.to have_selector("##{element.name}_#{element.id}")
+        end
+
+        context 'when page is cached' do
+          it "stores the element within its rendered page for cache invalidation use" do
+            expect(page).to receive(:cache_page?).and_return (true)
+            expect(element).to receive(:store_page).with(page)
+            subject
+          end
+        end
+
+        context 'when page is not cached' do
+          it "does not store the element for cache invalidation & saves a db lookup" do
+            allow(page).to receive(:cache_page?).and_return (false)
+            expect(element).not_to receive(:store_page)
+            subject
+          end
         end
 
         context 'with element view partial not found' do
@@ -40,6 +56,14 @@ module Alchemy
         let(:part) {:editor}
 
         it "renders the element's editor partial" do
+          expect(helper).to receive(:render_essence_editor_by_name)
+          subject
+        end
+
+        it "does not stores the element for cache invalidation" do
+          allow(page).to receive(:cache_page?).and_return true
+
+          expect(element).not_to receive(:store_page).with(page)
           expect(helper).to receive(:render_essence_editor_by_name)
           subject
         end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1737,6 +1737,42 @@ module Alchemy
       end
     end
 
+    describe '#cache_page?' do
+      let(:page) { Page.new(page_layout: "news") }
+      subject { page.cache_page? }
+
+      before { Rails.application.config.action_controller.perform_caching = true }
+      after { Rails.application.config.action_controller.perform_caching = false }
+
+      it 'returns true when everthing is alright' do
+        expect(subject).to be true
+      end
+
+      it 'returns false when the Rails app does not perform caching' do
+        Rails.application.config.action_controller.perform_caching = false
+        expect(subject).to be false
+      end
+
+      it 'returns false when caching is deactivated in the Alchemy config' do
+        allow(Alchemy::Config).to receive(:get).with(:cache_pages).and_return(false)
+        expect(subject).to be false
+      end
+
+      it 'returns false when the page layout is set to cache = false' do
+        page_layout = PageLayout.get('news')
+        page_layout['cache'] = false
+        allow(PageLayout).to receive(:get).with('news').and_return(page_layout)
+        expect(subject).to be false
+      end
+
+      it 'returns false when the page layout is set to searchresults = true' do
+        page_layout = PageLayout.get('news')
+        page_layout['searchresults'] = true
+        allow(PageLayout).to receive(:get).with('news').and_return(page_layout)
+        expect(subject).to be false
+      end
+    end
+
     describe '#slug' do
       context "with parents path saved in urlname" do
         let(:page) { build(:alchemy_page, urlname: 'root/parent/my-name')}


### PR DESCRIPTION
   * when not using page caching

   When page_cache is not turned off, it is unnecessary to store the
   element within the page it is being rendered using the `store_page`
   method. Thereby, the method call is unnecessary, and avoiding it
   saves an SQL query on every cached element render.

```
     Alchemy::Page Exists (2.2ms)  SELECT  DISTINCT 1 AS one FROM `alchemy_pages` INNER JOIN `alchemy_elements_alchemy_pages` ON `alchemy_pages`.`id` = `alchemy_elements_alchemy_pages`.`page_id` WHERE `alchemy_elements_alchemy_pages`.`element_id` = 569 AND `alchemy_pages`.`id` = 2 LIMIT 1
```

  So, if a non-cached page with N elements would result in N such queries.

  This change saves those Exists lookups.

Let me know if you prefer to place the pull request against 3.2 instead of master. 

Solves AlchemyCMS/alchemy_cms/issues/898
Thank you!