### PR TITLE
Unify Alchemy translation methods

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.char_counter.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.char_counter.js.coffee
@@ -3,7 +3,7 @@ class window.Alchemy.CharCounter
   constructor: (field) ->
     @$field = $(field)
     @max_chars = @$field.data('alchemy-char-counter')
-    @text = Alchemy._t('allowed_chars', @max_chars)
+    @text = Alchemy.t('allowed_chars', @max_chars)
     @$display = $('<small class="alchemy-char-counter"/>')
     @$field.after(@$display)
     countChars.call(this)

--- a/app/assets/javascripts/alchemy/alchemy.dirty.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.dirty.js.coffee
@@ -19,7 +19,7 @@ $.extend Alchemy,
 
   pageUnload: ->
     Alchemy.pleaseWaitOverlay(false)
-    Alchemy._t('page_dirty_notice')
+    Alchemy.t('page_dirty_notice')
 
   setElementClean: (element) ->
     $element = $(element)
@@ -46,10 +46,10 @@ $.extend Alchemy,
       callback = ->
         window.location.href = element.pathname
     if Alchemy.isPageDirty()
-      Alchemy.openConfirmDialog Alchemy._t('page_dirty_notice'),
-        title: Alchemy._t('warning')
-        ok_label: Alchemy._t('ok')
-        cancel_label: Alchemy._t('cancel')
+      Alchemy.openConfirmDialog Alchemy.t('page_dirty_notice'),
+        title: Alchemy.t('warning')
+        ok_label: Alchemy.t('ok')
+        cancel_label: Alchemy.t('cancel')
         on_ok: ->
           window.onbeforeunload = undefined
           Alchemy.pleaseWaitOverlay()

--- a/app/assets/javascripts/alchemy/alchemy.element_editors.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.element_editors.js.coffee
@@ -120,10 +120,10 @@ Alchemy.ElementEditors =
   toggle: (id, text) ->
     el = $("#element_#{id}")
     if Alchemy.isElementDirty(el)
-      Alchemy.openConfirmDialog Alchemy._t('element_dirty_notice'),
-        title: Alchemy._t('warning')
-        ok_label: Alchemy._t('ok')
-        cancel_label: Alchemy._t('cancel')
+      Alchemy.openConfirmDialog Alchemy.t('element_dirty_notice'),
+        title: Alchemy.t('warning')
+        ok_label: Alchemy.t('ok')
+        cancel_label: Alchemy.t('cancel')
         on_ok: =>
           @toggleFold(id)
       false

--- a/app/assets/javascripts/alchemy/alchemy.file_progress.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.file_progress.js.coffee
@@ -60,4 +60,4 @@ Alchemy.FileProgress::setCancelled = ->
     $(this).remove()
 
 Alchemy.FileProgress::setStatus = (status) ->
-  @$fileProgressStatus.text Alchemy._t(status)
+  @$fileProgressStatus.text Alchemy.t(status)

--- a/app/assets/javascripts/alchemy/alchemy.hotkeys.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.hotkeys.js.coffee
@@ -31,7 +31,7 @@ Alchemy.Hotkeys = (scope) ->
     $(document).on 'keypress', (e) ->
       if !$(e.target).is('input, textarea') && String.fromCharCode(e.which) == '?'
         Alchemy.openDialog '/admin/help',
-          title: Alchemy._t('help')
+          title: Alchemy.t('help')
           size: '400x492'
         false
       else

--- a/app/assets/javascripts/alchemy/alchemy.i18n.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.i18n.js.coffee
@@ -22,5 +22,5 @@ Alchemy.I18n =
 
 # Global utility method for translating a given string
 #
-Alchemy._t = (key, replacement) ->
+Alchemy.t = (key, replacement) ->
   Alchemy.I18n.translate(key, replacement)

--- a/app/assets/javascripts/alchemy/alchemy.link_dialog.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.link_dialog.js.coffee
@@ -215,7 +215,7 @@ class window.Alchemy.LinkDialog extends Alchemy.Dialog
 
   # Shows validation errors
   showValidationError: ->
-    $('#errors ul', @dialog_body).html("<li>#{Alchemy._t('url_validation_failed')}</li>")
+    $('#errors ul', @dialog_body).html("<li>#{Alchemy.t('url_validation_failed')}</li>")
     $('#errors', @dialog_body).show()
 
   # Populates the internal anchors select
@@ -227,7 +227,7 @@ class window.Alchemy.LinkDialog extends Alchemy.Dialog
         if element.id
           @$internal_anchor.append("<option value='#{element.id}'>##{element.id}</option>")
     else
-      @$internal_anchor.html("<option>#{Alchemy._t('No anchors found')}</option>")
+      @$internal_anchor.html("<option>#{Alchemy.t('No anchors found')}</option>")
     @$internal_anchor.change (e) =>
       # deselect any selected page from page tree
       @deselectPage()

--- a/app/assets/javascripts/alchemy/alchemy.preview.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.preview.js.coffee
@@ -43,7 +43,7 @@ Alchemy.initAlchemyPreviewMode = ($) ->
         @$previewElements = $elements
         $elements.mouseover (e) =>
           $el = $(e.delegateTarget)
-          $el.attr("title", Alchemy._t('click_to_edit'))
+          $el.attr("title", Alchemy.t('click_to_edit'))
           $el.css(@getStyle("hover")) unless $el.hasClass("selected")
           return
         $elements.mouseout (e) =>

--- a/app/assets/javascripts/alchemy/alchemy.sitemap.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.sitemap.js.coffee
@@ -27,10 +27,10 @@ Alchemy.Sitemap =
     self.filter_field_clear.show()
     length = results.length
     if length == 1
-      self.display.show().text("1 #{Alchemy._t('page_found')}")
+      self.display.show().text("1 #{Alchemy.t('page_found')}")
       $.scrollTo(results[0], {duration: 400, offset: -80})
     else if length > 1
-      self.display.show().text("#{length} #{Alchemy._t('pages_found')}")
+      self.display.show().text("#{length} #{Alchemy.t('pages_found')}")
     else
       self.items.removeClass('no-match highlight')
       self.display.hide()

--- a/app/controllers/alchemy/admin/attachments_controller.rb
+++ b/app/controllers/alchemy/admin/attachments_controller.rb
@@ -45,10 +45,10 @@ module Alchemy
           if in_overlay?
             set_instance_variables
           end
-          message = _t('File uploaded succesfully', name: @attachment.name)
+          message = Alchemy.t('File uploaded succesfully', name: @attachment.name)
           render json: {files: [@attachment.to_jq_upload], growl_message: message}, status: :created
         else
-          message = _t('File upload error', error: @attachment.errors[:file].join)
+          message = Alchemy.t('File upload error', error: @attachment.errors[:file].join)
           render json: {files: [@attachment.to_jq_upload], growl_message: message}, status: :unprocessable_entity
         end
       end
@@ -62,7 +62,7 @@ module Alchemy
             page: params[:page],
             q: params[:q]
           ),
-          _t("File successfully updated")
+          Alchemy.t("File successfully updated")
         )
       end
 
@@ -74,7 +74,7 @@ module Alchemy
           page: params[:page],
           q: params[:q]
         )
-        flash[:notice] = _t('File deleted successfully', name: name)
+        flash[:notice] = Alchemy.t('File deleted successfully', name: name)
       end
 
       def download

--- a/app/controllers/alchemy/admin/base_controller.rb
+++ b/app/controllers/alchemy/admin/base_controller.rb
@@ -107,7 +107,7 @@ module Alchemy
       #
       def render_errors_or_redirect(object, redirect_url, flash_notice)
         if object.errors.empty?
-          flash[:notice] = _t(flash_notice)
+          flash[:notice] = Alchemy.t(flash_notice)
           do_redirect_to redirect_url
         else
           render action: (params[:action] == 'update' ? 'edit' : 'new')

--- a/app/controllers/alchemy/admin/contents_controller.rb
+++ b/app/controllers/alchemy/admin/contents_controller.rb
@@ -37,13 +37,13 @@ module Alchemy
             Content.where(id: id).update_all(position: idx + 1)
           end
         end
-        @notice = _t("Successfully saved content position")
+        @notice = Alchemy.t("Successfully saved content position")
       end
 
       def destroy
         @content = Content.find(params[:id])
         @content_dom_id = @content.dom_id
-        @notice = _t("Successfully deleted content", content: @content.name_for_label)
+        @notice = Alchemy.t("Successfully deleted content", content: @content.name_for_label)
         @content.destroy
       end
 

--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -73,8 +73,8 @@ module Alchemy
           @element_validated = @element.update_attributes!(element_params)
         else
           @element_validated = false
-          @notice = _t('Validation failed')
-          @error_message = "<h2>#{@notice}</h2><p>#{_t(:content_validations_headline)}</p>".html_safe
+          @notice = Alchemy.t('Validation failed')
+          @error_message = "<h2>#{@notice}</h2><p>#{Alchemy.t(:content_validations_headline)}</p>".html_safe
         end
       end
 

--- a/app/controllers/alchemy/admin/essence_pictures_controller.rb
+++ b/app/controllers/alchemy/admin/essence_pictures_controller.rb
@@ -26,7 +26,7 @@ module Alchemy
           @default_box = @essence_picture.default_mask(@min_size)
           @initial_box = @essence_picture.cropping_mask || @default_box
         else
-          @no_image_notice = _t(:no_image_for_cropper_found)
+          @no_image_notice = Alchemy.t(:no_image_for_cropper_found)
         end
       end
 

--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -54,7 +54,7 @@ module Alchemy
       def create
         @page = paste_from_clipboard || Page.new(page_params)
         if @page.save
-          flash[:notice] = _t("Page created", name: @page.name)
+          flash[:notice] = Alchemy.t("Page created", name: @page.name)
           do_redirect_to(redirect_path_after_create_page)
         else
           @page_layouts = PageLayout.layouts_for_select(Language.current.id, @page.layoutpage?)
@@ -68,7 +68,7 @@ module Alchemy
       def edit
         # fetching page via before filter
         if page_is_locked?
-          flash[:notice] = _t('This page is locked', name: @page.locker_name)
+          flash[:notice] = Alchemy.t('This page is locked', name: @page.locker_name)
           redirect_to admin_pages_path
         else
           @page.lock_to!(current_alchemy_user)
@@ -90,7 +90,7 @@ module Alchemy
         # stores old page_layout value, because unfurtunally rails @page.changes does not work here.
         @old_page_layout = @page.page_layout
         if @page.update_attributes(page_params)
-          @notice = _t("Page saved", name: @page.name)
+          @notice = Alchemy.t("Page saved", name: @page.name)
           @while_page_edit = request.referer.include?('edit')
         else
           configure
@@ -104,7 +104,7 @@ module Alchemy
         @layoutpage = @page.layoutpage?
         if @page.destroy
           set_root_page
-          @message = _t("Page deleted", name: name)
+          @message = Alchemy.t("Page deleted", name: name)
           flash[:notice] = @message
           respond_to do |format|
             format.js
@@ -141,7 +141,7 @@ module Alchemy
       def unlock
         # fetching page via before filter
         @page.unlock!
-        flash[:notice] = _t(:unlocked_page, name: @page.name)
+        flash[:notice] = Alchemy.t(:unlocked_page, name: @page.name)
         @pages_locked_by_user = Page.from_current_site.locked_by(current_alchemy_user)
         respond_to do |format|
           format.js
@@ -164,13 +164,13 @@ module Alchemy
       def publish
         # fetching page via before filter
         @page.publish!
-        flash[:notice] = _t(:page_published, name: @page.name)
+        flash[:notice] = Alchemy.t(:page_published, name: @page.name)
         redirect_back_or_to_default(admin_pages_path)
       end
 
       def copy_language_tree
         language_root_to_copy_from.copy_children_to(copy_of_language_root)
-        flash[:notice] = _t(:language_pages_copied)
+        flash[:notice] = Alchemy.t(:language_pages_copied)
         redirect_to admin_pages_path
       end
 
@@ -191,7 +191,7 @@ module Alchemy
           end
         end
 
-        flash[:notice] = _t("Pages order saved")
+        flash[:notice] = Alchemy.t("Pages order saved")
         do_redirect_to admin_pages_path
       end
 

--- a/app/controllers/alchemy/admin/pictures_controller.rb
+++ b/app/controllers/alchemy/admin/pictures_controller.rb
@@ -41,10 +41,10 @@ module Alchemy
           if in_overlay?
             set_instance_variables
           end
-          message = _t('Picture uploaded succesfully', name: @picture.name)
+          message = Alchemy.t('Picture uploaded succesfully', name: @picture.name)
           render json: {files: [@picture.to_jq_upload], growl_message: message}, status: :created
         else
