### PR TITLE
[WIP] Page versions

### DIFF
--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -2,28 +2,27 @@ module Alchemy
   module Admin
     class ElementsController < Alchemy::Admin::BaseController
       before_action :load_element, only: [:update, :trash, :fold, :publish]
+      before_action :load_page, only: [:index, :list, :new, :create, :order]
+
       authorize_resource class: Alchemy::Element
 
       def index
-        @page = Page.find(params[:page_id])
         @cells = @page.cells
-        if @cells.blank?
-          @elements = @page.elements.not_trashed
-        else
-          @elements = @page.elements_grouped_by_cells
+        @elements = @page.current_elements.not_trashed
+
+        if @cells.exists?
+          @elements_by_cell = @page.elements_grouped_by_cells
         end
       end
 
       def list
-        @page_id = params[:page_id]
-        if @page_id.blank? && !params[:page_urlname].blank?
-          @page_id = Language.current.pages.find_by(urlname: params[:page_urlname]).id
+        if @page.blank? && !params[:page_urlname].blank?
+          @page = Language.current.pages.find_by(urlname: params[:page_urlname])
         end
-        @elements = Element.published.where(page_id: @page_id)
+        @elements = @page.current_elements.published
       end
 
       def new
-        @page = Page.find(params[:page_id])
         @parent_element = Element.find_by(id: params[:parent_element_id])
         @elements = @page.available_element_definitions(@parent_element.try(:name))
         @element = @page.elements.build
@@ -33,13 +32,12 @@ module Alchemy
 
       # Creates a element as discribed in config/alchemy/elements.yml on page via AJAX.
       def create
-        @page = Page.find(params[:element][:page_id])
         Element.transaction do
           if @paste_from_clipboard = params[:paste_from_clipboard].present?
             @element = paste_element_from_clipboard
             @cell = @element.cell
           else
-            @element = Element.new_from_scratch(params[:element])
+            @element = Element.new_from_scratch(create_element_params)
             if @page.can_have_cells?
               @cell = find_or_create_cell
               @element.cell = @cell
