### PR TITLE
Larger upload dropzone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ __New Features__
 
 __Notable Changes__
 
+* Larger upload dropzone
 * Uses Time.current instead of Time.now for proper timezone support
 * Adds year to `created_at` column of attachments table
 * Removes "available contents" feature.

--- a/app/assets/javascripts/alchemy/alchemy.uploader.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.uploader.js.coffee
@@ -10,6 +10,7 @@ window.Alchemy = {} if typeof(window.Alchemy) is 'undefined'
 Alchemy.Uploader = (settings) ->
   totalFilesCount = 0
   completedUploads = 0
+  $dropZone = $('#dropbox')
 
   # Normalize file types regex
   file_types = if settings.file_types == '*' then '.+' else settings.file_types
@@ -21,9 +22,12 @@ Alchemy.Uploader = (settings) ->
   # Hide the upload form submit button
   $('.upload-button').hide()
 
+  $dropZone.on 'dragleave', ->
+    $dropZone.removeClass('dragover')
+
   # Init jquery.fileupload
   $("#fileupload").fileupload
-    dropZone: '#dropbox'
+    dropZone: $dropZone
     dataType: 'json'
     filesContainer: $('#uploadProgressContainer')
     acceptFileTypes: new RegExp("(.|/)(#{file_types})", "i")
@@ -37,11 +41,14 @@ Alchemy.Uploader = (settings) ->
       @filesContainer
         .children()
         .not('.progressBarInProgress').length - 1
+    dragover: ->
+      $dropZone.addClass('dragover')
     add: (e, data) ->
       $this = $(this)
       data.context = new Alchemy.FileProgress(data.files[0])
       totalFilesCount = data.originalFiles.length
       $('.total-files-count').text(totalFilesCount)
+      $dropZone.removeClass('dragover').addClass('upload-in-progress')
       $('.overall-upload').show()
       # trigger validations
       data.process -> $this.fileupload('process', data)

--- a/app/assets/stylesheets/alchemy/upload.scss
+++ b/app/assets/stylesheets/alchemy/upload.scss
@@ -5,28 +5,37 @@ a#uploadswitcher, a.underline {
 .upload-container {
 
   label {
+    box-sizing: border-box;
+    width: 50%;
     @include button-defaults;
     text-align: center;
-    width: 80px;
   }
+
   input { display: none }
 }
 
-#dropbox {
+.drag-drop-note {
+  width: 50%;
   display: inline-block;
-  background: $medium-gray;
-  border: $default-border;
-  @extend %rounded-border;
-  padding: $default-padding 2*$default-padding;
   text-align: center;
   line-height: 19px;
-  width: 364px;
-  margin-left: 4px;
+  margin-left: -4px;
+}
+
+#dropbox {
+  height: 270px;
+  margin-top: 2*$default-margin;
+  @extend %rounded-border;
+  border: 1px dashed #ccc;
+  transition: background-color 200ms;
 
   &.dragover {
-    background: $dark-gray;
-    color: $light-gray;
-    border-color: $light-gray;
+    border: 0 none;
+    background-color: #ccc;
+  }
+
+  &.upload-in-progress {
+    border: 0 none;
   }
 }
 
@@ -53,7 +62,7 @@ a#uploadswitcher, a.underline {
 #uploadProgressContainer {
   overflow-x: hidden;
   overflow-y: auto;
-  height: 234px;
+  height: 236px;
 }
 
 #uploadProgressContainer .progressWrapper {

--- a/app/views/alchemy/admin/partials/_upload_form.html.erb
+++ b/app/views/alchemy/admin/partials/_upload_form.html.erb
@@ -20,17 +20,19 @@
 <div class="upload-container">
   <%= label_tag :fileupload, Alchemy.t(:browse) %>
   <input name="<%= model_name %>[<%= file_attribute %>]" id="fileupload" type="file" multiple value="<%= Alchemy.t(:browse) %>">
-  <div id="dropbox"><%= Alchemy.t('Or drag files over here') %></div>
+  <span class="drag-drop-note">&darr;&nbsp;<%= Alchemy.t('Or drag files over here') %>&nbsp;&darr;</span>
 </div>
 
-<div class="overall-upload">
-  <div class="progress">
-    <span class="progress-status">0%</span>
-    (<span class="uploaded-files-count">0</span>/<span class="total-files-count">0</span>)
+<div id="dropbox">
+  <div class="overall-upload">
+    <div class="progress">
+      <span class="progress-status">0%</span>
+      (<span class="uploaded-files-count">0</span>/<span class="total-files-count">0</span>)
+    </div>
   </div>
+  <div id="uploadProgressContainer"></div>
 </div>
 
-<div id="uploadProgressContainer"></div>
 
 <%- post_params = [
   {name: 'while_assigning', value: !!@while_assigning},

--- a/app/views/alchemy/admin/pictures/index.html.erb
+++ b/app/views/alchemy/admin/pictures/index.html.erb
@@ -7,7 +7,7 @@
       hotkey: 'alt+n',
       dialog_options: {
         title: Alchemy.t(:upload_image),
-        size: '540x525'
+        size: '540x550'
       },
       class: 'icon_button',
       title: Alchemy.t(:upload_image),

--- a/config/locales/alchemy.de.yml
+++ b/config/locales/alchemy.de.yml
@@ -315,7 +315,7 @@ de:
     attachment_filename_notice: "* Bitte verwenden Sie keine Sonderzeichen oder Umlaute in dem Dateinamen."
     auto_play: "Film automatisch abspielen"
     big_thumbnails: "große Miniaturbilder"
-    browse: "durchsuchen"
+    browse: "Ihren Computer durchsuchen"
     cancel: "abbrechen"
     cannot_delete_picture_notice: "Das Bild %{name} kann nicht gelöscht werden, da es noch auf Seiten benutzt wird."
     choose_element_as_target: "Wählen Sie ein Element dieser Seite als Ziel"


### PR DESCRIPTION
The dropzone was very small. Now the whole upload progress area is droppable.

<img width="590" alt="alchemy cms - images 2016-04-03 01-48-36" src="https://cloud.githubusercontent.com/assets/42868/14229816/fe85f8ea-f93e-11e5-84c1-228f7a25ecdd.png">

@moritzps will love this one!