### PR TITLE
Directly updates content position in database

### DIFF
--- a/app/controllers/alchemy/admin/contents_controller.rb
+++ b/app/controllers/alchemy/admin/contents_controller.rb
@@ -33,9 +33,10 @@ module Alchemy
       end
 
       def order
-        params[:content_ids].each do |id|
-          content = Content.find(id)
-          content.move_to_bottom
+        Content.transaction do
+          params[:content_ids].each_with_index do |id, idx|
+            Content.where(id: id).update_all(position: idx + 1)
+          end
         end
         @notice = _t("Successfully saved content position")
       end

--- a/spec/controllers/admin/contents_controller_spec.rb
+++ b/spec/controllers/admin/contents_controller_spec.rb
@@ -14,7 +14,6 @@ module Alchemy
         expect(Element).to receive(:find).and_return(element)
       end
 
-
       describe '#create' do
         let(:element) { build_stubbed(:element, name: 'headline') }
 
@@ -61,11 +60,17 @@ module Alchemy
 
     describe "#order" do
       context "with content_ids in params" do
+        let(:element) do
+          create(:element, name: 'all_you_can_eat', create_contents_after_create: true)
+        end
+
+        let(:content_ids) { element.contents.pluck(:id).shuffle }
+
         it "should reorder the contents" do
-          content_ids = element.contents.essence_texts.pluck(:id)
-          xhr :post, :order, {content_ids: content_ids.reverse}
+          xhr :post, :order, {content_ids: content_ids}
+
           expect(response.status).to eq(200)
-          expect(element.contents.essence_texts.pluck(:id)).to eq(content_ids.reverse)
+          expect(element.contents(true).pluck(:id)).to eq(content_ids)
         end
       end
     end

--- a/spec/features/admin/page_creation_feature_spec.rb
+++ b/spec/features/admin/page_creation_feature_spec.rb
@@ -30,8 +30,8 @@ module Alchemy
 
           it "the create page tab is visible by default" do
             within('#overlay_tabs') do
-              expect(find '#create_page_tab').to be_visible
-              expect(find '#paste_page_tab').to_not be_visible
+              expect(page).to have_selector('#create_page_tab', visible: true)
+              expect(page).to have_selector('#paste_page_tab')
             end
           end
 


### PR DESCRIPTION
Using `acts_as_lists` `#move_to_bottom` causes strange errors while
drag'n'drop sorting contents. 

Using a direct SQL `UPDATE` inside an
transaction ensures that position always reflects user sort order.