@@ -95,7 +93,7 @@ module Alchemy
             # Ensure to set page_id, cell_id and parent_element_id to the current page and
             # cell because of trashed elements could still have old values
             Element.where(id: element_id).update_all(
-              page_id: params[:page_id],
+              page_version_id: @page.current_version_id,
               cell_id: params[:cell_id],
               parent_element_id: params[:parent_element_id],
               position: idx + 1
@@ -112,8 +110,18 @@ module Alchemy
 
       private
 
+      def load_page
+        @page ||= Page.find_by(id: params[:page_id])
+      end
+
       def load_element
         @element = Element.find(params[:id])
+      end
+
+      def create_element_params
+        params[:element] ||= {}
+        params[:element][:page_version_id] = @page.current_version_id.to_s
+        params[:element]
       end
 
       # Returns the cell for element name in params.
@@ -122,7 +130,7 @@ module Alchemy
         if @paste_from_clipboard
           element_with_cell_name = params[:paste_from_clipboard]
         else
-          element_with_cell_name = params[:element][:name]
+          element_with_cell_name = create_element_params[:name]
         end
         return nil if element_with_cell_name.blank?
         return nil unless element_with_cell_name.include?('#')
@@ -143,14 +151,21 @@ module Alchemy
 
       def paste_element_from_clipboard
         @source_element = Element.find(element_from_clipboard['id'])
-        new_attributes = {page_id: @page.id}
+
+        new_attributes = {
+          page_version_id: @page.current_version_id
+        }
+
         if @page.can_have_cells?
-          new_attributes = new_attributes.merge({cell_id: find_or_create_cell.try(:id)})
+          new_attributes[:cell_id] = find_or_create_cell.try(:id)
         end
+
         element = Element.copy(@source_element, new_attributes)
+
         if element_from_clipboard['action'] == 'cut'
           cut_element
         end
+
         element
       end
 

--- a/app/controllers/alchemy/api/elements_controller.rb
+++ b/app/controllers/alchemy/api/elements_controller.rb
@@ -9,7 +9,8 @@ module Alchemy
     def index
       @elements = Element.accessible_by(current_ability, :index)
       if params[:page_id].present?
-        @elements = @elements.where(page_id: params[:page_id])
+        @elements = @elements.joins(page: :public_version)
+                      .where(alchemy_page_versions: {page_id: params[:page_id]})
       end
       if params[:named].present?
         @elements = @elements.named(params[:named])

--- a/app/helpers/alchemy/admin/pages_helper.rb
+++ b/app/helpers/alchemy/admin/pages_helper.rb
@@ -20,11 +20,10 @@ module Alchemy
       # Returns the translated explanation of the page status.
       #
       def combined_page_status(page)
-        page.status.map do |state, _value|
-          next if state == :locked
-          val = content_tag(:span, '', class: page.send(state) ? "page_status #{state}" : "page_status not_#{state}")
-          val + page.status_title(state)
-        end.delete_if(&:blank?).join("<br>").html_safe
+        page.status.delete_if { |s| s == :locked }.map do |state, true_value|
+          classes = true_value ? "page_status #{state}" : "page_status not_#{state}"
+          content_tag(:span, '', class: classes) + page.status_title(state)
+        end.join("<br>").html_safe
       end
 
       # Renders a label for page's page layout

--- a/app/helpers/alchemy/pages_helper.rb
+++ b/app/helpers/alchemy/pages_helper.rb
@@ -352,13 +352,13 @@ module Alchemy
       options = default_options.merge(options)
       # render meta description of the root page from language if the current meta description is empty
       if @page.meta_description.blank?
-        description = Language.current_root_page.try(:meta_description)
+        description = @page.get_language_root.try(:meta_description)
       else
         description = @page.meta_description
       end
       # render meta keywords of the root page from language if the current meta keywords is empty
       if @page.meta_keywords.blank?
-        keywords = Language.current_root_page.try(:meta_keywords)
+        keywords = @page.get_language_root.try(:meta_keywords)
       else
         keywords = @page.meta_keywords
       end

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -5,7 +5,7 @@
 #  id              :integer          not null, primary key
 #  name            :string(255)
 #  position        :integer
-#  page_id         :integer
+#  page_version_id :integer
 #  public          :boolean          default(TRUE)
 #  folded          :boolean          default(FALSE)
 #  unique          :boolean          default(FALSE)
@@ -45,15 +45,15 @@ module Alchemy
 
     acts_as_taggable
 
-    # All Elements that share the same page id, cell id and parent element id are considered a list.
+    # All Elements that share the same page_version id, cell id and parent element id are considered a list.
     #
     # If cell id and parent element id are nil (typical case for a simple page),
     # then all elements on that page are still in one list,
     # because acts_as_list correctly creates this statement:
     #
-    #   WHERE page_id = 1 and cell_id = NULL AND parent_element_id = NULL
+    #   WHERE page_version_id = 1 and cell_id = NULL AND parent_element_id = NULL
     #
-    acts_as_list scope: [:page_id, :cell_id, :parent_element_id]
+    acts_as_list scope: [:page_version_id, :cell_id, :parent_element_id]
 
     stampable stamper_class_name: Alchemy.user_class_name
 
@@ -67,7 +67,12 @@ module Alchemy
       dependent: :destroy
 
     belongs_to :cell
-    belongs_to :page
+
+    belongs_to :page_version,
+      class_name: 'Alchemy::PageVersion',
+      inverse_of: :elements
+
+    has_one :page, through: :page_version
 
     # A nested element belongs to a parent element.
     belongs_to :parent_element, class_name: 'Alchemy::Element', touch: true
@@ -97,6 +102,7 @@ module Alchemy
     scope :from_current_site, -> { where(Language.table_name => {site_id: Site.current || Site.default}).joins(page: 'language') }
     scope :folded,            -> { where(folded: true) }
     scope :expanded,          -> { where(folded: false) }
+    scope :with_version,      ->(version_id) { where(page_version_id: version_id) }
 
     delegate :restricted?, to: :page, allow_nil: true
 
@@ -201,17 +207,24 @@ module Alchemy
       end
     end
 
-    # Returns next public element from same page.
+    ## Instance Methods
+
+    # Elements having same page version as this element
+    def siblings
+      self.class.with_version(page_version_id)
+    end
+
+    # Returns next public element from same page version.
     #
-    # Pass an element name to get next of this kind.
+    # Pass an element name to only get next element of this kind.
     #
     def next(name = nil)
       previous_or_next('>', name)
     end
 
-    # Returns previous public element from same page.
+    # Returns previous public element from same page version.
     #
-    # Pass an element name to get previous of this kind.
+    # Pass an element name to only get previous element of this kind.
     #
     def prev(name = nil)
       previous_or_next('<', name)
@@ -300,7 +313,7 @@ module Alchemy
       nested_elements.map do |nested_element|
         Element.copy(nested_element, {
           parent_element_id: target_element.id,
-          page_id: target_element.page_id,
+          page_version_id: target_element.page_version_id,
           cell_id: target_element.cell_id
         })
       end
@@ -308,7 +321,7 @@ module Alchemy
 
     private
 
-    # Returns previous or next public element from same page.
+    # Returns previous or next public element from same page version.
     #
     # @param [String]
     #   Pass '>' or '<' to find next or previous public element.
@@ -316,7 +329,7 @@ module Alchemy
     #   Pass an element name to get previous of this kind.
     #
     def previous_or_next(dir, name = nil)
-      elements = page.elements.published.where("#{self.class.table_name}.position #{dir} #{position}")
+      elements = siblings.published.where("#{Element.table_name}.position #{dir} #{position}")
       elements = elements.named(name) if name.present?
       elements.reorder("position #{dir == '>' ? 'ASC' : 'DESC'}").limit(1).first
     end

--- a/app/models/alchemy/language.rb
+++ b/app/models/alchemy/language.rb
@@ -165,7 +165,7 @@ module Alchemy
     end
 
     def unpublish_pages
-      pages.update_all(public: false)
+      pages.update_all(public_version_id: nil)
     end
   end
 end

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -72,6 +72,15 @@ module Alchemy
 
     has_many :folded_pages
     has_many :legacy_urls, class_name: 'Alchemy::LegacyPageUrl'
+
+    has_many :versions,
+      class_name: 'Alchemy::PageVersion',
+      dependent: :destroy,
+      inverse_of: :page
+
+    belongs_to :current_version, class_name: 'Alchemy::PageVersion'
+    belongs_to :public_version, class_name: 'Alchemy::PageVersion'
+
     belongs_to :language
 
     validates_presence_of :language, on: :create, unless: :root

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -88,7 +88,11 @@ module Alchemy
     has_many :folded_pages
     has_many :legacy_urls, class_name: 'Alchemy::LegacyPageUrl'
 
-    has_many :versions, class_name: 'Alchemy::PageVersion', inverse_of: :page
+    has_many :versions,
+      class_name: 'Alchemy::PageVersion',
+      dependent: :destroy,
+      inverse_of: :page
+
     belongs_to :current_version, class_name: 'Alchemy::PageVersion'
     belongs_to :public_version, class_name: 'Alchemy::PageVersion'
 

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -375,7 +375,7 @@ module Alchemy
       end
     end
 
-    # Takes the current version and sets it as public version.
+    # Creates a public version from current version.
     #
     # Sets +public+ to true and the +published_at+ value to current time.
     #
@@ -383,7 +383,7 @@ module Alchemy
     #
     def publish!
       update_columns(
-        public_version_id: current_version_id,
+        public_version_id: create_version.id,
         published_at: Time.current,
         public: true
       )
@@ -424,14 +424,6 @@ module Alchemy
     #
     def create_current_version
       update_columns(current_version_id: create_version.id)
-    end
-
-    # Creates a new public version
-    #
-    # And copy all current elements, if any exist.
-    #
-    def create_public_version
-      update_columns(public_version_id: create_version.id)
     end
 
     private

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -356,14 +356,18 @@ module Alchemy
       end
     end
 
-    # Publishes the page.
+    # Takes the current version and sets it as public version.
     #
     # Sets +public+ to true and the +published_at+ value to current time.
     #
     # The +published_at+ attribute is used as +cache_key+.
     #
     def publish!
-      update_columns(published_at: Time.current, public: true)
+      update_columns(
+        public_version_id: current_version_id,
+        published_at: Time.current,
+        public: true
+      )
     end
 
     # Updates an Alchemy::Page based on a new ordering to be applied to it

--- a/app/models/alchemy/page/page_cells.rb
+++ b/app/models/alchemy/page/page_cells.rb
@@ -42,7 +42,7 @@ module Alchemy
 
     # Returns elements grouped by cell.
     def elements_grouped_by_cells
-      elements.not_trashed.in_cell.group_by(&:cell)
+      current_elements.not_trashed.in_cell.group_by(&:cell)
     end
 
     # Returns element names from cell definition.

--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -48,13 +48,6 @@ module Alchemy
 
       after_update :autogenerate_elements,
         if: :page_layout_changed?
-
-      after_destroy do
-        elements.each do |element|
-          next if element.trashed?
-          element.destroy
-        end
-      end
     end
 
     module ClassMethods

--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -5,25 +5,49 @@ module Alchemy
     included do
       attr_accessor :do_not_autogenerate
 
-      has_many :elements, -> { where(parent_element_id: nil).not_trashed.order(:position) }
+      has_many :public_elements,
+        -> { where(parent_element_id: nil).not_trashed.order(:position) },
+        through: :public_version,
+        source: :elements
+
+      alias_method :elements, :public_elements
+
+      has_many :current_elements,
+        -> { where(parent_element_id: nil).not_trashed.order(:position) },
+        through: :current_version,
+        source: :elements
+
       has_many :trashed_elements,
         -> { Element.trashed.order(:position) },
-        class_name: 'Alchemy::Element'
+        class_name: 'Alchemy::Element',
+        through: :public_version,
+        source: :elements
+
       has_many :descendent_elements,
         -> { order(:position).not_trashed },
-        class_name: 'Alchemy::Element'
-      has_many :contents, through: :elements
+        class_name: 'Alchemy::Element',
+        through: :public_version,
+        source: :elements
+
+      has_many :contents, through: :public_elements
+
       has_many :descendent_contents,
         through: :descendent_elements,
         class_name: 'Alchemy::Content',
         source: :contents
+
       has_and_belongs_to_many :to_be_swept_elements, -> { uniq },
         class_name: 'Alchemy::Element',
         join_table: ElementToPage.table_name
 
-      after_create :autogenerate_elements, unless: -> { systempage? || do_not_autogenerate }
-      after_update :trash_not_allowed_elements!, if: :page_layout_changed?
-      after_update :autogenerate_elements, if: :page_layout_changed?
+      after_create :autogenerate_elements,
+        unless: -> { systempage? || do_not_autogenerate }
+
+      after_update :trash_not_allowed_elements!,
+        if: :page_layout_changed?
+
+      after_update :autogenerate_elements,
+        if: :page_layout_changed?
 
       after_destroy do
         elements.each do |element|
@@ -42,18 +66,20 @@ module Alchemy
       #
       def copy_elements(source, target)
         new_elements = []
-        source.elements.not_trashed.each do |source_element|
+
+        source.current_elements.not_trashed.each do |source_element|
           cell = nil
           if source_element.cell
             cell = target.cells.find_by(name: source_element.cell.name)
           end
           new_element = Element.copy source_element, {
-            page_id: target.id,
+            page_version_id: target.current_version_id,
             cell_id: cell.try(:id)
           }
           new_element.move_to_bottom
           new_elements << new_element
         end
+
         new_elements
       end
     end
@@ -200,13 +226,13 @@ module Alchemy
       elements.available.named(definition['feed_elements'])
     end
 
-    # Returns an array of all EssenceRichtext contents ids from not folded elements
+    # Returns an array of all EssenceRichtext contents ids
+    # from not folded elements of current page version.
+    #
+    # Used to initialize TinMCE editors in page edit admin UI.
     #
     def richtext_contents_ids
-      descendent_contents
-        .where(Element.table_name => {folded: false})
-        .select(&:has_tinymce?)
-        .collect(&:id)
+      @_richtext_contents_ids ||= expanded_richtext_contents.collect(&:id)
     end
 
     def element_names_from_definition
@@ -214,6 +240,20 @@ module Alchemy
     end
 
     private
+
+    # Returns all contents that has tinymce enabled from expanded contents.
+    def expanded_richtext_contents
+      @_expanded_richtext_contents ||= expanded_contents.select(&:has_tinymce?)
+    end
+
+    # Returns all contents from not folded elements of current page version.
+    def expanded_contents
+      Content.joins(:element)
+        .where(Element.table_name => {
+          page_version_id: current_version_id,
+          folded: false
+        })
+    end
 
     def element_names_from_cell_definitions
       @_element_names_from_cell_definitions ||= cell_definitions.map do |d|
@@ -228,13 +268,13 @@ module Alchemy
     # If the page has cells, it looks if there are elements to generate.
     #
     def autogenerate_elements
-      elements_already_on_page = elements.available.pluck(:name)
-      elements = definition["autogenerate"]
-      if elements.present?
-        elements.each do |element|
-          next if elements_already_on_page.include?(element)
-          Element.create_from_scratch(attributes_for_element_name(element))
-        end
+      elements_already_on_page = current_elements.available.pluck(:name)
+      generatable_elements = definition["autogenerate"]
+      return if generatable_elements.blank?
+
+      generatable_elements.each do |element_name|
+        next if elements_already_on_page.include?(element_name)
+        Element.create_from_scratch(attributes_for_element_name(element_name))
       end
     end
 
@@ -243,15 +283,15 @@ module Alchemy
       element_cell_definition = cell_definitions.detect { |c| c['elements'].include?(element) }
       if has_cells? && element_cell_definition
         cell = cells.find_by!(name: element_cell_definition['name'])
-        {page_id: id, cell_id: cell.id, name: element}
+        {page_version_id: current_version_id, cell_id: cell.id, name: element}
       else
-        {page_id: id, name: element}
+        {page_version_id: current_version_id, name: element}
       end
     end
 
     # Trashes all elements that are not allowed for this page_layout.
     def trash_not_allowed_elements!
-      not_allowed_elements = elements.where([
+      not_allowed_elements = current_elements.where([
         "#{Element.table_name}.name NOT IN (?)",
         element_names_from_definition
       ])

--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -81,8 +81,6 @@ module Alchemy
     #
     # @param [Hash]
     #   options hash
-    # @param [Boolean] (false)
-    #   Pass true, if you want to also have not published elements.
     #
     # @option options [Array] only
     #   Returns only elements with given names
@@ -99,21 +97,26 @@ module Alchemy
     #
     # @return [ActiveRecord::Relation]
     #
-    def find_elements(options = {}, show_non_public = false)
+    def find_elements(options = {})
       elements = elements_from_cell_or_self(options[:from_cell])
+
       if options[:only].present?
         elements = elements.named(options[:only])
       elsif options[:except].present?
         elements = elements.excluded(options[:except])
       end
+
       if options[:reverse_sort] || options[:reverse]
         elements = elements.reverse_order
       end
+
       elements = elements.offset(options[:offset]).limit(options[:count])
+
       if options[:random]
         elements = elements.order("RAND()")
       end
-      show_non_public ? elements : elements.published
+
+      elements.published
     end
     alias_method :find_selected_elements, :find_elements
 
@@ -317,8 +320,25 @@ module Alchemy
       when 'String'
         cell_elements_by_name(cell)
       else
-        elements.not_in_cell
+        elements_from_version
       end
+    end
+
+    # Loads elements from one of page versions
+    #
+    # Defaults to elements from +public_version+
+    #
+    # If page is current preview page (because we currently edit it's content)
+    # loads elements from +current_version+ instead.
+    #
+    def elements_from_version(version: public_version)
+      if Page.current_preview == self
+        version = current_version
+      end
+
+      return Element.none if version.nil?
+
+      version.elements.not_in_cell
     end
 
     # Returns all elements from given cell name

--- a/app/models/alchemy/page/page_scopes.rb
+++ b/app/models/alchemy/page/page_scopes.rb
@@ -33,9 +33,9 @@ module Alchemy
       #
       scope :visible, -> { where(visible: true) }
 
-      # All public pages
+      # All pages having a public version
       #
-      scope :published, -> { where(public: true) }
+      scope :published, -> { joins(:public_version) }
 
       # All not restricted pages
       #

--- a/app/models/alchemy/page_version.rb
+++ b/app/models/alchemy/page_version.rb
@@ -1,0 +1,8 @@
+module Alchemy
+  class PageVersion < ActiveRecord::Base
+    belongs_to :page,
+      class_name: 'Alchemy::Page',
+      inverse_of: :versions,
+      required: true
+  end
+end

--- a/app/models/alchemy/page_version.rb
+++ b/app/models/alchemy/page_version.rb
@@ -4,5 +4,9 @@ module Alchemy
       class_name: 'Alchemy::Page',
       inverse_of: :versions,
       required: true
+
+    has_many :elements, -> { order(:position) },
+      class_name: 'Alchemy::Element',
+      inverse_of: :page_version
   end
 end

--- a/app/models/alchemy/page_version.rb
+++ b/app/models/alchemy/page_version.rb
@@ -8,5 +8,13 @@ module Alchemy
     has_many :elements, -> { order(:position) },
       class_name: 'Alchemy::Element',
       inverse_of: :page_version
+
+    after_destroy :destroy_not_trashed_elements
+
+    private
+
+    def destroy_not_trashed_elements
+      elements.not_trashed.destroy_all
+    end
   end
 end

--- a/app/serializers/alchemy/element_serializer.rb
+++ b/app/serializers/alchemy/element_serializer.rb
@@ -6,6 +6,7 @@ module Alchemy
       :name,
       :position,
       :page_id,
+      :page_version_id,
       :cell_id,
       :tag_list,
       :created_at,
@@ -15,6 +16,10 @@ module Alchemy
 
     def ingredients
       object.contents.collect(&:serialize)
+    end
+
+    def page_id
+      object.page_version.page_id
     end
   end
 end

--- a/app/views/alchemy/admin/elements/_new_element_form.html.erb
+++ b/app/views/alchemy/admin/elements/_new_element_form.html.erb
@@ -5,7 +5,7 @@
   </div>
 <%- else -%>
   <%= alchemy_form_for [:admin, @element] do |form| %>
-    <%= form.hidden_field :page_id %>
+    <%= hidden_field_tag(:page_id, @page.id) %>
   <%- if @page.can_have_cells? -%>
     <%= form.input :name,
       label: Alchemy.t(:element_of_type),

--- a/app/views/alchemy/admin/elements/index.html.erb
+++ b/app/views/alchemy/admin/elements/index.html.erb
@@ -1,8 +1,8 @@
-<% if @cells.any? %>
+<% if @cells.exists? %>
   <div id="cells">
     <ul>
       <li><a href="#cell_for_other_elements"><%= Alchemy.t(:main_content) %></a></li>
-      <% @elements.each do |cell, elements| %>
+      <% @elements_by_cell.each do |cell, elements| %>
         <li>
           <a href="#cell_<%= cell.name %>">
             <%= Alchemy.t(cell.name, scope: :cell_names) %>
@@ -12,9 +12,9 @@
     </ul>
     <div id="cell_for_other_elements" class="sortable_cell for_other_elements_cell">
       <%= render partial: 'alchemy/admin/elements/element',
-        collection: @page.elements.not_trashed.not_in_cell %>
+        collection: @elements.not_in_cell %>
     </div>
-    <% @elements.each do |cell, elements| -%>
+    <% @elements_by_cell.each do |cell, elements| -%>
       <%= content_tag :div,
         id: "cell_#{cell.name}",
         class: ["sortable_cell", "#{cell.name}_cell"].join(' '),

--- a/app/views/alchemy/admin/elements/new.html.erb
+++ b/app/views/alchemy/admin/elements/new.html.erb
@@ -11,7 +11,7 @@
   </div>
   <div id="paste_element_tab">
     <%= alchemy_form_for([:admin, @element]) do |f| %>
-      <%= f.hidden_field(:page_id) %>
+      <%= hidden_field_tag(:page_id, @page.id) %>
       <div class="input select">
         <label for="paste_from_clipboard" class="control-label"><%= Alchemy.t("Element") %></label>
         <%= select_tag 'paste_from_clipboard',

--- a/app/views/alchemy/admin/pages/_form.html.erb
+++ b/app/views/alchemy/admin/pages/_form.html.erb
@@ -8,10 +8,6 @@
     <label class="control-label"><%= Alchemy.t(:page_status) %></label>
     <div class="control_group">
       <label class="checkbox">
-        <%= f.check_box :public %>
-        <%= f.object.class.human_attribute_name :public %>
-      </label>
-      <label class="checkbox">
         <%= f.check_box :visible %>
         <%= f.object.class.human_attribute_name :visible %>
       </label>

--- a/db/migrate/20160301160033_create_alchemy_page_versions.rb
+++ b/db/migrate/20160301160033_create_alchemy_page_versions.rb
@@ -1,0 +1,9 @@
+class CreateAlchemyPageVersions < ActiveRecord::Migration
+  def change
+    create_table :alchemy_page_versions do |t|
+      t.references :page, index: true
+      t.string :title
+    end
+    add_foreign_key :alchemy_page_versions, :alchemy_pages, column_name: :page_id
+  end
+end

--- a/db/migrate/20160301203630_add_current_version_and_public_version_to_alchemy_pages.rb
+++ b/db/migrate/20160301203630_add_current_version_and_public_version_to_alchemy_pages.rb
@@ -1,0 +1,30 @@
+class AddCurrentVersionAndPublicVersionToAlchemyPages < ActiveRecord::Migration
+  def up
+    add_reference :alchemy_pages, :current_version, index: true
+    add_foreign_key :alchemy_pages, :alchemy_page_versions, column_name: :current_version_id
+    add_reference :alchemy_pages, :public_version, index: true
+    add_foreign_key :alchemy_pages, :alchemy_page_versions, column_name: :public_version_id
+
+    Alchemy::Page.find_each do |page|
+      next if page.systempage? || page.redirects_to_external?
+      page.build_current_version(page_id: page.id)
+      if page.public?
+        page.public_version = page.versions.last
+      end
+      page.save!
+      say "Created version for Page #{page.id}"
+    end
+  end
+
+  def down
+    remove_reference :alchemy_pages, :current_version
+    remove_foreign_key :alchemy_pages, :alchemy_page_versions
+    remove_reference :alchemy_pages, :public_version
+    remove_foreign_key :alchemy_pages, :alchemy_page_versions
+
+    Alchemy::Page.find_each do |page|
+      page.versions.destroy_all
+      say "Removed versions from Page #{page.id}"
+    end
+  end
+end

--- a/db/migrate/20160301205721_change_elements_page_association_to_page_version.rb
+++ b/db/migrate/20160301205721_change_elements_page_association_to_page_version.rb
@@ -1,0 +1,27 @@
+class ChangeElementsPageAssociationToPageVersion < ActiveRecord::Migration
+  def up
+    remove_index :alchemy_elements, [:page_id, :parent_element_id]
+    rename_column :alchemy_elements, :page_id, :page_version_id
+    add_index :alchemy_elements, [:page_version_id, :parent_element_id],
+      name: 'alchemy_elements_page_version_parent_element_idx'
+
+    Alchemy::Element.find_each do |element|
+      next unless element.page
+      version = element.page.public_version || element.page.current_version
+      element.update(page_version: version)
+      say "Assign element #{element.id} to #{version.id}"
+    end
+  end
+
+  def down
+    remove_index :alchemy_elements, name: 'alchemy_elements_page_version_parent_element_idx'
+    rename_column :alchemy_elements, :page_version_id, :page_id
+    add_index :alchemy_elements, [:page_id, :parent_element_id]
+
+    Alchemy::Element.find_each do |element|
+      page = element.page
+      element.update(page: page)
+      say "Set element #{element.id} page to #{page.id}"
+    end
+  end
+end

--- a/db/migrate/20160315212914_move_page_meta_data_to_page_versions.rb
+++ b/db/migrate/20160315212914_move_page_meta_data_to_page_versions.rb
@@ -1,0 +1,41 @@
+class MovePageMetaDataToPageVersions < ActiveRecord::Migration
+  def up
+    add_column :alchemy_page_versions, :meta_keywords, :string
+    add_column :alchemy_page_versions, :meta_description, :string
+
+    Alchemy::Page.contentpages.each do |page|
+      version = page.public_version || page.current_version
+      next unless version
+      version.update_columns(
+        title: page.title,
+        meta_keywords: page.meta_keywords,
+        meta_description: page.meta_description
+      )
+      say "Moves meta data from #{page} to #{version}"
+    end
+
+    remove_column :alchemy_pages, :title
+    remove_column :alchemy_pages, :meta_keywords
+    remove_column :alchemy_pages, :meta_description
+  end
+
+  def down
+    add_column :alchemy_pages, :title, :string
+    add_column :alchemy_pages, :meta_keywords, :string
+    add_column :alchemy_pages, :meta_description, :string
+
+    Alchemy::Page.contentpages.each do |page|
+      version = page.public_version || page.current_version
+      next unless version
+      page.update_columns(
+        title: version.title,
+        meta_keywords: version.meta_keywords,
+        meta_description: version.meta_description
+      )
+      say "Moves meta data from #{version} to #{page}"
+    end
+
+    remove_column :alchemy_page_versions, :meta_keywords
+    remove_column :alchemy_page_versions, :meta_description
+  end
+end

--- a/db/migrate/20160316202352_remove_public_from_alchemy_pages.rb
+++ b/db/migrate/20160316202352_remove_public_from_alchemy_pages.rb
@@ -1,0 +1,20 @@
+class RemovePublicFromAlchemyPages < ActiveRecord::Migration
+  def up
+    Alchemy::Page.where(public: true).each do |page|
+      next if page.public_version
+      page.update_columns(public_version_id: page.create_version.id)
+      say "Created public version for #{page}"
+    end
+
+    remove_column :alchemy_pages, :public
+  end
+
+  def down
+    add_column :alchemy_pages, :public, :boolean, default: false
+
+    Alchemy::Page.where.not(public_version_id: nil).each do |page|
+      page.update_columns(public: true)
+      say "Published #{page}"
+    end
+  end
+end

--- a/lib/alchemy/test_support/factories/page_factory.rb
+++ b/lib/alchemy/test_support/factories/page_factory.rb
@@ -9,7 +9,7 @@ FactoryGirl.define do
 
     parent_id do
       (Alchemy::Page.find_by(language_root: true) ||
-        FactoryGirl.create(:alchemy_page, :language_root)).id
+        FactoryGirl.create(:alchemy_page, :public, :language_root)).id
     end
 
     # This speeds up creating of pages dramatically.
@@ -20,13 +20,23 @@ FactoryGirl.define do
       name 'Startseite'
       page_layout { language.page_layout }
       language_root true
-      public true
       parent_id { Alchemy::Page.root.id }
     end
 
     trait :public do
       sequence(:name) { |n| "A Public Page #{n}" }
-      public true
+
+      after(:build) do |page|
+        page.public_version = FactoryGirl.build(:alchemy_page_version, page: page)
+      end
+
+      after(:stub) do |page|
+        page.public_version = FactoryGirl.build_stubbed(:alchemy_page_version, page: page)
+      end
+
+      after(:create) do |page|
+        page.update(public_version: FactoryGirl.create(:alchemy_page_version, page: page))
+      end
     end
 
     trait :system do

--- a/lib/alchemy/test_support/factories/page_version_factory.rb
+++ b/lib/alchemy/test_support/factories/page_version_factory.rb
@@ -1,0 +1,7 @@
+require 'factory_girl'
+
+FactoryGirl.define do
+  factory :alchemy_page_version, class: 'Alchemy::PageVersion' do
+    association :page, factory: :alchemy_page
+  end
+end

--- a/spec/controllers/alchemy/admin/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/elements_controller_spec.rb
@@ -2,10 +2,17 @@ require 'spec_helper'
 
 module Alchemy
   describe Admin::ElementsController do
-    let(:alchemy_page)         { create(:alchemy_page) }
-    let(:element)              { create(:alchemy_element, page_id: alchemy_page.id) }
-    let(:element_in_clipboard) { create(:alchemy_element, page_id: alchemy_page.id) }
-    let(:clipboard)            { session[:alchemy_clipboard] = {} }
+    let(:alchemy_page) { create(:alchemy_page) }
+
+    let(:element) do
+      create(:alchemy_element, page_version_id: alchemy_page.current_version_id)
+    end
+
+    let(:element_in_clipboard) do
+      create(:alchemy_element, page_version_id: alchemy_page.current_version_id)
+    end
+
+    let(:clipboard) { session[:alchemy_clipboard] = {} }
 
     before { authorize_user(:as_author) }
 
@@ -13,14 +20,14 @@ module Alchemy
       let(:alchemy_page) { build_stubbed(:alchemy_page) }
 
       before do
-        expect(Page).to receive(:find).and_return alchemy_page
+        expect(Page).to receive(:find_by).and_return alchemy_page
       end
 
       context 'with cells' do
-        let(:cell) { build_stubbed(:alchemy_cell, page: alchemy_page) }
+        let(:cell) { create(:alchemy_cell, page: alchemy_page) }
 
         before do
-          expect(alchemy_page).to receive(:cells).and_return [cell]
+          alchemy_page.cells << cell
         end
 
         it "groups elements by cell" do
@@ -31,12 +38,8 @@ module Alchemy
       end
 
       context 'without cells' do
-        before do
-          expect(alchemy_page).to receive(:cells).and_return []
-        end
-
         it "assigns page elements" do
-          expect(alchemy_page).to receive(:elements).and_return(double(not_trashed: []))
+          expect(alchemy_page).to receive(:current_elements).and_return(double(not_trashed: []))
           alchemy_get :index, {page_id: alchemy_page.id}
         end
       end
@@ -45,50 +48,70 @@ module Alchemy
     describe '#list' do
       context 'without page_id, but with page_urlname' do
         it "loads page from urlname" do
-          expect {
-            alchemy_xhr :get, :list, {page_urlname: alchemy_page.urlname}
-          }.to_not raise_error
+          alchemy_xhr :get, :list, {page_urlname: alchemy_page.urlname}
+          expect(assigns(:elements)).to eq(alchemy_page.current_elements.published)
         end
 
         describe 'view' do
           render_views
 
-          it "should return a select tag with elements" do
-            alchemy_xhr :get, :list, {page_urlname: alchemy_page.urlname}
+          it "returns a select tag with elements" do
+            alchemy_xhr :get, :list, {page_id: alchemy_page.id}
             expect(response.body).to match(/select(.*)elements_from_page_selector(.*)option/)
           end
         end
       end
 
       context 'with page_id' do
-        it "loads page from urlname" do
+        it "loads elements from page id" do
           alchemy_xhr :get, :list, {page_id: alchemy_page.id}
-          expect(assigns(:page_id)).to eq(alchemy_page.id.to_s)
+          expect(assigns(:elements)).to eq(alchemy_page.current_elements.published)
         end
       end
     end
 
     describe '#order' do
-      let(:element_1)   { create(:alchemy_element) }
-      let(:element_2)   { create(:alchemy_element) }
-      let(:element_3)   { create(:alchemy_element) }
-      let(:element_ids) { [element_1.id, element_3.id, element_2.id] }
+      let(:alchemy_page) { create(:alchemy_page) }
+
+      let(:element_1) do
+        create(:alchemy_element, page_version: alchemy_page.current_version)
+      end
+
+      let(:element_2) do
+        create(:alchemy_element, page_version: alchemy_page.current_version)
+      end
+
+      let(:element_3) do
+        create(:alchemy_element, page_version: alchemy_page.current_version)
+      end
+
+      let(:element_ids) do
+        [element_1.id, element_3.id, element_2.id]
+      end
 
       it "sets new position for given element ids" do
-        alchemy_xhr :post, :order, element_ids: element_ids
+        alchemy_xhr :post, :order, page_id: alchemy_page.id, element_ids: element_ids
         expect(Element.all.pluck(:id)).to eq(element_ids)
       end
 
       context 'with missing [:element_ids] param' do
         it 'does not raise any error and silently rejects to order' do
           expect {
-            alchemy_xhr :post, :order
+            alchemy_xhr :post, :order, page_id: alchemy_page.id
           }.to_not raise_error
         end
       end
 
       context "untrashing" do
-        let(:trashed_element) { create(:alchemy_element, public: false, position: nil, page_id: 58, cell_id: 32) }
+        let(:trashed_element) do
+          create :alchemy_element,
+            public: false,
+            position: nil,
+            page_version_id: alchemy_page.current_version_id,
+            cell_id: 32
+        end
+
+        let(:other_page) { create(:alchemy_page) }
 
         before do
           # Because of a before_create filter it can not be created with a nil position and needs to be trashed here
@@ -96,24 +119,24 @@ module Alchemy
         end
 
         it "sets a list of trashed element ids" do
-          alchemy_xhr :post, :order, element_ids: [trashed_element.id]
+          alchemy_xhr :post, :order, page_id: alchemy_page.id, element_ids: [trashed_element.id]
           expect(assigns(:trashed_element_ids).to_a).to eq [trashed_element.id]
         end
 
         it "sets a new position to the element" do
-          alchemy_xhr :post, :order, element_ids: [trashed_element.id]
+          alchemy_xhr :post, :order, page_id: alchemy_page.id, element_ids: [trashed_element.id]
           trashed_element.reload
           expect(trashed_element.position).to_not be_nil
         end
 
-        it "should assign the (new) page_id to the element" do
-          alchemy_xhr :post, :order, element_ids: [trashed_element.id], page_id: 1, cell_id: nil
+        it "should assign the (new) page_version_id to the element" do
+          alchemy_xhr :post, :order, element_ids: [trashed_element.id], page_id: other_page.id, cell_id: nil
           trashed_element.reload
-          expect(trashed_element.page_id).to be 1
+          expect(trashed_element.page_version_id).to be other_page.current_version_id
         end
 
         it "should assign the (new) cell_id to the element" do
-          alchemy_xhr :post, :order, element_ids: [trashed_element.id], page_id: 1, cell_id: 5
+          alchemy_xhr :post, :order, element_ids: [trashed_element.id], page_id: alchemy_page.id, cell_id: 5
           trashed_element.reload
           expect(trashed_element.cell_id).to be 5
         end
@@ -121,10 +144,12 @@ module Alchemy
     end
 
     describe '#new' do
-      let(:alchemy_page) { build_stubbed(:alchemy_page) }
+      let(:alchemy_page) do
+        build_stubbed(:alchemy_page)
+      end
 
       before do
-        expect(Page).to receive(:find).and_return(alchemy_page)
+        expect(Page).to receive(:find_by).and_return(alchemy_page)
       end
 
       it "assign variable for all available element definitions" do
@@ -133,9 +158,13 @@ module Alchemy
       end
 
       context "with elements in clipboard" do
-        let(:clipboard_items) { [{'id' => element.id.to_s, 'action' => 'copy'}] }
+        let(:clipboard_items) do
+          [{'id' => element.id.to_s, 'action' => 'copy'}]
+        end
 
-        before { clipboard['elements'] = clipboard_items }
+        before do
+          clipboard['elements'] = clipboard_items
+        end
 
         it "should load all elements from clipboard" do
           expect(Element).to receive(:all_from_clipboard_for_page).and_return(clipboard_items)
@@ -149,10 +178,10 @@ module Alchemy
       describe 'insertion position' do
         before { element }
 
-        it "should insert the element at bottom of list" do
-          alchemy_xhr :post, :create, {element: {name: 'news', page_id: alchemy_page.id}}
-          expect(alchemy_page.elements.count).to eq(2)
-          expect(alchemy_page.elements.last.name).to eq('news')
+        it "inserts the element at bottom of list" do
+          alchemy_xhr :post, :create, page_id: alchemy_page.id, element: {name: 'news'}
+          expect(alchemy_page.current_elements.count).to eq(2)
+          expect(alchemy_page.current_elements.last.name).to eq('news')
         end
 
         context "on a page with a setting for insert_elements_at of top" do
@@ -165,9 +194,9 @@ module Alchemy
           end
 
           it "should insert the element at top of list" do
-            alchemy_xhr :post, :create, {element: {name: 'news', page_id: alchemy_page.id}}
-            expect(alchemy_page.elements.count).to eq(2)
-            expect(alchemy_page.elements.first.name).to eq('news')
+            alchemy_xhr :post, :create, page_id: alchemy_page.id, element: {name: 'news'}
+            expect(alchemy_page.current_elements.count).to eq(2)
+            expect(alchemy_page.current_elements.first.name).to eq('news')
           end
         end
       end
@@ -191,15 +220,15 @@ module Alchemy
             end
 
             it "should put the element in the correct cell" do
-              alchemy_xhr :post, :create, {element: {name: "article#header", page_id: page.id}}
+              alchemy_xhr :post, :create, page_id: page.id, element: {name: "article#header"}
               expect(cell.elements.first).to be_an_instance_of(Element)
             end
           end
 
           context "and no cell name in element name" do
             it "should put the element in the main cell" do
-              alchemy_xhr :post, :create, {element: {name: "article", page_id: page.id}}
-              expect(page.elements.not_in_cell.first).to be_an_instance_of(Element)
+              alchemy_xhr :post, :create, page_id: page.id, element: {name: "article"}
+              expect(page.current_elements.not_in_cell.first).to be_an_instance_of(Element)
             end
           end
         end
@@ -224,17 +253,21 @@ module Alchemy
               end
 
               it "should create the element in the correct cell" do
-                alchemy_xhr :post, :create, {element: {page_id: page.id}, paste_from_clipboard: "#{element_in_clipboard.id}##{cell.name}"}
+                alchemy_xhr :post, :create, page_id: page.id, element: {}, paste_from_clipboard: "#{element_in_clipboard.id}##{cell.name}"
                 expect(cell.elements.first).to be_an_instance_of(Element)
               end
 
               context "with elements already in cell" do
                 before do
-                  cell.elements.create(page_id: page.id, name: "article", create_contents_after_create: false)
+                  cell.elements.create(
+                    page_version_id: page.current_version_id,
+                    name: "article",
+                    create_contents_after_create: false
+                  )
                 end
 
                 it "should set the correct position for the element" do
-                  alchemy_xhr :post, :create, {element: {page_id: page.id}, paste_from_clipboard: "#{element_in_clipboard.id}##{cell.name}"}
+                  alchemy_xhr :post, :create, page_id: page.id, element: {}, paste_from_clipboard: "#{element_in_clipboard.id}##{cell.name}"
                   expect(cell.elements.last.position).to eq(cell.elements.count)
                 end
               end
@@ -242,17 +275,34 @@ module Alchemy
 
             context "and no cell name in element name" do
               it "should create the element in the nil cell" do
-                alchemy_xhr :post, :create, {element: {page_id: page.id}, paste_from_clipboard: element_in_clipboard.id.to_s}
-                expect(page.elements.first.cell).to eq(nil)
+                alchemy_xhr :post, :create, page_id: page.id, element: {}, paste_from_clipboard: element_in_clipboard.id.to_s
+                expect(page.current_elements.first.cell).to eq(nil)
               end
             end
           end
 
           context "on a page with a setting for insert_elements_at of top" do
-            let!(:alchemy_page)         { create(:alchemy_page, :public, name: 'News') }
-            let!(:element_in_clipboard) { create(:alchemy_element, page: alchemy_page, name: 'news') }
-            let!(:cell)                 { create(:alchemy_cell, name: 'news', page: alchemy_page) }
-            let!(:element)              { create(:alchemy_element, name: 'news', page: alchemy_page, cell: cell) }
+            let!(:alchemy_page) do
+              create(:alchemy_page, :public, name: 'News')
+            end
+
+            let!(:element_in_clipboard) do
+              create :alchemy_element,
+                page_version: alchemy_page.current_version,
+                name: 'news'
+            end
+
+            let!(:cell) do
+              create(:alchemy_cell, name: 'news', page: alchemy_page)
+            end
+
+            let!(:element) do
+              create :alchemy_element,
+                page_version: alchemy_page.current_version,
+                name: 'news',
+                cell: cell
+            end
+
 
             before do
               expect(PageLayout).to receive(:get).at_least(:once).and_return({
@@ -261,16 +311,18 @@ module Alchemy
                 'insert_elements_at' => 'top',
                 'cells' => ['news']
               })
+
               expect(Cell).to receive(:definition_for).and_return({
                 'name' => 'news',
                 'elements' => ['news']
               })
+
               clipboard['elements'] = [{'id' => element_in_clipboard.id.to_s}]
               cell.elements << element
             end
 
             it "should insert the element at top of list" do
-              alchemy_xhr :post, :create, {element: {name: 'news', page_id: alchemy_page.id}, paste_from_clipboard: "#{element_in_clipboard.id}##{cell.name}"}
+              alchemy_xhr :post, :create, page_id: alchemy_page.id, element: {name: 'news'}, paste_from_clipboard: "#{element_in_clipboard.id}##{cell.name}"
               expect(cell.elements.count).to eq(2)
               expect(cell.elements.first.name).to eq('news')
               expect(cell.elements.first).not_to eq(element)
@@ -287,21 +339,21 @@ module Alchemy
         end
 
         it "should create an element from clipboard" do
-          alchemy_xhr :post, :create, {paste_from_clipboard: element_in_clipboard.id, element: {page_id: alchemy_page.id}}
+          alchemy_xhr :post, :create, page_id: alchemy_page.id, paste_from_clipboard: element_in_clipboard.id, element: {}
           expect(response.status).to eq(200)
           expect(response.body).to match(/Successfully added new element/)
         end
 
         context "and with cut as action parameter" do
           it "should also remove the element id from clipboard" do
-            alchemy_xhr :post, :create, {paste_from_clipboard: element_in_clipboard.id, element: {page_id: alchemy_page.id}}
+            alchemy_xhr :post, :create, page_id: alchemy_page.id, paste_from_clipboard: element_in_clipboard.id, element: {}
             expect(session[:alchemy_clipboard]['elements'].detect { |item| item['id'] == element_in_clipboard.id.to_s }).to be_nil
           end
         end
       end
 
       context 'if element could not be saved' do
-        subject { alchemy_post :create, {element: {page_id: alchemy_page.id}} }
+        subject { alchemy_post :create, page_id: alchemy_page.id, element: {} }
 
         before do
           expect_any_instance_of(Element).to receive(:save).and_return false
@@ -324,7 +376,7 @@ module Alchemy
             'name' => 'header',
             'elements' => ['header']
           })
