### PR TITLE
Directly updates content position in database

### DIFF
--- a/app/controllers/alchemy/admin/contents_controller.rb
+++ b/app/controllers/alchemy/admin/contents_controller.rb
@@ -33,9 +33,10 @@ module Alchemy
       end
 
       def order
-        params[:content_ids].each do |id|
-          content = Content.find(id)
-          content.move_to_bottom
+        Content.transaction do
+          params[:content_ids].each_with_index do |id, idx|
+            Content.where(id: id).update_all(position: idx + 1)
+          end
         end
         @notice = _t("Successfully saved content position")
       end

--- a/spec/controllers/admin/contents_controller_spec.rb
+++ b/spec/controllers/admin/contents_controller_spec.rb
@@ -60,11 +60,17 @@ module Alchemy
 
     describe "#order" do
       context "with content_ids in params" do
+        let(:element) do
+          create(:element, name: 'all_you_can_eat', create_contents_after_create: true)
+        end
+
+        let(:content_ids) { element.contents.pluck(:id).shuffle }
+
         it "should reorder the contents" do
-          content_ids = element.contents.essence_texts.pluck(:id)
-          alchemy_xhr :post, :order, {content_ids: content_ids.reverse}
+          alchemy_xhr :post, :order, {content_ids: content_ids}
+
           expect(response.status).to eq(200)
-          expect(element.contents.essence_texts.pluck(:id)).to eq(content_ids.reverse)
+          expect(element.contents(true).pluck(:id)).to eq(content_ids)
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,6 @@ require 'alchemy/test_support/factories'
 
 require_relative "support/hint_examples.rb"
 require_relative "support/transformation_examples.rb"
-require_relative "support/rspec-activemodel-mocks_patch.rb"
 
 ActionMailer::Base.delivery_method = :test
 ActionMailer::Base.perform_deliveries = true

--- a/spec/support/rspec-activemodel-mocks_patch.rb
+++ b/spec/support/rspec-activemodel-mocks_patch.rb
@@ -1,8 +1,0 @@
-# Manually applied the patch from https://github.com/jdelStrother/rspec-activemodel-mocks/commit/1211c347c5a574739616ccadf4b3b54686f9051f
-if Gem.loaded_specs['rspec-activemodel-mocks'].version.to_s != "1.0.1"
-  raise "RSpec-ActiveModel-Mocks version has changed, please check if the behaviour has already been fixed: https://github.com/rspec/rspec-activemodel-mocks/pull/10
-If so, this patch might be obsolete-"
-end
-RSpec::ActiveModel::Mocks::Mocks::ActiveRecordInstanceMethods.class_eval do
-  alias_method :_read_attribute, :[]
-end


### PR DESCRIPTION
Using `acts_as_lists` `#move_to_bottom` causes strange errors while
drag'n'drop sorting contents. 

Using a direct SQL UPDATE inside an
transaction ensures that position always reflects user sort order.