### PR TITLE
Allow tags_helper to be used outside of Alchemy engine.

### DIFF
--- a/app/controllers/alchemy/pictures_controller.rb
+++ b/app/controllers/alchemy/pictures_controller.rb
@@ -6,6 +6,8 @@ module Alchemy
 
     before_filter :ensure_secure_params
 
+    helper_method :resource_url_proxy
+
     load_and_authorize_resource
 
     def show

--- a/app/controllers/alchemy/pictures_controller.rb
+++ b/app/controllers/alchemy/pictures_controller.rb
@@ -32,6 +32,10 @@ module Alchemy
       respond_to { |format| send_image(@picture.image_file, format) }
     end
 
+    def resource_url_proxy
+      alchemy
+    end
+
     private
 
     def ensure_secure_params

--- a/app/helpers/alchemy/admin/tags_helper.rb
+++ b/app/helpers/alchemy/admin/tags_helper.rb
@@ -18,7 +18,7 @@ module Alchemy
           li_s << content_tag('li', name: tag.name, class: tag_list_tag_active?(tag, params) ? 'active' : nil) do
             link_to(
               "#{tag.name} (#{tag.count})",
-              url_for(
+              resource_url_proxy.url_for(
                 params.delete_if { |k, v| k == "page" }.merge(
                   action: 'index',
                   tagged_with: tags

--- a/app/views/alchemy/admin/attachments/_tag_list.html.erb
+++ b/app/views/alchemy/admin/attachments/_tag_list.html.erb
@@ -7,7 +7,7 @@
 <% if p[:tagged_with].present? %>
   <%= link_to(
     render_icon('delete-small') + _t('Remove tag filter'),
-    url_for(p.delete_if { |k, v| k == "tagged_with" }.merge(action: 'index')),
+    resource_url_proxy.url_for(p.delete_if { |k, v| k == "tagged_with" }.merge(action: 'index')),
     remote: request.xhr?,
     class: 'button small with_icon please_wait'
   ) %>

--- a/app/views/alchemy/admin/pictures/_tag_list.html.erb
+++ b/app/views/alchemy/admin/pictures/_tag_list.html.erb
@@ -8,7 +8,7 @@
   <% if p[:tagged_with].present? %>
     <%= link_to(
       render_icon('delete-small') + _t('Remove tag filter'),
-      url_for(p.delete_if { |k, v| k == "tagged_with" }.merge(action: 'index')),
+      resource_url_proxy.url_for(p.delete_if { |k, v| k == "tagged_with" }.merge(action: 'index')),
       remote: request.xhr?,
       class: 'button small with_icon please_wait'
     ) %>


### PR DESCRIPTION
I'm using a custom admin section subclassed from `ResourcesController` with a model with tagging. This change allows the `tags_helper` to be used outside of the Alchemy rails engine.