### PR TITLE
Allow Ransack >= 1.4

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'magiclabs-userstamp',              ['~> 2.1.0']
   gem.add_runtime_dependency 'non-stupid-digest-assets',         ['~> 1.0.8']
   gem.add_runtime_dependency 'rails',                            ['>= 4.2.0', '< 5.0']
-  gem.add_runtime_dependency 'ransack',                          ['~> 1.6']
+  gem.add_runtime_dependency 'ransack',                          ['~> 1.4']
   gem.add_runtime_dependency 'request_store',                    ['~> 1.2']
   gem.add_runtime_dependency 'responders',                       ['~> 2.0']
   gem.add_runtime_dependency 'sass-rails',                       ['~> 5.0']


### PR DESCRIPTION
Spree 3 depends on Ransack 1.4 so we need to lower this version