-          message = _t('Picture validation error', name: @picture.name)
+          message = Alchemy.t('Picture validation error', name: @picture.name)
           render(
             json: {
               files: [@picture.to_jq_upload],
@@ -63,12 +63,12 @@ module Alchemy
       def update
         if @picture.update(picture_params)
           @message = {
-            body: _t(:picture_updated_successfully, name: @picture.name),
+            body: Alchemy.t(:picture_updated_successfully, name: @picture.name),
             type: 'notice'
           }
         else
           @message = {
-            body: _t(:picture_update_failed),
+            body: Alchemy.t(:picture_update_failed),
             type: 'error'
           }
         end
@@ -80,7 +80,7 @@ module Alchemy
         @pictures.each do |picture|
           picture.update_name_and_tag_list!(params)
         end
-        flash[:notice] = _t("Pictures updated successfully")
+        flash[:notice] = Alchemy.t("Pictures updated successfully")
         redirect_to_index
       end
 
@@ -98,15 +98,15 @@ module Alchemy
             end
           end
           if not_deletable.any?
-            flash[:warn] = _t(
+            flash[:warn] = Alchemy.t(
               "These pictures could not be deleted, because they were in use",
               names: not_deletable.to_sentence
             )
           else
-            flash[:notice] = _t("Pictures deleted successfully", names: names.to_sentence)
+            flash[:notice] = Alchemy.t("Pictures deleted successfully", names: names.to_sentence)
           end
         else
-          flash[:warn] = _t("Could not delete Pictures")
+          flash[:warn] = Alchemy.t("Could not delete Pictures")
         end
       rescue => e
         flash[:error] = e.message
@@ -117,7 +117,7 @@ module Alchemy
       def destroy
         name = @picture.name
         @picture.destroy
-        flash[:notice] = _t("Picture deleted successfully", name: name)
+        flash[:notice] = Alchemy.t("Picture deleted successfully", name: name)
       rescue => e
         flash[:error] = e.message
       ensure
@@ -126,7 +126,7 @@ module Alchemy
 
       def flush
         FileUtils.rm_rf Rails.root.join('public', Alchemy::MountPoint.get, 'pictures')
-        @notice = _t('Picture cache flushed')
+        @notice = Alchemy.t('Picture cache flushed')
       end
 
       private

--- a/app/controllers/alchemy/admin/resources_controller.rb
+++ b/app/controllers/alchemy/admin/resources_controller.rb
@@ -87,7 +87,7 @@ module Alchemy
         when :destroy
           verb = "removed"
         end
-        flash[:notice] = _t("#{resource_handler.resource_name.classify} successfully #{verb}", default: _t("Succesfully #{verb}"))
+        flash[:notice] = Alchemy.t("#{resource_handler.resource_name.classify} successfully #{verb}", default: Alchemy.t("Succesfully #{verb}"))
       end
 
       def is_alchemy_module?

--- a/app/controllers/alchemy/admin/tags_controller.rb
+++ b/app/controllers/alchemy/admin/tags_controller.rb
@@ -18,7 +18,7 @@ module Alchemy
 
       def create
         @tag = ActsAsTaggableOn::Tag.create(tag_params)
-        render_errors_or_redirect @tag, admin_tags_path, _t('New Tag Created')
+        render_errors_or_redirect @tag, admin_tags_path, Alchemy.t('New Tag Created')
       end
 
       def edit
@@ -29,12 +29,12 @@ module Alchemy
         if tag_params[:merge_to]
           @new_tag = ActsAsTaggableOn::Tag.find(tag_params[:merge_to])
           Tag.replace(@tag, @new_tag)
-          operation_text = _t('Replaced Tag') % {old_tag: @tag.name, new_tag: @new_tag.name}
+          operation_text = Alchemy.t('Replaced Tag') % {old_tag: @tag.name, new_tag: @new_tag.name}
           @tag.destroy
         else
           @tag.update_attributes(tag_params)
           @tag.save
-          operation_text = _t(:successfully_updated_tag)
+          operation_text = Alchemy.t(:successfully_updated_tag)
         end
         render_errors_or_redirect @tag, admin_tags_path, operation_text
       end
@@ -42,7 +42,7 @@ module Alchemy
       def destroy
         if request.delete?
           @tag.destroy
-          flash[:notice] = _t(:successfully_deleted_tag)
+          flash[:notice] = Alchemy.t(:successfully_deleted_tag)
         end
         do_redirect_to admin_tags_path
       end

--- a/app/controllers/alchemy/base_controller.rb
+++ b/app/controllers/alchemy/base_controller.rb
@@ -64,7 +64,7 @@ WARN
     end
 
     def handle_redirect_for_user
-      flash[:warning] = _t('You are not authorized')
+      flash[:warning] = Alchemy.t('You are not authorized')
       if can?(:index, :alchemy_admin_dashboard)
         redirect_or_render_notice
       else
@@ -89,7 +89,7 @@ WARN
     end
 
     def handle_redirect_for_guest
-      flash[:info] = _t('Please log in')
+      flash[:info] = Alchemy.t('Please log in')
       if request.xhr?
         render :permission_denied
       else

--- a/app/controllers/alchemy/base_controller.rb
+++ b/app/controllers/alchemy/base_controller.rb
@@ -32,7 +32,8 @@ module Alchemy
 
     # Shortcut for Alchemy::I18n.translate method
     def _t(key, *args)
-      I18n.t(key, *args)
+      ActiveSupport::Deprecation.warn("Alchemys `_t` method is deprecated! Use `Alchemy.t` instead.", caller.unshift)
+      Alchemy.t(key, *args)
     end
 
     # Store current request path into session,

--- a/app/controllers/alchemy/messages_controller.rb
+++ b/app/controllers/alchemy/messages_controller.rb
@@ -94,7 +94,7 @@ module Alchemy
     end
 
     def redirect_to_success_page
-      flash[:notice] = _t(:success, scope: 'contactform.messages')
+      flash[:notice] = Alchemy.t(:success, scope: 'contactform.messages')
       if @element.ingredient(:success_page)
         urlname = @element.ingredient(:success_page)
       elsif mailer_config['forward_to_page'] && mailer_config['mail_success_page']

--- a/app/helpers/alchemy/admin/attachments_helper.rb
+++ b/app/helpers/alchemy/admin/attachments_helper.rb
@@ -4,7 +4,7 @@ module Alchemy
       include Alchemy::Admin::BaseHelper
 
       def mime_to_human(mime)
-        I18n.t(mime, scope: 'mime_types', default: _t(:document))
+        Alchemy.t(mime, scope: 'mime_types', default: Alchemy.t(:document))
       end
     end
   end

--- a/app/helpers/alchemy/admin/base_helper.rb
+++ b/app/helpers/alchemy/admin/base_helper.rb
@@ -21,7 +21,7 @@ module Alchemy
       def current_alchemy_user_name
         name = current_alchemy_user.try(:alchemy_display_name)
         if name.present?
-          content_tag :span, "#{_t('Logged in as')} #{name}", class: 'current-user-name'
+          content_tag :span, "#{Alchemy.t('Logged in as')} #{name}", class: 'current-user-name'
         end
       end
 
@@ -59,7 +59,7 @@ module Alchemy
       # Used for translations selector in Alchemy cockpit user settings.
       def translations_for_select
         Alchemy::I18n.available_locales.map do |locale|
-          [_t(locale, scope: :translations), locale]
+          [Alchemy.t(locale, scope: :translations), locale]
         end
       end
 
@@ -103,8 +103,8 @@ module Alchemy
         content_tag(:div, class: 'js_filter_field_box') do
           concat text_field_tag(nil, nil, options)
           concat render_icon(:search)
-          concat link_to('', '', class: 'js_filter_field_clear', title: _t(:click_to_show_all))
-          concat content_tag(:label, _t(:search), for: options[:id])
+          concat link_to('', '', class: 'js_filter_field_clear', title: Alchemy.t(:click_to_show_all))
+          concat content_tag(:label, Alchemy.t(:search), for: options[:id])
         end
       end
 
@@ -123,23 +123,23 @@ module Alchemy
       # @param [Hash] html_options
       #   HTML options get passed to the link
       #
-      # @option html_options [String] :title (_t(:please_confirm))
+      # @option html_options [String] :title (Alchemy.t(:please_confirm))
       #   The dialog title
       # @option html_options [String] :message (message)
       #   The message displayed in the dialog
-      # @option html_options [String] :ok_label (_t("Yes"))
+      # @option html_options [String] :ok_label (Alchemy.t("Yes"))
       #   The label for the ok button
-      # @option html_options [String] :cancel_label (_t("No"))
+      # @option html_options [String] :cancel_label (Alchemy.t("No"))
       #   The label for the cancel button
       #
       def link_to_confirm_dialog(link_string = "", message = "", url = "", html_options = {})
         link_to(link_string, url,
           html_options.merge(
             'data-alchemy-confirm-delete' => {
-              title: _t(:please_confirm),
+              title: Alchemy.t(:please_confirm),
               message: message,
-              ok_label: _t("Yes"),
-              cancel_label: _t("No")
+              ok_label: Alchemy.t("Yes"),
+              cancel_label: Alchemy.t("No")
             }.to_json
           )
         )
@@ -166,10 +166,10 @@ module Alchemy
       #
       def button_with_confirm(value = "", url = "", options = {}, html_options = {})
         options = {
-          message: _t(:confirm_to_proceed),
-          ok_label: _t("Yes"),
-          title: _t(:please_confirm),
-          cancel_label: _t("No")
+          message: Alchemy.t(:confirm_to_proceed),
+          ok_label: Alchemy.t("Yes"),
+          title: Alchemy.t(:please_confirm),
+          cancel_label: Alchemy.t("No")
         }.merge(options)
         form_tag url, {method: html_options.delete(:method), class: 'button-with-confirm'} do
           button_tag value, html_options.merge('data-alchemy-confirm' => options.to_json)
@@ -187,8 +187,8 @@ module Alchemy
       #
       def delete_button(url, options = {}, html_options = {})
         options = {
-          title: _t('Delete'),
-          message: _t('Are you sure?'),
+          title: Alchemy.t('Delete'),
+          message: Alchemy.t('Are you sure?'),
           icon: 'destroy'
         }.merge(options)
         button_with_confirm(
@@ -208,7 +208,7 @@ module Alchemy
         if content_for?(:title)
           title = content_for(:title)
         else
-          title = _t(controller_name, scope: :modules)
+          title = Alchemy.t(controller_name, scope: :modules)
         end
         "Alchemy CMS - #{title}"
       end
@@ -282,7 +282,7 @@ module Alchemy
       #
       # == Example
       #
-      #   <% label_title = _t("Create #{resource_name}", default: _t('Create')) %>
+      #   <% label_title = Alchemy.t("Create #{resource_name}", default: Alchemy.t('Create')) %>
       #   <% toolbar(
       #     buttons: [
       #       {

--- a/app/helpers/alchemy/admin/contents_helper.rb
+++ b/app/helpers/alchemy/admin/contents_helper.rb
@@ -18,7 +18,7 @@ module Alchemy
         end
         if content.definition.blank?
           warning("Content #{content.name} is missing its definition")
-          title = _t(:content_definition_missing)
+          title = Alchemy.t(:content_definition_missing)
           content_name = %(<span class="warning icon" title="#{title}"></span>&nbsp;#{content_name}).html_safe
         end
         if content.has_validations?

--- a/app/helpers/alchemy/admin/elements_helper.rb
+++ b/app/helpers/alchemy/admin/elements_helper.rb
@@ -73,7 +73,7 @@ module Alchemy
             element_array_for_options(e, object_method, cell)
           end
         end
-        options[_t(:main_content)] = elements_for_main_content(elements).map do |e|
+        options[Alchemy.t(:main_content)] = elements_for_main_content(elements).map do |e|
           element_array_for_options(e, object_method)
         end
         # Remove empty cells

--- a/app/helpers/alchemy/admin/essences_helper.rb
+++ b/app/helpers/alchemy/admin/essences_helper.rb
@@ -19,7 +19,7 @@ module Alchemy
       #
       def render_essence_editor_by_name(element, name, options = {}, html_options = {})
         if element.blank?
-          return warning('Element is nil', _t(:no_element_given))
+          return warning('Element is nil', Alchemy.t(:no_element_given))
         end
         content = element.content_by_name(name)
         if content.nil?
@@ -41,7 +41,7 @@ module Alchemy
       #   Method that is called on the page object to get the value that is passed with the params of the form.
       #
       def pages_for_select(pages = nil, selected = nil, prompt = "Choose page", page_attribute = :id)
-        values = [[_t(prompt), ""]]
+        values = [[Alchemy.t(prompt), ""]]
         pages ||= begin
           nested = true
           Language.current.pages.published.order(:lft)
@@ -75,7 +75,7 @@ module Alchemy
           }.merge(image_options)),
           alt: content.ingredient.name,
           class: 'img_paddingtop',
-          title: _t(:image_name) + ": #{content.ingredient.name}"
+          title: Alchemy.t(:image_name) + ": #{content.ingredient.name}"
         )
       end
 

--- a/app/helpers/alchemy/admin/pages_helper.rb
+++ b/app/helpers/alchemy/admin/pages_helper.rb
@@ -8,10 +8,10 @@ module Alchemy
       def sitemap_folder_link(page)
         if page.folded?(current_alchemy_user.id)
           css_class = 'folded'
-          title = _t('Show childpages')
+          title = Alchemy.t('Show childpages')
         else
           css_class = 'collapsed'
-          title = _t('Hide childpages')
+          title = Alchemy.t('Hide childpages')
         end
         link_to(
           '',
@@ -29,12 +29,12 @@ module Alchemy
       def preview_sizes_for_select
         options_for_select([
           'auto',
-          [_t('240', scope: 'preview_sizes'), 240],
-          [_t('320', scope: 'preview_sizes'), 320],
-          [_t('480', scope: 'preview_sizes'), 480],
-          [_t('768', scope: 'preview_sizes'), 768],
-          [_t('1024', scope: 'preview_sizes'), 1024],
-          [_t('1280', scope: 'preview_sizes'), 1280]
+          [Alchemy.t('240', scope: 'preview_sizes'), 240],
+          [Alchemy.t('320', scope: 'preview_sizes'), 320],
+          [Alchemy.t('480', scope: 'preview_sizes'), 480],
+          [Alchemy.t('768', scope: 'preview_sizes'), 768],
+          [Alchemy.t('1024', scope: 'preview_sizes'), 1024],
+          [Alchemy.t('1280', scope: 'preview_sizes'), 1280]
         ])
       end
 
@@ -57,12 +57,12 @@ module Alchemy
           [
             content_tag(:span, '',
               class: 'inline warning icon',
-              title: _t(:page_definition_missing)
+              title: Alchemy.t(:page_definition_missing)
             ),
-            _t(:page_type)
+            Alchemy.t(:page_type)
           ].join('&nbsp;').html_safe
         else
-          _t(:page_type)
+          Alchemy.t(:page_type)
         end
       end
     end

--- a/app/helpers/alchemy/base_helper.rb
+++ b/app/helpers/alchemy/base_helper.rb
@@ -1,7 +1,8 @@
 module Alchemy
   module BaseHelper
     def _t(key, *args)
-      I18n.t(key, *args)
+      ActiveSupport::Deprecation.warn("Alchemys `_t` method is deprecated! Use `Alchemy.t` instead.", caller.unshift)
+      Alchemy.t(key, *args)
     end
 
     # An alias for truncate.

--- a/app/helpers/alchemy/essences_helper.rb
+++ b/app/helpers/alchemy/essences_helper.rb
@@ -63,9 +63,9 @@ module Alchemy
     def render_essence(content, part = :view, options = {}, html_options = {})
       options = {for_view: {}, for_editor: {}}.update(options)
       if content.nil?
-        return part == :view ? "" : warning('Content is nil', _t(:content_not_found))
+        return part == :view ? "" : warning('Content is nil', Alchemy.t(:content_not_found))
       elsif content.essence.nil?
-        return part == :view ? "" : warning('Essence is nil', _t(:content_essence_not_found))
+        return part == :view ? "" : warning('Essence is nil', Alchemy.t(:content_essence_not_found))
       end
       render partial: "alchemy/essences/#{content.essence_partial_name}_#{part}", locals: {
         content: content,

--- a/app/models/alchemy/attachment.rb
+++ b/app/models/alchemy/attachment.rb
@@ -40,7 +40,7 @@ module Alchemy
     validates_property :ext, of: :file,
       in: Config.get(:uploader)['allowed_filetypes']['attachments'],
       case_sensitive: false,
-      message: I18n.t("not a valid file"),
+      message: Alchemy.t("not a valid file"),
       unless: -> { Config.get(:uploader)['allowed_filetypes']['attachments'].include?('*') }
 
     before_create do

--- a/app/models/alchemy/cell.rb
+++ b/app/models/alchemy/cell.rb
@@ -50,7 +50,7 @@ module Alchemy
       end
 
       def translated_label_for(cell_name)
-        I18n.t(cell_name, scope: 'cell_names', default: cell_name.to_s.humanize)
+        Alchemy.t(cell_name, scope: 'cell_names', default: cell_name.to_s.humanize)
       end
 
       private

--- a/app/models/alchemy/content.rb
+++ b/app/models/alchemy/content.rb
@@ -75,10 +75,10 @@ module Alchemy
       #         foo: Baz
       #
       def translated_label_for(content_name, element_name = nil)
-        I18n.t(
+        Alchemy.t(
           content_name,
           scope: "content_names.#{element_name}",
-          default: I18n.t("content_names.#{content_name}", default: content_name.humanize)
+          default: Alchemy.t("content_names.#{content_name}", default: content_name.humanize)
         )
       end
     end
@@ -261,7 +261,7 @@ module Alchemy
     def default_text(default)
       case default
       when Symbol
-        I18n.t(default, scope: :default_content_texts)
+        Alchemy.t(default, scope: :default_content_texts)
       else
         default
       end

--- a/app/models/alchemy/element/element_essences.rb
+++ b/app/models/alchemy/element/element_essences.rb
@@ -92,7 +92,7 @@ module Alchemy
       messages = []
       essence_errors.each do |content_name, errors|
         errors.each do |error|
-          messages << I18n.t(
+          messages << Alchemy.t(
             "#{name}.#{content_name}.#{error}",
             scope: 'content_validations',
             default: [

--- a/app/models/alchemy/element/presenters.rb
+++ b/app/models/alchemy/element/presenters.rb
@@ -21,7 +21,7 @@ module Alchemy
       # If no translation is found a humanized name is used.
       #
       def display_name_for(name)
-        I18n.t(name, scope: 'element_names', default: name.to_s.humanize)
+        Alchemy.t(name, scope: 'element_names', default: name.to_s.humanize)
       end
     end
 

--- a/app/models/alchemy/language.rb
+++ b/app/models/alchemy/language.rb
@@ -81,7 +81,7 @@ module Alchemy
       if attrib.to_sym == :code
         code
       else
-        I18n.t(code, default: name)
+        Alchemy.t(code, default: name)
       end
     end
 
@@ -101,7 +101,7 @@ module Alchemy
 
     def publicity_of_default_language
       if default? && !public?
-        errors.add(:public, I18n.t("Default language has to be public"))
+        errors.add(:public, Alchemy.t("Default language has to be public"))
         return false
       else
         return true
@@ -110,7 +110,7 @@ module Alchemy
 
     def presence_of_default_language
       if Language.default == self && default_changed?
-        errors.add(:default, I18n.t("We need at least one default."))
+        errors.add(:default, Alchemy.t("We need at least one default."))
         return false
       else
         return true

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -190,10 +190,11 @@ module Alchemy
       end
 
       def link_target_options
-        options = [[I18n.t(:default, scope: 'link_target_options'), '']]
+        options = [[Alchemy.t(:default, scope: 'link_target_options'), '']]
         link_target_options = Config.get(:link_target_options)
         link_target_options.each do |option|
-          options << [I18n.t(option, scope: 'link_target_options', default: option.to_s.humanize), option]
+          options << [Alchemy.t(option, scope: 'link_target_options',
+                                default: option.to_s.humanize), option]
         end
         options
       end
@@ -235,7 +236,7 @@ module Alchemy
       #
       def new_name_for_copy(custom_name, source_name)
         return custom_name if custom_name.present?
-        "#{source_name} (#{I18n.t('Copy')})"
+        "#{source_name} (#{Alchemy.t('Copy')})"
       end
     end
 

--- a/app/models/alchemy/page/page_natures.rb
+++ b/app/models/alchemy/page/page_natures.rb
@@ -58,7 +58,7 @@ module Alchemy
     # @param [Symbol] status_type
     #
     def status_title(status_type)
-      I18n.t(status[status_type].to_s, scope: "page_states.#{status_type}")
+      Alchemy.t(status[status_type].to_s, scope: "page_states.#{status_type}")
     end
 
     # Returns the self#page_layout definition from config/alchemy/page_layouts.yml file.
@@ -76,7 +76,7 @@ module Alchemy
     # Page layout names are defined inside the config/alchemy/page_layouts.yml file.
     # Translate the name in your config/locales language yml file.
     def layout_display_name
-      I18n.t(page_layout, scope: 'page_layout_names')
+      Alchemy.t(page_layout, scope: 'page_layout_names')
     end
 
     # Returns the name for the layout partial

--- a/app/models/alchemy/page/page_users.rb
+++ b/app/models/alchemy/page/page_users.rb
@@ -26,7 +26,7 @@ module Alchemy
     # does not respond to +#name+ it returns +'unknown'+
     #
     def creator_name
-      (creator && creator.try(:name)) || I18n.t('unknown')
+      (creator && creator.try(:name)) || Alchemy.t('unknown')
     end
 
     # Returns the name of the last updater of this page.
@@ -35,7 +35,7 @@ module Alchemy
     # does not respond to +#name+ it returns +'unknown'+
     #
     def updater_name
-      (updater && updater.try(:name)) || I18n.t('unknown')
+      (updater && updater.try(:name)) || Alchemy.t('unknown')
     end
 
     # Returns the name of the user currently editing this page.
@@ -44,7 +44,7 @@ module Alchemy
     # does not respond to +#name+ it returns +'unknown'+
     #
     def locker_name
-      (locker && locker.try(:name)) || I18n.t('unknown')
+      (locker && locker.try(:name)) || Alchemy.t('unknown')
     end
 
     private

--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -37,7 +37,7 @@ module Alchemy
     # to ensure this runs before Dragonfly's before_destroy callback.
     #
     before_destroy unless: :deletable? do
-      raise PictureInUseError, I18n.t(:cannot_delete_picture_notice) % { name: name }
+      raise PictureInUseError, Alchemy.t(:cannot_delete_picture_notice) % { name: name }
     end
 
     # Enables Dragonfly image processing
@@ -56,7 +56,7 @@ module Alchemy
       of: :image_file,
       in: Config.get(:uploader)['allowed_filetypes']['pictures'],
       case_sensitive: false,
-      message: I18n.t("not a valid image")
+      message: Alchemy.t("not a valid image")
 
     acts_as_taggable
 

--- a/app/views/alchemy/_menubar.html.erb
+++ b/app/views/alchemy/_menubar.html.erb
@@ -1,11 +1,11 @@
 <% if !@preview_mode && can?(:edit_content, @page) %>
   <div id="alchemy_menubar" style="display: none">
     <ul>
-      <li><%= link_to _t(:to_alchemy), alchemy.admin_dashboard_url %></li>
-      <li><%= link_to _t(:edit_page), alchemy.edit_admin_page_url(@page) %></li>
+      <li><%= link_to Alchemy.t(:to_alchemy), alchemy.admin_dashboard_url %></li>
+      <li><%= link_to Alchemy.t(:edit_page), alchemy.edit_admin_page_url(@page) %></li>
       <li>
         <%= form_tag Alchemy.logout_path, method: 'delete' do %>
-          <%= button_tag _t(:logout) %>
+          <%= button_tag Alchemy.t(:logout) %>
         <% end %>
       </li>
     </ul>

--- a/app/views/alchemy/admin/attachments/_archive_overlay.html.erb
+++ b/app/views/alchemy/admin/attachments/_archive_overlay.html.erb
@@ -8,13 +8,13 @@
           options: @options.to_json
         ),
         {
-          title: _t(:upload_file),
+          title: Alchemy.t(:upload_file),
           size: '540x550'
         },
-        title: _t(:upload_file),
+        title: Alchemy.t(:upload_file),
         class: 'icon_button'
       ) %>
-    <label><%= _t(:upload_file) %></label>
+    <label><%= Alchemy.t(:upload_file) %></label>
   </div>
   <%= render 'alchemy/admin/partials/remote_search_form' %>
 </div>

--- a/app/views/alchemy/admin/attachments/_attachment.html.erb
+++ b/app/views/alchemy/admin/attachments/_attachment.html.erb
@@ -12,7 +12,7 @@
         size: "fullscreen"
       },
       {
-        title: _t('View File')
+        title: Alchemy.t('View File')
       }
     ) %>
   <% else %>
@@ -28,14 +28,14 @@
     <%= link_to(
       "",
       alchemy.download_admin_attachment_path(attachment),
-      title: _t("download_file", filename: attachment.file_name),
+      title: Alchemy.t("download_file", filename: attachment.file_name),
       class: "icon file_download"
     ) %>
   <% end %>
   <% if can?(:destroy, attachment) %>
     <%= link_to_confirm_dialog(
       "",
-      _t(:confirm_to_delete_file),
+      Alchemy.t(:confirm_to_delete_file),
       alchemy.admin_attachment_path(
         id: attachment,
         q: params[:q],
@@ -44,7 +44,7 @@
       ),
       {
         class: 'icon file_delete',
-        title: _t(:delete_file)
+        title: Alchemy.t(:delete_file)
       }
     ) %>
   <% end %>
@@ -52,11 +52,11 @@
     <%= link_to_dialog("",
       alchemy.edit_admin_attachment_path(attachment, q: params[:q], page: params[:page]),
       {
-        title: _t(:rename_file),
+        title: Alchemy.t(:rename_file),
         size: '380x250'
       },
       class: 'icon file_edit',
-      title: _t(:rename_file)
+      title: Alchemy.t(:rename_file)
     ) %>
   <% end %>
   </td>

--- a/app/views/alchemy/admin/attachments/_files_list.html.erb
+++ b/app/views/alchemy/admin/attachments/_files_list.html.erb
@@ -1,12 +1,12 @@
 <% if @attachments.blank? && params[:q].blank? %>
 <div class="info" id="no_files_notice">
   <%= render_icon('info') %>
-  <%= _t(:no_files_in_archive) %>
+  <%= Alchemy.t(:no_files_in_archive) %>
 </div>
 <% elsif @attachments.blank? %>
 <div class="info">
   <%= render_icon('info') %>
-  <%= _t(:no_search_results) %>
+  <%= Alchemy.t(:no_search_results) %>
 </div>
 <% end %>
 <table id="all_files" class="list">

--- a/app/views/alchemy/admin/attachments/_overlay_file_list.html.erb
+++ b/app/views/alchemy/admin/attachments/_overlay_file_list.html.erb
@@ -1,7 +1,7 @@
 <% if @attachments.empty? %>
   <div class="info">
     <%= render_icon('info') %>
-    <%= _t(:no_files_in_archive) %>
+    <%= Alchemy.t(:no_files_in_archive) %>
   </div>
 <% else %>
   <ul>

--- a/app/views/alchemy/admin/attachments/_tag_list.html.erb
+++ b/app/views/alchemy/admin/attachments/_tag_list.html.erb
@@ -1,12 +1,12 @@
 <% p = params.dup %>
-<h2><%= _t("Filter by tag") %></h2>
+<h2><%= Alchemy.t("Filter by tag") %></h2>
 <%= js_filter_field '#tag_list li' %>
 <ul>
   <%= render_tag_list('Alchemy::Attachment', p) %>
 </ul>
 <% if p[:tagged_with].present? %>
   <%= link_to(
-    render_icon('delete-small') + _t('Remove tag filter'),
+    render_icon('delete-small') + Alchemy.t('Remove tag filter'),
     url_for(p.delete_if { |k, v| k == "tagged_with" }.merge(action: 'index')),
     remote: request.xhr?,
     class: 'button small with_icon please_wait'

--- a/app/views/alchemy/admin/attachments/edit.html.erb
+++ b/app/views/alchemy/admin/attachments/edit.html.erb
@@ -1,10 +1,10 @@
 <%= alchemy_form_for([:admin, @attachment],
   url: {action: :update, q: params[:q], page: params[:page]}) do |f| -%>
   <%= f.input :name, input_html: {autofocus: true} %>
-  <%= f.input :file_name, input_html: {autofocus: true}, hint: _t(:attachment_filename_notice) %>
+  <%= f.input :file_name, input_html: {autofocus: true}, hint: Alchemy.t(:attachment_filename_notice) %>
   <div class="input string">
     <%= f.label :tag_list %>
     <%= render 'alchemy/admin/partials/autocomplete_tag_list', f: f %>
   </div>
-  <%= f.submit _t(:save) %>
+  <%= f.submit Alchemy.t(:save) %>
 <% end %>

--- a/app/views/alchemy/admin/attachments/index.html.erb
+++ b/app/views/alchemy/admin/attachments/index.html.erb
@@ -6,12 +6,12 @@
       url: alchemy.new_admin_attachment_path,
       hotkey: 'alt+n',
       dialog_options: {
-        title: _t(:upload_file),
+        title: Alchemy.t(:upload_file),
         size: '540x515'
       },
-      title: _t(:upload_file),
+      title: Alchemy.t(:upload_file),
       class: 'icon_button',
-      label: _t(:upload_file),
+      label: Alchemy.t(:upload_file),
       if_permitted_to: [:create, Alchemy::Attachment]
     }
   ]

--- a/app/views/alchemy/admin/attachments/new.html.erb
+++ b/app/views/alchemy/admin/attachments/new.html.erb
@@ -1,7 +1,7 @@
 <%= form_for [:admin, @attachment], html: {multipart: true} do |f| %>
   <%= render 'alchemy/admin/partials/upload_form', {
       file_types: configuration(:uploader)['allowed_filetypes']['attachments'],
-      file_types_description: _t(:documents),
+      file_types_description: Alchemy.t(:documents),
       redirect_url: admin_attachments_path(
         swap: @swap,
         element_id: @element ? @element.id : nil,
@@ -9,6 +9,6 @@
         options: @options ? @options.to_json : nil),
       model_name: 'attachment',
       file_attribute: 'file',
-      item_type: _t(:files)
+      item_type: Alchemy.t(:files)
     } %>
 <% end %>

--- a/app/views/alchemy/admin/clipboard/clear.js.erb
+++ b/app/views/alchemy/admin/clipboard/clear.js.erb
@@ -1,3 +1,3 @@
-$("#clipboard_items").replaceWith("<%= j render_message { _t('No items in your clipboard') } -%>");
+$("#clipboard_items").replaceWith("<%= j render_message { Alchemy.t('No items in your clipboard') } -%>");
 $('#clipboard_button .icon.clipboard').removeClass('full');
 Alchemy.pleaseWaitOverlay(false);

--- a/app/views/alchemy/admin/clipboard/index.html.erb
+++ b/app/views/alchemy/admin/clipboard/index.html.erb
@@ -1,7 +1,7 @@
 <%- if @clipboard_items.blank? -%>
 <div class="info">
   <%= render_icon('info') %>
-  <%= _t('No items in your clipboard') %>
+  <%= Alchemy.t('No items in your clipboard') %>
 </div>
 <%- else -%>
 <div id="clipboard_items">
@@ -11,12 +11,12 @@
     <li id="clipboard_item_<%= item.id -%>" class="<%= item_class -%>">
       <%= render_icon("clipboard_#{item_class}") %>
       <%= item.class.to_s == 'Alchemy::Element' ? item.display_name_with_preview_text(60) : item.name %>
-      <span class="float_right"><%= link_to(render_icon('delete-small'), alchemy.remove_admin_clipboard_path(remarkable_type: item_class, remarkable_id: item.id), remote: true, method: 'delete', title: _t('Remove item from clipboard')) %></span>
+      <span class="float_right"><%= link_to(render_icon('delete-small'), alchemy.remove_admin_clipboard_path(remarkable_type: item_class, remarkable_id: item.id), remote: true, method: 'delete', title: Alchemy.t('Remove item from clipboard')) %></span>
     </li>
     <%- end -%>
   </ul>
   <p>
-    <%= link_to_confirm_dialog(_t('clear clipboard'), _t('Do you really want to clear the clipboard?'), alchemy.clear_admin_clipboard_path(remarkable_type: params[:remarkable_type]), class: 'button') %>
+    <%= link_to_confirm_dialog(Alchemy.t('clear clipboard'), Alchemy.t('Do you really want to clear the clipboard?'), alchemy.clear_admin_clipboard_path(remarkable_type: params[:remarkable_type]), class: 'button') %>
   </p>
 </div>
 <%- end -%>

--- a/app/views/alchemy/admin/clipboard/insert.js.erb
+++ b/app/views/alchemy/admin/clipboard/insert.js.erb
@@ -8,11 +8,11 @@ $('#element_area .sortable_cell').sortable('refresh');
 
 <% end -%>
 
-Alchemy.growl('<%= j _t("item moved to clipboard", name: @item.class.to_s == "Alchemy::Element" ? @item.display_name_with_preview_text : @item.name) %>');
+Alchemy.growl('<%= j Alchemy.t("item moved to clipboard", name: @item.class.to_s == "Alchemy::Element" ? @item.display_name_with_preview_text : @item.name) %>');
 
 <% else -%>
 
-Alchemy.growl('<%= j _t("item copied to clipboard", name: @item.class.to_s == "Alchemy::Element" ? @item.display_name_with_preview_text : @item.name) %>')
+Alchemy.growl('<%= j Alchemy.t("item copied to clipboard", name: @item.class.to_s == "Alchemy::Element" ? @item.display_name_with_preview_text : @item.name) %>')
 
 <% end -%>
 

--- a/app/views/alchemy/admin/clipboard/remove.js.erb
+++ b/app/views/alchemy/admin/clipboard/remove.js.erb
@@ -1,10 +1,10 @@
 (function($) {
 
   $("#clipboard_item_<%= @item.id -%>").remove();
-  Alchemy.growl('<%= _t("item removed from clipboard", :name => @item.class.to_s == "Element" ? @item.display_name_with_preview_text : @item.name) -%>');
+  Alchemy.growl('<%= Alchemy.t("item removed from clipboard", :name => @item.class.to_s == "Element" ? @item.display_name_with_preview_text : @item.name) -%>');
 <%- if @clipboard.blank? -%>
   $('#clipboard_button .icon.clipboard').removeClass('full');
-  $("#clipboard_items").replaceWith("<p><%= _t('No items in your clipboard') -%></p>");
+  $("#clipboard_items").replaceWith("<p><%= Alchemy.t('No items in your clipboard') -%></p>");
 <%- end -%>
 
 })(jQuery);

--- a/app/views/alchemy/admin/contents/_missing.html.erb
+++ b/app/views/alchemy/admin/contents/_missing.html.erb
@@ -1,8 +1,8 @@
 <div class="content_editor missing" data-element-<%= element.id %>-missing-content="<%= name %>">
   <label><%= Alchemy::Content.translated_label_for(name, element.name) %></label>
   <%= render_message :warning do %>
-    <p><%= _t(:content_not_found) %></p>
-    <%= link_to _t(:create),
+    <p><%= Alchemy.t(:content_not_found) %></p>
+    <%= link_to Alchemy.t(:create),
       alchemy.admin_contents_path(
         content: {
           element_id: element.id,

--- a/app/views/alchemy/admin/contents/create.js.erb
+++ b/app/views/alchemy/admin/contents/create.js.erb
@@ -16,7 +16,7 @@ $("<%= @content_dom_id %>").before('<%= j(
   )
 ) %>');
 Alchemy.Buttons.enable();
-Alchemy.growl('<%= j _t("Successfully added content") % {content: @content.name_for_label} %>')
+Alchemy.growl('<%= j Alchemy.t("Successfully added content") % {content: @content.name_for_label} %>')
 
 <% end %>
 

--- a/app/views/alchemy/admin/contents/new.html.erb
+++ b/app/views/alchemy/admin/contents/new.html.erb
@@ -3,9 +3,9 @@
   <%= hidden_field_tag('options', @options.to_json) %>
   <%= f.input :name, collection: @contents.map { |content|
       [
-        _t(content['name'], scope: 'content_names', default: content['name'].humanize),
+        Alchemy.t(content['name'], scope: 'content_names', default: content['name'].humanize),
         content['name']
       ]
     }, include_blank: false, input_html: {class: 'alchemy_selectbox'} %>
-  <%= f.submit _t(:create) %>
+  <%= f.submit Alchemy.t(:create) %>
 <% end %>

--- a/app/views/alchemy/admin/dashboard/_locked_pages.html.erb
+++ b/app/views/alchemy/admin/dashboard/_locked_pages.html.erb
@@ -1,9 +1,9 @@
 <div class="widget">
-  <h2><%= _t('Currently locked pages') %>:</h2>
+  <h2><%= Alchemy.t('Currently locked pages') %>:</h2>
   <table>
   <% if @all_locked_pages.blank? %>
     <tr class="even">
-      <td><%= _t('no pages') %></td>
+      <td><%= Alchemy.t('no pages') %></td>
     </tr>
   <% else %>
     <% @all_locked_pages.each do |page| %>
@@ -13,11 +13,11 @@
         <%= link_to(page.name, alchemy.edit_admin_page_path(page)) %>
       </td>
       <td>
-        <small><%= _t(:me) %></small>
+        <small><%= Alchemy.t(:me) %></small>
       </td>
       <td>
         <%= form_tag(alchemy.unlock_admin_page_path(page, :redirect_to => alchemy.admin_dashboard_url)) do %>
-          <button class="icon_button small" title="<%= _t(:explain_unlocking) %>">
+          <button class="icon_button small" title="<%= Alchemy.t(:explain_unlocking) %>">
             <%= render_icon('close small') %>
           </button>
         <% end %>

--- a/app/views/alchemy/admin/dashboard/_recent_pages.html.erb
+++ b/app/views/alchemy/admin/dashboard/_recent_pages.html.erb
@@ -1,9 +1,9 @@
 <div class="widget">
-  <h2><%= _t('Your last updated pages') %>:</h2>
+  <h2><%= Alchemy.t('Your last updated pages') %>:</h2>
   <table>
   <% if @last_edited_pages.blank? %>
     <tr class="even">
-      <td><%= _t('no pages') %></td>
+      <td><%= Alchemy.t('no pages') %></td>
     </tr>
   <% else %>
     <% @last_edited_pages.each do |page| %>

--- a/app/views/alchemy/admin/dashboard/_users.html.erb
+++ b/app/views/alchemy/admin/dashboard/_users.html.erb
@@ -1,9 +1,9 @@
 <div class="widget">
-  <h2><%= _t('Who else is online') %>:</h2>
+  <h2><%= Alchemy.t('Who else is online') %>:</h2>
   <table>
   <% if @online_users.blank? %>
     <tr class="even">
-      <td><%= _t('no users') %></td>
+      <td><%= Alchemy.t('no users') %></td>
     </tr>
   <% else %>
     <% @online_users.each do |user| %>

--- a/app/views/alchemy/admin/dashboard/help.html.erb
+++ b/app/views/alchemy/admin/dashboard/help.html.erb
@@ -1,21 +1,21 @@
-<h2><%= _t('Global shortcuts') %></h2>
+<h2><%= Alchemy.t('Global shortcuts') %></h2>
 <ul class="shortcuts">
-  <li><kbd>?</kbd><%= _t('Open help window', scope: 'help.shortcuts') %></li>
-  <li><kbd>esc</kbd><%= _t('Close current dialog', scope: 'help.shortcuts') %></li>
-  <li><kbd>alt</kbd><kbd>q</kbd><%= _t('Open logout dialog', scope: 'help.shortcuts') %></li>
-  <li><kbd>alt</kbd><kbd>f</kbd><%= _t('Focus search field', scope: 'help.shortcuts') %></li>
-  <li><kbd>alt</kbd><kbd>n</kbd><%= _t('Create a new record', scope: 'help.shortcuts') %></li>
+  <li><kbd>?</kbd><%= Alchemy.t('Open help window', scope: 'help.shortcuts') %></li>
+  <li><kbd>esc</kbd><%= Alchemy.t('Close current dialog', scope: 'help.shortcuts') %></li>
+  <li><kbd>alt</kbd><kbd>q</kbd><%= Alchemy.t('Open logout dialog', scope: 'help.shortcuts') %></li>
+  <li><kbd>alt</kbd><kbd>f</kbd><%= Alchemy.t('Focus search field', scope: 'help.shortcuts') %></li>
+  <li><kbd>alt</kbd><kbd>n</kbd><%= Alchemy.t('Create a new record', scope: 'help.shortcuts') %></li>
 </ul>
-<h2><%= _t('Page edit shortcuts') %></h2>
+<h2><%= Alchemy.t('Page edit shortcuts') %></h2>
 <ul class="shortcuts">
-  <li><kbd>alt</kbd><kbd>i</kbd><%= _t('Show page infos', scope: 'help.shortcuts') %></li>
-  <li><kbd>alt</kbd><kbd>n</kbd><%= _t('Create new element', scope: 'help.shortcuts') %></li>
-  <li><kbd>alt</kbd><kbd>e</kbd><%= _t('Edit page properties', scope: 'help.shortcuts') %></li>
-  <li><kbd>alt</kbd><kbd>r</kbd><%= _t('Reload the preview', scope: 'help.shortcuts') %></li>
-  <li><kbd>alt</kbd><kbd>x</kbd><%= _t('Leave the page', scope: 'help.shortcuts') %></li>
+  <li><kbd>alt</kbd><kbd>i</kbd><%= Alchemy.t('Show page infos', scope: 'help.shortcuts') %></li>
+  <li><kbd>alt</kbd><kbd>n</kbd><%= Alchemy.t('Create new element', scope: 'help.shortcuts') %></li>
+  <li><kbd>alt</kbd><kbd>e</kbd><%= Alchemy.t('Edit page properties', scope: 'help.shortcuts') %></li>
+  <li><kbd>alt</kbd><kbd>r</kbd><%= Alchemy.t('Reload the preview', scope: 'help.shortcuts') %></li>
+  <li><kbd>alt</kbd><kbd>x</kbd><%= Alchemy.t('Leave the page', scope: 'help.shortcuts') %></li>
 </ul>
-<h2><%= _t('Library shortcuts') %></h2>
+<h2><%= Alchemy.t('Library shortcuts') %></h2>
 <ul class="shortcuts">
-  <li><kbd>alt</kbd><kbd>n</kbd><%= _t('Open upload form', scope: 'help.shortcuts') %></li>
-  <li><kbd>alt</kbd><kbd>a</kbd><%= _t('Select all pictures', scope: 'help.shortcuts') %></li>
+  <li><kbd>alt</kbd><kbd>n</kbd><%= Alchemy.t('Open upload form', scope: 'help.shortcuts') %></li>
+  <li><kbd>alt</kbd><kbd>a</kbd><%= Alchemy.t('Select all pictures', scope: 'help.shortcuts') %></li>
 </ul>

--- a/app/views/alchemy/admin/dashboard/index.html.erb
+++ b/app/views/alchemy/admin/dashboard/index.html.erb
@@ -2,11 +2,11 @@
   buttons: [
     {
       icon: 'info',
-      label: _t(:info),
+      label: Alchemy.t(:info),
       url: alchemy.dashboard_info_path,
-      title: _t(:info),
+      title: Alchemy.t(:info),
       dialog_options: {
-        title: _t(:info),
+        title: Alchemy.t(:info),
         size: "420x380"
       },
       if_permitted_to: [:info, :alchemy_admin_dashboard],
@@ -19,14 +19,14 @@
 <div id="dashboard">
   <h1>
     <% if @first_time -%>
-    <%= _t(:welcome_note, name: current_alchemy_user.try(:name)) %>
+    <%= Alchemy.t(:welcome_note, name: current_alchemy_user.try(:name)) %>
     <% else -%>
-    <%= _t(:welcome_back_note, name: current_alchemy_user.try(:name)) %>
+    <%= Alchemy.t(:welcome_back_note, name: current_alchemy_user.try(:name)) %>
     <% end -%>
   </h1>
   <% if @last_sign_at %>
   <p>
-    <small><%= _t('Your last login was on', time: l(@last_sign_at)) %></small>
+    <small><%= Alchemy.t('Your last login was on', time: l(@last_sign_at)) %></small>
   </p>
   <% end %>
   <div class="column left">

--- a/app/views/alchemy/admin/dashboard/info.html.erb
+++ b/app/views/alchemy/admin/dashboard/info.html.erb
@@ -1,26 +1,26 @@
 <p class="center"><%= image_tag('alchemy/alchemy-logo.svg') %></p>
 <h2 class="center">
-  <%= _t("Version") %>: <%= @alchemy_version %>
+  <%= Alchemy.t("Version") %>: <%= @alchemy_version %>
 </h2>
 <% if can? :update_check, :alchemy_admin_dashboard %>
 <p class="center" id="update_check">
   <span id="update_available">
     <%= render_icon('warning') %>
-    <%= _t 'Update available' %>
+    <%= Alchemy.t 'Update available' %>
   </span>
   <span id="up_to_date">
     <%= render_icon('ok') %>
-    <%= _t 'Alchemy is up to date' %>
+    <%= Alchemy.t 'Alchemy is up to date' %>
   </span>
   <span id="error">
     <%= render_icon('warning') %>
-    <%= _t 'Update status unavailable' %>
+    <%= Alchemy.t 'Update status unavailable' %>
   </span>
 </p>
 <% end %>
 <div class="info">
   <%= render_icon('info') %>
-  <p><%= _t('Alchemy is open software and itself uses open software and free resources:') %></p>
+  <p><%= Alchemy.t('Alchemy is open software and itself uses open software and free resources:') %></p>
   <ul>
     <li>
       <a href="http://rubyonrails.org" target="_blank">RubyOnRails</a>

--- a/app/views/alchemy/admin/elements/_add_picture.html.erb
+++ b/app/views/alchemy/admin/elements/_add_picture.html.erb
@@ -6,7 +6,7 @@
       options: options
     ),
     {
-      title: _t(:add_image_to_element),
+      title: Alchemy.t(:add_image_to_element),
       size: '780x580',
       padding: false
     }

--- a/app/views/alchemy/admin/elements/_element.html.erb
+++ b/app/views/alchemy/admin/elements/_element.html.erb
@@ -39,13 +39,13 @@
       <% end %>
 
       <% if element.expanded? %>
-        <%= link_to_dialog render_icon(:create) + _t("New Element"),
+        <%= link_to_dialog render_icon(:create) + Alchemy.t("New Element"),
           alchemy.new_admin_element_path(
             parent_element_id: element.id,
             page_id: element.page.id
           ), {
             size: "320x125",
-            title: _t("New Element")
+            title: Alchemy.t("New Element")
           }, class: "button with_icon add-nestable-element-button" %>
       <% end %>
     </div>

--- a/app/views/alchemy/admin/elements/_element_footer.html.erb
+++ b/app/views/alchemy/admin/elements/_element_footer.html.erb
@@ -1,11 +1,11 @@
 <div class="element-footer">
   <% if element.has_validations? %>
     <p class="validation_notice">
-      <span class="validation_indicator">*</span> <%= _t('Mandatory') %>
+      <span class="validation_indicator">*</span> <%= Alchemy.t('Mandatory') %>
     </p>
   <% end %>
 
   <button type="submit" form="element_<%= element.id %>_form" class="button" data-alchemy-button>
-    <%= _t(:save) %>
+    <%= Alchemy.t(:save) %>
   </button>
 </div>

--- a/app/views/alchemy/admin/elements/_element_header.html.erb
+++ b/app/views/alchemy/admin/elements/_element_header.html.erb
@@ -2,7 +2,7 @@
   <span class="element-handle">
     <%= render_icon(:element) %>
     <% if element.definition.blank? %>
-    <span class="warning icon" title="<%= _t(:element_definition_missing) %>"></span>
+    <span class="warning icon" title="<%= Alchemy.t(:element_definition_missing) %>"></span>
     <% else %>
     <%= render_icon("element_#{element.public? ? 'public' : 'draft'}") %>
     <% end %>
@@ -16,7 +16,7 @@
     <%= link_to '', '#', {
       'data-element-toggle' => element.id,
       class: element.folded? ? 'expand_element' : 'fold_element',
-      title: element.folded? ? _t(:show_element_content) : _t(:hide_element_content),
+      title: element.folded? ? Alchemy.t(:show_element_content) : Alchemy.t(:hide_element_content),
       id: "element_#{element.id}_folder"
     } %>
   </span>

--- a/app/views/alchemy/admin/elements/_element_toolbar.html.erb
+++ b/app/views/alchemy/admin/elements/_element_toolbar.html.erb
@@ -9,7 +9,7 @@
         method: :post,
         class: "icon_button"
       ) %>
-      <label><%= _t(:copy_element) %></label>
+      <label><%= Alchemy.t(:copy_element) %></label>
     </div>
     <div class="button_with_label">
       <%= link_to(
@@ -19,7 +19,7 @@
         method: :post,
         class: "icon_button"
       ) %>
-      <label><%= _t(:cut_element) %></label>
+      <label><%= Alchemy.t(:cut_element) %></label>
     </div>
     <div class="button_with_label">
       <%= link_to(
@@ -29,7 +29,7 @@
         class: "icon_button",
         remote: true
       ) -%>
-      <label><%= _t("trash element") %></label>
+      <label><%= Alchemy.t("trash element") %></label>
     </div>
     <div class="button_with_label publish-element-button">
       <%= link_to(
@@ -40,9 +40,9 @@
         class: "icon_button"
       ) %>
       <% if element.public? %>
-        <label><%= _t(:hide_element) %></label>
+        <label><%= Alchemy.t(:hide_element) %></label>
       <% else %>
-        <label><%= _t(:show_element) %></label>
+        <label><%= Alchemy.t(:show_element) %></label>
       <% end %>
     </div>
   </span>

--- a/app/views/alchemy/admin/elements/_new_element_form.html.erb
+++ b/app/views/alchemy/admin/elements/_new_element_form.html.erb
@@ -1,27 +1,27 @@
 <%- if @elements.blank? -%>
   <div class="info">
     <%= render_icon('info') %>
-    <%= _t(:no_more_elements_to_add) %>
+    <%= Alchemy.t(:no_more_elements_to_add) %>
   </div>
 <%- else -%>
   <%= alchemy_form_for [:admin, @element] do |form| %>
     <%= form.hidden_field :page_id %>
   <%- if @page.can_have_cells? -%>
     <%= form.input :name,
-      label: _t(:element_of_type),
+      label: Alchemy.t(:element_of_type),
       collection: grouped_elements_for_select(@elements),
       as: :grouped_select,
       group_method: :second,
-      prompt: _t(:select_element),
+      prompt: Alchemy.t(:select_element),
       input_html: {class: 'alchemy_selectbox', autofocus: true} %>
   <%- else -%>
     <%= form.input :name,
-      label: _t(:element_of_type),
+      label: Alchemy.t(:element_of_type),
       collection: elements_for_select(@elements),
-      prompt: _t(:select_element),
+      prompt: Alchemy.t(:select_element),
       input_html: {class: 'alchemy_selectbox', autofocus: true} %>
   <%- end -%>
     <%= form.hidden_field :parent_element_id, value: @parent_element.try(:id) %>
-    <%= form.submit _t(:add) %>
+    <%= form.submit Alchemy.t(:add) %>
   <%- end -%>
 <%- end -%>

--- a/app/views/alchemy/admin/elements/_picture_gallery_editor.html.erb
+++ b/app/views/alchemy/admin/elements/_picture_gallery_editor.html.erb
@@ -1,6 +1,6 @@
 <%- max_image_count = options[:maximum_amount_of_images] || options[:max_images] -%>
 <div class="content_editor picture_gallery_editor">
-  <label><%= _t("picture_gallery_editor.#{element.name}", default: _t(:picture_gallery_editor)) %></label>
+  <label><%= Alchemy.t("picture_gallery_editor.#{element.name}", default: Alchemy.t(:picture_gallery_editor)) %></label>
   <div class="picture_gallery_images" id="element_<%= element.id %>_contents">
     <%- pictures.each do |picture| -%>
       <%= render_essence_editor(picture, {dragable: (pictures.size > 1)}.merge(options)) %>

--- a/app/views/alchemy/admin/elements/create.js.erb
+++ b/app/views/alchemy/admin/elements/create.js.erb
@@ -9,9 +9,9 @@
 
 <%- if @page.can_have_cells? -%>
   if ($('#cells').length == 0) {
-    Alchemy.buildTabbedCells('<%= _t(:main_content) %>');
+    Alchemy.buildTabbedCells('<%= Alchemy.t(:main_content) %>');
   }
-  Alchemy.selectOrCreateCellTab('<%= @cell_name %>', '<%= @cell.nil? ? _t(:main_content) : @cell.name_for_label %>');
+  Alchemy.selectOrCreateCellTab('<%= @cell_name %>', '<%= @cell.nil? ? Alchemy.t(:main_content) : @cell.name_for_label %>');
 <%- end -%>
 
 <%- if @element.parent_element -%>
@@ -32,7 +32,7 @@
     $element_area.sortable('refresh');
   }
 
-  Alchemy.growl('<%= _t(:successfully_added_element) %>');
+  Alchemy.growl('<%= Alchemy.t(:successfully_added_element) %>');
   Alchemy.closeCurrentDialog();
   Alchemy.Tinymce.init(<%= @element.richtext_contents_ids.to_json %>);
   Alchemy.PreviewWindow.refresh(function() {

--- a/app/views/alchemy/admin/elements/index.html.erb
+++ b/app/views/alchemy/admin/elements/index.html.erb
@@ -1,11 +1,11 @@
 <% if @cells.any? %>
   <div id="cells">
     <ul>
-      <li><a href="#cell_for_other_elements"><%= _t(:main_content) %></a></li>
+      <li><a href="#cell_for_other_elements"><%= Alchemy.t(:main_content) %></a></li>
       <% @elements.each do |cell, elements| %>
         <li>
           <a href="#cell_<%= cell.name %>">
-            <%= _t(cell.name, scope: :cell_names) %>
+            <%= Alchemy.t(cell.name, scope: :cell_names) %>
           </a>
         </li>
       <% end %>

--- a/app/views/alchemy/admin/elements/list.html.erb
+++ b/app/views/alchemy/admin/elements/list.html.erb
@@ -1,16 +1,16 @@
 <%= render_message do %>
-  <p><%= _t(:choose_element_as_target) %></p>
+  <p><%= Alchemy.t(:choose_element_as_target) %></p>
 <% end %>
 <%= form_tag '' do %>
   <%= select_tag "element_from_page_#{@page_id}_to_link",
     options_for_select(
       @elements.collect { |m| [m.display_name_with_preview_text.html_safe, "##{m.dom_id}"] }
     ),
-    prompt: _t(:choose_element_to_link),
+    prompt: Alchemy.t(:choose_element_to_link),
     class: 'elements_from_page_selector alchemy_selectbox',
     autofocus: true
   %>
   <div class="submit">
-    <%= button_tag _t(:apply) %>
+    <%= button_tag Alchemy.t(:apply) %>
   </div>
 <% end %>

--- a/app/views/alchemy/admin/elements/new.html.erb
+++ b/app/views/alchemy/admin/elements/new.html.erb
@@ -3,8 +3,8 @@
 <%- else -%>
 <div id="overlay_tabs">
   <ul>
-    <li><a href="#create_element_tab"><%= _t('New') %></a></li>
-    <li><a href="#paste_element_tab"><%= _t('Paste from clipboard') %></a></li>
+    <li><a href="#create_element_tab"><%= Alchemy.t('New') %></a></li>
+    <li><a href="#paste_element_tab"><%= Alchemy.t('Paste from clipboard') %></a></li>
   </ul>
   <div id="create_element_tab">
     <%= render 'new_element_form' %>
@@ -13,12 +13,12 @@
     <%= alchemy_form_for([:admin, @element]) do |f| %>
       <%= f.hidden_field(:page_id) %>
       <div class="input select">
-        <label for="paste_from_clipboard" class="control-label"><%= _t("Element") %></label>
+        <label for="paste_from_clipboard" class="control-label"><%= Alchemy.t("Element") %></label>
         <%= select_tag 'paste_from_clipboard',
           clipboard_select_tag_options(@clipboard_items),
           class: 'alchemy_selectbox' %>
       </div>
-      <%= f.submit _t(:paste) %>
+      <%= f.submit Alchemy.t(:paste) %>
     <% end %>
   </div>
 </div>

--- a/app/views/alchemy/admin/elements/order.js.erb
+++ b/app/views/alchemy/admin/elements/order.js.erb
@@ -1,7 +1,7 @@
 $('#element_area .ajax-folder').show();
 Alchemy.PreviewWindow.refresh();
 <% if @trashed_element_ids.any? %>
-Alchemy.growl('<%= _t(:successfully_restored_element) -%>');
+Alchemy.growl('<%= Alchemy.t(:successfully_restored_element) -%>');
 <% element_ids = @trashed_element_ids.collect do |id|
                    "#element_area [data-element-id=\"#{id}\"]"
                  end.join(", ").html_safe %>
@@ -9,5 +9,5 @@ Alchemy.growl('<%= _t(:successfully_restored_element) -%>');
 $('<%= element_ids %>').each(function() { this.id = 'element_' + <%= id %> });
 <% end %>
 <% else %>
-Alchemy.growl('<%= _t(:successfully_saved_element_position) -%>');
+Alchemy.growl('<%= Alchemy.t(:successfully_saved_element_position) -%>');
 <% end %>

--- a/app/views/alchemy/admin/elements/publish.js.erb
+++ b/app/views/alchemy/admin/elements/publish.js.erb
@@ -5,11 +5,11 @@ var label = el.find('> .element-toolbar .publish-element-button label');
 <%- if @element.public? -%>
   icon.removeClass('element_draft');
   icon.addClass('element_public');
-  label.text('<%= _t(:hide_element) %>');
+  label.text('<%= Alchemy.t(:hide_element) %>');
 <%- else -%>
   icon.removeClass('element_public');
   icon.addClass('element_draft');
-  label.text('<%= _t(:show_element) %>');
+  label.text('<%= Alchemy.t(:show_element) %>');
 <%- end -%>
 
 Alchemy.reloadPreview();

--- a/app/views/alchemy/admin/elements/trash.js.erb
+++ b/app/views/alchemy/admin/elements/trash.js.erb
@@ -1,6 +1,6 @@
 $('#element_<%= @element.id %>').hide(200, function() {
   $(this).remove();
-  Alchemy.growl('<%= j _t("Element trashed") %>');
+  Alchemy.growl('<%= j Alchemy.t("Element trashed") %>');
   $('#element_area .sortable_cell').sortable('refresh');
   Alchemy.TrashWindow.refresh();
   $('#element_trash_button .icon').addClass('full');

--- a/app/views/alchemy/admin/elements/update.js.erb
+++ b/app/views/alchemy/admin/elements/update.js.erb
@@ -8,7 +8,7 @@
   $el.find('> .element-header').replaceWith('<%= j render("element_header", element: @element) %>');
   $errors.hide();
   Alchemy.setElementSaved($el);
-  Alchemy.growl('<%= _t(:element_saved) %>');
+  Alchemy.growl('<%= Alchemy.t(:element_saved) %>');
   Alchemy.PreviewWindow.refresh(function() {
     Alchemy.ElementEditors.selectElementInPreview(<%= @element.id %>);
   });

--- a/app/views/alchemy/admin/essence_files/edit.html.erb
+++ b/app/views/alchemy/admin/essence_files/edit.html.erb
@@ -6,16 +6,16 @@
   <%- if css_classes.present? -%>
     <%= f.input :css_class,
       collection: css_classes,
-      include_blank: _t('None'),
+      include_blank: Alchemy.t('None'),
       input_html: {class: 'alchemy_selectbox'} %>
   <%- else -%>
     <%= f.input :css_class,
-      label: _t(:position_in_text),
+      label: Alchemy.t(:position_in_text),
       collection: [
-        [_t(:above), "no_float"],
-        [_t(:left), "left"],
-        [_t(:right), "right"]
-      ], include_blank: _t('Layout default'), input_html: {class: 'alchemy_selectbox'} %>
+        [Alchemy.t(:above), "no_float"],
+        [Alchemy.t(:left), "left"],
+        [Alchemy.t(:right), "right"]
+      ], include_blank: Alchemy.t('Layout default'), input_html: {class: 'alchemy_selectbox'} %>
   <%- end -%>
-  <%= f.submit _t(:save) %>
+  <%= f.submit Alchemy.t(:save) %>
 <% end %>

--- a/app/views/alchemy/admin/essence_pictures/crop.html.erb
+++ b/app/views/alchemy/admin/essence_pictures/crop.html.erb
@@ -5,7 +5,7 @@
   <% end %>
 <% else %>
   <%= render_message do %>
-    <%= simple_format _t(:explain_cropping) %>
+    <%= simple_format Alchemy.t(:explain_cropping) %>
   <% end %>
   <div class="thumbnail_background">
     <%= image_tag(
@@ -22,8 +22,8 @@
     <%= f.hidden_field :crop_from %>
     <%= f.hidden_field :crop_size %>
     <%= hidden_field_tag :content_id, @content.id %>
-    <%= f.button "#{render_icon(:true)} #{_t(:apply)}".html_safe, class: 'with_icon' %>
-    <%= link_to _t('Reset Imagemask'), '#', {
+    <%= f.button "#{render_icon(:true)} #{Alchemy.t(:apply)}".html_safe, class: 'with_icon' %>
+    <%= link_to Alchemy.t('Reset Imagemask'), '#', {
       onclick: 'Alchemy.ImageCropper.reset(); return false',
       class: 'reset_mask'
     } %>

--- a/app/views/alchemy/admin/essence_pictures/edit.html.erb
+++ b/app/views/alchemy/admin/essence_pictures/edit.html.erb
@@ -6,23 +6,23 @@
   <%= f.input :alt_tag %>
   <%- if @options[:sizes].present? -%>
     <%= f.input :render_size,
-      collection: [[_t('Layout default'), @options[:image_size]]] + @options[:sizes].to_a,
+      collection: [[Alchemy.t('Layout default'), @options[:image_size]]] + @options[:sizes].to_a,
       include_blank: false,
       input_html: {class: 'alchemy_selectbox'} %>
   <%- end -%>
   <%- if @options[:css_classes].present? -%>
     <%= f.input :css_class,
       collection: @options[:css_classes],
-      include_blank: _t('None'),
+      include_blank: Alchemy.t('None'),
       input_html: {class: 'alchemy_selectbox'} %>
   <%- else -%>
     <%= f.input :css_class,
-      label: _t(:position_in_text),
+      label: Alchemy.t(:position_in_text),
       collection: [
-        [_t(:above), "no_float"],
-        [_t(:left), "left"],
-        [_t(:right), "right"]
-      ], include_blank: _t("Layout default"), input_html: {class: 'alchemy_selectbox'} %>
+        [Alchemy.t(:above), "no_float"],
+        [Alchemy.t(:left), "left"],
+        [Alchemy.t(:right), "right"]
+      ], include_blank: Alchemy.t("Layout default"), input_html: {class: 'alchemy_selectbox'} %>
   <%- end -%>
-  <%= f.submit _t(:save) %>
+  <%= f.submit Alchemy.t(:save) %>
 <% end %>

--- a/app/views/alchemy/admin/languages/_form.html.erb
+++ b/app/views/alchemy/admin/languages/_form.html.erb
@@ -1,7 +1,7 @@
 <%= alchemy_form_for [alchemy, :admin, @language] do |f| %>
   <%= f.input :name, autofocus: true %>
-  <%= f.input :language_code, placeholder: _t(:language_code_placeholder) %>
-  <%= f.input :country_code, as: 'string', placeholder: _t(:country_code_placeholder), hint: _t(:country_code_foot_note) %>
+  <%= f.input :language_code, placeholder: Alchemy.t(:language_code_placeholder) %>
+  <%= f.input :country_code, as: 'string', placeholder: Alchemy.t(:country_code_placeholder), hint: Alchemy.t(:country_code_foot_note) %>
   <%= f.input :frontpage_name %>
   <%= f.input :page_layout,
     collection: Alchemy::PageLayout.all,
@@ -10,5 +10,5 @@
     input_html: {class: 'alchemy_selectbox'} %>
   <%= f.input :public %>
   <%= f.input :default %>
-  <%= f.submit _t(:save) %>
+  <%= f.submit Alchemy.t(:save) %>
 <% end %>

--- a/app/views/alchemy/admin/languages/_language.html.erb
+++ b/app/views/alchemy/admin/languages/_language.html.erb
@@ -29,12 +29,12 @@
       '',
       alchemy.edit_admin_language_path(language),
       {
-        title: _t("Edit"),
+        title: Alchemy.t("Edit"),
         size: "430x415"
       },
       {
         class: "icon edit",
-        title: _t("Edit")
+        title: Alchemy.t("Edit")
       }
     ) -%>
   <%- end -%>

--- a/app/views/alchemy/admin/languages/_table.html.erb
+++ b/app/views/alchemy/admin/languages/_table.html.erb
@@ -31,7 +31,7 @@
   </tbody>
 </table>
 <%- elsif params[:q].present? -%>
-<p><%= _t('Nothing found') %></p>
+<p><%= Alchemy.t('Nothing found') %></p>
 <%- end -%>
 
 <%= paginate @languages, theme: 'alchemy' %>

--- a/app/views/alchemy/admin/languages/index.html.erb
+++ b/app/views/alchemy/admin/languages/index.html.erb
@@ -1,4 +1,4 @@
-<% label_title = _t("Create #{resource_name}", default: _t('Create')) %>
+<% label_title = Alchemy.t("Create #{resource_name}", default: Alchemy.t('Create')) %>
 
 <% toolbar(
   buttons: [

--- a/app/views/alchemy/admin/layoutpages/_layoutpage.html.erb
+++ b/app/views/alchemy/admin/layoutpages/_layoutpage.html.erb
@@ -2,7 +2,7 @@
   <div class="sitemap_page<%= layoutpage.locked ? ' locked' : '' %>">
     <div class="sitemap_left_images">
     <% if layoutpage.definition.blank? %>
-      <span class="inline warning icon" title="<%= _t(:page_definition_missing) %>"></span>
+      <span class="inline warning icon" title="<%= Alchemy.t(:page_definition_missing) %>"></span>
     <% else %>
       <%= render_icon(:page) %>
     <% end %>
@@ -13,11 +13,11 @@
         render_icon('configure_page'),
         alchemy.edit_admin_layoutpage_path(layoutpage),
         {
-          title: _t(:edit_page_properties),
+          title: Alchemy.t(:edit_page_properties),
           size: '410x170'
         },
         class: 'sitemap_tool',
-        title: _t(:edit_page_properties)
+        title: Alchemy.t(:edit_page_properties)
       ) -%>
       <%- end -%>
       <span class="sitemap_sitetools">
@@ -31,13 +31,13 @@
           remote: true,
           method: 'post',
           class: "sitemap_tool",
-          title: _t(:copy_page)
+          title: Alchemy.t(:copy_page)
         ) %>
       <%- end -%>
       <%- if can?(:destroy, layoutpage) -%>
         <%= link_to_confirm_dialog(
           render_icon('delete_page'),
-          _t(:confirm_to_delete_page),
+          Alchemy.t(:confirm_to_delete_page),
           url_for(
             controller: 'pages',
             action: 'destroy',
@@ -45,7 +45,7 @@
           ),
           {
             class: "sitemap_tool",
-            title: _t(:delete_page)
+            title: Alchemy.t(:delete_page)
           }
         ) -%>
       <%- end -%>
@@ -55,7 +55,7 @@
       <%= link_to(
         layoutpage.name,
         alchemy.edit_admin_page_path(layoutpage),
-        title: _t(:edit_page),
+        title: Alchemy.t(:edit_page),
         class: "sitemap_pagename_link #{cycle('even', 'odd')}"
       ) -%>
     </div>

--- a/app/views/alchemy/admin/layoutpages/edit.html.erb
+++ b/app/views/alchemy/admin/layoutpages/edit.html.erb
@@ -1,7 +1,7 @@
 <%= alchemy_form_for [:admin, @page], class: 'edit_page' do |f| %>
   <%= f.input :page_layout,
     collection: @page_layouts,
-    label: @page.definition.blank? ? (%(<span class="inline warning icon" title="#{ _t(:page_definition_missing) }"></span>&nbsp;) + _t(:page_type)).html_safe : _t(:page_type),
+    label: @page.definition.blank? ? (%(<span class="inline warning icon" title="#{ Alchemy.t(:page_definition_missing) }"></span>&nbsp;) + Alchemy.t(:page_type)).html_safe : Alchemy.t(:page_type),
     include_blank: false,
     input_html: {class: 'alchemy_selectbox'} %>
   <%= f.input :name, autofocus: true %>
@@ -11,5 +11,5 @@
       <%= render 'alchemy/admin/partials/autocomplete_tag_list', f: f %>
     </div>
   <% end %>
-  <%= f.submit _t(:save) %>
+  <%= f.submit Alchemy.t(:save) %>
 <% end %>

--- a/app/views/alchemy/admin/layoutpages/index.html.erb
+++ b/app/views/alchemy/admin/layoutpages/index.html.erb
@@ -7,24 +7,24 @@
     url: alchemy.new_admin_page_path(parent_id: @layout_root.id, layoutpage: true),
     hotkey: 'alt+n',
     dialog_options: {
-      title: _t('Add global page'),
+      title: Alchemy.t('Add global page'),
       size: '340x170',
       overflow: true
     },
-    title: _t('Add global page'),
-    label: _t('Add global page'),
+    title: Alchemy.t('Add global page'),
+    label: Alchemy.t('Add global page'),
     if_permitted_to: [:create, Alchemy::Page]
   ) %>
   <%= toolbar_button(
     icon: "clipboard#{clipboard_empty?('pages') ? '' : ' full'}",
     url: alchemy.admin_clipboard_path(remarkable_type: 'pages'),
     dialog_options: {
-      title: _t('Clipboard'),
+      title: Alchemy.t('Clipboard'),
       size: '380x270'
     },
-    title: _t('Show clipboard'),
+    title: Alchemy.t('Show clipboard'),
     id: "clipboard_button",
-    label: _t('Show clipboard')
+    label: Alchemy.t('Show clipboard')
   ) %>
 </div>
 <% end %>

--- a/app/views/alchemy/admin/leave.html.erb
+++ b/app/views/alchemy/admin/leave.html.erb
@@ -1,11 +1,11 @@
 <%= render_message do %>
-  <%= _t("You are about to leave Alchemy") %>
+  <%= Alchemy.t("You are about to leave Alchemy") %>
 <% end %>
 <p class="buttons">
-  <label><%= _t("Do you want to") %></label>
-  <%= link_to _t('stay logged in'), alchemy.root_path, class: 'button' %>
+  <label><%= Alchemy.t("Do you want to") %></label>
+  <%= link_to Alchemy.t('stay logged in'), alchemy.root_path, class: 'button' %>
 </p>
 <%= form_tag Alchemy.logout_path, method: 'delete', class: 'buttons' do %>
-  <label><%= _t('or to completely') %></label>
-  <%= button_tag _t(:logout), autofocus: true %>
+  <label><%= Alchemy.t('or to completely') %></label>
+  <%= button_tag Alchemy.t(:logout), autofocus: true %>
 <% end %>

--- a/app/views/alchemy/admin/legacy_page_urls/_form.html.erb
+++ b/app/views/alchemy/admin/legacy_page_urls/_form.html.erb
@@ -1,5 +1,5 @@
 <%= alchemy_form_for [:admin, @legacy_page_url ||= Alchemy::LegacyPageUrl.new] do |f| %>
   <%= hidden_field_tag :page_id, @page.id %>
   <%= f.input :urlname %>
-  <%= f.submit _t(:save) %>
+  <%= f.submit Alchemy.t(:save) %>
 <% end %>

--- a/app/views/alchemy/admin/legacy_page_urls/_legacy_page_url.html.erb
+++ b/app/views/alchemy/admin/legacy_page_urls/_legacy_page_url.html.erb
@@ -3,11 +3,11 @@
   <td class="tools">
     <%= link_to_dialog render_icon(:edit),
       edit_admin_legacy_page_url_path(legacy_page_url, page_id: @page.id),
-      {size: '400x125', title: _t('Edit link')},
-      {title: _t(:edit)} %>
+      {size: '400x125', title: Alchemy.t('Edit link')},
+      {title: Alchemy.t(:edit)} %>
     <%= link_to_confirm_dialog render_icon(:destroy),
-      _t('Are you sure?'),
+      Alchemy.t('Are you sure?'),
       admin_legacy_page_url_path(legacy_page_url, page_id: @page.id),
-      {title: _t(:remove)} %>
+      {title: Alchemy.t(:remove)} %>
   </td>
 </tr>

--- a/app/views/alchemy/admin/legacy_page_urls/_new.html.erb
+++ b/app/views/alchemy/admin/legacy_page_urls/_new.html.erb
@@ -13,7 +13,7 @@
     <div class="right-column">
       <button class="with_icon">
         <%= render_icon(:create) %>
-        <%= _t(:add) %>
+        <%= Alchemy.t(:add) %>
       </button>
     </div>
   </div>

--- a/app/views/alchemy/admin/pages/_create_language_form.html.erb
+++ b/app/views/alchemy/admin/pages/_create_language_form.html.erb
@@ -1,21 +1,21 @@
 <% if root = Alchemy::Page.rootpage %>
 <div id="create_language_tree_form">
   <%= render_message do %>
-    <h2><%= _t(:language_does_not_exist) %></h2>
+    <h2><%= Alchemy.t(:language_does_not_exist) %></h2>
   <% end %>
 <%- if @language -%>
 
   <%- if @languages_with_page_tree.size >= 1 -%>
     <%= form_tag(alchemy.copy_language_tree_admin_pages_path) do %>
-      <h3><%= _t(:copy_language_tree_heading) %></h3>
-      <p><%= _t(:want_to_make_copy_of_existing_language) %></p>
+      <h3><%= Alchemy.t(:copy_language_tree_heading) %></h3>
+      <p><%= Alchemy.t(:want_to_make_copy_of_existing_language) %></p>
       <div class="input select">
-        <%= label_tag('languages[old_lang_id]', _t('Language tree'), class: 'control-label') %>
+        <%= label_tag('languages[old_lang_id]', Alchemy.t('Language tree'), class: 'control-label') %>
         <%= select_tag("languages[old_lang_id]", options_for_select(@languages_with_page_tree.map{ |l| [l.name, l.id] }), class: "alchemy_selectbox") %>
         <%= hidden_field_tag("languages[new_lang_id]", @language.id) %>
       </div>
       <div class="submit">
-        <%= button_tag _t(:copy) %>
+        <%= button_tag Alchemy.t(:copy) %>
       </div>
     <% end %>
   <%- end -%>
@@ -23,8 +23,8 @@
   <%- if params[:action] == "index" -%>
 
   <%= form_for([:admin, Alchemy::Page.new]) do |form| %>
-    <h3><%= _t(:create_language_tree_heading) %></h3>
-    <p><%= _t(:want_to_create_new_language) %></p>
+    <h3><%= Alchemy.t(:create_language_tree_heading) %></h3>
+    <p><%= Alchemy.t(:want_to_create_new_language) %></p>
     <%= form.hidden_field :name, value: @language.frontpage_name %>
     <%= form.hidden_field :language_id, value: @language.id %>
     <%= form.hidden_field :language_code, value: @language.code %>
@@ -33,7 +33,7 @@
     <%= form.hidden_field :parent_id, value: root.id %>
     <%= form.hidden_field :public, value: Alchemy::Language.all.size == 1 %>
     <div class="submit">
-      <%= form.button _t("create_tree_as_new_language", language: @language.name), autofocus: true %>
+      <%= form.button Alchemy.t("create_tree_as_new_language", language: @language.name), autofocus: true %>
     </div>
   <% end %>
 
@@ -41,7 +41,7 @@
 
 <%- else -%>
 
-  <p><%= _t("Actually this language does not exist. Please create this language first.") %></p>
+  <p><%= Alchemy.t("Actually this language does not exist. Please create this language first.") %></p>
 
 <%- end -%>
 

--- a/app/views/alchemy/admin/pages/_external_link.html.erb
+++ b/app/views/alchemy/admin/pages/_external_link.html.erb
@@ -1,8 +1,8 @@
 <%= form_tag do %>
   <%= render_message do %>
-    <h2><%= _t(:enter_external_link) %></h2>
-    <p><%= _t(:external_link_notice_1) %></p>
-    <p><%= _t(:external_link_notice_2) %></p>
+    <h2><%= Alchemy.t(:enter_external_link) %></h2>
+    <p><%= Alchemy.t(:external_link_notice_1) %></p>
+    <p><%= Alchemy.t(:external_link_notice_2) %></p>
   <% end %>
   <div id="errors" class="errors">
     <ul></ul>
@@ -13,19 +13,19 @@
   </div>
   <div class="input text">
     <label for="external_link_title" class="control-label">
-      <%= _t(:link_title) %>
+      <%= Alchemy.t(:link_title) %>
     </label>
     <%= text_field_tag "external_link_title", '', class: 'link_title' %>
   </div>
   <div class="input select">
     <label for="external_link_target" class="control-label">
-      <%= _t("Open Link in") %>
+      <%= Alchemy.t("Open Link in") %>
     </label>
     <%= select_tag 'external_link_target',
       options_for_select(Alchemy::Page.link_target_options),
       class: 'alchemy_selectbox link_target' %>
   </div>
   <div class="submit">
-    <%= link_to _t(:apply), '#', class: 'create-link button', 'data-link-type' => 'external' %>
+    <%= link_to Alchemy.t(:apply), '#', class: 'create-link button', 'data-link-type' => 'external' %>
   </div>
 <% end %>

--- a/app/views/alchemy/admin/pages/_file_link.html.erb
+++ b/app/views/alchemy/admin/pages/_file_link.html.erb
@@ -1,31 +1,31 @@
 <%= form_tag do %>
   <%= render_message do %>
-    <h2><%= _t(:choose_file_to_link) %></h2>
+    <h2><%= Alchemy.t(:choose_file_to_link) %></h2>
   <% end %>
   <div class="input select">
     <label for="public_filename" class="control-label">
-      <%= _t(:file) %>
+      <%= Alchemy.t(:file) %>
     </label>
     <%= select_tag "public_filename",
       options_for_select(@attachments),
-      prompt: _t('Please choose'),
+      prompt: Alchemy.t('Please choose'),
       class: "alchemy_selectbox" %>
   </div>
   <div class="input text">
     <label for="file_link_title" class="control-label">
-      <%= _t(:link_title) %>
+      <%= Alchemy.t(:link_title) %>
     </label>
     <%= text_field_tag "file_link_title", '', class: 'link_title' %>
   </div>
   <div class="input select">
     <label for="file_link_target" class="control-label">
-      <%= _t("Open Link in") %>
+      <%= Alchemy.t("Open Link in") %>
     </label>
     <%= select_tag 'file_link_target',
       options_for_select(Alchemy::Page.link_target_options),
       class: 'alchemy_selectbox link_target' %>
   </div>
   <div class="submit">
-    <%= link_to _t(:apply), '#', class: 'create-link button', 'data-link-type' => 'file' %>
+    <%= link_to Alchemy.t(:apply), '#', class: 'create-link button', 'data-link-type' => 'file' %>
   </div>
 <% end %>

--- a/app/views/alchemy/admin/pages/_form.html.erb
+++ b/app/views/alchemy/admin/pages/_form.html.erb
@@ -5,7 +5,7 @@
     include_blank: false,
     input_html: {class: 'alchemy_selectbox'} %>
   <div class="input check_boxes">
-    <label class="control-label"><%= _t(:page_status) %></label>
+    <label class="control-label"><%= Alchemy.t(:page_status) %></label>
     <div class="control_group">
       <label class="checkbox">
         <%= f.check_box :public %>
@@ -27,14 +27,14 @@
     <% end %>
     </div>
   </div>
-  <h2><%= _t(:names) %></h2>
+  <h2><%= Alchemy.t(:names) %></h2>
   <%= f.input :name, autofocus: true %>
   <%= f.input :urlname, as: 'string', input_html: {value: @page.slug} %>
   <%= f.input :title,
     input_html: {'data-alchemy-char-counter' => 60} %>
-  <h2><%= _t(:meta_data) %></h2>
+  <h2><%= Alchemy.t(:meta_data) %></h2>
   <div class="input check_boxes">
-    <label class="control-label"><%= _t(:search_engines) %></label>
+    <label class="control-label"><%= Alchemy.t(:search_engines) %></label>
     <div class="control_group">
       <label class="checkbox">
         <%= f.check_box :robot_index %>
@@ -51,12 +51,12 @@
     input_html: {'data-alchemy-char-counter' => 160} %>
   <%= f.input :meta_keywords,
     as: 'text',
-    hint: _t('pages.update.comma_seperated') %>
+    hint: Alchemy.t('pages.update.comma_seperated') %>
   <% if @page.taggable? %>
     <div class="input string">
       <%= f.label :tag_list %>
       <%= render 'alchemy/admin/partials/autocomplete_tag_list', f: f %>
     </div>
   <% end %>
-  <%= f.submit _t(:save) %>
+  <%= f.submit Alchemy.t(:save) %>
 <% end %>

--- a/app/views/alchemy/admin/pages/_internal_link.html.erb
+++ b/app/views/alchemy/admin/pages/_internal_link.html.erb
@@ -1,8 +1,8 @@
 <%= form_tag do %>
   <%= render_message do %>
-    <h2><%= _t(:internal_link_headline) %></h2>
-    <p><%= _t(:internal_link_page_elements_explanation) %></p>
-    <p><%= _t(:internal_link_page_anchors_explanation) %></p>
+    <h2><%= Alchemy.t(:internal_link_headline) %></h2>
+    <p><%= Alchemy.t(:internal_link_page_elements_explanation) %></p>
+    <p><%= Alchemy.t(:internal_link_page_anchors_explanation) %></p>
   <% end %>
   <div id="page_selector_container">
     <% if @page_root %>
@@ -13,21 +13,21 @@
   </div>
   <div class="input select">
     <label for="internal_anchor" class="control-label">
-      <%= _t(:anchor) %>
+      <%= Alchemy.t(:anchor) %>
     </label>
     <%= select_tag(:internal_anchor,
-      options_for_select([[_t('Please choose'), '']]),
+      options_for_select([[Alchemy.t('Please choose'), '']]),
       class: 'alchemy_selectbox') %>
   </div>
   <div class="input text">
     <label for="internal_link_title" class="control-label">
-      <%= _t(:link_title) %>
+      <%= Alchemy.t(:link_title) %>
     </label>
     <%= text_field_tag "internal_link_title", '', class: 'link_title' %>
   </div>
   <div class="input select">
     <label for="internal_link_target" class="control-label">
-      <%= _t("Open Link in") %>
+      <%= Alchemy.t("Open Link in") %>
     </label>
     <%= select_tag 'internal_link_target',
       options_for_select(Alchemy::Page.link_target_options),
@@ -36,6 +36,6 @@
   <div class="submit">
     <%= hidden_field_tag(:internal_urlname) %>
     <%= hidden_field_tag(:page_anchor) %>
-    <%= link_to _t(:apply), '', class: 'create-link button', 'data-link-type' => 'internal' %>
+    <%= link_to Alchemy.t(:apply), '', class: 'create-link button', 'data-link-type' => 'internal' %>
   </div>
 <% end %>

--- a/app/views/alchemy/admin/pages/_legacy_urls.html.erb
+++ b/app/views/alchemy/admin/pages/_legacy_urls.html.erb
@@ -1,5 +1,5 @@
 <%= render_message do %>
-  <p><%== _t(:legacy_url_info_text) %></p>
+  <p><%== Alchemy.t(:legacy_url_info_text) %></p>
 <% end %>
 
 <table class="list" id="legacy_page_urls">
@@ -12,12 +12,12 @@
   <%= render partial: 'alchemy/admin/legacy_page_urls/legacy_page_url',
     collection: @page.legacy_urls %>
   <tr class="even" id="no_page_links_notice" style="display: <%= @page.legacy_urls.any? ? 'none' : 'table-row' %>">
-    <td><%= _t('No page links for this page found') %></td>
+    <td><%= Alchemy.t('No page links for this page found') %></td>
     <td class="tools"></td>
   </tr>
 </table>
 
 <fieldset>
-  <legend><%= _t('Add page link') %></legend>
+  <legend><%= Alchemy.t('Add page link') %></legend>
   <%= render 'alchemy/admin/legacy_page_urls/new' %>
 </fieldset>

--- a/app/views/alchemy/admin/pages/_locked_page.html.erb
+++ b/app/views/alchemy/admin/pages/_locked_page.html.erb
@@ -4,7 +4,7 @@
   <div class="subnavi_tab wide" id="locked_page_<%= locked_page.id %>">
     <%= link_to alchemy.edit_admin_page_path(locked_page) do %>
       <% if locked_page.definition.blank? %>
-        <span class="inline warning icon" title="<%= _t(:page_definition_missing) %>"></span>
+        <span class="inline warning icon" title="<%= Alchemy.t(:page_definition_missing) %>"></span>
       <% end %>
       <span class="page_name" title="<%= locked_page.name %>">
         <%= truncate locked_page.name, length: 15 %>
@@ -16,7 +16,7 @@
       <%- end -%>
     <% end %>
     <%= form_tag(alchemy.unlock_admin_page_path(locked_page), remote: true) do %>
-      <button class="icon_button small" title="<%= _t(:explain_unlocking) %>">
+      <button class="icon_button small" title="<%= Alchemy.t(:explain_unlocking) %>">
         <%= render_icon('close small') %>
       </button>
     <% end %>

--- a/app/views/alchemy/admin/pages/_new_page_form.html.erb
+++ b/app/views/alchemy/admin/pages/_new_page_form.html.erb
@@ -3,9 +3,9 @@
   <%= f.hidden_field(:layoutpage) %>
   <%= f.input :page_layout,
     collection: @page_layouts,
-    label: _t(:page_type),
+    label: Alchemy.t(:page_type),
     include_blank: false,
     input_html: {class: 'alchemy_selectbox'} %>
   <%= f.input :name %>
-  <%= f.submit _t(:create) %>
+  <%= f.submit Alchemy.t(:create) %>
 <% end %>

--- a/app/views/alchemy/admin/pages/_page.html.erb
+++ b/app/views/alchemy/admin/pages/_page.html.erb
@@ -3,7 +3,7 @@
     <div class="sitemap_left_images">
       <%= sitemap_folder_link(page) unless page.level == 1 || page.children.blank? || @sorting %>
       <% if page.definition.blank? %>
-        <span class="inline warning icon" title="<%= _t(:page_definition_missing) %>"></span>
+        <span class="inline warning icon" title="<%= Alchemy.t(:page_definition_missing) %>"></span>
       <% else %>
         <div class="page icon <%= @sorting && page.level > 1 ? 'handle' : nil %>"></div>
       <% end %>
@@ -15,11 +15,11 @@
           render_icon('info'),
           alchemy.info_admin_page_path(page),
           {
-            title: _t(:page_infos),
+            title: Alchemy.t(:page_infos),
             size: '520x290'
           },
           {
-            title: _t(:page_infos),
+            title: Alchemy.t(:page_infos),
             class: 'sitemap_tool'
           }
         ) %>
@@ -29,10 +29,10 @@
           render_icon('configure_page'),
           alchemy.configure_admin_page_path(page),
           {
-            title: _t(:edit_page_properties),
+            title: Alchemy.t(:edit_page_properties),
             size: page.redirects_to_external? ? '450x330' : '450x720'
           },
-          title: _t(:edit_page_properties),
+          title: Alchemy.t(:edit_page_properties),
           class: 'sitemap_tool'
         ) -%>
       <%- end -%>
@@ -46,21 +46,21 @@
           ),
           remote: true,
           method: 'post',
-          title: _t(:copy_page),
+          title: Alchemy.t(:copy_page),
           class: 'sitemap_tool'
         ) %>
       <%- end -%>
       <%- if can?(:destroy, page) -%>
         <%= link_to_confirm_dialog(
           render_icon('delete_page'),
-          _t(:confirm_to_delete_page),
+          Alchemy.t(:confirm_to_delete_page),
           url_for(
             controller: 'pages',
             action: 'destroy',
             id: page.id
           ),
           {
-            title: _t(:delete_page),
+            title: Alchemy.t(:delete_page),
             class: 'sitemap_tool'
           }
         ) -%>
@@ -70,11 +70,11 @@
           render_icon('add_page'),
           alchemy.new_admin_page_path(parent_id: page.id),
           {
-            title: _t(:create_page),
+            title: Alchemy.t(:create_page),
             size: '340x165',
             overflow: true
           },
-          title: _t(:create_page),
+          title: Alchemy.t(:create_page),
           class: 'sitemap_tool'
         ) -%>
       <%- end -%>
