### PR TITLE
Display year for created_at of an attachment in the backend

### DIFF
--- a/app/views/alchemy/admin/attachments/_attachment.html.erb
+++ b/app/views/alchemy/admin/attachments/_attachment.html.erb
@@ -22,7 +22,7 @@
   <td class="file_name"><%= attachment.file_name %></td>
   <td class="file_type"><%= mime_to_human(attachment.file_mime_type) %></td>
   <td class="file_size"><%= number_to_human_size(attachment.file_size) %></td>
-  <td class="date"><%= l(attachment.created_at, format: :short) %></td>
+  <td class="date"><%= l(attachment.created_at, format: :default) %></td>
   <td class="tools long">
   <% if can?(:download, attachment) %>
     <%= link_to(


### PR DESCRIPTION
Currenty the declaration of the `created_at` field for attachments within the view for attachments in the backend does not consider the year. e.g. `8. February, 11:45h` . This can be confusing while handling of files from different years. 

According to #929 this PR changes the time format from `:short` to `:default` which makes the year visible. 
e.g. `08. Feb. 2016, 11:45 Uhr` 

I've realised that the `en` locale time formats differ from the `de` settings. The `:default` english time format contains the **abbreviated weekday name**. 

This might be worth thinking about to adjust in order to gain consitency.   