### PR TITLE
Also migrate available contents defined on parent

### DIFF
--- a/lib/alchemy/upgrader/tasks/nestable_elements_migration.rb
+++ b/lib/alchemy/upgrader/tasks/nestable_elements_migration.rb
@@ -30,9 +30,18 @@ module Alchemy::Upgrader::Tasks
     end
 
     def element_content_names(el)
-      el.definition.fetch('contents', []).collect do |definition|
+      # names of contents directly defined on element
+      content_names = el.definition.fetch('contents', []).collect do |definition|
         definition['name']
       end
+
+      # names of contents defined on elements nestable elements
+      nestable_content_names = el.definition['nestable_elements'].collect { |name|
+        Alchemy::Element.definition_by_name(name).try(:content_definitions)
+      }.compact.collect { |c| c['name'] }.uniq
+
+      # we only want content names that are not defined on nestable elements, so we can move them
+      content_names - nestable_content_names
     end
 
     def create_element_for_content(content)


### PR DESCRIPTION
Sometimes `available_contents` where also defined as part of `contents` on the element.

Example:

    - name: link_list
      contents:
      - name: link
        type: EssenceLink
      available_contents:
      - name: link
        type: EssenceLink

These contents are missed in current upgrader. Now they get migrated to
nested elements as well.

Follow up to #965