-          expect(controller).to receive(:params).and_return({element: {name: 'header#header'}})
+          allow(controller).to receive(:params).and_return({element: {name: 'header#header'}})
         end
 
         context "with cell not existing" do
@@ -350,7 +402,7 @@ module Alchemy
 
       context "with only the element name in the params" do
         before do
-          expect(controller).to receive(:params).and_return({element: {name: 'header'}})
+          allow(controller).to receive(:params).and_return({element: {name: 'header'}})
         end
 
         it "should return nil" do
@@ -360,7 +412,7 @@ module Alchemy
 
       context 'with cell definition not found' do
         before do
-          expect(controller).to receive(:params).and_return({element: {name: 'header#header'}})
+          allow(controller).to receive(:params).and_return({element: {name: 'header#header'}})
           expect(Cell).to receive(:definition_for).and_return nil
         end
 

--- a/spec/controllers/alchemy/admin/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/pages_controller_spec.rb
@@ -26,7 +26,7 @@ module Alchemy
 
       describe '#index' do
         let(:language)      { build_stubbed(:alchemy_language) }
-        let(:language_root) { build_stubbed(:alchemy_page, :language_root) }
+        let(:language_root) { build_stubbed(:alchemy_page, :public, :language_root) }
 
         context 'with existing language root page' do
           before do
