### PR TITLE
Don't show trashed elements when using a fallback

### DIFF
--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -276,7 +276,7 @@ module Alchemy
         page = fallback_options[:from]
       end
       return [] if page.blank?
-      page.elements.named(fallback_options[:with].blank? ? fallback_options[:for] : fallback_options[:with])
+      page.elements.not_trashed.named(fallback_options[:with].presence || fallback_options[:for])
     end
 
     def render_element_view_partials(elements, options = {})

--- a/spec/helpers/elements_helper_spec.rb
+++ b/spec/helpers/elements_helper_spec.rb
@@ -160,7 +160,7 @@ module Alchemy
 
           before do
             allow(Language).to receive(:current).and_return double(pages: double(find_by: another_page))
-            allow(another_page).to receive(:elements).and_return double(named: elements)
+            allow(another_page).to receive(:elements).and_return double(not_trashed: double(named: elements))
           end
 
           it "renders the fallback element" do
@@ -172,7 +172,7 @@ module Alchemy
           let(:options) { {fallback: {for: 'higgs', with: 'news', from: another_page}} }
 
           before do
-            allow(another_page).to receive(:elements).and_return double(named: elements)
+            allow(another_page).to receive(:elements).and_return double(not_trashed: double(named: elements))
           end
 
           it "renders the fallback element" do


### PR DESCRIPTION
Trashed elements are still shown when they're used as a fallback. This change filters them out.