### PR TITLE
Fail pull requests on hound violations

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -6,3 +6,4 @@ coffeescript:
   enabled: false
 javascript:
   enabled: false
+fail_on_violations: true


### PR DESCRIPTION
Now that we have relaxed hound and rubocop settings we can
fail pull requests if any violations happen.