@@ -406,8 +406,8 @@ module Alchemy
 
       describe '#copy_language_tree' do
         let(:params)                     { {languages: {new_lang_id: '2', old_lang_id: '1'}} }
-        let(:language_root_to_copy_from) { build_stubbed(:alchemy_page, :language_root) }
-        let(:copy_of_language_root)      { build_stubbed(:alchemy_page, :language_root) }
+        let(:language_root_to_copy_from) { build_stubbed(:alchemy_page, :public, :language_root) }
+        let(:copy_of_language_root)      { build_stubbed(:alchemy_page, :public, :language_root) }
         let(:root_page)                  { mock_model('Page') }
 
         before do
@@ -517,11 +517,11 @@ module Alchemy
       end
 
       describe '#publish' do
-        let(:page) { stub_model(Page, published_at: nil, public: false, name: "page", parent_id: 1, urlname: "page", language: stub_model(Language), page_layout: "bla") }
+        let(:page) { build_stubbed(:alchemy_page) }
 
         before do
-          allow(@controller).to receive(:load_page).and_return(page)
-          @controller.instance_variable_set("@page", page)
+          allow(controller).to receive(:load_page).and_return(page)
+          controller.instance_variable_set("@page", page)
         end
 
         it "should publish the page" do

--- a/spec/controllers/alchemy/api/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/api/elements_controller_spec.rb
@@ -5,7 +5,7 @@ module Alchemy
     describe '#index' do
       let(:page) do
         page = create(:alchemy_page, :public)
-        page.create_public_version
+        page.publish!
         page
       end
 

--- a/spec/controllers/alchemy/api/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/api/elements_controller_spec.rb
@@ -5,9 +5,7 @@ module Alchemy
     describe '#index' do
       let(:page) do
         page = create(:alchemy_page, :public)
-        # TODO: Investigate why this is horribly broken in AR!
-        page.build_public_version(page_id: page.id)
-        page.save!
+        page.create_public_version
         page
       end
 

--- a/spec/controllers/alchemy/api/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/api/elements_controller_spec.rb
@@ -3,10 +3,16 @@ require 'spec_helper'
 module Alchemy
   describe Api::ElementsController do
     describe '#index' do
-      let(:page) { create(:alchemy_page, :public) }
+      let(:page) do
+        page = create(:alchemy_page, :public)
+        # TODO: Investigate why this is horribly broken in AR!
+        page.build_public_version(page_id: page.id)
+        page.save!
+        page
+      end
 
       before do
-        2.times { create(:alchemy_element, page: page) }
+        create_list(:alchemy_element, 2, page_version: page.public_version)
       end
 
       it "returns all public elements as json objects" do

--- a/spec/controllers/alchemy/api/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/api/elements_controller_spec.rb
@@ -3,11 +3,7 @@ require 'spec_helper'
 module Alchemy
   describe Api::ElementsController do
     describe '#index' do
-      let(:page) do
-        page = create(:alchemy_page, :public)
-        page.publish!
-        page
-      end
+      let(:page) { create(:alchemy_page, :public) }
 
       before do
         create_list(:alchemy_element, 2, page_version: page.public_version)

--- a/spec/controllers/alchemy/on_page_layout_mixin_spec.rb
+++ b/spec/controllers/alchemy/on_page_layout_mixin_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Alchemy::PagesController, 'OnPageLayout mixin', type: :controller
       context "for index action" do
         %w(standard news).each do |page_layout|
           it "runs callback on #{page_layout} layout" do
-            create(:alchemy_page, :language_root, page_layout: page_layout)
+            create(:alchemy_page, :public, :language_root, page_layout: page_layout)
 
             alchemy_get :index
             expect(assigns(:on_all_layouts)).to eq(page_layout)
@@ -59,7 +59,7 @@ RSpec.describe Alchemy::PagesController, 'OnPageLayout mixin', type: :controller
         end
 
         context "for index action" do
-          let!(:page) { create(:alchemy_page, :language_root, page_layout: 'standard') }
+          let!(:page) { create(:alchemy_page, :public, :language_root, page_layout: 'standard') }
 
           it 'runs the callback' do
             alchemy_get :index
@@ -79,7 +79,7 @@ RSpec.describe Alchemy::PagesController, 'OnPageLayout mixin', type: :controller
         end
 
         context "for index action" do
-          let!(:page) { create(:alchemy_page, :language_root, page_layout: 'news') }
+          let!(:page) { create(:alchemy_page, :public, :language_root, page_layout: 'news') }
 
           it "doesn't run the callback" do
             alchemy_get :index
@@ -128,7 +128,7 @@ RSpec.describe Alchemy::PagesController, 'OnPageLayout mixin', type: :controller
 
         %w(standard news).each do |page_layout|
           it "runs both callbacks on #{page_layout} layout" do
-            create(:alchemy_page, :language_root, page_layout: page_layout)
+            create(:alchemy_page, :public, :language_root, page_layout: page_layout)
 
             alchemy_get :index
             expect(assigns(:page_layout)).to eq(page_layout)
@@ -159,7 +159,7 @@ RSpec.describe Alchemy::PagesController, 'OnPageLayout mixin', type: :controller
       end
 
       context "for index action" do
-        let!(:page) { create(:alchemy_page, :language_root, page_layout: 'standard') }
+        let!(:page) { create(:alchemy_page, :public, :language_root, page_layout: 'standard') }
 
         it 'runs both callbacks' do
           alchemy_get :index
@@ -186,7 +186,7 @@ RSpec.describe Alchemy::PagesController, 'OnPageLayout mixin', type: :controller
       end
 
       context 'for index action' do
-        let!(:page) { create(:alchemy_page, :language_root, page_layout: 'standard') }
+        let!(:page) { create(:alchemy_page, :public, :language_root, page_layout: 'standard') }
 
         it 'evaluates the given block' do
           alchemy_get :index
@@ -214,7 +214,7 @@ RSpec.describe Alchemy::PagesController, 'OnPageLayout mixin', type: :controller
       end
 
       context 'for index action' do
-        let!(:page) { create(:alchemy_page, :language_root, page_layout: 'standard') }
+        let!(:page) { create(:alchemy_page, :public, :language_root, page_layout: 'standard') }
 
         it 'runs the given callback method' do
           alchemy_get :index
@@ -253,7 +253,7 @@ RSpec.describe Alchemy::PagesController, 'OnPageLayout mixin', type: :controller
 
       %w(standard news).each do |page_layout|
         it 'evaluates the given callback on both page_layouts for index action' do
-          create(:alchemy_page, :language_root, page_layout: page_layout)
+          create(:alchemy_page, :public, :language_root, page_layout: page_layout)
 
           alchemy_get :index
           expect(assigns(:successful)).to eq(page_layout)

