### PR TITLE
Respect :reverse flag as per documentation

### DIFF
--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -76,7 +76,8 @@ module Alchemy
     def render_elements(options = {})
       options = {
         from_page: @page,
-        render_format: 'html'
+        render_format: 'html',
+        reverse: false
       }.update(options)
 
       pages = pages_holding_elements(options.delete(:from_page))
@@ -89,7 +90,11 @@ module Alchemy
       elements = collect_elements_from_pages(pages, options)
 
       if options[:sort_by].present?
-        elements = sort_elements_by_content(elements, options.delete(:sort_by))
+        elements = sort_elements_by_content(
+          elements,
+          options.delete(:sort_by),
+          options[:reverse]
+        )
       end
 
       render_element_view_partials(elements, options)
@@ -224,14 +229,17 @@ module Alchemy
     #
     # @param [Array] elements - The elements you want to sort
     # @param [String] content_name - The name of the content you want to sort by
+    # @param [Boolean] reverse - Reverse the sorted elements order
     #
     # @return [Array]
     #
-    def sort_elements_by_content(elements, content_name)
-      elements.sort_by do |element|
+    def sort_elements_by_content(elements, content_name, reverse = false)
+      sorted_elements = elements.sort_by do |element|
         content = element.content_by_name(content_name)
         content ? content.ingredient.to_s : ''
       end
+
+      reverse ? sorted_elements.reverse : sorted_elements
     end
 
     private

--- a/spec/helpers/elements_helper_spec.rb
+++ b/spec/helpers/elements_helper_spec.rb
@@ -136,12 +136,28 @@ module Alchemy
         it { is_expected.to be_blank }
       end
 
+      context 'with sort_by and reverse option given' do
+        let(:options)           { {sort_by: true, reverse: true} }
+        let(:sorted_elements) { [another_element, element] }
+
+        before do
+          expect(elements).to receive(:sort_by).and_return(sorted_elements)
+          expect(sorted_elements).to receive(:reverse).and_return(elements)
+          expect(page).to receive(:find_elements).and_return(elements)
+        end
+
+        it "renders the sorted elements in reverse order" do
+          is_expected.not_to be_blank
+        end
+      end
+
       context 'with sort_by option given' do
         let(:options)         { {sort_by: 'title'} }
         let(:sorted_elements) { [another_element, element] }
 
         before do
           expect(elements).to receive(:sort_by).and_return(sorted_elements)
+          expect(elements).not_to receive(:reverse)
           expect(page).to receive(:find_elements).and_return(elements)
         end
 


### PR DESCRIPTION
As per the docs this fixes `render_elements` to correctly reverse the order of rendered elements when the `:reverse` option is true.