### PR TITLE
fix: wrong week number

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.datepicker.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.datepicker.js.coffee
@@ -17,6 +17,7 @@ $.extend Alchemy,
     if Alchemy.locale is "de"
       $.extend datepicker_options,
         dateFormat: "dd.mm.yy"
+        firstDay: 1
         dayNames: ["Sonntag", "Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag"]
         dayNamesMin: ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"]
         monthNames: ["Januar", "Februar", "März", "April", "Mai", "Juni", "Juli", "August", "September", "Oktober", "November", "Dezember"]


### PR DESCRIPTION
Set firstDay to 1 to show the correct week number in german locale
See my issue #949 