--- a/spec/controllers/alchemy/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/pages_controller_spec.rb
@@ -165,7 +165,7 @@ module Alchemy
       end
 
       it "should include content" do
-        page.create_public_version
+        page.publish!
         page.elements.first.content_by_name('news_headline').essence.update_attributes({body: 'Peters Petshop'})
         alchemy_get :show, urlname: 'news', format: :rss
         expect(response.body).to match /Peters Petshop/
@@ -199,7 +199,7 @@ module Alchemy
       before do
         allow(Alchemy.user_class).to receive(:admins).and_return(OpenStruct.new(count: 1))
         allow(Config).to receive(:get) { |arg| arg == :url_nesting ? true : false }
-        product.create_public_version
+        product.publish!
         product.elements.find_by(name: 'article').contents.essence_texts.first.essence.update_column(:body, 'screwdriver')
       end
 

--- a/spec/controllers/alchemy/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/pages_controller_spec.rb
@@ -6,10 +6,9 @@ module Alchemy
     let(:default_language) { Language.default }
 
     let(:default_language_root) do
-      create :alchemy_page, :language_root,
+      create :alchemy_page, :public, :language_root,
         language: default_language,
-        name: 'Home',
-        public: true
+        name: 'Home'
     end
 
     let(:page) do
@@ -23,7 +22,7 @@ module Alchemy
     end
 
     before do
-      allow(controller).to receive(:signup_required?).and_return(false)
+      allow(controller).to receive(:signup_required?) { false }
     end
 
     describe "#index" do
@@ -51,7 +50,7 @@ module Alchemy
 
         context 'and the root page is not public' do
           before do
-            default_language_root.update!(public: false)
+            default_language_root.public_version.delete
           end
 
           context 'and redirect_to_public_child is set to false' do
@@ -124,8 +123,9 @@ module Alchemy
         end
 
         let!(:startseite) do
-          create :alchemy_page, :language_root,
-            language: deutsch, public: true, name: 'Startseite'
+          create :alchemy_page, :public, :language_root,
+            language: deutsch,
+            name: 'Startseite'
         end
 
         before do
@@ -192,9 +192,33 @@ module Alchemy
     describe "url nesting" do
       render_views
 
-      let(:catalog)  { create(:alchemy_page, :public, name: "Catalog", urlname: 'catalog', parent: default_language_root, language: default_language, visible: true) }
-      let(:products) { create(:alchemy_page, :public, name: "Products", urlname: 'products', parent: catalog, language: default_language, visible: true) }
-      let(:product)  { create(:alchemy_page, :public, name: "Screwdriver", urlname: 'screwdriver', parent: products, language: default_language, do_not_autogenerate: false, visible: true) }
+      let(:catalog) do
+        create :alchemy_page, :public,
+          name: "Catalog",
+          urlname: 'catalog',
+          parent: default_language_root,
+          language: default_language,
+          visible: true
+      end
+
+      let(:products) do
+        create :alchemy_page, :public,
+          name: "Products",
+          urlname: 'products',
+          parent: catalog,
+          language: default_language,
+          visible: true
+      end
+
+      let(:product) do
+        create :alchemy_page, :public,
+          name: "Screwdriver",
+          urlname: 'screwdriver',
+          parent: products,
+          language: default_language,
+          do_not_autogenerate: false,
+          visible: true
+      end
 
       before do
         allow(Alchemy.user_class).to receive(:admins).and_return(OpenStruct.new(count: 1))

--- a/spec/controllers/alchemy/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/pages_controller_spec.rb
@@ -165,10 +165,7 @@ module Alchemy
       end
 
       it "should include content" do
-        # TODO: Investigate why this is horribly broken in AR!
-        page.build_public_version(page_id: page.id)
-        page.save!
-        page.public_version.elements << page.current_elements
+        page.create_public_version
         page.elements.first.content_by_name('news_headline').essence.update_attributes({body: 'Peters Petshop'})
         alchemy_get :show, urlname: 'news', format: :rss
         expect(response.body).to match /Peters Petshop/
@@ -202,9 +199,7 @@ module Alchemy
       before do
         allow(Alchemy.user_class).to receive(:admins).and_return(OpenStruct.new(count: 1))
         allow(Config).to receive(:get) { |arg| arg == :url_nesting ? true : false }
-        product.build_public_version(page_id: product.id)
-        product.save!
-        product.public_version.elements << product.current_elements
+        product.create_public_version
         product.elements.find_by(name: 'article').contents.essence_texts.first.essence.update_column(:body, 'screwdriver')
       end
 

--- a/spec/dummy/db/migrate/20160301160033_create_alchemy_page_versions.rb
+++ b/spec/dummy/db/migrate/20160301160033_create_alchemy_page_versions.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20160301160033_create_alchemy_page_versions.rb

--- a/spec/dummy/db/migrate/20160301203630_add_current_version_and_public_version_to_alchemy_pages.rb
+++ b/spec/dummy/db/migrate/20160301203630_add_current_version_and_public_version_to_alchemy_pages.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20160301203630_add_current_version_and_public_version_to_alchemy_pages.rb

--- a/spec/dummy/db/migrate/20160301205721_change_elements_page_association_to_page_version.rb
+++ b/spec/dummy/db/migrate/20160301205721_change_elements_page_association_to_page_version.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20160301205721_change_elements_page_association_to_page_version.rb

--- a/spec/dummy/db/migrate/20160315212914_move_page_meta_data_to_page_versions.rb
+++ b/spec/dummy/db/migrate/20160315212914_move_page_meta_data_to_page_versions.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20160315212914_move_page_meta_data_to_page_versions.rb

--- a/spec/dummy/db/migrate/20160316202352_remove_public_from_alchemy_pages.rb
+++ b/spec/dummy/db/migrate/20160316202352_remove_public_from_alchemy_pages.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20160316202352_remove_public_from_alchemy_pages.rb

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160301203630) do
+ActiveRecord::Schema.define(version: 20160301205721) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string   "name"
@@ -52,7 +52,7 @@ ActiveRecord::Schema.define(version: 20160301203630) do
   create_table "alchemy_elements", force: :cascade do |t|
     t.string   "name"
     t.integer  "position"
-    t.integer  "page_id"
+    t.integer  "page_version_id"
     t.boolean  "public",            default: true
     t.boolean  "folded",            default: false
     t.boolean  "unique",            default: false
@@ -65,8 +65,8 @@ ActiveRecord::Schema.define(version: 20160301203630) do
     t.integer  "parent_element_id"
   end
 
-  add_index "alchemy_elements", ["page_id", "parent_element_id"], name: "index_alchemy_elements_on_page_id_and_parent_element_id"
-  add_index "alchemy_elements", ["page_id", "position"], name: "index_elements_on_page_id_and_position"
+  add_index "alchemy_elements", ["page_version_id", "parent_element_id"], name: "alchemy_elements_page_version_parent_element_idx"
+  add_index "alchemy_elements", ["page_version_id", "position"], name: "index_elements_on_page_id_and_position"
 
   create_table "alchemy_elements_alchemy_pages", id: false, force: :cascade do |t|
     t.integer "element_id"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160315212914) do
+ActiveRecord::Schema.define(version: 20160316202352) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string   "name"
@@ -228,7 +228,6 @@ ActiveRecord::Schema.define(version: 20160315212914) do
     t.integer  "parent_id"
     t.integer  "depth"
     t.boolean  "visible",            default: false
-    t.boolean  "public",             default: false
     t.boolean  "locked",             default: false
     t.integer  "locked_by"
     t.boolean  "restricted",         default: false

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160301205721) do
+ActiveRecord::Schema.define(version: 20160315212914) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string   "name"
@@ -211,6 +211,8 @@ ActiveRecord::Schema.define(version: 20160301205721) do
   create_table "alchemy_page_versions", force: :cascade do |t|
     t.integer "page_id"
     t.string  "title"
+    t.string  "meta_keywords"
+    t.string  "meta_description"
   end
 
   add_index "alchemy_page_versions", ["page_id"], name: "index_alchemy_page_versions_on_page_id"
@@ -218,12 +220,9 @@ ActiveRecord::Schema.define(version: 20160301205721) do
   create_table "alchemy_pages", force: :cascade do |t|
     t.string   "name"
     t.string   "urlname"
-    t.string   "title"
     t.string   "language_code"
     t.boolean  "language_root"
     t.string   "page_layout"
-    t.text     "meta_keywords"
-    t.text     "meta_description"
     t.integer  "lft"
     t.integer  "rgt"
     t.integer  "parent_id"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150906195818) do
+ActiveRecord::Schema.define(version: 20160301160033) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string   "name"
@@ -207,6 +207,13 @@ ActiveRecord::Schema.define(version: 20150906195818) do
   end
 
   add_index "alchemy_legacy_page_urls", ["urlname"], name: "index_alchemy_legacy_page_urls_on_urlname"
+
+  create_table "alchemy_page_versions", force: :cascade do |t|
+    t.integer "page_id"
+    t.string  "title"
+  end
+
+  add_index "alchemy_page_versions", ["page_id"], name: "index_alchemy_page_versions_on_page_id"
 
   create_table "alchemy_pages", force: :cascade do |t|
     t.string   "name"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160301160033) do
+ActiveRecord::Schema.define(version: 20160301203630) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string   "name"
@@ -228,26 +228,30 @@ ActiveRecord::Schema.define(version: 20160301160033) do
     t.integer  "rgt"
     t.integer  "parent_id"
     t.integer  "depth"
-    t.boolean  "visible",          default: false
-    t.boolean  "public",           default: false
-    t.boolean  "locked",           default: false
+    t.boolean  "visible",            default: false
+    t.boolean  "public",             default: false
+    t.boolean  "locked",             default: false
     t.integer  "locked_by"
-    t.boolean  "restricted",       default: false
-    t.boolean  "robot_index",      default: true
-    t.boolean  "robot_follow",     default: true
-    t.boolean  "sitemap",          default: true
-    t.boolean  "layoutpage",       default: false
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
+    t.boolean  "restricted",         default: false
+    t.boolean  "robot_index",        default: true
+    t.boolean  "robot_follow",       default: true
+    t.boolean  "sitemap",            default: true
+    t.boolean  "layoutpage",         default: false
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
     t.integer  "creator_id"
     t.integer  "updater_id"
     t.integer  "language_id"
     t.text     "cached_tag_list"
     t.datetime "published_at"
+    t.integer  "current_version_id"
+    t.integer  "public_version_id"
   end
 
+  add_index "alchemy_pages", ["current_version_id"], name: "index_alchemy_pages_on_current_version_id"
   add_index "alchemy_pages", ["language_id"], name: "index_pages_on_language_id"
   add_index "alchemy_pages", ["parent_id", "lft"], name: "index_pages_on_parent_id_and_lft"
+  add_index "alchemy_pages", ["public_version_id"], name: "index_alchemy_pages_on_public_version_id"
   add_index "alchemy_pages", ["urlname"], name: "index_pages_on_urlname"
 
   create_table "alchemy_pictures", force: :cascade do |t|

--- a/spec/features/admin/edit_elements_feature_spec.rb
+++ b/spec/features/admin/edit_elements_feature_spec.rb
@@ -26,10 +26,12 @@ RSpec.feature "The edit elements feature" do
   end
 
   context 'With an element having nestable elements defined' do
-    let!(:element) { create(:alchemy_element, :with_nestable_elements, page: a_page) }
+    let!(:element) do
+      create(:alchemy_element, :with_nestable_elements, page_version: a_page.current_version)
+    end
 
     scenario 'a button to add an nestable element appears.' do
-      visit alchemy.admin_elements_path(page_id: element.page_id)
+      visit alchemy.admin_elements_path(page_id: element.page_version.page_id)
       expect(page).to have_selector('.add-nestable-element-button')
     end
   end

--- a/spec/features/admin/language_tree_feature_spec.rb
+++ b/spec/features/admin/language_tree_feature_spec.rb
@@ -4,13 +4,13 @@ describe 'Language tree feature', type: :feature, js: true do
   let(:klingon) { create(:alchemy_language, :klingon) }
 
   before do
-    create(:alchemy_page, :language_root)
+    create(:alchemy_page, :public, :language_root)
     authorize_user(:as_admin)
   end
 
   context "in a multilangual environment" do
     before do
-      create(:alchemy_page, :language_root, name: 'Klingon', language: klingon)
+      create(:alchemy_page, :public, :language_root, name: 'Klingon', language: klingon)
     end
 
     it "one should be able to switch the language tree" do

--- a/spec/features/admin/link_overlay_spec.rb
+++ b/spec/features/admin/link_overlay_spec.rb
@@ -24,7 +24,7 @@ describe "Link overlay" do
 
   context "linking internal pages", js: true do
     let(:lang_root) do
-      create(:alchemy_page, :language_root)
+      create(:alchemy_page, :public, :language_root)
     end
 
     before do

--- a/spec/features/admin/page_creation_feature_spec.rb
+++ b/spec/features/admin/page_creation_feature_spec.rb
@@ -25,7 +25,7 @@ module Alchemy
         context "", js: true do
           before do
             visit admin_pages_path
-            page.first(:link, 'Create a new subpage').click
+            page.first(:link, 'Create a new subpage', minimum: 1).click
           end
 
           it "the create page tab is visible by default" do

--- a/spec/features/page_feature_spec.rb
+++ b/spec/features/page_feature_spec.rb
@@ -36,9 +36,7 @@ module Alchemy
     describe 'gets rendered' do
       let!(:public_page) do
         page = create(:alchemy_page, :public)
-        # TODO: Investigate why this is horribly broken in AR!
-        page.build_public_version(page_id: page.id)
-        page.save!
+        page.create_public_version
         page
       end
 

