### PR TITLE
Fix querying page_layouts by attributes

### DIFF
--- a/lib/alchemy/page_layout.rb
+++ b/lib/alchemy/page_layout.rb
@@ -41,7 +41,7 @@ module Alchemy
       def get_all_by_attributes(attributes)
         return [] if attributes.blank?
 
-        if attributes.class.is_a? Hash
+        if attributes.is_a? Hash
           layouts = []
           attributes.stringify_keys.each do |key, value|
             result = all.select { |l| l.key?(key) && l[key].to_s.casecmp(value.to_s) == 0 }

--- a/spec/libraries/page_layout_spec.rb
+++ b/spec/libraries/page_layout_spec.rb
@@ -54,6 +54,14 @@ module Alchemy
       end
     end
 
+    describe ".get_all_by_attributes" do
+      subject { PageLayout.get_all_by_attributes(unique: true) }
+
+      it "should return all page layout with the given attribute" do
+        expect(subject.map { |page_layout| page_layout['name'] }.to_a).to eq(['index', 'news', 'contact', 'erb_layout'])
+      end
+    end
+
     describe '.layouts_with_own_for_select' do
       it "should not hold a layout twice" do
         layouts = PageLayout.layouts_with_own_for_select('standard', 1, false)


### PR DESCRIPTION
Refers to #958 by fixing wrong comparison. 

`....class.is_a? Hash`will never evaluate to `true`.