@@ -88,7 +88,7 @@
     <%- if page.redirects_to_external? -%>
       <span class="sitemap_pagename_link inactive"><%= page.name %></span>
       <span class="redirect_url" title="<%= h page.urlname %>">
-        &raquo; <%= _t('Redirects to') %>:
+        &raquo; <%= Alchemy.t('Redirects to') %>:
         <%= h page.external_urlname %>
       </span>
     <%- else -%>
@@ -96,7 +96,7 @@
         @sorting,
         page.name,
         alchemy.edit_admin_page_path(page),
-        title: _t(:edit_page),
+        title: Alchemy.t(:edit_page),
         class: "sitemap_pagename_link"
       ) { content_tag('span', page.name, class: "sitemap_pagename_link") } -%>
     <%- end -%>

--- a/app/views/alchemy/admin/pages/_page_for_links.html.erb
+++ b/app/views/alchemy/admin/pages/_page_for_links.html.erb
@@ -13,7 +13,7 @@
             url: @url_prefix + page_for_links.urlname
           },
           class: "show_elements_to_link",
-          title: _t(:show_elements_from_page)
+          title: Alchemy.t(:show_elements_from_page)
         %>
       <% end %>
     </div>
@@ -29,7 +29,7 @@
             'page-id' => page_for_links.id,
             url: @url_prefix + page_for_links.urlname
           },