--- a/spec/features/page_feature_spec.rb
+++ b/spec/features/page_feature_spec.rb
@@ -5,7 +5,7 @@ module Alchemy
     let!(:default_language) { Language.default }
 
     let!(:default_language_root) do
-      create(:alchemy_page, :language_root, language: default_language, name: 'Home')
+      create(:alchemy_page, :public, :language_root, language: default_language, name: 'Home')
     end
 
     let(:public_page) do
@@ -35,9 +35,7 @@ module Alchemy
 
     describe 'gets rendered' do
       let!(:public_page) do
-        page = create(:alchemy_page, :public)
-        page.publish!
-        page
+        create(:alchemy_page, :public)
       end
 
       let!(:article) do
@@ -50,7 +48,7 @@ module Alchemy
       let!(:essence) { article.contents.find_by!(name: 'intro').essence }
 
       before do
-        essence.update(body: 'Welcome to Peters Petshop', public: true)
+        essence.update(body: 'Welcome to Peters Petshop')
       end
 
       it "includes all its elements and contents" do
@@ -174,7 +172,7 @@ module Alchemy
     end
 
     describe 'accessing restricted pages' do
-      let!(:restricted_page) { create(:alchemy_page, :restricted, public: true) }
+      let!(:restricted_page) { create(:alchemy_page, :restricted, :public) }
 
       context 'as a guest user' do
         it "I am not able to visit the page" do

--- a/spec/features/page_feature_spec.rb
+++ b/spec/features/page_feature_spec.rb
@@ -36,7 +36,7 @@ module Alchemy
     describe 'gets rendered' do
       let!(:public_page) do
         page = create(:alchemy_page, :public)
-        page.create_public_version
+        page.publish!
         page
       end
 

--- a/spec/features/page_redirects_spec.rb
+++ b/spec/features/page_redirects_spec.rb
@@ -302,12 +302,8 @@ module Alchemy
 
       context "redirects to public child" do
         before do
-          public_page.update_attributes(
-            public: false,
-            visible: false,
-            name: 'Not Public',
-            urlname: ''
-          )
+          public_page.update(name: 'Not Public', urlname: '', visible: false)
+          public_page.public_version.delete
           public_child
         end
 

--- a/spec/features/page_redirects_spec.rb
+++ b/spec/features/page_redirects_spec.rb
@@ -5,7 +5,7 @@ module Alchemy
     let!(:default_language) { Language.default }
 
     let!(:default_language_root) do
-      create(:alchemy_page, :language_root, language: default_language, name: 'Home')
+      create(:alchemy_page, :public, :language_root, language: default_language, name: 'Home')
     end
 
     let(:public_page) do
@@ -87,11 +87,11 @@ module Alchemy
       context "if requested page is unpublished" do
         before do
           public_page.update_attributes(
-            public: false,
             visible: false,
             name: 'Not Public',
             urlname: ''
           )
+          public_page.public_version.delete
           public_child
         end
 
@@ -102,7 +102,7 @@ module Alchemy
 
         context "with only unpublished pages in page tree" do
           before do
-            public_child.update_attributes(public: false)
+            public_child.public_version.delete
           end
 
           it "should raise not found error" do

--- a/spec/helpers/alchemy/admin/pages_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/pages_helper_spec.rb
@@ -9,23 +9,29 @@ describe Alchemy::Admin::PagesHelper do
   end
 
   describe '#combined_page_status' do
-    let(:page) { build_stubbed(:alchemy_page, restricted: true, visible: true, public: true, locked: true) }
+    let(:page) do
+      build_stubbed :alchemy_page, :public,
+        restricted: true,
+        visible: true,
+        locked: true
+    end
+
     subject { helper.combined_page_status(page) }
 
     context 'when page is locked' do
-      it { is_expected.not_to match(/locked/) } # We don't want the locked status in the return string
+      it { is_expected.not_to match(/<span.+locked/) } # We don't want the locked status in the return string
     end
 
     context 'when page is restricted' do
-      it { is_expected.to match(/is restricted/) }
+      it { is_expected.to match(/<span.+is restricted/) }
     end
 
     context 'when page is visible in navigation' do
-      it { is_expected.to match(/is visible/) }
+      it { is_expected.to match(/<span.+is visible/) }
     end
 
     context 'when page is published' do
-      it { is_expected.to match(/is published/) }
+      it { is_expected.to match(/<span.+is published/) }
     end
   end
 

--- a/spec/helpers/alchemy/pages_helper_spec.rb
+++ b/spec/helpers/alchemy/pages_helper_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 module Alchemy
   describe PagesHelper do
     # Fixtures
-    let(:language)                 { mock_model('Language', code: 'en') }
+    let(:language)                 { mock_model('Language', code: 'en', page_layout: 'index') }
     let(:default_language)         { Language.default }
     let(:language_root)            { create(:alchemy_page, :language_root) }
     let(:public_page)              { create(:alchemy_page, :public) }
@@ -288,22 +288,21 @@ module Alchemy
     end
 
     describe "#render_meta_data" do
