### PR TITLE
Update engine.rb

### DIFF
--- a/lib/alchemy/engine.rb
+++ b/lib/alchemy/engine.rb
@@ -92,7 +92,7 @@ module Alchemy
         Dir.glob(essences).each { |essence| load(essence) }
       end
     end
-    
+ 
     config.to_prepare do
       Dir.glob(Rails.root + "app/decorators/**/*_decorator*.rb").each do |decorator|
         require_dependency(decorator)

--- a/lib/alchemy/engine.rb
+++ b/lib/alchemy/engine.rb
@@ -92,6 +92,12 @@ module Alchemy
         Dir.glob(essences).each { |essence| load(essence) }
       end
     end
+    
+    config.to_prepare do
+      Dir.glob(Rails.root + "app/decorators/**/*_decorator*.rb").each do |decorator|
+        require_dependency(decorator)
+      end
+    end
 
     config.after_initialize do
       require_relative './userstamp'


### PR DESCRIPTION
This PR allows for the main app that's making use of the AlchemyCMS engine to easily extend its models via the decorator pattern. This configuration will allow for simple class modifications using `Class#class_eval` by nesting the decorators at `MyApp/app/decorators/models/alchemy/<model_of_choice>_decorator.rb`. This is the recommended convention for extending engine models per the Rails Guides. More information available in [the guides](http://edgeguides.rubyonrails.org/engines.html#overriding-models-and-controllers).

This is in relation to #947 