### PR TITLE
Fix page loading

### DIFF
--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -25,7 +25,10 @@ module Alchemy
 
     def load_page
       @page = Page.find_by(id: params[:id]) ||
-              Page.find_by(urlname: params[:urlname]) ||
+              Language.current.pages.find_by(
+                urlname: params[:urlname],
+                language_code: params[:locale] || Language.current.code
+              ) ||
               raise(ActiveRecord::RecordNotFound)
     end
   end

--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -173,7 +173,7 @@ module Alchemy
 
     def signup_required?
       if Alchemy.user_class.respond_to?(:admins)
-        Alchemy.user_class.admins.size == 0 && @page.nil?
+        Alchemy.user_class.admins.empty? && @page.nil?
       end
     end
 

--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -101,7 +101,7 @@ module Alchemy
     # @return NilClass
     #
     def load_page
-      @page ||= Page.contentpages.find_by(
+      @page ||= Language.current.pages.contentpages.find_by(
         urlname: params[:urlname],
         language_code: params[:locale] || Language.current.code
       )

--- a/lib/alchemy/shell.rb
+++ b/lib/alchemy/shell.rb
@@ -48,15 +48,15 @@ module Alchemy
     # Prints out all the todos
     #
     def display_todos
-      if todos.length > 0
-        log "\nTODOs:", :message
-        log "------\n", :message
-        todos.each_with_index do |todo, i|
-          title = "\n#{i + 1}. #{todo[0]}"
-          log title, :message
-          puts '-' * title.length
-          log todo[1], :message
-        end
+      return if todos.empty?
+
+      log "\nTODOs:", :message
+      log "------\n", :message
+      todos.each_with_index do |todo, i|
+        title = "\n#{i + 1}. #{todo[0]}"
+        log title, :message
+        puts '-' * title.length
+        log todo[1], :message
       end
     end
 

--- a/spec/controllers/alchemy/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/pages_controller_spec.rb
@@ -296,6 +296,28 @@ module Alchemy
       end
     end
 
+    context 'in an environment with multiple languages' do
+      let(:klingonian) { create(:alchemy_language, :klingonian) }
+
+      context 'having two pages with the same url names in different languages' do
+        render_views
+
+        let!(:klingonian_page) { create(:alchemy_page, :public, language: klingonian, name: "same-name", do_not_autogenerate: false) }
+        let!(:english_page) { create(:alchemy_page, :public, language: default_language, name: "same-name") }
+
+        before do
+          # Set a text in an essence rendered on the page so we can match against that
+          klingonian_page.essence_texts.first.update_column(:body, 'klingonian page')
+        end
+
+        it 'renders the page related to its language' do
+          alchemy_get :show, {urlname: "same-name", locale: klingonian_page.language_code}
+          expect(response.body).to have_content("klingonian page")
+        end
+      end
+
+    end
+
     describe '#page_etag' do
       subject { controller.send(:page_etag) }
 

--- a/spec/controllers/alchemy/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/pages_controller_spec.rb
@@ -315,7 +315,6 @@ module Alchemy
           expect(response.body).to have_content("klingonian page")
         end
       end
-
     end
 
     describe '#page_etag' do


### PR DESCRIPTION
Pages need to be loaded from current Language respectively Site. In #904 we changed the loading of the page and introduced a bug, that loads pages only from it's `locale` and `urlname`, without respecting the current site. So if you have a site `http://example.com/en/home` and a site `http://website.com/en/home` we can't be shure which one will be loaded.

By scoping the finding of the page to `Language.current` we fix this.

### Todo

- [x] Load page by site
- [x] Add tests

fixes #928 