-          title: _t('page_for_links.choose_page', name: page_for_links.name),
+          title: Alchemy.t('page_for_links.choose_page', name: page_for_links.name),
           class: "sitemap_pagename_link"
         }) %>
       <% end %>

--- a/app/views/alchemy/admin/pages/_page_status.html.erb
+++ b/app/views/alchemy/admin/pages/_page_status.html.erb
@@ -1,6 +1,6 @@
 <div class="page_status_and_name" id="page_<%= page.id %>_status">
   <% if page.definition.blank? %>
-    <span class="inline warning icon" title="<%= _t(:page_definition_missing) %>"></span>
+    <span class="inline warning icon" title="<%= Alchemy.t(:page_definition_missing) %>"></span>
   <% end %>
   <span class="page_name"><%= page.name %></span>
   <%- if multi_language? -%>

--- a/app/views/alchemy/admin/pages/configure.html.erb
+++ b/app/views/alchemy/admin/pages/configure.html.erb
@@ -1,6 +1,6 @@
 <div id="overlay_tabs">
   <ul>
-    <li><a href="#page_properties"><%= _t('Properties') %></a></li>
+    <li><a href="#page_properties"><%= Alchemy.t('Properties') %></a></li>
     <li>
       <a href="#legacy_urls" id="legacy_urls_label">
         <%= render 'alchemy/admin/legacy_page_urls/label', count: @page.legacy_urls.size %>

