### PR TITLE
Support for sprockets 3

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'awesome_nested_set',               ['~> 3.0.0']
   gem.add_runtime_dependency 'cancancan',                        ['~> 1.9']
   gem.add_runtime_dependency 'coffee-rails',                     ['~> 4.0']
-  gem.add_runtime_dependency 'compass-rails',                    ['~> 2.0', '>= 2.0.4']
+  gem.add_runtime_dependency 'compass-rails',                    ['>= 2.0.4', '< 4.0']
   gem.add_runtime_dependency 'dragonfly',                        ['~> 1.0.1']
   gem.add_runtime_dependency 'jquery-rails',                     ['~> 4.0']
   gem.add_runtime_dependency 'jquery-ui-rails',                  ['~> 5.0.0']

--- a/lib/alchemy/engine.rb
+++ b/lib/alchemy/engine.rb
@@ -63,6 +63,7 @@ module Alchemy
     initializer 'alchemy.assets' do |app|
       app.config.assets.precompile += [
         'alchemy/alchemy.js',
+        'alchemy/favicon.ico',
         'alchemy/preview.js',
         'alchemy/admin.css',
         'alchemy/menubar.css',


### PR DESCRIPTION
In order to support compass-rails 3 and sprockets 3 we need to add the alchemy favicon to precompiled assets. Refs #954 and #950