### PR TITLE
Respect trashed elements when checking cell_empty?

### DIFF
--- a/app/helpers/alchemy/pages_helper.rb
+++ b/app/helpers/alchemy/pages_helper.rb
@@ -410,7 +410,7 @@ module Alchemy
     def cell_empty?(name)
       cell = @page.cells.find_by_name(name)
       return true if cell.blank?
-      cell.elements.blank?
+      cell.elements.not_trashed.empty?
     end
 
     # Include this in your layout file to have element selection magic in the page edit preview window.

--- a/spec/helpers/alchemy/pages_helper_spec.rb
+++ b/spec/helpers/alchemy/pages_helper_spec.rb
@@ -449,6 +449,44 @@ module Alchemy
       end
     end
 
+    describe "#cell_empty" do
+      let(:cell)    { create(:alchemy_cell, name: 'test_cell', page: public_page) }
+      let(:element) { create(:alchemy_element) }
+
+      before { @page = public_page }
+
+      context "with elements" do
+        before do
+          cell.elements << element
+          cell.save!
+        end
+
+        it "should return true" do
+          expect(helper.cell_empty?('test_cell')).to eq(false)
+        end
+      end
+
+      context "with zero elements" do
+        it "should return true" do
+          expect(helper.cell_empty?('test_cell')).to eq(true)
+        end
+      end
+
+      context "with trashed elements" do
+        before do
+          cell.elements << element
+          cell.save!
+
+          element.trash!
+          element.save!
+        end
+
+        it "should return true" do
+          expect(helper.cell_empty?('test_cell')).to eq(true)
+        end
+      end
+    end
+
     describe "#picture_essence_caption" do
       let(:essence) { mock_model('EssencePicture', caption: 'my caption') }
       let(:content) { mock_model('Content', essence: essence) }


### PR DESCRIPTION
Currently the `cell_empty?` helper returns true if an element within a cell has been deleted. This can make for a confusing experience when trying to understand why something is or isn't showing when relying on this check.