--- a/app/views/alchemy/admin/pages/configure_external.html.erb
+++ b/app/views/alchemy/admin/pages/configure_external.html.erb
@@ -1,11 +1,11 @@
 <%= alchemy_form_for [:admin, @page] do |f| %>
   <%= f.input :page_layout,
     collection: @page_layouts,
-    label: _t(:page_type),
+    label: Alchemy.t(:page_type),
     include_blank: false,
     input_html: {class: 'alchemy_selectbox'} %>
   <div class="input check_boxes">
-    <label class="control-label"><%= _t(:page_status) %></label>
+    <label class="control-label"><%= Alchemy.t(:page_status) %></label>
     <div class="control_group">
       <label class="checkbox">
         <%= f.check_box :visible %>
@@ -19,7 +19,7 @@
     <% end %>
     </div>
   </div>
-  <h2><%= _t(:names) %></h2>
+  <h2><%= Alchemy.t(:names) %></h2>
   <%= f.input :name, autofocus: true %>
   <%= f.input :urlname, as: 'string' %>
   <%= f.input :title %>
@@ -29,5 +29,5 @@
       <%= render 'alchemy/admin/partials/autocomplete_tag_list', f: f %>
     </div>
   <% end %>
-  <%= f.submit _t(:save) %>
+  <%= f.submit Alchemy.t(:save) %>
 <% end %>

--- a/app/views/alchemy/admin/pages/edit.html.erb
+++ b/app/views/alchemy/admin/pages/edit.html.erb
@@ -4,20 +4,20 @@
 <div class="toolbar_buttons">
   <div class="button_with_label">
     <%= form_tag alchemy.unlock_admin_page_path(@page, redirect_to: @layoutpage ? alchemy.admin_layoutpages_path : alchemy.admin_pages_path), id: 'unlock_page_form' do %>
-      <button class="icon_button" title="<%= _t(:explain_unlocking) %>" data-alchemy-hotkey="alt+x">
+      <button class="icon_button" title="<%= Alchemy.t(:explain_unlocking) %>" data-alchemy-hotkey="alt+x">
         <%= render_icon('close') %>
       </button>
-      <label><%= _t(:unlock_page) %></label>
+      <label><%= Alchemy.t(:unlock_page) %></label>
     <% end %>
   </div>
   <div class="toolbar_spacer"></div>
   <% unless @page.layoutpage? %>
   <div class="button_with_label">
     <%= form_tag alchemy.visit_admin_page_path(@page), id: 'visit_page_form' do %>
-      <button class="icon_button" title="<%= _t('Visit page') %>">
+      <button class="icon_button" title="<%= Alchemy.t('Visit page') %>">
         <%= render_icon('visit_page') %>
       </button>
-      <label><%= _t("Visit page") %></label>
+      <label><%= Alchemy.t("Visit page") %></label>
     <% end %>
   </div>
   <% end %>
@@ -26,16 +26,16 @@
       render_icon('info'),
       alchemy.info_admin_page_path(@page),
       {
-        title: _t(:page_infos),
+        title: Alchemy.t(:page_infos),
         size: '520x320'
       },
       {
         class: 'icon_button',
-        title: _t(:page_infos),
+        title: Alchemy.t(:page_infos),
         'data-alchemy-hotkey' => 'alt+i'
       }
     ) %>
-    <label><%= _t(:page_infos) %></label>
+    <label><%= Alchemy.t(:page_infos) %></label>
   </div>
   <div class="button_with_label">
     <% if @page.layoutpage? %>
@@ -43,11 +43,11 @@
         render_icon('settings'),
         alchemy.edit_admin_layoutpage_path(@page),
         {
-          title: _t(:edit_page_properties),
+          title: Alchemy.t(:edit_page_properties),
           size: '450x170'
         },
         class: :icon_button,
-        title: _t(:edit_page_properties),
+        title: Alchemy.t(:edit_page_properties),
         'data-alchemy-hotkey' => 'alt+e'
       ) %>
     <% else %>
@@ -55,29 +55,29 @@
         render_icon('settings'),
         alchemy.configure_admin_page_path(@page),
         {
-          title: _t(:edit_page_properties),
+          title: Alchemy.t(:edit_page_properties),
           size: '450x720'
         },
         class: :icon_button,
-        title: _t(:edit_page_properties),
+        title: Alchemy.t(:edit_page_properties),
         'data-alchemy-hotkey' => 'alt+e'
       ) %>
     <% end %>
-    <label><%= _t(:page_properties) %></label>
+    <label><%= Alchemy.t(:page_properties) %></label>
   </div>
   <% if can?(:publish, @page) && !@page.layoutpage? %>
     <div class="button_with_label">
       <%= form_tag alchemy.publish_admin_page_path(@page), id: 'publish_page_form' do %>
-        <%= button_tag class: 'icon_button', title: _t(:explain_publishing) do %>
+        <%= button_tag class: 'icon_button', title: Alchemy.t(:explain_publishing) do %>
           <%= render_icon('publish') %>
         <% end %>
-        <label><%= _t("Publish page") %></label>
+        <label><%= Alchemy.t("Publish page") %></label>
       <% end %>
     </div>
   <% end %>
   <div class="toolbar_spacer"></div>
   <div class="select_with_label">
-    <label><%= _t(:preview_size) %></label>
+    <label><%= Alchemy.t(:preview_size) %></label>
     <%= select_tag 'preview_size',
       preview_sizes_for_select,
       class: 'alchemy_selectbox medium' %>
@@ -85,20 +85,20 @@
   <div class="toolbar_spacer"></div>
   <div class="button_with_label">
     <%= link_to render_icon(:reload), '#', {
-      title: _t('Reload Preview'),
+      title: Alchemy.t('Reload Preview'),
       class: 'icon_button',
       id: 'reload_preview_button'
     } %>
-    <label><%= _t('Reload Preview') %></label>
+    <label><%= Alchemy.t('Reload Preview') %></label>
   </div>
 </div>
 <div class="toolbar_buttons right">
   <div class="button_with_label" id="element_window_button">
     <%= link_to render_icon(:element_window), '', {
-      title: _t(:hide_elements),
+      title: Alchemy.t(:hide_elements),
       class: 'icon_button'
     } %>
-    <label><%= _t(:hide_elements) %></label>
+    <label><%= Alchemy.t(:hide_elements) %></label>
   </div>
 </div>
 <% end %>
@@ -119,46 +119,46 @@
     Alchemy.PreviewWindow.init('<%= admin_page_url(@page) %>');
     Alchemy.ElementsWindow.init('<%= alchemy.admin_elements_path(page_id: @page.id) %>', {
       texts: {
-        title: '<%= _t("Elements") %>',
-        dirtyTitle: '<%= _t("Warning!") %>',
-        dirtyMessage: '<%= _t(:element_dirty_close_window_notice) %>',
-        ok_label: '<%= _t("Yes") %>',
-        cancel_label: '<%= _t("No") %>',
-        hideElements: '<%= _t(:hide_elements) %>',
-        showElements: '<%= _t(:show_elements) %>'
+        title: '<%= Alchemy.t("Elements") %>',
+        dirtyTitle: '<%= Alchemy.t("Warning!") %>',
+        dirtyMessage: '<%= Alchemy.t(:element_dirty_close_window_notice) %>',
+        ok_label: '<%= Alchemy.t("Yes") %>',
+        cancel_label: '<%= Alchemy.t("No") %>',
+        hideElements: '<%= Alchemy.t(:hide_elements) %>',
+        showElements: '<%= Alchemy.t(:show_elements) %>'
       },
       toolbarButtons: [
         {
-          title: '<%= _t("New Element") %>',
-          label: '<%= _t("New Element") %>',
+          title: '<%= Alchemy.t("New Element") %>',
+          label: '<%= Alchemy.t("New Element") %>',
           hotkey: 'alt+n',
           iconClass: 'new_element',
           onClick: function() {
             Alchemy.openDialog('<%= alchemy.new_admin_element_path(page_id: @page.id) %>', {
-              title: '<%= _t("New Element") %>',
+              title: '<%= Alchemy.t("New Element") %>',
               size: '320x125'
             });
           }
         },
         {
-          title: '<%= _t("Clipboard") %>',
-          label: '<%= _t("Show clipboard") %>',
+          title: '<%= Alchemy.t("Clipboard") %>',
+          label: '<%= Alchemy.t("Show clipboard") %>',
           iconClass: 'clipboard<%= clipboard_empty?("elements") ? "" : " full" %>',
           buttonId: 'clipboard_button',
           onClick: function() {
             Alchemy.openDialog('<%= alchemy.admin_clipboard_path(remarkable_type: "elements") %>', {
-              title :'<%= _t("Clipboard") %>',
+              title :'<%= Alchemy.t("Clipboard") %>',
               size: '400x305'
             });
           }
         },
         {
-          title: '<%= _t("Show trash") %>',
-          label: '<%= _t("Show trash") %>',
+          title: '<%= Alchemy.t("Show trash") %>',
+          label: '<%= Alchemy.t("Show trash") %>',
           iconClass: 'trash<%= trash_empty?("elements") ? "" : " full" %>',
           buttonId: 'element_trash_button',
           onClick: function() {
-            Alchemy.TrashWindow.open(<%= @page.id %>, '<%= _t("Trash") %>');
+            Alchemy.TrashWindow.open(<%= @page.id %>, '<%= Alchemy.t("Trash") %>');
           }
         }
       ]

--- a/app/views/alchemy/admin/pages/flush.js.erb
+++ b/app/views/alchemy/admin/pages/flush.js.erb
@@ -1,2 +1,2 @@
-Alchemy.growl('<%= _t("Page cache flushed") -%>');
+Alchemy.growl('<%= Alchemy.t("Page cache flushed") -%>');
 Alchemy.pleaseWaitOverlay(false);

--- a/app/views/alchemy/admin/pages/index.html.erb
+++ b/app/views/alchemy/admin/pages/index.html.erb
@@ -10,9 +10,9 @@
       :remote => true,
       :method => :post,
       :class => 'icon_button please_wait',
-      :title => _t('Flush page cache')
+      :title => Alchemy.t('Flush page cache')
     ) %>
-    <label><%= _t('Flush page cache') %></label>
+    <label><%= Alchemy.t('Flush page cache') %></label>
   </div>
   <% end %>
   <% if can?(:sort, Alchemy::Page) %>
@@ -24,9 +24,9 @@
       :method => :get,
       :remote => true,
       :class => 'icon_button please_wait',
-      :title => _t('Sort pages')
+      :title => Alchemy.t('Sort pages')
     ) %>
