### PR TITLE
Show a welcome page if fresh installed

### DIFF
--- a/app/assets/stylesheets/alchemy/welcome.sass
+++ b/app/assets/stylesheets/alchemy/welcome.sass
@@ -1,0 +1,49 @@
+body
+  background: #f2f2f2
+  color: #7f8c8d
+  font-family: 'Open Sans', Helvetica, Arial, sans-serif
+  font-weight: normal
+  font-size: 15px
+  line-height: 22px
+
+h3
+  color: #34495e
+  font-family: 'Bitter', serif
+  font-weight: normal
+  font-size: 25px
+  line-height: 1.2
+  margin-bottom: 20px
+  padding-top: 20px
+
+.container
+  position: absolute
+  top: 50%
+  left: 50%
+  width: 600px
+  margin-top: -50px
+  transform: translateY(-50%) translateX(-300px)
+
+ul
+  line-height: 1.6
+  margin-bottom: 17px
+  padding: 0
+  padding-left: 20px
+  margin: 0px
+  list-style-position: outside
+
+li
+  color: #2980b9
+  font-weight: 600
+  margin-bottom: 12px
+  background-color: none
+  border-bottom: 0 none
+  line-height: 22px
+
+a
+  color: #87ab5a
+  text-decoration: underline
+  transition: all 0.1s ease-in-out
+
+  &:hover
+    color: #2980b9
+    text-decoration: underline

--- a/app/views/alchemy/welcome.html.erb
+++ b/app/views/alchemy/welcome.html.erb
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Welcome to AlchemyCMS</title>
+    <link href='https://fonts.googleapis.com/css?family=Bitter' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
+    <%= stylesheet_link_tag "alchemy/welcome", media: "all" %>
+  </head>
+  <body>
+    <div class="container">
+      <%= image_tag 'alchemy/alchemy-logo.svg' %>
+      <h3>You have succesfully installed AlchemyCMS!</h3>
+      <p>
+        Thank you for using Alchemy. We hope you enjoy using it as much as we do.
+      </p>
+      <p>
+        The first thing you probably want to do before creating your first page:
+      </p>
+      <ul>
+        <li><%= link_to 'Create your first admin user', Alchemy.signup_path %></li>
+        <li><%= link_to 'Read the guidelines', 'http://guides.alchemy-cms.com/stable', target: '_blank' %></li>
+      </ul>
+    </div>
+  </body>
+</html>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,5 +8,6 @@ Rails.application.config.assets.precompile += [
   'alchemy/menubar.css',
   'alchemy/menubar.js',
   'alchemy/print.css',
+  'alchemy/welcome.css',
   'tinymce/*'
 ]

--- a/spec/controllers/alchemy/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/pages_controller_spec.rb
@@ -3,11 +3,28 @@ require 'spec_helper'
 
 module Alchemy
   describe PagesController do
-    let(:default_language)      { Language.default }
-    let(:default_language_root) { create(:alchemy_page, :language_root, language: default_language, name: 'Home', public: true) }
-    let(:page) { create(:alchemy_page, :public, parent_id: default_language_root.id, page_layout: 'news', name: 'News', urlname: 'news', language: default_language, do_not_autogenerate: false) }
+    let(:default_language) { Language.default }
 
-    before { allow(controller).to receive(:signup_required?).and_return(false) }
+    let(:default_language_root) do
+      create :alchemy_page, :language_root,
+        language: default_language,
+        name: 'Home',
+        public: true
+    end
+
+    let(:page) do
+      create :alchemy_page, :public,
+        parent_id: default_language_root.id,
+        page_layout: 'news',
+        name: 'News',
+        urlname: 'news',
+        language: default_language,
+        do_not_autogenerate: false
+    end
+
+    before do
+      allow(controller).to receive(:signup_required?).and_return(false)
+    end
 
     describe "#index" do
       before do

--- a/spec/dummy/app/models/dummy_user.rb
+++ b/spec/dummy/app/models/dummy_user.rb
@@ -5,6 +5,10 @@ class DummyUser < ActiveRecord::Base
     []
   end
 
+  def self.admins
+    [first].compact
+  end
+
   def alchemy_roles
     @alchemy_roles || %w(admin)
   end

--- a/spec/dummy/config/initializers/alchemy.rb
+++ b/spec/dummy/config/initializers/alchemy.rb
@@ -1,2 +1,3 @@
 Alchemy.register_ability Ability
 Alchemy.user_class_name = 'DummyUser'
+Alchemy.signup_path = '/admin/pages' unless Rails.env.test?

--- a/spec/features/page_feature_spec.rb
+++ b/spec/features/page_feature_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Alchemy
-  describe 'Page' do
+  describe 'Show page feature:' do
     let!(:default_language) { Language.default }
 
     let!(:default_language_root) do
@@ -14,6 +14,23 @@ module Alchemy
 
     let(:public_child) do
       create(:alchemy_page, :public, name: 'Public Child', parent_id: public_page.id)
+    end
+
+    context "When no page is present" do
+      before do
+        Alchemy::Page.delete_all
+      end
+
+      context "and no admin user is present yet" do
+        before do
+          Alchemy.user_class.delete_all
+        end
+
+        it 'shows a welcome page' do
+          visit "/"
+          expect(page).to have_content('Welcome to Alchemy')
+        end
+      end
     end
 
     context 'rendered' do


### PR DESCRIPTION
When no users and no pages are present yet, show a meaningful welcome page, instead of rendering a routing error.

![welcome to alchemycms 2016-03-21 09-52-45](https://cloud.githubusercontent.com/assets/42868/13913858/bfbfd6ec-ef4a-11e5-8acb-202e43c4510c.png)