-      let(:page) do
-        mock_model('Page',
-          language: language,
+      let!(:root_page) do
+        create(:alchemy_page, :language_root, language: language)
+      end
+
+      let!(:page) do
+        create(:alchemy_page, :public,
           title: 'A Public Page',
-          meta_keywords: '',
-          meta_description: '',
-          robot_index?: false,
-          robot_follow?: false,
-          contains_feed?: false,
-          updated_at: '2011-11-29-23:00:00'
+          updated_at: '2011-11-29-23:00:00',
+          parent: root_page
         )
       end
 
-      let(:root_page) { Page.new }
-
-      before { helper.instance_variable_set('@page', page) }
+      before do
+        helper.instance_variable_set('@page', page)
+      end
 
       subject { helper.render_meta_data }
 
@@ -332,28 +331,40 @@ module Alchemy
       end
 
       context 'when the current page is missing its meta description' do
-        before { allow(Language).to receive(:current_root_page).and_return(root_page) }
+        context "but the root page has meta description" do
+          before do
+            root_page.current_version.update(meta_description: "root page's description")
+            root_page.publish!
+          end
 
-        it "should use the the one from the language root's page" do
-          root_page.meta_description = "root page's description"
-          is_expected.to match /meta name="description" content="root page's description"/
+          it "uses these" do
+            is_expected.to match /meta name="description" content="root page's description"/
+          end
         end
 
-        it "should not be set when language root's page is also missing one" do
-          is_expected.not_to match /meta name="description"/
+        context "and the root page also has no meta description" do
+          it "does not set it at all" do
+            is_expected.not_to match /meta name="description"/
+          end
         end
       end
 
       context 'when the current page is missing its meta keywords' do
-        before { allow(Language).to receive(:current_root_page).and_return(root_page) }
+        context "but the root page has meta keywords" do
+          before do
+            root_page.current_version.update(meta_keywords: "root page's keywords")
+            root_page.publish!
+          end
 
-        it "should use the the one from the language root's page" do
-          root_page.meta_keywords = "root page's keywords"
-          is_expected.to match /meta name="keywords" content="root page's keywords"/
+          it "uses these" do
+            is_expected.to match /meta name="keywords" content="root page's keywords"/
+          end
         end
 
-        it "should not be set when language root's page is also missing one" do
-          is_expected.not_to match /meta name="keywords"/
+        context "and the root page also has no meta keywords" do
+          it "does not set it at all" do
+            is_expected.not_to match /meta name="keywords"/
+          end
         end
       end
     end

--- a/spec/helpers/alchemy/pages_helper_spec.rb
+++ b/spec/helpers/alchemy/pages_helper_spec.rb
@@ -6,7 +6,7 @@ module Alchemy
     # Fixtures
     let(:language)                 { mock_model('Language', code: 'en', page_layout: 'index') }
     let(:default_language)         { Language.default }
-    let(:language_root)            { create(:alchemy_page, :language_root) }
+    let(:language_root)            { create(:alchemy_page, :public, :language_root) }
     let(:public_page)              { create(:alchemy_page, :public) }
     let(:visible_page)             { create(:alchemy_page, :public, visible: true) }
     let(:restricted_page)          { create(:alchemy_page, :public, visible: true, restricted: true) }
@@ -14,7 +14,7 @@ module Alchemy
     let(:level_3_page)             { create(:alchemy_page, :public, parent_id: level_2_page.id, visible: true, name: 'Level 3') }
     let(:level_4_page)             { create(:alchemy_page, :public, parent_id: level_3_page.id, visible: true, name: 'Level 4') }
     let(:klingon)                  { create(:alchemy_language, :klingon) }
-    let(:klingon_language_root)    { create(:alchemy_page, :language_root, language: klingon) }
+    let(:klingon_language_root)    { create(:alchemy_page, :public, :language_root, language: klingon) }
     let(:klingon_public_page)      { create(:alchemy_page, :public, language: klingon, parent_id: klingon_language_root.id) }
 
     before do
@@ -61,7 +61,7 @@ module Alchemy
       end
 
       it "should render visible unpublished pages" do
-        unpublished_visible_page = create(:alchemy_page, visible: true, public: false)
+        unpublished_visible_page = create(:alchemy_page, visible: true)
         expect(helper.render_navigation).to match(/#{unpublished_visible_page.name}/)
       end
 
@@ -268,7 +268,7 @@ module Alchemy
       end
 
       it "should render a breadcrumb of visible and unpublished pages" do
-        page.update_attributes!(public: false, urlname: 'a-unpublic-page', name: 'A Unpublic Page', title: 'A Unpublic Page')
+        page.update_attributes!(name: 'A Unpublic Page')
         expect(helper.render_breadcrumb(page: page)).to match(/A Unpublic Page/)
       end
 
@@ -288,11 +288,11 @@ module Alchemy
     end
 
     describe "#render_meta_data" do
-      let!(:root_page) do
-        create(:alchemy_page, :language_root, language: language)
+      let(:root_page) do
+        create(:alchemy_page, :public, :language_root, language: language)
       end
 
-      let!(:page) do
+      let(:page) do
         create(:alchemy_page, :public,
           title: 'A Public Page',
           updated_at: '2011-11-29-23:00:00',
@@ -333,8 +333,7 @@ module Alchemy
       context 'when the current page is missing its meta description' do
         context "but the root page has meta description" do
           before do
-            root_page.current_version.update(meta_description: "root page's description")
-            root_page.publish!
+            root_page.public_version.update(meta_description: "root page's description")
           end
 
           it "uses these" do
@@ -352,8 +351,7 @@ module Alchemy
       context 'when the current page is missing its meta keywords' do
         context "but the root page has meta keywords" do
           before do
-            root_page.current_version.update(meta_keywords: "root page's keywords")
-            root_page.publish!
+            root_page.public_version.update(meta_keywords: "root page's keywords")
           end
 
           it "uses these" do

--- a/spec/libraries/permissions_spec.rb
+++ b/spec/libraries/permissions_spec.rb
@@ -10,10 +10,10 @@ describe Alchemy::Permissions do
   let(:picture)                 { mock_model(Alchemy::Picture, restricted?: false) }
   let(:restricted_picture)      { mock_model(Alchemy::Picture, restricted?: true) }
   let(:public_page)             { build_stubbed(:alchemy_page, :public, restricted: false) }
-  let(:unpublic_page)           { build_stubbed(:alchemy_page, public: false) }
+  let(:unpublic_page)           { build_stubbed(:alchemy_page) }
   let(:visible_page)            { build_stubbed(:alchemy_page, restricted: false, visible: true) }
   let(:not_visible_page)        { build_stubbed(:alchemy_page, :public, restricted: false, visible: false) }
-  let(:restricted_page)         { build_stubbed(:alchemy_page, :public, public: true, restricted: true) }
+  let(:restricted_page)         { build_stubbed(:alchemy_page, :public, restricted: true) }
   let(:visible_restricted_page) { build_stubbed(:alchemy_page, visible: true, restricted: true) }
   let(:published_element)       { mock_model(Alchemy::Element, restricted?: false, public?: true, trashed?: false) }
   let(:restricted_element)      { mock_model(Alchemy::Element, restricted?: true, public?: true, trashed?: false) }

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -489,7 +489,7 @@ module Alchemy
     end
 
     context 'previous and next elements.' do
-      let(:page) { create(:alchemy_page, :language_root) }
+      let(:page) { create(:alchemy_page, :public, :language_root) }
 
       let!(:element1) do
         create(:alchemy_element, page_version: page.current_version, name: 'headline')

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -224,7 +224,7 @@ module Alchemy
         end
       end
 
-      context "Saving a normal page" do
+      context "Creating a normal page" do
         let(:page) do
           build(:alchemy_page, language_code: nil, language: klingon, do_not_autogenerate: false)
         end
@@ -324,6 +324,12 @@ module Alchemy
             expect(page.elements).to be_empty
           end
         end
+
+        it 'creates a current page version' do
+          page.save!
+          expect(page.versions).to_not be_empty
+          expect(page.current_version).to be_present
+        end
       end
 
       context "Creating a systempage" do
@@ -335,6 +341,10 @@ module Alchemy
 
         it "does not autogenerate the elements" do
           expect(page.elements).to be_empty
+        end
+
+        it 'does not create a page version' do
+          expect(page.versions).to be_empty
         end
       end
 

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -867,19 +867,6 @@ module Alchemy
       end
     end
 
-    describe '#destroy' do
-      context "with trashed but still assigned elements" do
-        before do
-          news_page.current_elements.map(&:trash!)
-        end
-
-        it "should not delete the trashed elements" do
-          news_page.destroy
-          expect(Element.trashed).not_to be_empty
-        end
-      end
-    end
-
     describe "#elements" do
       let(:page) { create(:alchemy_page, :public) }
       let(:element_1) { create(:alchemy_element, page_version: page.public_version) }

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -867,6 +867,13 @@ module Alchemy
       end
     end
 
+    describe '#destroy' do
+      it 'removes all versions' do
+        news_page.destroy
+        expect(news_page.versions).to be_empty
+      end
+    end
+
     describe "#elements" do
       let(:page) { create(:alchemy_page, :public) }
       let(:element_1) { create(:alchemy_element, page_version: page.public_version) }

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -7,7 +7,7 @@ module Alchemy
     let(:rootpage)      { Page.root }
     let(:language)      { Language.default }
     let(:klingon)       { create(:alchemy_language, :klingon) }
-    let(:language_root) { create(:alchemy_page, :language_root) }
+    let(:language_root) { create(:alchemy_page, :public, :language_root) }
     let(:page)          { mock_model(Page, page_layout: 'foo') }
     let(:public_page)   { create(:alchemy_page, :public) }
     let(:news_page)     { create(:alchemy_page, :public, page_layout: 'news', do_not_autogenerate: false) }
@@ -186,28 +186,6 @@ module Alchemy
             page.urlname = 'my-testpage'
             page.save!
             expect(page.legacy_urls).to be_empty
-          end
-        end
-
-        context "public has changed" do
-          it "should update published_at" do
-            expect {
-              page.update_attributes!(public: true)
-            }.to change { page.read_attribute(:published_at) }
-          end
-
-          it "should not update already set published_at" do
-            page.update_attributes!(published_at: 2.weeks.ago)
-            expect {
-              page.update_attributes!(public: true)
-            }.to_not change { page.read_attribute(:published_at) }
-          end
-        end
-
-        context "public has not changed" do
-          it "should not update published_at" do
-            page.update_attributes!(name: 'New Name')
-            expect(page.read_attribute(:published_at)).to be_nil
           end
         end
 
@@ -487,7 +465,7 @@ module Alchemy
       end
 
       let!(:klingon_lang_root) do
-        create :alchemy_page, :language_root, {
+        create :alchemy_page, :public, :language_root, {
           name: 'klingon_lang_root',
           layoutpage: nil,
           language: klingon
@@ -731,7 +709,7 @@ module Alchemy
 
     describe '.public_language_roots' do
       it "should return pages that public language roots" do
-        create(:alchemy_page, :public, name: 'First Public Child', parent_id: language_root.id, language: language)
+        create(:alchemy_page, :public, :language_root, name: 'Language root', language: language)
         expect(Page.public_language_roots.size).to eq(1)
       end
     end
@@ -898,7 +876,6 @@ module Alchemy
       let(:element_3) { create(:alchemy_element, page_version: page.public_version) }
 
       before do
-        page.publish!
         element_3.move_to_top
       end
 
@@ -968,11 +945,7 @@ module Alchemy
     end
 
     describe "#descendent_elements" do
-      let!(:page) do
-        page = create(:alchemy_page)
-        page.publish!
-        page
-      end
+      let!(:page) { create(:alchemy_page, :public) }
 
       let!(:element_1) do
         create(:alchemy_element, page_version: page.public_version)
@@ -994,11 +967,7 @@ module Alchemy
     end
 
     describe "#descendent_contents" do
-      let!(:page) do
-        page = create(:alchemy_page)
-        page.publish!
-        page
-      end
+      let!(:page) { create(:alchemy_page, :public) }
 
       let!(:element_1) do
         create :alchemy_element, :with_nestable_elements, :with_contents,
@@ -1161,9 +1130,7 @@ module Alchemy
 
     describe '#feed_elements' do
       let(:page) do
-        page = create(:alchemy_page, :public, page_layout: 'news')
-        page.publish!
-        page
+        create(:alchemy_page, :public, page_layout: 'news')
       end
 
       let(:news_element) do
@@ -1304,7 +1271,10 @@ module Alchemy
 
     describe '#first_public_child' do
       before do
-        create(:alchemy_page, name: "First child", language: language, public: false, parent_id: language_root.id)
+        create :alchemy_page,
+          name: "First child",
+          language: language,
+          parent_id: language_root.id
       end
 
       it "should return first_public_child" do
@@ -1450,7 +1420,7 @@ module Alchemy
       let(:center_page)     { create(:alchemy_page, :public, name: 'Center Page') }
       let(:next_page)       { create(:alchemy_page, :public, name: 'Next Page') }
       let(:non_public_page) { create(:alchemy_page, name: 'Not public Page') }
-      let(:restricted_page) { create(:alchemy_page, :restricted, public: true) }
+      let(:restricted_page) { create(:alchemy_page, :public, :restricted) }
 
       before do
         public_page
@@ -1515,17 +1485,14 @@ module Alchemy
     end
 
     describe '#publish!' do
-      let!(:page) { create(:alchemy_page, public: false) }
+      let!(:page) { create(:alchemy_page) }
       let!(:current_time) { Time.current }
 
       before do
         allow(Time).to receive(:now).and_return(current_time)
-        page.publish!
       end
 
-      it "sets public attribute to true" do
-        expect(page.public).to eq(true)
-      end
+      subject! { page.publish! }
 
       it "sets published_at attribute to current time" do
         expect(page.published_at).to eq(current_time)
@@ -1932,11 +1899,18 @@ module Alchemy
     end
 
     context 'page status methods' do
-      let(:page) { build(:alchemy_page, public: true, visible: true, restricted: false, locked: false) }
+      let(:page) do
+        build_stubbed(:alchemy_page, :public, visible: true, restricted: false, locked: false)
+      end
 
       describe '#status' do
         it "returns a combined status hash" do
-          expect(page.status).to eq({public: true, visible: true, restricted: false, locked: false})
+          expect(page.status).to eq(
+            public: true,
+            visible: true,
+            restricted: false,
+            locked: false
+          )
         end
       end
 
@@ -2137,6 +2111,22 @@ module Alchemy
 
       it "returns a partial renderer compatible name" do
         expect(page.layout_partial_name).to eq('standard_page')
+      end
+    end
+
+    describe '#public?' do
+      let(:page) { build_stubbed(:alchemy_page) }
+
+      subject { page.public? }
+
+      context "when public version is present" do
+        before { page.publish! }
+
+        it { is_expected.to be(true) }
+      end
+
+      context "when public version is missing" do
+        it { is_expected.to be(false) }
       end
     end
 

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -953,7 +953,7 @@ module Alchemy
     describe "#descendent_elements" do
       let!(:page) do
         page = create(:alchemy_page)
-        page.create_public_version
+        page.publish!
         page
       end
 
@@ -979,7 +979,7 @@ module Alchemy
     describe "#descendent_contents" do
       let!(:page) do
         page = create(:alchemy_page)
-        page.create_public_version
+        page.publish!
         page
       end
 
@@ -1145,7 +1145,7 @@ module Alchemy
     describe '#feed_elements' do
       let(:page) do
         page = create(:alchemy_page, :public, page_layout: 'news')
-        page.create_public_version
+        page.publish!
         page
       end
 
@@ -1498,11 +1498,10 @@ module Alchemy
     end
 
     describe '#publish!' do
-      let(:page) { build_stubbed(:alchemy_page, public: false) }
-      let(:current_time) { Time.current }
+      let!(:page) { create(:alchemy_page, public: false) }
+      let!(:current_time) { Time.current }
 
       before do
-        current_time
         allow(Time).to receive(:now).and_return(current_time)
         page.publish!
       end
@@ -1515,8 +1514,9 @@ module Alchemy
         expect(page.published_at).to eq(current_time)
       end
 
-      it "sets current version as public version" do
-        expect(page.public_version_id).to eq(page.current_version_id)
+      it "creates public version from current version" do
+        expect(page.public_version).to be_present
+        expect(page.public_version.elements).to match_array(page.current_version.elements)
       end
     end
 

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -126,26 +126,35 @@ module Alchemy
 
     # Callbacks
 
-    context 'callbacks' do
+    describe 'callbacks' do
       let(:page) do
-        create(:alchemy_page, name: 'My Testpage', language: language, parent_id: language_root.id)
+        create :alchemy_page,
+          name: 'My Testpage',
+          language: language,
+          parent_id: language_root.id
       end
 
-      context 'before_save' do
-        it "should not set the title automatically if the name changed but title is not blank" do
-          page.name = "My Renaming Test"
-          page.save; page.reload
-          expect(page.title).to eq("My Testpage")
+      describe 'before_save' do
+        context "if the name changed but title is not blank" do
+          before do
+            page.current_version.update!(title: "My Title")
+          end
+
+          it "does not set the title from name" do
+            page.update!(name: "My changed Name")
+            expect(page.current_version.title).to eq("My Title")
+          end
         end
 
-        it "should not automatically set the title if it changed its value" do
-          page.title = "I like SEO"
-          page.save; page.reload
-          expect(page.title).to eq("I like SEO")
+        context "if the title changed its value" do
+          it "does not set the title from name" do
+            page.current_version.update!(title: "I like SEO")
+            expect(page.current_version.title).to eq("I like SEO")
+          end
         end
       end
 
-      context 'after_update' do
+      describe 'after_update' do
         context "urlname has changed" do
           it "should store legacy url if page is not redirect to external page" do
             page.urlname = 'new-urlname'
@@ -232,7 +241,7 @@ module Alchemy
         end
       end
 
-      context 'after_move' do
+      describe 'after_move' do
         let(:parent_1) { create(:alchemy_page, name: 'Parent 1', visible: true) }
         let(:parent_2) { create(:alchemy_page, name: 'Parent 2', visible: true) }
         let(:page)     { create(:alchemy_page, parent_id: parent_1.id, name: 'Page', visible: true) }
@@ -253,7 +262,7 @@ module Alchemy
         end
       end
 
-      context "Creating a normal page" do
+      describe "Creating a normal page" do
         let(:page) do
           build(:alchemy_page, language_code: nil, language: klingon, do_not_autogenerate: false)
         end
@@ -350,7 +359,7 @@ module Alchemy
         end
       end
 
-      context "Creating a systempage" do
+      describe "Creating a systempage" do
         let!(:page) { create(:alchemy_page, :system) }
 
         it "does not get the language code from language" do
@@ -592,12 +601,20 @@ module Alchemy
     describe '.create' do
       context "before/after filter" do
         it "should automatically set the title from its name" do
-          page = create(:alchemy_page, name: 'My Testpage', language: language, parent_id: language_root.id)
-          expect(page.title).to eq('My Testpage')
+          page = create :alchemy_page,
+                   name: 'My Testpage',
+                   language: language,
+                   parent_id: language_root.id
+
+          expect(page.current_version.title).to eq('My Testpage')
         end
 
         it "should get a webfriendly urlname" do
-          page = create(:alchemy_page, name: 'klingon$&stößel ', language: language, parent_id: language_root.id)
+          page = create :alchemy_page,
+                   name: 'klingon$&stößel ',
+                   language: language,
+                   parent_id: language_root.id
+
           expect(page.urlname).to eq('klingon-stoessel')
         end
 

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -201,6 +201,35 @@ module Alchemy
             expect(page.read_attribute(:published_at)).to be_nil
           end
         end
+
+        context 'with elements already on the current page version' do
+          let!(:page) do
+            create(:alchemy_page, do_not_autogenerate: false)
+          end
+
+          it "does not autogenerate new ones" do
+            page.update!(name: 'New Name')
+
+            expect(page.current_elements.select { |e|
+              e.name == 'header'
+            }.length).to eq(1)
+          end
+        end
+
+        context "after changing the page layout" do
+          it "all elements not allowed on this page should be trashed" do
+            expect(news_page.current_version.elements.trashed).to be_empty
+            news_page.update!(page_layout: 'standard')
+            trashed = news_page.current_version.elements.trashed.pluck(:name)
+            expect(trashed).to eq(['news'])
+            expect(trashed).to_not include('article', 'header')
+          end
+
+          it "should autogenerate elements" do
+            news_page.update!(page_layout: 'contact')
+            expect(news_page.current_elements.pluck(:name)).to include('contactform')
+          end
+        end
       end
 
       context 'after_move' do
@@ -234,20 +263,9 @@ module Alchemy
           expect(page.language_code).to eq("kl")
         end
 
-        it "autogenerates the elements" do
+        it "autogenerates the elements on the current version" do
           page.save!
-          expect(page.elements).not_to be_empty
-        end
-
-        context 'with elements already on the page' do
-          before do
-            page.elements << create(:alchemy_element, name: 'header')
-          end
-
-          it "does not autogenerate" do
-            page.save!
-            expect(page.elements.select { |e| e.name == 'header' }.length).to eq(1)
-          end
+          expect(page.current_elements).not_to be_empty
         end
 
         context "with cells" do
@@ -345,23 +363,6 @@ module Alchemy
 
         it 'does not create a page version' do
           expect(page.versions).to be_empty
-        end
-      end
-
-      context "after changing the page layout" do
-        let(:news_element) { news_page.elements.find_by(name: 'news') }
-
-        it "all elements not allowed on this page should be trashed" do
-          expect(news_page.trashed_elements).to be_empty
-          news_page.update_attributes(page_layout: 'standard')
-          trashed = news_page.trashed_elements.pluck(:name)
-          expect(trashed).to eq(['news'])
-          expect(trashed).to_not include('article', 'header')
-        end
-
-        it "should autogenerate elements" do
-          news_page.update_attributes(page_layout: 'contact')
-          expect(news_page.elements.pluck(:name)).to include('contactform')
         end
       end
     end
@@ -513,6 +514,7 @@ module Alchemy
 
     describe '.copy' do
       let(:page) { create(:alchemy_page, name: 'Source') }
+
       subject { Page.copy(page) }
 
       it "the copy should have added (copy) to name" do
@@ -520,7 +522,10 @@ module Alchemy
       end
 
       context "page with tags" do
-        before { page.tag_list = 'red, yellow'; page.save }
+        before do
+          page.tag_list = 'red, yellow'
+          page.save
+        end
 
         it "the copy should have source tag_list" do
           # The order of tags varies between postgresql and sqlite/mysql
@@ -532,22 +537,26 @@ module Alchemy
       end
 
       context "page with elements" do
-        before { page.elements << create(:alchemy_element) }
+        before do
+          page.current_version.elements << create(:alchemy_element)
+        end
 
         it "the copy should have source elements" do
-          expect(subject.elements).not_to be_empty
-          expect(subject.elements.count).to eq(page.elements.count)
+          expect(subject.current_elements).not_to be_empty
+          expect(subject.current_elements.count).to eq(page.current_elements.count)
         end
       end
 
       context "page with trashed elements" do
+        let(:element) { create(:alchemy_element) }
+
         before do
-          page.elements << create(:alchemy_element)
-          page.elements.first.trash!
+          page.current_version.elements << element
+          element.trash!
         end
 
         it "the copy should not hold a copy of the trashed elements" do
-          expect(subject.elements).to be_empty
+          expect(subject.current_elements).to be_empty
         end
       end
 
@@ -860,7 +869,9 @@ module Alchemy
 
     describe '#destroy' do
       context "with trashed but still assigned elements" do
-        before { news_page.elements.map(&:trash!) }
+        before do
+          news_page.current_elements.map(&:trash!)
+        end
 
         it "should not delete the trashed elements" do
           news_page.destroy
@@ -870,12 +881,13 @@ module Alchemy
     end
 
     describe "#elements" do
-      let(:page) { create(:alchemy_page) }
-      let!(:element_1) { create(:alchemy_element, page: page) }
-      let!(:element_2) { create(:alchemy_element, page: page) }
-      let!(:element_3) { create(:alchemy_element, page: page) }
+      let(:page) { create(:alchemy_page, :public) }
+      let(:element_1) { create(:alchemy_element, page_version: page.public_version) }
+      let(:element_2) { create(:alchemy_element, page_version: page.public_version) }
+      let(:element_3) { create(:alchemy_element, page_version: page.public_version) }
 
       before do
+        page.publish!
         element_3.move_to_top
       end
 
@@ -884,11 +896,17 @@ module Alchemy
       end
 
       context 'with nestable elements' do
-        let(:nestable_element) { create(:alchemy_element, :with_nestable_elements) }
+        let(:nestable_element) do
+          create(:alchemy_element, :with_nestable_elements)
+        end
+
+        let(:nested_element) do
+          create(:alchemy_element, name: 'slide')
+        end
 
         before do
-          nestable_element.nested_elements << create(:alchemy_element, name: 'slide')
-          page.elements << nestable_element
+          nestable_element.nested_elements << nested_element
+          page.public_version.elements << nestable_element
         end
 
         it 'does not contain nested elements of an element' do
@@ -898,51 +916,101 @@ module Alchemy
       end
     end
 
+    describe "#current_elements" do
+      let(:page) { create(:alchemy_page) }
+      let(:element_1) { create(:alchemy_element) }
+      let(:element_2) { create(:alchemy_element) }
+      let(:element_3) { create(:alchemy_element) }
+
+      before do
+        page.current_version.elements << element_3
+        page.current_version.elements << element_1
+        page.current_version.elements << element_2
+      end
+
+      it 'returns an ordered collection of elements from current version of that page' do
+        expect(page.current_elements).to_not be_empty
+        expect(page.current_elements[0].id).to eq(element_3.id)
+        expect(page.current_elements[1].id).to eq(element_1.id)
+        expect(page.current_elements[2].id).to eq(element_2.id)
+      end
+
+      context 'with nestable elements' do
+        let(:nestable_element) do
+          create(:alchemy_element, :with_nestable_elements)
+        end
+
+        let(:nested_element) do
+          create(:alchemy_element, name: 'slide')
+        end
+
+        before do
+          nestable_element.nested_elements << nested_element
+          page.current_version.elements << nestable_element
+        end
+
+        it 'does not contain nested elements of an element' do
+          expect(nestable_element.nested_elements).to_not be_empty
+          expect(page.current_elements).to_not include(nestable_element.nested_elements.first)
+        end
+      end
+    end
+
     describe "#descendent_elements" do
       let!(:page) do
-        create(:alchemy_page)
+        page = create(:alchemy_page)
+        page.create_public_version!(page_id: page.id)
+        page
       end
 
       let!(:element_1) do
-        create(:alchemy_element, page_id: page.id)
+        create(:alchemy_element, page_version: page.public_version)
       end
 
       let!(:element_2) do
-        create(:alchemy_element, :with_nestable_elements, page_id: page.id, parent_element_id: element_1.id)
+        create :alchemy_element, :with_nestable_elements,
+          page_version: page.public_version,
+          parent_element_id: element_1.id
       end
 
       let!(:element_3) do
-        create(:alchemy_element, page_id: page.id)
+        create(:alchemy_element, page_version: page.public_version)
       end
 
-      it 'returns an active record collection of all elements including nested elements on that page' do
+      it 'returns a collection of all elements including nested elements from public version of that page' do
         expect(page.descendent_elements.count).to eq(3)
       end
     end
 
     describe "#descendent_contents" do
       let!(:page) do
-        create(:alchemy_page)
+        page = create(:alchemy_page)
+        page.create_public_version!(page_id: page.id)
+        page
       end
 
       let!(:element_1) do
-        create(:alchemy_element, :with_nestable_elements, :with_contents, name: 'slider', page_id: page.id)
+        create :alchemy_element, :with_nestable_elements, :with_contents,
+          name: 'slider',
+          page_version: page.public_version
       end
 
       let!(:element_2) do
         create :alchemy_element,
           :with_contents, {
             name: 'slide',
-            page_id: page.id,
+            page_version: page.public_version,
             parent_element_id: element_1.id
           }
       end
 
       let!(:element_3) do
-        create(:alchemy_element, :with_contents, name: 'slide', page_id: page.id)
+        create :alchemy_element, :with_contents,
+          name: 'slide',
+          page_version: page.public_version
       end
 
-      it 'returns an active record collection of all content including nested elements on that page' do
+      it 'returns a collection of all contents including nested elements on public version of page' do
         expect(page.descendent_contents.count).to eq(2)
       end
     end
@@ -1081,21 +1149,44 @@ module Alchemy
     end
 
     describe '#feed_elements' do
-      let(:news_element) { create(:alchemy_element, name: 'news', public: false, page: news_page) }
-
-      it "should return all published rss feed elements" do
-        expect(news_page.feed_elements).not_to be_empty
-        expect(news_page.feed_elements).to eq(Element.where(name: 'news').available.to_a)
+      let(:page) do
+        page = create(:alchemy_page, :public, page_layout: 'news')
+        page.create_public_version!(page_id: page.id)
+        page
       end
 
-      it "should not return unpublished rss feed elements" do
-        expect(news_page.feed_elements).not_to include(news_element)
+      let(:news_element) do
+        create(:alchemy_element, name: 'news')
       end
 
-      it "should not return trashed rss feed elements" do
-        news_element.update(public: true)
-        news_element.trash!
-        expect(news_page.feed_elements).not_to include(news_element)
+      let(:unpublic_news_element) do
+        create :alchemy_element,
+          name: 'news',
+          public: false,
+          page_version: page.public_version
+      end
+
+      let(:trashed_news_element) do
+        unpublic_news_element.update(public: true)
+        unpublic_news_element.trash!
+        unpublic_news_element
+      end
+
+      before do
+        page.public_version.elements << news_element
+      end
+
+      it "returns all rss feed elements from public version of page" do
+        expect(page.feed_elements).to be_present
+        expect(page.feed_elements).to eq(Element.where(name: 'news').available.to_a)
+      end
+
+      it "does not return unpublished rss feed elements" do
+        expect(page.feed_elements).not_to include(unpublic_news_element)
+      end
+
+      it "doest not return trashed rss feed elements" do
+        expect(page.feed_elements).not_to include(trashed_news_element)
       end
     end
 
@@ -2064,7 +2155,7 @@ module Alchemy
       let!(:expanded_element) do
         create :alchemy_element,
           name: 'article',
-          page: page,
+          page_version: page.current_version,
           folded: false,
           create_contents_after_create: true
       end
@@ -2072,17 +2163,23 @@ module Alchemy
       let!(:folded_element) do
         create :alchemy_element,
           name: 'article',
-          page: page,
+          page_version: page.current_version,
           folded: true,
           create_contents_after_create: true
+      end
+
+      let!(:expanded_rtf_contents) do
+        expanded_element.contents.essence_richtexts
+      end
+
+      let!(:folded_rtf_content) do
+        folded_element.contents.essence_richtexts.first
       end
 
       subject(:richtext_contents_ids) { page.richtext_contents_ids }
 
       it 'returns content ids for all expanded elements that have tinymce enabled' do
-        expanded_rtf_contents = expanded_element.contents.essence_richtexts
         expect(richtext_contents_ids).to eq(expanded_rtf_contents.pluck(:id))
-        folded_rtf_content = folded_element.contents.essence_richtexts.first
         expect(richtext_contents_ids).to_not include(folded_rtf_content.id)
       end
 
@@ -2090,7 +2187,7 @@ module Alchemy
         let!(:nested_expanded_element) do
           create :alchemy_element,
             name: 'article',
-            page: page,
+            page_version: page.current_version,
             parent_element: expanded_element,
             folded: false,
             create_contents_after_create: true
@@ -2099,21 +2196,26 @@ module Alchemy
         let!(:nested_folded_element) do
           create :alchemy_element,
             name: 'article',
-            page: page,
+            page_version: page.current_version,
             parent_element: folded_element,
             folded: true,
             create_contents_after_create: true
         end
 
+        let!(:nested_expanded_rtf_contents) do
+          nested_expanded_element.contents.essence_richtexts
+        end
+
+        let!(:rtf_content_ids) do
+          expanded_rtf_contents.pluck(:id) + nested_expanded_rtf_contents.pluck(:id)
+        end
+
+        let!(:nested_folded_rtf_content) do
+          nested_folded_element.contents.essence_richtexts.first
+        end
+
         it 'returns content ids for all expanded nested elements that have tinymce enabled' do
-          expanded_rtf_contents = expanded_element.contents.essence_richtexts
-          nested_expanded_rtf_contents = nested_expanded_element.contents.essence_richtexts
-          rtf_content_ids = expanded_rtf_contents.pluck(:id) +
-                            nested_expanded_rtf_contents.pluck(:id)
           expect(richtext_contents_ids.sort).to eq(rtf_content_ids)
-
-          nested_folded_rtf_content = nested_folded_element.contents.essence_richtexts.first
-
           expect(richtext_contents_ids).to_not include(nested_folded_rtf_content.id)
         end
       end

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1429,6 +1429,10 @@ module Alchemy
       it "sets published_at attribute to current time" do
         expect(page.published_at).to eq(current_time)
       end
+
+      it "sets current version as public version" do
+        expect(page.public_version_id).to eq(page.current_version_id)
+      end
     end
 
     describe '#set_language_from_parent_or_default' do

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -959,7 +959,7 @@ module Alchemy
     describe "#descendent_elements" do
       let!(:page) do
         page = create(:alchemy_page)
-        page.create_public_version!(page_id: page.id)
+        page.create_public_version
         page
       end
 
@@ -985,7 +985,7 @@ module Alchemy
     describe "#descendent_contents" do
       let!(:page) do
         page = create(:alchemy_page)
-        page.create_public_version!(page_id: page.id)
+        page.create_public_version
         page
       end
 
@@ -1151,7 +1151,7 @@ module Alchemy
     describe '#feed_elements' do
       let(:page) do
         page = create(:alchemy_page, :public, page_layout: 'news')
-        page.create_public_version!(page_id: page.id)
+        page.create_public_version
         page
       end
 

--- a/spec/models/alchemy/page_version_spec.rb
+++ b/spec/models/alchemy/page_version_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+module Alchemy
+  RSpec.describe PageVersion do
+    let!(:page) { create(:alchemy_page, do_not_autogenerate: false) }
+    let!(:page_version) { page.current_version }
+
+    describe '#destroy' do
+      it 'destroys all elements' do
+        page_version.destroy
+        expect(page_version.elements).to be_empty
+      end
+
+      context "with trashed but still assigned elements" do
+        before do
+          page_version.elements.map(&:trash!)
+        end
+
+        it "should not delete the trashed elements" do
+          page_version.destroy
+          expect(Element.trashed).not_to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/alchemy/site_requests_spec.rb
+++ b/spec/requests/alchemy/site_requests_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Site requests' do
 
     let(:page) do
       Alchemy::Site.current = site
-      root = create(:alchemy_page, :language_root, language: site.languages.last)
+      root = create(:alchemy_page, :public, :language_root, language: site.languages.last)
       create(:alchemy_page, :public, parent: root)
     end
 


### PR DESCRIPTION
- [x] Add PageVersion model and associate with page
- [x] Add current and public version to page
- [x] Assign current version as public version on page publish
- [x] Associate elements with page version
- [x] Copy elements from current to new page version
- [x] Destroy not trashed elements on page version destroy
- [x] Destroy page versions when destroying page
- [x] Creates public version from current if publishing page
- [x] Move page meta data to page version
- [x] `Page#public?` is true, if a public version is present
- [x] Page edit admin interface should load the current version
- [ ] Add `public_from` and `public_until` to `PageVersion`
- [ ] Write proper Upgrade Task
- [ ] Cells should also be associated to a page version. But we plan to remove the cells anyway. Care about?