-    <label><%= _t('Sort pages') %></label>
+    <label><%= Alchemy.t('Sort pages') %></label>
   </div>
   <% end %>
   <div class="button_with_label" id="clipboard_button">
@@ -34,24 +34,24 @@
       render_icon("clipboard#{clipboard_empty?('pages') ? '' : ' full'}"),
       alchemy.admin_clipboard_path(:remarkable_type => 'pages'),
       {
-        :title => _t('Clipboard'),
+        :title => Alchemy.t('Clipboard'),
         :size => '380x305'
       },
       :class => 'icon_button',
-      :title => _t('Show clipboard')
+      :title => Alchemy.t('Show clipboard')
     ) %>
-    <label><%= _t('Show clipboard') %></label>
+    <label><%= Alchemy.t('Show clipboard') %></label>
   </div>
 </div>
 <div class="js_filter_field_box">
   <%= text_field_tag 'filter', '',
     class: 'thin_border js_filter_field',
     id: 'search_field',
-    placeholder: _t(:search) %>
+    placeholder: Alchemy.t(:search) %>
   <%= render_icon :search %>
   <%= link_to('', '#', {
     class: "js_filter_field_clear",
-    title: _t(:click_to_show_all)
+    title: Alchemy.t(:click_to_show_all)
   }) %>
 </div>
 <% end %>
@@ -62,19 +62,19 @@
   <div id="sort_panel" style="display: none">
     <div class="info">
       <%= render_icon('info') %>
-      <%= _t(:explain_sitemap_dragndrop_sorting) %>
+      <%= Alchemy.t(:explain_sitemap_dragndrop_sorting) %>
     </div>
     <div class="buttons">
-      <%= link_to( _t(:cancel), alchemy.admin_pages_path, :class => 'button' ) %>&nbsp;
-      <%= submit_tag( _t('save order'), :id => 'save_page_order', :class => 'button' ) %>
+      <%= link_to( Alchemy.t(:cancel), alchemy.admin_pages_path, :class => 'button' ) %>&nbsp;
+      <%= submit_tag( Alchemy.t('save order'), :id => 'save_page_order', :class => 'button' ) %>
     </div>
   </div>
 
   <h1 id="page_filter_result"></h1>
 
   <h2 id="sitemap_heading">
-    <span class="page_name"><%= _t('Name') %></span>
-    <span class="page_infos"><%= _t('Status') %></span>
+    <span class="page_name"><%= Alchemy.t('Name') %></span>
+    <span class="page_infos"><%= Alchemy.t('Status') %></span>
   </h2>
 
   <%= render :partial => 'sitemap' %>

--- a/app/views/alchemy/admin/pages/info.html.erb
+++ b/app/views/alchemy/admin/pages/info.html.erb
@@ -7,7 +7,7 @@
   <div class="value">
     <label>
       <% if @page.definition.blank? %>
-        <span class="inline warning icon" title="<%= _t(:page_definition_missing) %>"></span>
+        <span class="inline warning icon" title="<%= Alchemy.t(:page_definition_missing) %>"></span>
       <% end %>
       <%= Alchemy::Page.human_attribute_name(:page_layout) %>
     </label>
@@ -23,20 +23,20 @@
   <% end %>
   </div>
   <div class="value">
-    <label><%= _t(:page_status) %></label>
+    <label><%= Alchemy.t(:page_status) %></label>
     <p><%= combined_page_status(@page) %></p>
   </div>
   <div class="value">
-    <label><%= _t(:page_was_created) %></label>
-    <p><%= _t(:from_at) % {by: @page.creator_name, at: l(@page.created_at, format: :page_status)} %></p>
+    <label><%= Alchemy.t(:page_was_created) %></label>
+    <p><%= Alchemy.t(:from_at) % {by: @page.creator_name, at: l(@page.created_at, format: :page_status)} %></p>
   </div>
   <div class="value">
-    <label><%= _t(:page_was_updated) %></label>
-    <p><%= _t(:from_at) % {by: @page.updater_name, at: l(@page.updated_at, format: :page_status)} %></p>
+    <label><%= Alchemy.t(:page_was_updated) %></label>
+    <p><%= Alchemy.t(:from_at) % {by: @page.updater_name, at: l(@page.updated_at, format: :page_status)} %></p>
   </div>
   <% if @page.locked? %>
   <div class="value">
-    <label><%= _t(:currently_edited_by) %></label>
+    <label><%= Alchemy.t(:currently_edited_by) %></label>
     <p><%= @page.locker_name %></p>
   </div>
   <% end %>

--- a/app/views/alchemy/admin/pages/link.html.erb
+++ b/app/views/alchemy/admin/pages/link.html.erb
@@ -1,8 +1,8 @@
 <div id="overlay_tabs">
   <ul>
-    <li><a href="#overlay_tab_internal_link"><%= _t('link_overlay_tab_label.internal') %></a></li>
-    <li><a href="#overlay_tab_external_link"><%= _t('link_overlay_tab_label.external') %></a></li>
-    <li><a href="#overlay_tab_file_link"><%= _t('link_overlay_tab_label.file') %></a></li>
+    <li><a href="#overlay_tab_internal_link"><%= Alchemy.t('link_overlay_tab_label.internal') %></a></li>
+    <li><a href="#overlay_tab_external_link"><%= Alchemy.t('link_overlay_tab_label.external') %></a></li>
+    <li><a href="#overlay_tab_file_link"><%= Alchemy.t('link_overlay_tab_label.file') %></a></li>
   </ul>
   <div id="overlay_tab_internal_link">
     <%= render partial: 'internal_link' %>

--- a/app/views/alchemy/admin/pages/locked.html.erb
+++ b/app/views/alchemy/admin/pages/locked.html.erb
@@ -1,3 +1,3 @@
 <div>
-  <p><%= _t("page_states.locked.true") %></p>
+  <p><%= Alchemy.t("page_states.locked.true") %></p>
 </div>

--- a/app/views/alchemy/admin/pages/new.html.erb
+++ b/app/views/alchemy/admin/pages/new.html.erb
@@ -3,8 +3,8 @@
 <%- else -%>
 <div id="overlay_tabs">
   <ul>
-    <li><a href="#create_page_tab"><%= _t('New page') %></a></li>
-    <li><a href="#paste_page_tab"><%= _t('Paste from clipboard') %></a></li>
+    <li><a href="#create_page_tab"><%= Alchemy.t('New page') %></a></li>
+    <li><a href="#paste_page_tab"><%= Alchemy.t('Paste from clipboard') %></a></li>
   </ul>
   <div id="create_page_tab">
     <%= render 'new_page_form' %>
@@ -13,13 +13,13 @@
     <%= alchemy_form_for [:admin, @page] do |f| %>
       <%= f.hidden_field(:parent_id) %>
       <div class="input select">
-        <label for="paste_from_clipboard" class="control-label"><%= _t("Page") %></label>
+        <label for="paste_from_clipboard" class="control-label"><%= Alchemy.t("Page") %></label>
         <%= select_tag 'paste_from_clipboard',
           clipboard_select_tag_options(@clipboard_items),
           class: 'alchemy_selectbox' %>
       </div>
       <%= f.input :name %>
-      <%= f.submit _t(:paste) %>
+      <%= f.submit Alchemy.t(:paste) %>
     <% end %>
   </div>
 </div>

--- a/app/views/alchemy/admin/pages/update.js.erb
+++ b/app/views/alchemy/admin/pages/update.js.erb
@@ -5,7 +5,7 @@
 
 <% if @old_page_layout != @page.page_layout -%>
   Alchemy.ElementsWindow.reload();
-  Alchemy.growl('<%= j _t(:page_layout_changed_notice) %>');
+  Alchemy.growl('<%= j Alchemy.t(:page_layout_changed_notice) %>');
 <% end -%>
 
 <% if @while_page_edit -%>
@@ -26,7 +26,7 @@
   <% if @page.restricted? -%>
     $('.page_status:nth-child(3)', $page).addClass('restricted', 'not_restricted').removeClass('not_restricted');
   <% elsif @page.redirects_to_external? -%>
-    $('span.redirect_url', $page).html('&raquo; <%= _t("Redirects to") %>: <%= h @page.external_urlname %>');
+    $('span.redirect_url', $page).html('&raquo; <%= Alchemy.t("Redirects to") %>: <%= h @page.external_urlname %>');
   <% else -%>
     $('.page_status:nth-child(3)', $page).addClass('not_restricted').removeClass('restricted');
   <% end -%>

--- a/app/views/alchemy/admin/partials/_language_tree_select.html.erb
+++ b/app/views/alchemy/admin/partials/_language_tree_select.html.erb
@@ -7,5 +7,5 @@
       data: {'auto-submit' => true}
     ) %>
   <% end %>
-  <label><%= _t("Language tree") %></label>
+  <label><%= Alchemy.t("Language tree") %></label>
 </div>

--- a/app/views/alchemy/admin/partials/_main_navigation_entry.html.erb
+++ b/app/views/alchemy/admin/partials/_main_navigation_entry.html.erb
@@ -7,6 +7,6 @@
     <% else %>
     <span class="module icon"></span>
     <% end %>
-    <label><%= truncate _t(navigation["name"]), length: 10 %></label>
+    <label><%= truncate Alchemy.t(navigation["name"]), length: 10 %></label>
   <% end %>
 <% end %>

--- a/app/views/alchemy/admin/partials/_remote_search_form.html.erb
+++ b/app/views/alchemy/admin/partials/_remote_search_form.html.erb
@@ -9,7 +9,7 @@
   <%= render_icon('search') %>
     <%= f.search_field resource_handler.search_field_name,
       id: 'search_input_field',
-      placeholder: _t(:search) %>
+      placeholder: Alchemy.t(:search) %>
     <%= link_to '', url_for(
         action: 'index',
         element_id: @element.blank? ? '' : @element.id,
@@ -21,7 +21,7 @@
       remote: true,
       class: 'search_field_clear',
       id: 'search_field_clear',
-      title: _t(:click_to_show_all),
+      title: Alchemy.t(:click_to_show_all),
       style: params[:q].blank? ? 'display: none' : 'display: block' %>
   </div>
 <% end %>

--- a/app/views/alchemy/admin/partials/_search_form.html.erb
+++ b/app/views/alchemy/admin/partials/_search_form.html.erb
@@ -5,14 +5,14 @@
     <%= render_icon('search') %>
     <%= f.search_field resource_handler.search_field_name,
       id: 'search_input_field',
-      placeholder: _t(:search) %>
+      placeholder: Alchemy.t(:search) %>
     <% local_assigns.fetch(:additional_query_fields, []).each do |field| %>
       <%= f.hidden_field field %>
     <% end %>
     <%= link_to '', url,
         class: 'search_field_clear',
         id: 'search_field_clear',
-        title: _t(:click_to_show_all),
+        title: Alchemy.t(:click_to_show_all),
         style: params.fetch(:q, {}).fetch(resource_handler.search_field_name, '').present? ? 'display: block' : 'display: none' %>
     <% local_assigns.fetch(:additional_params, []).each do |additional_param| %>
       <%= hidden_field_tag additional_param, params[additional_param] %>

--- a/app/views/alchemy/admin/partials/_sub_navigation.html.erb
+++ b/app/views/alchemy/admin/partials/_sub_navigation.html.erb
@@ -2,7 +2,7 @@
   <% entry.stringify_keys! %>
   <% if can? *navigate_module(entry) %>
   <div class="subnavi_tab<%= entry_active?(entry) ? ' active' : nil %>">
-    <%= link_to _t(entry['name']), url_for_module_sub_navigation(entry) %>
+    <%= link_to Alchemy.t(entry['name']), url_for_module_sub_navigation(entry) %>
   </div>
   <% end %>
 <% end %>

--- a/app/views/alchemy/admin/partials/_upload_form.html.erb
+++ b/app/views/alchemy/admin/partials/_upload_form.html.erb
@@ -1,26 +1,26 @@
 <div class="info">
   <%= render_icon('info') %>
-  <p><%= _t('explain_upload.intro', name: item_type) %>:</p>
+  <p><%= Alchemy.t('explain_upload.intro', name: item_type) %>:</p>
   <ol>
-    <li><%= _t('explain_upload.step1', name: item_type) %></li>
-    <li><%= _t('explain_upload.step2', name: item_type) %>*</li>
-    <li id="explain_step3"><%= _t('explain_upload.step3') %></li>
-    <li id="explain_drag_n_drop"><%= _t('explain_upload.dragndrop', name: item_type) %></li>
+    <li><%= Alchemy.t('explain_upload.step1', name: item_type) %></li>
+    <li><%= Alchemy.t('explain_upload.step2', name: item_type) %>*</li>
+    <li id="explain_step3"><%= Alchemy.t('explain_upload.step3') %></li>
+    <li id="explain_drag_n_drop"><%= Alchemy.t('explain_upload.dragndrop', name: item_type) %></li>
   </ol>
   <% unless file_types.first == '*' %>
   <p>
-    <%= _t('You may upload files with following extensions',
+    <%= Alchemy.t('You may upload files with following extensions',
       file_types_description: file_types_description,
       file_types: file_types.to_sentence) %>.
   </p>
   <% end %>
-  <small>*<%= _t('explain_upload.footnote', name: item_type) %></small>
+  <small>*<%= Alchemy.t('explain_upload.footnote', name: item_type) %></small>
 </div>
 
 <div class="upload-container">
-  <%= label_tag :fileupload, _t(:browse) %>
-  <input name="<%= model_name %>[<%= file_attribute %>]" id="fileupload" type="file" multiple value="<%= _t(:browse) %>">
-  <div id="dropbox"><%= _t('Or drag files over here') %></div>
+  <%= label_tag :fileupload, Alchemy.t(:browse) %>
+  <input name="<%= model_name %>[<%= file_attribute %>]" id="fileupload" type="file" multiple value="<%= Alchemy.t(:browse) %>">
+  <div id="dropbox"><%= Alchemy.t('Or drag files over here') %></div>
 </div>
 
 <div class="overall-upload">

--- a/app/views/alchemy/admin/pictures/_archive.html.erb
+++ b/app/views/alchemy/admin/pictures/_archive.html.erb
@@ -6,24 +6,24 @@
 </div>
 <%= form_tag delete_multiple_admin_pictures_path, :method => :delete do %>
   <div class="selected_item_tools">
-    <h2><%= _t(:edit_selected_pictures) %></h2>
+    <h2><%= Alchemy.t(:edit_selected_pictures) %></h2>
     <%= link_to(
-      render_icon('edit') + _t("Edit"),
+      render_icon('edit') + Alchemy.t("Edit"),
       edit_multiple_admin_pictures_path,
       :class => 'button with_icon',
-      :title => _t('Edit multiple pictures'),
+      :title => Alchemy.t('Edit multiple pictures'),
       :id => 'edit_multiple_pictures',
       :style => 'float: none'
     ) %>
-    <%= button_tag render_icon('destroy') + _t("Delete"), 'data-alchemy-confirm' => {
-      :title => _t(:please_confirm),
-      :message => _t(:confirm_to_delete_images_from_server),
-      :ok_label => _t("Yes"),
-      :cancel_label => _t("No")
+    <%= button_tag render_icon('destroy') + Alchemy.t("Delete"), 'data-alchemy-confirm' => {
+      :title => Alchemy.t(:please_confirm),
+      :message => Alchemy.t(:confirm_to_delete_images_from_server),
+      :ok_label => Alchemy.t("Yes"),
+      :cancel_label => Alchemy.t("No")
     }.to_json, :class => 'button with_icon' %>
-    &nbsp;<%= _t(:or) %>&nbsp;
+    &nbsp;<%= Alchemy.t(:or) %>&nbsp;
     <%= link_to(
-      render_icon('delete-small') + _t("Clear selection"),
+      render_icon('delete-small') + Alchemy.t("Clear selection"),
       admin_pictures_path(
         :q => params[:q],
         :tagged_with => params[:tagged_with],
@@ -38,12 +38,12 @@
   <% if @pictures.blank? and @recent_pictures.blank? and params[:q].blank? %>
     <div class="info">
       <%= render_icon('info') %>
-      <%= _t(:no_images_in_archive) %>
+      <%= Alchemy.t(:no_images_in_archive) %>
     </div>
   <% elsif @pictures.blank? and @recent_pictures.blank? %>
     <div class="info">
       <%= render_icon('info') %>
-      <%= _t(:no_search_results) %>
+      <%= Alchemy.t(:no_search_results) %>
     </div>
   <% else %>
     <%= render :partial => 'picture', :collection => @pictures %>

--- a/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
+++ b/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
@@ -12,14 +12,14 @@
       ),
       {
         size: "540x550",
-        title: _t(:upload_image)
+        title: Alchemy.t(:upload_image)
       },
       {
         class: 'icon_button',
-        title: _t(:upload_image)
+        title: Alchemy.t(:upload_image)
       }
     ) %>
-    <label><%= _t(:upload_image) %></label>
+    <label><%= Alchemy.t(:upload_image) %></label>
   </div>
   <div class="toolbar_spacer"></div>
   <div class="button_group">
@@ -37,7 +37,7 @@
           tagged_with: params[:tagged_with]
         }),
         remote: true,
-        title: _t(:small_thumbnails),
+        title: Alchemy.t(:small_thumbnails),
         class: "icon_button"
       ) %>
     </div>
@@ -55,7 +55,7 @@
           tagged_with: params[:tagged_with]
         }),
         remote: true,
-        title: _t(:medium_thumbnails),
+        title: Alchemy.t(:medium_thumbnails),
         class: "icon_button"
       ) %>
     </div>
@@ -73,11 +73,11 @@
           tagged_with: params[:tagged_with]
         }),
         remote: true,
-        title: _t(:big_thumbnails),
+        title: Alchemy.t(:big_thumbnails),
         class: "icon_button"
       ) %>
     </div>
-    <label><%= _t('Image size') %></label>
+    <label><%= Alchemy.t('Image size') %></label>
     <%= hidden_field_tag('size', @size, id: 'overlay_thumbnails_size') %>
   </div>
   <%= render partial: 'alchemy/admin/partials/remote_search_form' %>

--- a/app/views/alchemy/admin/pictures/_filter_bar.html.erb
+++ b/app/views/alchemy/admin/pictures/_filter_bar.html.erb
@@ -1,14 +1,14 @@
 <% params_to_keep = [:size, :tagged_with, :query, :element_id, :options, :content_id, :_] %>
 
 <div id="filter_bar">
