### PR TITLE
Re-use #current_root_page from Language in #render_meta_data

### DIFF
--- a/app/helpers/alchemy/pages_helper.rb
+++ b/app/helpers/alchemy/pages_helper.rb
@@ -352,13 +352,13 @@ module Alchemy
       options = default_options.merge(options)
       # render meta description of the root page from language if the current meta description is empty
       if @page.meta_description.blank?
-        description = Language.current.pages.published.language_roots.try(:meta_description)
+        description = Language.current_root_page.try(:meta_description)
       else
         description = @page.meta_description
       end
       # render meta keywords of the root page from language if the current meta keywords is empty
       if @page.meta_keywords.blank?
-        keywords = Language.current.pages.published.language_roots.try(:meta_keywords)
+        keywords = Language.current_root_page.try(:meta_keywords)
       else
         keywords = @page.meta_keywords
       end


### PR DESCRIPTION
  * eliminates duplication

  * fixes bug whereby `first` was missing #render_meta_data

  * allows for a single place to override #current_root_page