-  <h2><%= _t('Filter') %></h2>
+  <h2><%= Alchemy.t('Filter') %></h2>
   <%= select_tag(
     'picture_filter',
     options_for_select([
-      [_t(:all_pictures), ''],
-      [_t(:last_upload_only), 'last_upload'],
-      [_t(:recently_uploaded_only), 'recent'],
-      [_t(:without_tag), 'without_tag']
+      [Alchemy.t(:all_pictures), ''],
+      [Alchemy.t(:last_upload_only), 'last_upload'],
+      [Alchemy.t(:recently_uploaded_only), 'recent'],
+      [Alchemy.t(:without_tag), 'without_tag']
     ], params[:filter]),
     :data => { :remote => !!request.xhr? },
     :class => 'alchemy_selectbox'

--- a/app/views/alchemy/admin/pictures/_form.html.erb
+++ b/app/views/alchemy/admin/pictures/_form.html.erb
@@ -1,14 +1,14 @@
 <%= alchemy_form_for [:admin, @picture] do |f| %>
-  <h2><%= _t('Edit image') %></h2>
+  <h2><%= Alchemy.t('Edit image') %></h2>
   <%= f.input :name %>
   <div class="input tag_list">
     <%= f.label :tag_list %>
     <%= render 'alchemy/admin/partials/autocomplete_tag_list', f: f %>
-    <small class="hint"><%= _t('Please seperate the tags with commata') %></small>
+    <small class="hint"><%= Alchemy.t('Please seperate the tags with commata') %></small>
   </div>
   <%= hidden_field_tag :q, params[:q] %>
   <%= hidden_field_tag :size, params[:size] %>
   <%= hidden_field_tag :tagged_with, params[:tagged_with] %>
   <%= hidden_field_tag :filter, params[:filter] %>
-  <%= f.submit _t(:save) %>
+  <%= f.submit Alchemy.t(:save) %>
 <% end %>

--- a/app/views/alchemy/admin/pictures/_infos.html.erb
+++ b/app/views/alchemy/admin/pictures/_infos.html.erb
@@ -1,6 +1,6 @@
 <div class="resource_info">
   <div class="picture-file-infos">
-    <h2><%= _t('Picture infos') %></h2>
+    <h2><%= Alchemy.t('Picture infos') %></h2>
     <div class="value">
       <label><%= Alchemy::Picture.human_attribute_name(:image_file_name) %></label>
       <p><%= @picture.image_file_name %></p>
@@ -17,7 +17,7 @@
 </div>
 
 <div class="picture-usage-info resource_info">
-  <h2><%= _t(:this_picture_is_used_on_these_pages) %></h2>
+  <h2><%= Alchemy.t(:this_picture_is_used_on_these_pages) %></h2>
   <div id="pictures_page_list">
     <% if @pages.any? %>
       <ol>
@@ -33,7 +33,7 @@
                     <% pictures = essence_pictures.collect do |e|
                                     e.content.name_for_label
                                   end.to_sentence %>
-                    <%== _t(:pictures_in_page, page: page_link, pictures: pictures) %>
+                    <%== Alchemy.t(:pictures_in_page, page: page_link, pictures: pictures) %>
                   </li>
                 <% end %>
               </ul>
@@ -43,7 +43,7 @@
       </ol>
     <% else %>
       <%= render_message do %>
-        <%= _t(:picture_not_in_use_yet) %>
+        <%= Alchemy.t(:picture_not_in_use_yet) %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/alchemy/admin/pictures/_overlay_picture_list.html.erb
+++ b/app/views/alchemy/admin/pictures/_overlay_picture_list.html.erb
@@ -1,7 +1,7 @@
 <% if @pictures.empty? %>
   <div class="info">
     <%= render_icon('info') %>
-    <%= _t(:no_images_in_archive) %>
+    <%= Alchemy.t(:no_images_in_archive) %>
   </div>
 <% else %>
   <%= render partial: 'picture_to_assign',

--- a/app/views/alchemy/admin/pictures/_picture.html.erb
+++ b/app/views/alchemy/admin/pictures/_picture.html.erb
@@ -6,7 +6,7 @@
   <span class="picture_tool delete">
     <%= link_to_confirm_dialog(
       "",
-      _t(:confirm_to_delete_image_from_server),
+      Alchemy.t(:confirm_to_delete_image_from_server),
       alchemy.admin_picture_path(
         id: picture,
         q: params[:q],
@@ -16,7 +16,7 @@
         filter: params[:filter]
       ),
       {
-        title: _t('Delete image')
+        title: Alchemy.t('Delete image')
       }
     ) -%>
   </span>
@@ -24,7 +24,7 @@
   <% image = image_tag(
     alchemy.thumbnail_path(id: picture, size: @size, sh: picture.security_token(size: @size)),
     alt: picture.name,
-    title: _t(:zoom_image)
+    title: Alchemy.t(:zoom_image)
   ) %>
   <% if can?(:edit, picture) %>
     <%= link_to(

--- a/app/views/alchemy/admin/pictures/_picture_to_assign.html.erb
+++ b/app/views/alchemy/admin/pictures/_picture_to_assign.html.erb
@@ -19,7 +19,7 @@
     remote: true,
     onclick: '$(self).attr("href", "#").off("click"); return false',
     method: action_method,
-    title: _t(:assign_image),
+    title: Alchemy.t(:assign_image),
     class: 'thumbnail_background'
   ) %>
   <div class="picture_name" title="<%= picture_to_assign.name %>">

--- a/app/views/alchemy/admin/pictures/_tag_list.html.erb
+++ b/app/views/alchemy/admin/pictures/_tag_list.html.erb
@@ -1,13 +1,13 @@
 <% p = params.dup %>
 <% if Alchemy::Picture.tag_counts.any? %>
-  <h2><%= _t("Filter by tag") %></h2>
+  <h2><%= Alchemy.t("Filter by tag") %></h2>
   <%= js_filter_field '#tag_list li' %>
   <ul>
     <%= render_tag_list('Alchemy::Picture', p) %>
   </ul>
   <% if p[:tagged_with].present? %>
     <%= link_to(
-      render_icon('delete-small') + _t('Remove tag filter'),
+      render_icon('delete-small') + Alchemy.t('Remove tag filter'),
       url_for(p.delete_if { |k, v| k == "tagged_with" }.merge(action: 'index')),
       remote: request.xhr?,
       class: 'button small with_icon please_wait'

--- a/app/views/alchemy/admin/pictures/edit_multiple.html.erb
+++ b/app/views/alchemy/admin/pictures/edit_multiple.html.erb
@@ -10,21 +10,21 @@
 
   <div class="info">
     <%= render_icon :info %>
-    <p><%= _t('You are about to edit many pictures at once') % {length: @pictures.size} %></p>
+    <p><%= Alchemy.t('You are about to edit many pictures at once') % {length: @pictures.size} %></p>
   </div>
 
   <div class="input text">
-    <%= label_tag :pictures_name, _t('Name'), class: 'control-label' %>
+    <%= label_tag :pictures_name, Alchemy.t('Name'), class: 'control-label' %>
     <%= text_field_tag :pictures_name %>
   </div>
 
   <div class="input tag_list">
-    <%= label_tag :pictures_tag_list, _t(:tags), class: 'control-label' %>
+    <%= label_tag :pictures_tag_list, Alchemy.t(:tags), class: 'control-label' %>
     <%= text_field_tag :pictures_tag_list, @tags, data: {autocomplete: alchemy.autocomplete_admin_tags_path} %>
-    <small class="hint"><%= _t('Please seperate the tags with commata') %></small>
+    <small class="hint"><%= Alchemy.t('Please seperate the tags with commata') %></small>
   </div>
 
   <div class="submit">
-    <%= button_tag _t(:save), name: nil, class: 'button' %>
+    <%= button_tag Alchemy.t(:save), name: nil, class: 'button' %>
   </div>
 <% end %>

--- a/app/views/alchemy/admin/pictures/index.html.erb
+++ b/app/views/alchemy/admin/pictures/index.html.erb
@@ -2,15 +2,15 @@
   <div class="toolbar_buttons">
     <%= toolbar_button(
       icon: 'upload',
-      label: _t(:upload_image),
+      label: Alchemy.t(:upload_image),
       url: alchemy.new_admin_picture_path(size: @size),
       hotkey: 'alt+n',
       dialog_options: {
-        title: _t(:upload_image),
+        title: Alchemy.t(:upload_image),
         size: '540x525'
       },
       class: 'icon_button',
-      title: _t(:upload_image),
+      title: Alchemy.t(:upload_image),
       if_permitted_to: [:create, Alchemy::Picture]
     ) %>
     <% if can? :create, Alchemy::Picture %>
@@ -21,7 +21,7 @@
         <%= link_to(
           render_icon('zoom-out'),
           alchemy.admin_pictures_path(size: "small", q: params[:q]),
-          title: _t(:small_thumbnails),
+          title: Alchemy.t(:small_thumbnails),
           class: "icon_button please_wait"
         ) %>
       </div>
@@ -29,7 +29,7 @@
         <%= link_to(
           render_icon('zoom-equal'),
           alchemy.admin_pictures_path(size: "medium", q: params[:q]),
-          title: _t(:medium_thumbnails),
+          title: Alchemy.t(:medium_thumbnails),
           class: "icon_button please_wait"
         ) %>
       </div>
@@ -37,11 +37,11 @@
         <%= link_to(
           render_icon('zoom-in'),
           alchemy.admin_pictures_path(size: "large", q: params[:q]),
-          title: _t(:big_thumbnails),
+          title: Alchemy.t(:big_thumbnails),
           class: "icon_button please_wait"
         ) %>
       </div>
-      <label><%= _t('Image size') %></label>
+      <label><%= Alchemy.t('Image size') %></label>
       <%= hidden_field_tag('size', @size, id: 'overlay_thumbnails_size') %>
     </div>
     <% if can?(:flush, Alchemy::Picture) %>
@@ -54,9 +54,9 @@
           remote: true,
           method: :post
         },
-        label: _t('Flush picture cache'),
+        label: Alchemy.t('Flush picture cache'),
         class: 'icon_button please_wait',
-        title: _t('Flush picture cache'),
+        title: Alchemy.t('Flush picture cache'),
         skip_permission_check: true
       ) %>
     <% end %>
@@ -69,7 +69,7 @@
         class: 'icon_button',
         'data-alchemy-hotkey' => 'alt+a'
       ) %>
-      <label><%= _t("Select all") %></label>
+      <label><%= Alchemy.t("Select all") %></label>
     </div>
   </div>
 
@@ -81,7 +81,7 @@
   <h1>
     <%= @pictures.total_count %>
     <%= Alchemy::Picture.model_name.human(count: @pictures.total_count) %>
-    <%= _t("picture_library.filter.#{params[:filter]}") if params[:filter].present? %>
+    <%= Alchemy.t("picture_library.filter.#{params[:filter]}") if params[:filter].present? %>
   </h1>
   <%= render 'archive' %>
 </div>

--- a/app/views/alchemy/admin/pictures/new.html.erb
+++ b/app/views/alchemy/admin/pictures/new.html.erb
@@ -1,7 +1,7 @@
 <%= form_for [:admin, @picture], html: {multipart: true} do |f| %>
   <%= render 'alchemy/admin/partials/upload_form', {
       file_types: configuration(:uploader)['allowed_filetypes']['pictures'],
-      file_types_description: _t(:images),
+      file_types_description: Alchemy.t(:images),
       redirect_url: admin_pictures_path(
         size: params[:size],
         filter: 'last_upload',
@@ -10,7 +10,7 @@
         options: @options ? @options.to_json : nil),
       model_name: 'picture',
       file_attribute: 'image_file',
-      item_type: _t(:images)
+      item_type: Alchemy.t(:images)
     } %>
   <%= f.submit :upload, class: 'upload-button' %>
 <% end %>

--- a/app/views/alchemy/admin/resources/_form.html.erb
+++ b/app/views/alchemy/admin/resources/_form.html.erb
@@ -3,11 +3,11 @@
     <% if relation = attribute[:relation] %>
       <%= f.association relation[:name].to_sym,
         label_method: relation[:attr_method],
-        include_blank: _t(:blank, scope: 'resources.relation_select'),
+        include_blank: Alchemy.t(:blank, scope: 'resources.relation_select'),
         input_html: {class: 'alchemy_selectbox'} %>
     <% else %>
       <%= f.input attribute[:name], resource_attribute_field_options(attribute) %>
     <% end %>
   <% end %>
-  <%= f.submit _t(:save) %>
+  <%= f.submit Alchemy.t(:save) %>
 <% end %>

--- a/app/views/alchemy/admin/resources/_resource.html.erb
+++ b/app/views/alchemy/admin/resources/_resource.html.erb
@@ -17,12 +17,12 @@
       '',
       edit_resource_path(resource, current_location_params),
       {
-        title: _t('Edit'),
+        title: Alchemy.t('Edit'),
         size: resource_window_size
       },
       {
         class: 'icon edit',
-        title: _t('Edit')
+        title: Alchemy.t('Edit')
       }
     ) %>
     <% end %>

--- a/app/views/alchemy/admin/resources/_table.html.erb
+++ b/app/views/alchemy/admin/resources/_table.html.erb
@@ -18,7 +18,7 @@
   </tbody>
 </table>
 <% elsif params[:q].present? %>
-<p><%= _t('Nothing found') %></p>
+<p><%= Alchemy.t('Nothing found') %></p>
 <% end %>
 
 <%= paginate resources_instance_variable, scope: resource_url_proxy, theme: 'alchemy' %>

--- a/app/views/alchemy/admin/resources/index.html.erb
+++ b/app/views/alchemy/admin/resources/index.html.erb
@@ -1,4 +1,4 @@
-<% label_title = _t("Create #{resource_name}", default: _t('Create')) %>
+<% label_title = Alchemy.t("Create #{resource_name}", default: Alchemy.t('Create')) %>
 
 <% toolbar(
   buttons: [
@@ -17,8 +17,8 @@
     {
       icon: 'download',
       url: resource_url_proxy.url_for(action: 'index', format: 'csv', q: params[:q], sort: params[:sort]),
-      label: _t(:download_csv),
-      title: _t(:download_csv),
+      label: Alchemy.t(:download_csv),
+      title: Alchemy.t(:download_csv),
       dialog: false,
       loading_indicator: false,
       if_permitted_to: [:index, resource_model]

--- a/app/views/alchemy/admin/sites/index.html.erb
+++ b/app/views/alchemy/admin/sites/index.html.erb
@@ -1,4 +1,4 @@
-<% label_title = _t("Create #{resource_name}", default: _t('Create')) %>
+<% label_title = Alchemy.t("Create #{resource_name}", default: Alchemy.t('Create')) %>
 
 <% toolbar(
   buttons: [

--- a/app/views/alchemy/admin/tags/_tag.html.erb
+++ b/app/views/alchemy/admin/tags/_tag.html.erb
@@ -8,20 +8,20 @@
   <td class="tools">
     <% if can?(:destroy, Alchemy::Tag) %>
     <%= delete_button admin_tag_path(tag), {
-      message: _t(:do_you_really_want_to_delete_this_tag?),
+      message: Alchemy.t(:do_you_really_want_to_delete_this_tag?),
       icon: 'tag_delete',
-      title: _t(:delete_tag)
+      title: Alchemy.t(:delete_tag)
     } %>
     <% end %>
     <% if can?(:edit, Alchemy::Tag) %>
     <%= link_to_dialog '',
       edit_admin_tag_path(tag),
       {
-        title: _t(:edit_tag),
+        title: Alchemy.t(:edit_tag),
         size: '360x410'
       },
       {
-        title: _t(:edit_tag),
+        title: Alchemy.t(:edit_tag),
         class: 'icon tag_edit'
       }
     %>

--- a/app/views/alchemy/admin/tags/edit.html.erb
+++ b/app/views/alchemy/admin/tags/edit.html.erb
@@ -1,17 +1,17 @@
 <%= alchemy_form_for @tag, as: 'tag', url: alchemy.admin_tag_path(@tag), html: {method: 'patch'} do |f| %>
   <%= render_message :info do %>
-    <%= _t(:you_can_rename_this_tag) %>
+    <%= Alchemy.t(:you_can_rename_this_tag) %>
   <% end %>
   <%= f.input :name %>
-  <%= f.submit _t(:rename) %>
+  <%= f.submit Alchemy.t(:rename) %>
 <% end %>
 <% if @tags.any? -%>
   <%= alchemy_form_for @tag, as: 'tag', url: alchemy.admin_tag_path(@tag), html: {method: 'patch'} do |f| %>
     <%= render_message :info do %>
-      <%= _t(:or_replace_it_with_an_existing_tag) %>
+      <%= Alchemy.t(:or_replace_it_with_an_existing_tag) %>
     <% end %>
     <div class="input tags">
-      <label class="control-label"><%= _t('Tags') %></label>
+      <label class="control-label"><%= Alchemy.t('Tags') %></label>
       <div class="control_group" id="tags_tag_list">
         <%= js_filter_field '#tag_list li' %>
         <ul id="tag_list" class="tags">
@@ -19,6 +19,6 @@
         </ul>
       </div>
     </div>
-    <%= f.submit _t(:replace) %>
+    <%= f.submit Alchemy.t(:replace) %>
   <% end %>
 <% end %>

--- a/app/views/alchemy/admin/tags/index.html.erb
+++ b/app/views/alchemy/admin/tags/index.html.erb
@@ -2,12 +2,12 @@
   buttons: [
     {
       icon: 'tag_add',
-      label: _t('New Tag'),
+      label: Alchemy.t('New Tag'),
       url: alchemy.new_admin_tag_path,
-      title: _t('New Tag'),
+      title: Alchemy.t('New Tag'),
       hotkey: 'alt+n',
       dialog_options: {
-        title: _t('New Tag'),
+        title: Alchemy.t('New Tag'),
         size: '310x180'
       },
       if_permitted_to: [:create, Alchemy::Tag]
@@ -42,9 +42,9 @@
   <% else %>
 
   <%= render_message do %>
-    <h2><%= _t('No Tags found') %></h2>
+    <h2><%= Alchemy.t('No Tags found') %></h2>
     <% if params[:q].blank? %>
-      <p><%= _t(:tags_get_created_if_used_the_first_time) %></p>
+      <p><%= Alchemy.t(:tags_get_created_if_used_the_first_time) %></p>
     <% end %>
   <% end %>
 

--- a/app/views/alchemy/admin/tags/new.html.erb
+++ b/app/views/alchemy/admin/tags/new.html.erb
@@ -1,7 +1,7 @@
 <%= alchemy_form_for [:admin, @tag], as: 'tag', url: admin_tags_path do |form| %>
   <%= render_message do %>
-    <p><%= _t(:tags_get_created_if_used_the_first_time) %></p>
+    <p><%= Alchemy.t(:tags_get_created_if_used_the_first_time) %></p>
   <% end %>
   <%= form.input :name, autofocus: true %>
-  <%= form.submit _t(:save) %>
+  <%= form.submit Alchemy.t(:save) %>
 <% end %>

--- a/app/views/alchemy/admin/trash/clear.js.erb
+++ b/app/views/alchemy/admin/trash/clear.js.erb
@@ -1,4 +1,4 @@
-Alchemy.growl('<%= _t("Cleared trash") %>');
+Alchemy.growl('<%= Alchemy.t("Cleared trash") %>');
 Alchemy.TrashWindow.refresh();
 jQuery('#element_trash_button .icon').removeClass('full');
 Alchemy.pleaseWaitOverlay(false);

--- a/app/views/alchemy/admin/trash/index.html.erb
+++ b/app/views/alchemy/admin/trash/index.html.erb
@@ -1,11 +1,11 @@
 <%- if @elements.blank? -%>
 <div id="trash_empty_notice" <%= @elements.blank? ? '' : 'style="display: none"' %> class="info">
   <%= render_icon('info') %>
-  <%= _t('Your trash is empty') %>
+  <%= Alchemy.t('Your trash is empty') %>
 </div>
 <%- else -%>
 <%= render_message do %>
-  <%= _t('Drag an element over to the element window to restore it') %>
+  <%= Alchemy.t('Drag an element over to the element window to restore it') %>
 <% end %>
 <div id="trash_items">
 <%- @elements.each do |element| -%>
@@ -19,8 +19,8 @@
 <%- end -%>
 </div>
 <p>
-  <%= link_to_confirm_dialog _t('clear trash'),
-    _t('Do you really want to clear the trash?'),
+  <%= link_to_confirm_dialog Alchemy.t('clear trash'),
+    Alchemy.t('Do you really want to clear the trash?'),
     alchemy.clear_admin_trash_path(page_id: @page.id),
     class: 'button' %>
 </p>

--- a/app/views/alchemy/base/500.html.erb
+++ b/app/views/alchemy/base/500.html.erb
@@ -3,8 +3,8 @@
     {
       icon: 'back',
       url: request.referer || "#{Alchemy::MountPoint.get}/admin/dashboard",
-      label: _t(:back),
-      title: _t(:back),
+      label: Alchemy.t(:back),
+      title: Alchemy.t(:back),
       hotkey: 'alt+z',
       dialog: false,
       skip_permission_check: true
@@ -13,7 +13,7 @@
 ) %>
 
 <%= render_message(:error) do %>
-  <h1><%= _t('An error happened') %></h1>
+  <h1><%= Alchemy.t('An error happened') %></h1>
   <h2>
     <%= @error.class %>
     <%= @notice %>

--- a/app/views/alchemy/elements/_editor_not_found.html.erb
+++ b/app/views/alchemy/elements/_editor_not_found.html.erb
@@ -1,5 +1,5 @@
 <div class="error">
   <%= render_icon('error') %>
-  <h1><%= _t(:element_editor_not_found) %>:</h1>
+  <h1><%= Alchemy.t(:element_editor_not_found) %>:</h1>
   <p><%= error.html_safe %></p>
 </div>

--- a/app/views/alchemy/essences/_essence_boolean_view.html.erb
+++ b/app/views/alchemy/essences/_essence_boolean_view.html.erb
@@ -1,3 +1,3 @@
 <%- cache(content) do -%>
-<%= _t(content.ingredient) -%>
+<%= Alchemy.t(content.ingredient) -%>
 <%- end -%>

--- a/app/views/alchemy/essences/_essence_file_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_file_editor.html.erb
@@ -8,13 +8,13 @@
     options: local_assigns.fetch(:options, {}).to_json
   ),
   {
-    title: _t(:assign_file),
+    title: Alchemy.t(:assign_file),
     size: '780x585',
     padding: false
   },
   {
     class: 'assign_file',
-    title: _t(:assign_file)
+    title: Alchemy.t(:assign_file)
   }
 ) %>
 
@@ -30,7 +30,7 @@
     </div>
     <div class="file_name">
       <%= content.ingredient.try(:name) ||
-        ("&#x2190;" + _t(:assign_file_from_archive)).html_safe %>
+        ("&#x2190;" + Alchemy.t(:assign_file_from_archive)).html_safe %>
     </div>
     <div class="essence_file_tools">
       <%= dialog_link %>
@@ -40,11 +40,11 @@
           options: local_assigns.fetch(:options, {}).to_json
         ),
         {
-          title: _t(:edit_file_properties),
+          title: Alchemy.t(:edit_file_properties),
           size: '400x215'
         },
         class: 'edit_file',
-        title: _t(:edit_file_properties) %>
+        title: Alchemy.t(:edit_file_properties) %>
     </div>
     <% if content.ingredient %>
       <%= hidden_field_tag content.form_field_name(:attachment_id),

--- a/app/views/alchemy/essences/_essence_picture_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_picture_editor.html.erb
@@ -8,18 +8,18 @@
     <div class="picture_thumbnail">
       <span class="picture_tool delete">
         <% if options[:grouped] %>
-          <%= link_to_confirm_dialog "", _t(:confirm_to_delete_image),
+          <%= link_to_confirm_dialog "", Alchemy.t(:confirm_to_delete_image),
             alchemy.admin_essence_picture_path(
               id: content,
               options: options
-            ), {title: _t(:delete_image)} %>
+            ), {title: Alchemy.t(:delete_image)} %>
         <% else %>
           <%= link_to '', '#',
             onclick: "return Alchemy.removePicture('##{content.form_field_id(:picture_id)}');" %>
         <% end %>
       </span>
       <%- if content.ingredient -%>
-        <div class="picture_handle" title="<%= _t(:drag_to_sort) if options[:dragable] %>"></div>
+        <div class="picture_handle" title="<%= Alchemy.t(:drag_to_sort) if options[:dragable] %>"></div>
       <%- end -%>
       <div class="picture_image">
         <div class="thumbnail_background<%= ' missing' if content.ingredient.nil? %>">
@@ -31,7 +31,7 @@
       </div>
       <%- if content.essence.css_class.present? -%>
         <div class="essence_picture_css_class">
-          <%= _t("alchemy.essence_pictures.css_classes.#{content.essence.css_class}",
+          <%= Alchemy.t("alchemy.essence_pictures.css_classes.#{content.essence.css_class}",
             default: content.essence.css_class.camelcase) %>
         </div>
       <%- end -%>

--- a/app/views/alchemy/essences/shared/_essence_picture_tools.html.erb
+++ b/app/views/alchemy/essences/shared/_essence_picture_tools.html.erb
@@ -7,10 +7,10 @@
       options: content.settings.update(options).to_json
     ), {
       size: "1000x615",
-      title: _t('Edit Picturemask'),
+      title: Alchemy.t('Edit Picturemask'),
       image_loader: false,
       padding: false
-    }, {title: _t('Edit Picturemask')} %>
+    }, {title: Alchemy.t('Edit Picturemask')} %>
 <%- else -%>
   <a href="#" class="disabled"><%= render_icon('crop') %></a>
 <%- end -%>
@@ -23,16 +23,16 @@
     options: options.to_json
   ),
   {
-    title: (content.ingredient ? _t(:swap_image) : _t(:insert_image)),
+    title: (content.ingredient ? Alchemy.t(:swap_image) : Alchemy.t(:insert_image)),
     size: '780x580',
     padding: false
   },
-  title: (content.ingredient ? _t(:swap_image) : _t(:insert_image)) %>
+  title: (content.ingredient ? Alchemy.t(:swap_image) : Alchemy.t(:insert_image)) %>
 
 <%= link_to_if linkable, render_icon(:link), '', {
   onclick: 'd = new Alchemy.LinkDialog(this); d.open(); return false;',
   class: content.linked? ? 'linked' : nil,
-  title: _t(:link_image),
+  title: Alchemy.t(:link_image),
   'data-content-id' => content.id,
   id: "edit_link_#{content.id}"
 } %>
@@ -40,7 +40,7 @@
 <%= link_to_if linkable, render_icon('unlink'), '', {
   onclick: "return Alchemy.LinkDialog.removeLink(this, #{content.id})",
   class: content.linked? ? 'linked' : 'disabled',
-  title: _t(:unlink)
+  title: Alchemy.t(:unlink)
 } %>
 
 <%= link_to_dialog render_icon('edit'),
@@ -49,6 +49,6 @@
     content_id: content.id,
     options: options.to_json
   ), {
-    title: _t(:edit_image_properties),
+    title: Alchemy.t(:edit_image_properties),
     size: edit_picture_dialog_size(content, options)
-  }, title: _t(:edit_image_properties) %>
+  }, title: Alchemy.t(:edit_image_properties) %>

--- a/app/views/alchemy/essences/shared/_linkable_essence_tools.html.erb
+++ b/app/views/alchemy/essences/shared/_linkable_essence_tools.html.erb
@@ -5,7 +5,7 @@
     onclick: "d = new Alchemy.LinkDialog(this); d.open(); return false;",
     class: "icon_button#{content.linked? ? ' linked' : ''} link-essence",
     'data-content-id' => content.id,
-    title: _t(:place_link),
+    title: Alchemy.t(:place_link),
     id: "edit_link_#{content.id}"
   ) %>
   <%= link_to(
@@ -14,6 +14,6 @@
     onclick: "return Alchemy.LinkDialog.removeLink(this, #{content.id})",
     class: "icon_button unlink-essence #{content.linked? ? 'linked' : 'disabled'}",
     'data-content-id' => content.id,
-    title: _t(:unlink)
+    title: Alchemy.t(:unlink)
   ) %>
 </span>

--- a/app/views/alchemy/language_links/_language.html.erb
+++ b/app/views/alchemy/language_links/_language.html.erb
@@ -10,7 +10,7 @@
     languages.first == language ? 'first' : nil,
     languages.last == language ? 'last' : nil
   ].compact,
-  title: options[:show_title] ? _t(
+  title: options[:show_title] ? Alchemy.t(
     "#{language.code}.title",
     scope: 'language_links',
     default: language.name

--- a/app/views/alchemy/messages/contact_form_mail.de.text.erb
+++ b/app/views/alchemy/messages/contact_form_mail.de.text.erb
@@ -4,7 +4,7 @@
 
 Absender:
 
-<%= Alchemy::I18n.t(@message.salutation, scope: 'contactform.labels') %> <%= @message.firstname %> <%= @message.lastname %>
+<%= Alchemy.t(@message.salutation, scope: 'contactform.labels') %> <%= @message.firstname %> <%= @message.lastname %>
 <%= @message.address %>
 <%= @message.zip %> <%= @message.city %>
 

--- a/app/views/alchemy/messages/contact_form_mail.en.text.erb
+++ b/app/views/alchemy/messages/contact_form_mail.en.text.erb
@@ -4,7 +4,7 @@
 
 Sender:
 
-<%= Alchemy::I18n.t(@message.salutation, scope: 'contactform.labels') %> <%= @message.firstname %> <%= @message.lastname %>
+<%= Alchemy.t(@message.salutation, scope: 'contactform.labels') %> <%= @message.firstname %> <%= @message.lastname %>
 <%= @message.address %>
 <%= @message.zip %> <%= @message.city %>
 

--- a/app/views/alchemy/messages/contact_form_mail.es.text.erb
+++ b/app/views/alchemy/messages/contact_form_mail.es.text.erb
@@ -4,7 +4,7 @@
 
 Remitente:
 
-<%= Alchemy::I18n.t(@message.salutation, scope: 'contactform.labels') %> <%= @message.firstname %> <%= @message.lastname %>
+<%= Alchemy.t(@message.salutation, scope: 'contactform.labels') %> <%= @message.firstname %> <%= @message.lastname %>
 <%= @message.address %>
 <%= @message.zip %> <%= @message.city %>
 

--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -39,12 +39,12 @@
   </head>
   <body id="alchemy" class="<%= alchemy_body_class %>">
     <noscript>
-      <h1><%= _t(:javascript_disabled_headline) %></h1>
-      <p><%= _t(:javascript_disabled_text) %></p>
+      <h1><%= Alchemy.t(:javascript_disabled_headline) %></h1>
+      <p><%= Alchemy.t(:javascript_disabled_text) %></p>
     </noscript>
     <div id="overlay">
       <div id="overlay_text_box">
-        <span id="overlay_text"><%= _t(:please_wait) %></span>
+        <span id="overlay_text"><%= Alchemy.t(:please_wait) %></span>
       </div>
     </div>
     <div id="left_menu">
@@ -57,15 +57,15 @@
       <div id="logout">
         <% if current_alchemy_user %>
           <%= link_to_dialog(
-            "#{render_icon('exit module')}<label>#{_t(:leave)}</label>".html_safe,
+            "#{render_icon('exit module')}<label>#{Alchemy.t(:leave)}</label>".html_safe,
             alchemy.leave_admin_path, {
               size: "300x155",
-              title: _t("Leave Alchemy")
+              title: Alchemy.t("Leave Alchemy")
           }, {'data-alchemy-hotkey' => 'alt+q'}) %>
         <% else %>
           <%= link_to(alchemy.root_path) do %>
             <span class="module icon exit"></span>
-            <label><%= _t(:leave) %></label>
+            <label><%= Alchemy.t(:leave) %></label>
           <% end %>
         <% end %>
       </div>
@@ -76,7 +76,7 @@
         <%= admin_subnavigation %>
         <% if @locked_pages.present? %>
           <div id="locked_pages">
-            <label><%= _t(:locked_pages) %> &raquo;</label>
+            <label><%= Alchemy.t(:locked_pages) %> &raquo;</label>
             <%= render partial: 'alchemy/admin/pages/locked_page', collection: @locked_pages %>
           </div>
         <% end %>

--- a/lib/alchemy/hints.rb
+++ b/lib/alchemy/hints.rb
@@ -35,7 +35,7 @@ module Alchemy
     def hint
       hint = definition['hint']
       if hint == true
-        I18n.t(name, scope: hint_translation_scope)
+        Alchemy.t(name, scope: hint_translation_scope)
       else
         hint
       end

--- a/lib/alchemy/i18n.rb
+++ b/lib/alchemy/i18n.rb
@@ -1,52 +1,65 @@
 module Alchemy
+  class << self
+    # Alchemy shortcut translation method
+    #
+    # Instead of having to call:
+    #
+    #     Alchemy::I18n.translate(:hello)
+    #
+    # You can use this shortcut method:
+    #
+    #     Alchemy.t(:hello)
+    #
+    def t(msg, *args)
+      Alchemy::I18n.translate(msg, *args)
+    end
+  end
+
   module I18n
     class << self
+      def t(msg, *args)
+        ActiveSupport::Deprecation.warn('`Alchemy::I18n.t` is deprecated! Use `Alchemy.t` instead.', caller.unshift)
+        Alchemy::I18n.translate(msg, *args)
+      end
+
       # Alchemy translation methods
       #
       # Instead of having to translate strings and defining a default value:
       #
-      #     Alchemy::I18n.t("Hello World!", :default => 'Hello World!')
+      #     Alchemy::I18n.translate("Hello World!", default: 'Hello World!')
       #
       # We define this method to define the value only once:
       #
-      #     Alchemy::I18n.t("Hello World!")
+      #     Alchemy::I18n.translate("Hello World!")
       #
       # Note that interpolation still works:
       #
-      #     Alchemy::I18n.t("Hello %{world}!", :world => @world)
-      #
-      # It offers a shortcut method and view helper called _t
+      #     Alchemy::I18n.translate("Hello %{world}!", world: @world)
       #
       # === Notes
       #
       # All translations are scoped into the +alchemy+ namespace.
       # Even scopes are scoped into the +alchemy+ namespace.
       #
-      # So a call for _t('hello', :scope => :world) has to be translated like this:
+      # So a call for Alchemy::translate('hello', scope: 'world') has to be translated like this:
       #
       #   de:
       #     alchemy:
       #       world:
       #         hello: Hallo
       #
-      def t(msg, *args)
+      def translate(msg, *args)
         options = args.extract_options!
         humanize_default_string!(msg, options)
-        scope = ['alchemy']
-        case options[:scope].class.name
-        when "Array"
-          scope += options[:scope]
-        when "String"
-          scope << options[:scope]
-        when "Symbol"
-          scope << options[:scope] unless options[:scope] == :alchemy
-        end
+        scope = alchemy_scoped_scope(options)
         ::I18n.t(msg, options.merge(scope: scope))
       end
 
       def available_locales
         @@available_locales ||= nil
-        @@available_locales || translation_files.collect { |f| f.match(/.{2}\.yml$/).to_s.gsub(/\.yml/, '').to_sym }
+        @@available_locales || translation_files.collect do |f|
+          f.match(/.{2}\.yml$/).to_s.gsub(/\.yml/, '').to_sym
+        end
       end
 
       def available_locales=(locales)
@@ -61,8 +74,23 @@ module Alchemy
       private
 
       def humanize_default_string!(msg, options)
-        if options[:default].blank?
-          options[:default] = msg.is_a?(Symbol) ? msg.to_s.humanize : msg
+        return if options[:default].present?
+        options[:default] = msg.is_a?(Symbol) ? msg.to_s.humanize : msg
+      end
+
+      def alchemy_scoped_scope(options)
+        default_scope = ['alchemy']
+        case options[:scope]
+        when Array
+          default_scope += options[:scope]
+        when String
+          default_scope << options[:scope]
+        when Symbol
+          if options[:scope] != :alchemy
+            default_scope << options[:scope]
+          end
+        else
+          default_scope
         end
       end
     end

--- a/lib/alchemy/page_layout.rb
+++ b/lib/alchemy/page_layout.rb
@@ -56,7 +56,7 @@ module Alchemy
       # Returns page layouts ready for Rails' select form helper.
       #
       def layouts_for_select(language_id, only_layoutpages = false)
-        @map_array = [[I18n.t('Please choose'), '']]
+        @map_array = [[Alchemy.t('Please choose'), '']]
         mapped_layouts_for_select(selectable_layouts(language_id, only_layoutpages))
       end
 
@@ -116,7 +116,7 @@ module Alchemy
       #   The layout name
       #
       def human_layout_name(layout)
-        I18n.t(layout, scope: 'page_layout_names', default: layout.to_s.humanize)
+        Alchemy.t(layout, scope: 'page_layout_names', default: layout.to_s.humanize)
       end
 
       private

--- a/lib/alchemy/resources_helper.rb
+++ b/lib/alchemy/resources_helper.rb
@@ -84,7 +84,7 @@ module Alchemy
       value
     rescue ActiveRecord::RecordNotFound => e
       warning e
-      _t(:not_found)
+      Alchemy.t(:not_found)
     end
 
     # Returns a options hash for simple_form input fields.

--- a/spec/controllers/admin/essence_pictures_controller_spec.rb
+++ b/spec/controllers/admin/essence_pictures_controller_spec.rb
@@ -33,7 +33,7 @@ module Alchemy
 
         it "renders error message" do
           alchemy_get :crop, id: 1
-          expect(assigns(:no_image_notice)).to eq(Alchemy::I18n.t(:no_image_for_cropper_found))
+          expect(assigns(:no_image_notice)).to eq(Alchemy.t(:no_image_for_cropper_found))
         end
       end
 

--- a/spec/controllers/admin/pictures_controller_spec.rb
+++ b/spec/controllers/admin/pictures_controller_spec.rb
@@ -274,7 +274,7 @@ module Alchemy
         it "sets success notice" do
           subject
           expect(assigns(:message)[:body]).to \
-            eq(Alchemy::I18n.t(:picture_updated_successfully, name: picture.name))
+            eq(Alchemy.t(:picture_updated_successfully, name: picture.name))
           expect(assigns(:message)[:type]).to eq('notice')
         end
       end
@@ -286,7 +286,7 @@ module Alchemy
 
         it "sets error notice" do
           subject
-          expect(assigns(:message)[:body]).to eq(Alchemy::I18n.t(:picture_update_failed))
+          expect(assigns(:message)[:body]).to eq(Alchemy.t(:picture_update_failed))
           expect(assigns(:message)[:type]).to eq('error')
         end
       end

--- a/spec/features/admin/legacy_page_url_management_spec.rb
+++ b/spec/features/admin/legacy_page_url_management_spec.rb
@@ -11,7 +11,7 @@ describe 'Legacy page url management', type: :feature, js: true do
   def open_page_properties
     visit admin_pages_path
     within "#page_#{a_page.id}" do
-      click_link Alchemy::I18n.t(:edit_page_properties)
+      click_link Alchemy.t(:edit_page_properties)
     end
   end
 
@@ -52,7 +52,7 @@ describe 'Legacy page url management', type: :feature, js: true do
       click_button 'Yes'
       within '#legacy_page_urls' do
         expect(page).to_not have_content('a-page-link')
-        expect(page).to have_content(Alchemy::I18n.t('No page links for this page found'))
+        expect(page).to have_content(Alchemy.t('No page links for this page found'))
       end
       within '#legacy_urls_label' do
         expect(page).to have_content('(0) Links')

--- a/spec/features/admin/page_editing_feature_spec.rb
+++ b/spec/features/admin/page_editing_feature_spec.rb
@@ -18,7 +18,7 @@ describe 'Page editing feature' do
     it 'can publish page.' do
       visit alchemy.edit_admin_page_path(a_page)
       find('#publish_page_form button').click
-      expect(page).to have_content Alchemy::I18n.t(:page_published, name: a_page.name)
+      expect(page).to have_content Alchemy.t(:page_published, name: a_page.name)
     end
 
     context 'while editing a global page' do

--- a/spec/helpers/admin/base_helper_spec.rb
+++ b/spec/helpers/admin/base_helper_spec.rb
@@ -247,7 +247,7 @@ module Alchemy
         let(:user) { double('User', alchemy_display_name: 'Peter Schroeder') }
 
         it "Returns a span showing the name of the currently logged in user." do
-          is_expected.to have_content("#{Alchemy::I18n.t('Logged in as')} Peter Schroeder")
+          is_expected.to have_content("#{Alchemy.t('Logged in as')} Peter Schroeder")
           is_expected.to have_selector("span.current-user-name")
         end
       end

--- a/spec/helpers/admin/navigation_helper_spec.rb
+++ b/spec/helpers/admin/navigation_helper_spec.rb
@@ -56,7 +56,7 @@ describe Alchemy::Admin::NavigationHelper do
   describe '#alchemy_main_navigation_entry' do
     before do
       allow(helper).to receive(:url_for_module).and_return('')
-      allow(helper).to receive(:_t).and_return(alchemy_module['name'])
+      allow(Alchemy).to receive(:t).and_return(alchemy_module['name'])
     end
 
     context "with permission" do
@@ -84,7 +84,7 @@ describe Alchemy::Admin::NavigationHelper do
     before do
       allow(helper).to receive(:current_alchemy_module).and_return(alchemy_module)
       allow(helper).to receive(:url_for_module_sub_navigation).and_return('')
-      allow(helper).to receive(:_t).and_return(alchemy_module['name'])
+      allow(Alchemy).to receive(:t).and_return(alchemy_module['name'])
     end
 
     context "with permission" do

--- a/spec/helpers/admin/pages_helper_spec.rb
+++ b/spec/helpers/admin/pages_helper_spec.rb
@@ -67,7 +67,7 @@ describe Alchemy::Admin::PagesHelper do
 
     context 'when page is not yet persisted' do
       it 'displays text only' do
-        is_expected.to eq(Alchemy::I18n.t(:page_type))
+        is_expected.to eq(Alchemy.t(:page_type))
       end
     end
 
@@ -76,7 +76,7 @@ describe Alchemy::Admin::PagesHelper do
 
       context 'with page layout existing' do
         it 'displays text only' do
-          is_expected.to eq(Alchemy::I18n.t(:page_type))
+          is_expected.to eq(Alchemy.t(:page_type))
         end
       end
 

--- a/spec/helpers/essences_helper_spec.rb
+++ b/spec/helpers/essences_helper_spec.rb
@@ -41,7 +41,7 @@ describe Alchemy::EssencesHelper do
       context 'editor given as part' do
         subject { helper.render_essence(content, :editor) }
 
-        before { allow(helper).to receive(:_t).and_return('') }
+        before { allow(Alchemy).to receive(:t).and_return('') }
 
         it "displays warning" do
           expect(helper).to receive(:warning).and_return('')
@@ -60,7 +60,7 @@ describe Alchemy::EssencesHelper do
       context 'editor given as part' do
         subject { helper.render_essence(content, :editor) }
 
-        before { allow(helper).to receive(:_t).and_return('') }
+        before { allow(Alchemy).to receive(:t).and_return('') }
 
         it "displays warning" do
           expect(helper).to receive(:warning).and_return('')

--- a/spec/helpers/pages_helper_spec.rb
+++ b/spec/helpers/pages_helper_spec.rb
@@ -434,7 +434,7 @@ module Alchemy
           context "with options[:show_title]" do
             context "set to true" do
               it "should render the language links with titles" do
-                allow(helper).to receive(:_t).and_return("my title")
+                allow(Alchemy).to receive(:t).and_return("my title")
                 expect(helper.language_links(show_title: true)).to have_selector('a[title="my title"]')
               end
             end

--- a/spec/libraries/i18n_spec.rb
+++ b/spec/libraries/i18n_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 module Alchemy
+  describe ".t" do
+    it 'scopes translations intro alchemy namespace' do
+      expect(::I18n).to receive(:t).with(:foo, default: 'Foo', scope: ['alchemy'])
+      ::Alchemy.t(:foo)
+    end
+  end
+
   describe I18n do
     describe '.translation_files' do
       subject { I18n.translation_files }

--- a/spec/libraries/page_layout_spec.rb
+++ b/spec/libraries/page_layout_spec.rb
@@ -131,7 +131,7 @@ module Alchemy
       end
 
       context "with translation present" do
-        before { expect(I18n).to receive(:t).and_return('Kontakt') }
+        before { expect(Alchemy).to receive(:t).and_return('Kontakt') }
 
         it "returns the translated name" do
           is_expected.to eq('Kontakt')

--- a/spec/models/element_spec.rb
+++ b/spec/models/element_spec.rb
@@ -136,7 +136,7 @@ module Alchemy
 
     describe '.display_name_for' do
       it "should return the translation for the given name" do
-        expect(I18n).to receive(:t).with('subheadline', scope: "element_names", default: 'Subheadline').and_return('Überschrift')
+        expect(Alchemy).to receive(:t).with('subheadline', scope: "element_names", default: 'Subheadline').and_return('Überschrift')
         expect(Element.display_name_for('subheadline')).to eq('Überschrift')
       end
 
@@ -366,13 +366,13 @@ module Alchemy
       let(:element) { Element.new(name: 'article') }
 
       it "should return the translation with the translated content label" do
-        expect(I18n).to receive(:t)
+        expect(Alchemy).to receive(:t)
           .with('content_names.content', default: 'Content')
           .and_return('Content')
-        expect(I18n).to receive(:t)
+        expect(Alchemy).to receive(:t)
           .with('content', scope: "content_names.article", default: 'Content')
           .and_return('Contenido')
-        expect(I18n).to receive(:t)
+        expect(Alchemy).to receive(:t)
           .with('article.content.invalid', {
             scope: "content_validations",
             default: [:"fields.content.invalid", :"errors.invalid"],

--- a/spec/support/hint_examples.rb
+++ b/spec/support/hint_examples.rb
@@ -16,7 +16,7 @@ module Alchemy
       context 'with hint set to true' do
         before do
           expect(subject).to receive(:definition).and_return({'hint' => true})
-          expect(I18n).to receive(:t).and_return('The hint')
+          expect(Alchemy).to receive(:t).and_return('The hint')
         end
 
         it "returns the hint from translation" do

--- a/spec/views/admin/pictures/show_spec.rb
+++ b/spec/views/admin/pictures/show_spec.rb
@@ -18,7 +18,6 @@ describe "alchemy/admin/pictures/show.html.erb" do
 
   before do
     allow(view).to receive(:admin_picture_path).and_return("/path")
-    allow(view).to receive(:_t) {}
     allow(view).to receive(:render_message) {}
     view.extend Alchemy::Admin::FormHelper
   end

--- a/spec/views/essences/essence_boolean_view_spec.rb
+++ b/spec/views/essences/essence_boolean_view_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'alchemy/essences/_essence_boolean_view' do
   context 'with true as ingredient' do
     let(:content) { Alchemy::EssenceBoolean.new(ingredient: true) }
-    before { allow(view).to receive(:_t).and_return('true') }
+    before { allow(Alchemy).to receive(:t).and_return('true') }
 
     it "renders true" do
       render content, content: content
@@ -13,7 +13,7 @@ describe 'alchemy/essences/_essence_boolean_view' do
 
   context 'with false as ingredient' do
     let(:content) { Alchemy::EssenceBoolean.new(ingredient: false) }
-    before { allow(view).to receive(:_t).and_return('false') }
+    before { allow(Alchemy).to receive(:t).and_return('false') }
 
     it "renders false" do
       render content, content: content

--- a/spec/views/essences/essence_file_editor_spec.rb
+++ b/spec/views/essences/essence_file_editor_spec.rb
@@ -12,7 +12,6 @@ describe 'alchemy/essences/_essence_editor_view' do
 
   before do
     view.class.send :include, Alchemy::Admin::BaseHelper
-    allow(view).to receive(:_t).and_return('')
     allow(view).to receive(:content_label).and_return('')
   end
 


### PR DESCRIPTION
Currently we have `Alchemy::I18n.t`, a controller method `_t` and a view helper `_t`.

This unifies them to one `Alchemy.t` method and deprecates all other ones. 

Even renames the `Alchemy._t` javascript function in to `Alchemy.t` for consistency.

**CAUTION** large diffs
