### PR TITLE
Add locale select to language admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ log
 spec/dummy/uploads/
 spec/dummy/db/*.sqlite3*
 spec/dummy/public/assets
-spec/dummy/config/locales/**/*
 .rvmrc
 /coverage/
 *.gem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ __New Features__
 
 __Notable Changes__
 
+* Allow uppercase country codes
 * Larger upload dropzone
 * Uses Time.current instead of Time.now for proper timezone support
 * Adds year to `created_at` column of attachments table

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ __Notable Changes__
 
 __Fixed Bugs__
 
+* Add `locale` to `Alchemy::Language` to avoid errors for languages with missing locale files #831
 * Fixes `Alchemy::PageLayout.get_all_by_attributes`
 * Fix tag list display in picture library
 * Animated GIFs display correctly

--- a/app/assets/stylesheets/alchemy/_mixins.scss
+++ b/app/assets/stylesheets/alchemy/_mixins.scss
@@ -60,6 +60,17 @@
   @extend .border-box-sizing;
 }
 
+@mixin form-hint($background-color: $light_yellow, $border-color: $medium-gray) {
+  font-size: 10px;
+  line-height: 1.5em;
+  padding: $default-padding;
+  background-color: $background-color;
+  border: 1px solid $border-color;
+  display: block;
+  clear: both;
+  @extend %rounded-border;
+}
+
 @mixin animate-left {
   -webkit-transition: left 0.15s ease-in-out;
   -moz-transition: left 0.15s ease-in-out;

--- a/app/assets/stylesheets/alchemy/base.scss
+++ b/app/assets/stylesheets/alchemy/base.scss
@@ -402,14 +402,7 @@ div#images {
 }
 
 .foot_note, form .input .hint {
-  font-size: 10px;
-  line-height: 1.5em;
-  padding: $default-padding;
-  background-color: $light_yellow;
-  border: 1px solid $medium-gray;
-  @extend %rounded-border;
-  display: block;
-  clear: both;
+  @include form-hint;
 }
 
 #all_files td.name a {

--- a/app/assets/stylesheets/alchemy/forms.scss
+++ b/app/assets/stylesheets/alchemy/forms.scss
@@ -113,6 +113,14 @@ form {
       text-align: right;
       margin-bottom: 0.25em;
     }
+
+    &.language_locale small.error {
+      @include form-hint(
+        $background-color: $error_background_color,
+        $border-color: $error_border_color
+      );
+      text-align: left;
+    }
   }
 
   .inline-input {

--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -36,7 +36,7 @@ module Alchemy
         @preview_mode = true
         Page.current_preview = @page
         # Setting the locale to pages language, so the page content has it's correct translations.
-        ::I18n.locale = @page.language_code
+        ::I18n.locale = @page.language.locale
         render layout: 'application'
       end
 

--- a/app/controllers/alchemy/base_controller.rb
+++ b/app/controllers/alchemy/base_controller.rb
@@ -23,7 +23,7 @@ module Alchemy
     # Sets +I18n.locale+ to current Alchemy language.
     #
     def set_locale
-      ::I18n.locale = Language.current.code
+      ::I18n.locale = Language.current.locale
     end
 
     def not_found_error!(msg = "Not found \"#{request.fullpath}\"")

--- a/app/models/alchemy/language.rb
+++ b/app/models/alchemy/language.rb
@@ -22,19 +22,23 @@ module Alchemy
     belongs_to :site
     has_many :pages
 
-    validates_presence_of :name
-    validates_presence_of :language_code
-    validates_presence_of :page_layout
-    validates_presence_of :frontpage_name
-    validates_uniqueness_of :language_code, scope: [:site_id, :country_code]
+    before_validation :set_locale
+
+    validates :name, presence: true
+    validates :page_layout, presence: true
+    validates :frontpage_name, presence: true
+
+    validates :language_code,
+      presence: true,
+      uniqueness: { scope: [:site_id, :country_code] },
+      format: { with: /\A[a-z]{2}\z/, if: -> { language_code.present? } }
+
+    validates :country_code,
+      format: { with: /\A[a-z]{2}\z/, if: -> { country_code.present? } }
+
     validate :presence_of_default_language
     validate :publicity_of_default_language
-
-    validates_format_of :language_code, with: /\A[a-z]{2}\z/,
-      if: -> { language_code.present? }
-
-    validates_format_of :country_code, with: /\A[a-z]{2}\z/,
-      if: -> { country_code.present? }
+    validate :presence_of_locale_file, if: -> { language_code.present? }
 
     before_save :remove_old_default,
       if: -> { default_changed? && self != Language.default }
@@ -97,7 +101,31 @@ module Alchemy
       @layout_root_page ||= Page.layout_root_for(id)
     end
 
+    # All available locales matching this language
+    #
+    # Matching either the code (+language_code+ + +country_code+) or the +language_code+
+    #
+    # @return [Array]
+    #
+    def matching_locales
+      @_matching_locales ||= ::I18n.available_locales.select do |locale|
+        locale.to_s.split('-')[0] == language_code
+      end
+    end
+
     private
+
+    def set_locale
+      self.locale = matching_locales.reverse.detect do |locale|
+        locale.to_s == code || locale.to_s == language_code
+      end
+    end
+
+    def presence_of_locale_file
+      if locale.nil?
+        errors.add(:locale, :missing_file)
+      end
+    end
 
     def publicity_of_default_language
       if default? && !public?

--- a/app/models/alchemy/language.rb
+++ b/app/models/alchemy/language.rb
@@ -34,7 +34,7 @@ module Alchemy
       format: { with: /\A[a-z]{2}\z/, if: -> { language_code.present? } }
 
     validates :country_code,
-      format: { with: /\A[a-z]{2}\z/, if: -> { country_code.present? } }
+      format: { with: /\A[a-zA-Z]{2}\z/, if: -> { country_code.present? } }
 
     validate :presence_of_default_language
     validate :publicity_of_default_language

--- a/app/models/alchemy/language.rb
+++ b/app/models/alchemy/language.rb
@@ -22,7 +22,7 @@ module Alchemy
     belongs_to :site
     has_many :pages
 
-    before_validation :set_locale
+    before_validation :set_locale, if: -> { locale.blank? }
 
     validates :name, presence: true
     validates :page_layout, presence: true

--- a/app/models/alchemy/site.rb
+++ b/app/models/alchemy/site.rb
@@ -82,6 +82,7 @@ module Alchemy
       languages.build(
         name:           default_language['name'],
         language_code:  default_language['code'],
+        locale:         default_language['code'],
         frontpage_name: default_language['frontpage_name'],
         page_layout:    default_language['page_layout'],
         public:         true,

--- a/app/views/alchemy/admin/languages/_form.html.erb
+++ b/app/views/alchemy/admin/languages/_form.html.erb
@@ -1,7 +1,16 @@
 <%= alchemy_form_for [alchemy, :admin, @language] do |f| %>
   <%= f.input :name, autofocus: true %>
   <%= f.input :language_code, placeholder: Alchemy.t(:language_code_placeholder) %>
-  <%= f.input :country_code, as: 'string', placeholder: Alchemy.t(:country_code_placeholder), hint: Alchemy.t(:country_code_foot_note) %>
+  <%= f.input :country_code,
+    as: 'string',
+    placeholder: Alchemy.t(:country_code_placeholder),
+    hint: Alchemy.t(:country_code_foot_note) %>
+  <% if @language.errors[:locale].present? || @language.locale.present? %>
+    <%= f.input :locale,
+      collection: @language.matching_locales.presence || ::I18n.available_locales,
+      selected: @language.locale || @language.language_code || ::I18n.default_locale.to_s,
+      input_html: {class: 'alchemy_selectbox'} %>
+  <% end %>
   <%= f.input :frontpage_name %>
   <%= f.input :page_layout,
     collection: Alchemy::PageLayout.all,

--- a/app/views/alchemy/admin/languages/_language.html.erb
+++ b/app/views/alchemy/admin/languages/_language.html.erb
@@ -9,6 +9,12 @@
     <%= language.country_code %>
   </td>
   <td>
+    <%= language.code %>
+  </td>
+  <td>
+    <%= language.locale %>
+  </td>
+  <td>
     <%= language.frontpage_name %>
   </td>
   <td>

--- a/app/views/alchemy/admin/languages/_table.html.erb
+++ b/app/views/alchemy/admin/languages/_table.html.erb
@@ -12,6 +12,12 @@
         <%= sort_link @query, :country_code, hide_indicator: true %>
       </th>
       <th>
+        <%= Alchemy::Language.human_attribute_name(:code) %>
+      </th>
+      <th>
+        <%= Alchemy::Language.human_attribute_name(:locale) %>
+      </th>
+      <th>
         <%= Alchemy::Language.human_attribute_name(:frontpage_name) %>
       </th>
       <th>

--- a/config/locales/alchemy.de.yml
+++ b/config/locales/alchemy.de.yml
@@ -337,7 +337,7 @@ de:
     copy_page: "Seite kopieren"
     "Could not delete Pictures": "Bilder konnten nicht gelöscht werden"
     copy_language_tree_heading: "Einen Sprachbaum kopieren"
-    country_code_placeholder: 'z.B. at (optional)'
+    country_code_placeholder: 'z.B. AT (optional)'
     country_code_foot_note: "Das Länderkürzel ist nur notwendig, wenn Sie unterschiedliche Länder mit der gleichen Sprache versehen wollen."
     create: "erstellen"
     "Create language": "Eine neue Sprache erstellen"

--- a/config/locales/alchemy.de.yml
+++ b/config/locales/alchemy.de.yml
@@ -338,7 +338,7 @@ de:
     "Could not delete Pictures": "Bilder konnten nicht gelöscht werden"
     copy_language_tree_heading: "Einen Sprachbaum kopieren"
     country_code_placeholder: 'z.B. at (optional)'
-    country_code_foot_note: "Der Ländercode ist nur notwendig, wenn Sie unterschiedliche Länder mit der gleichen Sprache versehen wollen."
+    country_code_foot_note: "Das Länderkürzel ist nur notwendig, wenn Sie unterschiedliche Länder mit der gleichen Sprache versehen wollen."
     create: "erstellen"
     "Create language": "Eine neue Sprache erstellen"
     "Create site": "Eine neue Website erstellen"
@@ -754,7 +754,7 @@ de:
             invalid: 'ist nicht korrekt. Bitte exakt zwei Kleinbuchstaben verwenden.'
             taken: 'ist für dieses Länderkürzel bereits vergeben.'
           locale:
-            missing_file: "Eine Übersetzungsdatei für dieses Sprachkürzel konnte nicht gefunden werden. Bitte wählen Sie eine der vorhandenen aus."
+            missing_file: "Eine Lokalisierung für dieses Sprachkürzel konnte nicht gefunden werden. Bitte wählen Sie eine der vorhandenen aus."
       alchemy/page:
         attributes:
           name:
@@ -875,7 +875,8 @@ de:
         name: "Name"
         page_layout: "Seitentyp der Startseite"
         public: "Sprache veröffentlichen"
-        locale: Übersetzungsdatei
+        locale: Lokalisierung
+        code: ISO-Code
 
       alchemy/legacy_page_url:
         urlname: "URL-Pfad"

--- a/config/locales/alchemy.de.yml
+++ b/config/locales/alchemy.de.yml
@@ -338,7 +338,7 @@ de:
     "Could not delete Pictures": "Bilder konnten nicht gelöscht werden"
     copy_language_tree_heading: "Einen Sprachbaum kopieren"
     country_code_placeholder: 'z.B. at (optional)'
-    country_code_foot_note: "Der Ländercode ist nur notwendig, wenn Sie mehrere Länder mit unterschiedlichen Sprachen versehen wollen."
+    country_code_foot_note: "Der Ländercode ist nur notwendig, wenn Sie unterschiedliche Länder mit der gleichen Sprache versehen wollen."
     create: "erstellen"
     "Create language": "Eine neue Sprache erstellen"
     "Create site": "Eine neue Website erstellen"
@@ -753,6 +753,8 @@ de:
           language_code:
             invalid: 'ist nicht korrekt. Bitte exakt zwei Kleinbuchstaben verwenden.'
             taken: 'ist für dieses Länderkürzel bereits vergeben.'
+          locale:
+            missing_file: "Eine Übersetzungsdatei für dieses Sprachkürzel konnte nicht gefunden werden. Bitte wählen Sie eine der vorhandenen aus."
       alchemy/page:
         attributes:
           name:
@@ -873,6 +875,7 @@ de:
         name: "Name"
         page_layout: "Seitentyp der Startseite"
         public: "Sprache veröffentlichen"
+        locale: Übersetzungsdatei
 
       alchemy/legacy_page_url:
         urlname: "URL-Pfad"

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -874,6 +874,7 @@ en:
         page_layout: "Pagetype of frontpage"
         public: "Public"
         locale: Localization
+        code: ISO Code
 
       alchemy/legacy_page_url:
         urlname: "URL path"

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -755,7 +755,7 @@ en:
             invalid: '^Format of languagecode is not valid. Please use exactly two lowercase characters.'
             taken: 'is already taken for this country code.'
           locale:
-            missing_file: "Locale file not found for given language code. Please choose an existing one."
+            missing_file: "Localization not found for given language code. Please choose an existing one."
       alchemy/page:
         attributes:
           name:
@@ -873,7 +873,7 @@ en:
         name: "Name"
         page_layout: "Pagetype of frontpage"
         public: "Public"
-        locale: Locale file
+        locale: Localization
 
       alchemy/legacy_page_url:
         urlname: "URL path"

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -337,7 +337,7 @@ en:
     copy_page: "Copy page"
     "Could not delete Pictures": "Could not delete Pictures"
     copy_language_tree_heading: "Copy page tree"
-    country_code_placeholder: 'i.e. us (optional)'
+    country_code_placeholder: 'i.e. US (optional)'
     country_code_foot_note: "You only need to set a country code if you want to support multiple countries with the same language."
     create: "create"
     "Create language": "Create a new language"

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -338,7 +338,7 @@ en:
     "Could not delete Pictures": "Could not delete Pictures"
     copy_language_tree_heading: "Copy page tree"
     country_code_placeholder: 'i.e. us (optional)'
-    country_code_foot_note: "You only need to set a country code if you want to provide each country with an individual language."
+    country_code_foot_note: "You only need to set a country code if you want to support multiple countries with the same language."
     create: "create"
     "Create language": "Create a new language"
     "Create site": "Create a new site"
@@ -754,6 +754,8 @@ en:
           language_code:
             invalid: '^Format of languagecode is not valid. Please use exactly two lowercase characters.'
             taken: 'is already taken for this country code.'
+          locale:
+            missing_file: "Locale file not found for given language code. Please choose an existing one."
       alchemy/page:
         attributes:
           name:
@@ -871,6 +873,7 @@ en:
         name: "Name"
         page_layout: "Pagetype of frontpage"
         public: "Public"
+        locale: Locale file
 
       alchemy/legacy_page_url:
         urlname: "URL path"

--- a/config/locales/alchemy.es.yml
+++ b/config/locales/alchemy.es.yml
@@ -912,6 +912,7 @@ es:
         page_layout: "Tipo de la primera página"
         public: "Pública"
         locale: Localización
+        code: Código ISO
 
       alchemy/legacy_page_url:
         urlname: "Ruta URL"

--- a/config/locales/alchemy.es.yml
+++ b/config/locales/alchemy.es.yml
@@ -792,7 +792,7 @@ es:
             invalid: '^El formato del código de lenguaje no es válido. Por favor usa exactamente 2 letras minúsculas.'
             taken: 'ya está en uso para este código de país.'
           locale:
-            missing_file: Archivo de traducción no encontrado para el código de idioma dado. Por favor, elige uno de los existentes.
+            missing_file: Localización no encontrado para el código de idioma dado. Por favor, elige uno de los existentes.
       alchemy/page:
         attributes:
           name:
@@ -911,7 +911,7 @@ es:
         name: "Nombre"
         page_layout: "Tipo de la primera página"
         public: "Pública"
-        locale: Archivo de traducción
+        locale: Localización
 
       alchemy/legacy_page_url:
         urlname: "Ruta URL"

--- a/config/locales/alchemy.es.yml
+++ b/config/locales/alchemy.es.yml
@@ -338,7 +338,7 @@ es:
     copy_page: "Copiar página"
     "Could not delete Pictures": "No se puede eliminar las imágenes"
     copy_language_tree_heading: "Copiar árbol de páginas"
-    country_code_placeholder: 'i.e. es (opcional)'
+    country_code_placeholder: 'i.e. ES (opcional)'
     country_code_foot_note: "Solo es necesario establecer un código de país si desea establecer cada país con su idioma."
     create: "Crear"
     "Create language": "Crear un nuevo idioma"

--- a/config/locales/alchemy.es.yml
+++ b/config/locales/alchemy.es.yml
@@ -791,6 +791,8 @@ es:
           language_code:
             invalid: '^El formato del código de lenguaje no es válido. Por favor usa exactamente 2 letras minúsculas.'
             taken: 'ya está en uso para este código de país.'
+          locale:
+            missing_file: Archivo de traducción no encontrado para el código de idioma dado. Por favor, elige uno de los existentes.
       alchemy/page:
         attributes:
           name:
@@ -909,6 +911,7 @@ es:
         name: "Nombre"
         page_layout: "Tipo de la primera página"
         public: "Pública"
+        locale: Archivo de traducción
 
       alchemy/legacy_page_url:
         urlname: "Ruta URL"

--- a/config/locales/alchemy.fr.yml
+++ b/config/locales/alchemy.fr.yml
@@ -777,6 +777,8 @@ fr:
           language_code:
             invalid: "n'est pas correct. S'il vous plaît utiliser deux minuscules exactement."
             taken: 'existe déjà pour les codes de ce pays.'
+          locale:
+            missing_file: "Locale file not found for given language code. Please choose an existing one."
       alchemy/page:
         attributes:
           name:
@@ -894,6 +896,7 @@ fr:
         name: "Naom"
         page_layout: "Page Type de Page d'accueil"
         public: "publier langage"
+        locale: Locale file
 
       alchemy/page:
         created_at: "créée le"

--- a/config/locales/alchemy.fr.yml
+++ b/config/locales/alchemy.fr.yml
@@ -897,6 +897,7 @@ fr:
         page_layout: "Page Type de Page d'accueil"
         public: "publier langage"
         locale: Localization
+        code: ISO code
 
       alchemy/page:
         created_at: "créée le"

--- a/config/locales/alchemy.fr.yml
+++ b/config/locales/alchemy.fr.yml
@@ -778,7 +778,7 @@ fr:
             invalid: "n'est pas correct. S'il vous plaît utiliser deux minuscules exactement."
             taken: 'existe déjà pour les codes de ce pays.'
           locale:
-            missing_file: "Locale file not found for given language code. Please choose an existing one."
+            missing_file: "Localization not found for given language code. Please choose an existing one."
       alchemy/page:
         attributes:
           name:
@@ -896,7 +896,7 @@ fr:
         name: "Naom"
         page_layout: "Page Type de Page d'accueil"
         public: "publier langage"
-        locale: Locale file
+        locale: Localization
 
       alchemy/page:
         created_at: "créée le"

--- a/config/locales/alchemy.fr.yml
+++ b/config/locales/alchemy.fr.yml
@@ -358,7 +358,7 @@ fr:
     copy_page: "Copier page"
     "Could not delete Pictures": "Images n'ont pas pu être supprimés"
     copy_language_tree_heading: "Copier un langage d'arbres"
-    country_code_placeholder: 'par exemple at (optionnel)'
+    country_code_placeholder: 'par exemple AT (optionnel)'
     country_code_foot_note: "Le code du pays est seulement nécessaire si vous souhaitez appliquer plusieurs pays de langues différentes."
     create: "Etablir"
     "Create language": "Création d´un nouveau langage"

--- a/config/locales/alchemy.nl.yml
+++ b/config/locales/alchemy.nl.yml
@@ -334,7 +334,7 @@ nl:
     copy_page: "Pagina kopiëren"
     "Could not delete Pictures": "Kan de afbeeldingen niet verwijderen"
     copy_language_tree_heading: "Paginastructuur kopiëren"
-    country_code_placeholder: 'bijv. us (optioneel)'
+    country_code_placeholder: 'bijv. US (optioneel)'
     country_code_foot_note: "Een landcode is alleen nodig voor het toewijzen van een aparte taal aan elk land."
     create: "maken"
     "Create language": "Nieuwe taal maken"

--- a/config/locales/alchemy.nl.yml
+++ b/config/locales/alchemy.nl.yml
@@ -753,7 +753,7 @@ nl:
             invalid: '^Formaat van de taalcode is niet juist. Gebruik exact twee kleine letters.'
             taken: 'Is al in gebruik.'
           locale:
-            missing_file: "Locale file not found for given language code. Please choose an existing one."
+            missing_file: "Localization not found for given language code. Please choose an existing one."
       alchemy/page:
         attributes:
           name:
@@ -872,7 +872,7 @@ nl:
         name: "Naam"
         page_layout: "Paginatype van voorpagina"
         public: "Publiek"
-        locale: Locale file
+        locale: Localization
 
       alchemy/legacy_page_url:
         urlname: "URL pad"

--- a/config/locales/alchemy.nl.yml
+++ b/config/locales/alchemy.nl.yml
@@ -752,6 +752,8 @@ nl:
           code:
             invalid: '^Formaat van de taalcode is niet juist. Gebruik exact twee kleine letters.'
             taken: 'Is al in gebruik.'
+          locale:
+            missing_file: "Locale file not found for given language code. Please choose an existing one."
       alchemy/page:
         attributes:
           name:
@@ -870,6 +872,7 @@ nl:
         name: "Naam"
         page_layout: "Paginatype van voorpagina"
         public: "Publiek"
+        locale: Locale file
 
       alchemy/legacy_page_url:
         urlname: "URL pad"

--- a/config/locales/alchemy.nl.yml
+++ b/config/locales/alchemy.nl.yml
@@ -873,6 +873,7 @@ nl:
         page_layout: "Paginatype van voorpagina"
         public: "Publiek"
         locale: Localization
+        code: ISO Code
 
       alchemy/legacy_page_url:
         urlname: "URL pad"

--- a/config/locales/alchemy.ru.yml
+++ b/config/locales/alchemy.ru.yml
@@ -338,7 +338,6 @@ ru:
     "Could not delete Pictures": "Невозможно удалить изображения"
     copy_language_tree_heading: "Копировать дерево страниц"
     country_code_placeholder: 'например, ru (необязательно)'
-    country_code_foot_note: "You only need to set a country code if you want to provide each country with an individual language."
     country_code_foot_note: "Вам нужно установать код страны, если Вы хотите использовать индивидуальный перевод для каждой страны."
     create: "создать"
     "Create language": "Создать новый язык"
@@ -651,6 +650,8 @@ ru:
           language_code:
             invalid: 'Неверный формат кода языка. Используйте две латинские строчные буквы.'
             taken: 'уже занят для кода этой страны.'
+          locale:
+            missing_file: "Locale file not found for given language code. Please choose an existing one."
       alchemy/page:
         attributes:
           name:
@@ -786,6 +787,7 @@ ru:
         name: "Название"
         page_layout: "Тип главной страницы"
         public: "Публичный"
+        locale: Locale file
 
       alchemy/legacy_page_url:
         urlname: "Путь URL"

--- a/config/locales/alchemy.ru.yml
+++ b/config/locales/alchemy.ru.yml
@@ -337,7 +337,7 @@ ru:
     copy_page: "Копировать страницу"
     "Could not delete Pictures": "Невозможно удалить изображения"
     copy_language_tree_heading: "Копировать дерево страниц"
-    country_code_placeholder: 'например, ru (необязательно)'
+    country_code_placeholder: 'например, RU (необязательно)'
     country_code_foot_note: "Вам нужно установать код страны, если Вы хотите использовать индивидуальный перевод для каждой страны."
     create: "создать"
     "Create language": "Создать новый язык"

--- a/config/locales/alchemy.ru.yml
+++ b/config/locales/alchemy.ru.yml
@@ -651,7 +651,7 @@ ru:
             invalid: 'Неверный формат кода языка. Используйте две латинские строчные буквы.'
             taken: 'уже занят для кода этой страны.'
           locale:
-            missing_file: "Locale file not found for given language code. Please choose an existing one."
+            missing_file: "Localization not found for given language code. Please choose an existing one."
       alchemy/page:
         attributes:
           name:
@@ -787,7 +787,7 @@ ru:
         name: "Название"
         page_layout: "Тип главной страницы"
         public: "Публичный"
-        locale: Locale file
+        locale: Localization
 
       alchemy/legacy_page_url:
         urlname: "Путь URL"

--- a/config/locales/alchemy.ru.yml
+++ b/config/locales/alchemy.ru.yml
@@ -788,6 +788,7 @@ ru:
         page_layout: "Тип главной страницы"
         public: "Публичный"
         locale: Localization
+        code: ISO Code
 
       alchemy/legacy_page_url:
         urlname: "Путь URL"

--- a/db/migrate/20150906195818_add_locale_to_alchemy_languages.rb
+++ b/db/migrate/20150906195818_add_locale_to_alchemy_languages.rb
@@ -1,0 +1,7 @@
+class AddLocaleToAlchemyLanguages < ActiveRecord::Migration
+  def change
+    add_column :alchemy_languages, :locale, :string
+    execute \
+      "UPDATE #{Alchemy::Language.table_name} SET locale = language_code WHERE locale IS NULL;"
+  end
+end

--- a/lib/alchemy/routing_constraints.rb
+++ b/lib/alchemy/routing_constraints.rb
@@ -8,7 +8,7 @@ module Alchemy
   # don't want to swallow the rails/info routes in development mode.
   #
   class RoutingConstraints
-    LOCALE_REGEXP = /[a-z]{2}(-[a-z]{2})?/
+    LOCALE_REGEXP = /[a-z]{2}(-[a-zA-Z]{2})?/
 
     def matches?(request)
       @request = request

--- a/spec/controllers/alchemy/admin/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/pages_controller_spec.rb
@@ -103,7 +103,8 @@ module Alchemy
       end
 
       describe '#show' do
-        let(:page) { build_stubbed(:alchemy_page, language_code: 'nl') }
+        let(:language) { build_stubbed(:alchemy_language, locale: 'nl') }
+        let(:page) { build_stubbed(:alchemy_page, language: language) }
 
         before do
           expect(Page).to receive(:find).with(page.id.to_s).and_return(page)
@@ -353,11 +354,11 @@ module Alchemy
           allow_any_instance_of(Page).to receive(:move_to_child_of)
           allow_any_instance_of(Page).to receive(:copy_children_to)
           allow(controller).to receive(:store_current_language)
-          allow(Language).to receive(:current).and_return(mock_model('Language', language_code: 'it', code: 'it'))
+          allow(Language).to receive(:current).and_return(mock_model('Language', locale: 'de', code: 'de'))
         end
 
         it "should copy the language root page over to the other language" do
-          expect(Page).to receive(:copy).with(language_root_to_copy_from, {language_id: '2', language_code: 'it'})
+          expect(Page).to receive(:copy).with(language_root_to_copy_from, {language_id: '2', language_code: 'de'})
           alchemy_post :copy_language_tree, params
         end
 

--- a/spec/controllers/alchemy/messages_controller_spec.rb
+++ b/spec/controllers/alchemy/messages_controller_spec.rb
@@ -181,7 +181,7 @@ module Alchemy
               end
 
               context "and mailer_config has no instructions for success_page" do
-                let(:language) { mock_model('Language', code: 'en', pages: double(find_by: build_stubbed(:alchemy_page))) }
+                let(:language) { mock_model('Language', code: 'en', locale: 'en', pages: double(find_by: build_stubbed(:alchemy_page))) }
 
                 before do
                   allow(controller).to receive(:mailer_config).and_return({})

--- a/spec/dummy/app/views/alchemy/page_layouts/_standard.html.erb
+++ b/spec/dummy/app/views/alchemy/page_layouts/_standard.html.erb
@@ -10,5 +10,6 @@
   <%- end -%>
 </div>
 <div id="content">
+  <h1><%= t(:hello) %></h1>
   <%= render_elements :except => ["claim", "header"] %>
 </div>

--- a/spec/dummy/config/locales/kl.yml
+++ b/spec/dummy/config/locales/kl.yml
@@ -1,0 +1,2 @@
+kl:
+  hello_world: qo' vIvan

--- a/spec/dummy/db/migrate/20150906195818_add_locale_to_alchemy_languages.rb
+++ b/spec/dummy/db/migrate/20150906195818_add_locale_to_alchemy_languages.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20150906195818_add_locale_to_alchemy_languages.rb

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150729151825) do
+ActiveRecord::Schema.define(version: 20150906195818) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string   "name"
@@ -192,6 +192,7 @@ ActiveRecord::Schema.define(version: 20150729151825) do
     t.boolean  "default",        default: false
     t.string   "country_code",   default: "",      null: false
     t.integer  "site_id"
+    t.string   "locale"
   end
 
   add_index "alchemy_languages", ["language_code", "country_code"], name: "index_alchemy_languages_on_language_code_and_country_code"

--- a/spec/features/admin/languages_features_spec.rb
+++ b/spec/features/admin/languages_features_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+RSpec.feature "Admin::LanguagesFeatures", type: :feature do
+  before do
+    authorize_user(:as_admin)
+  end
+
+  describe 'creating a new language' do
+    context 'when selected locale is not an available locale' do
+      before do
+        allow(::I18n).to receive(:available_locales) { [:de, :en] }
+      end
+
+      it 'shows a locale select and an error message' do
+        visit alchemy.new_admin_language_path
+
+        fill_in 'language_language_code', with: 'kl'
+        click_button 'Save'
+
+        expect(page).to have_select('language_locale', options: %w(de en))
+        expect(page).to have_selector('.language_locale.field_with_errors .error')
+      end
+    end
+  end
+
+  describe 'editing an language' do
+    let!(:language) { create(:alchemy_language) }
+
+    context 'when selected locale has multiple matching locale files' do
+      before do
+        allow(::I18n).to receive(:available_locales) { [:de, :'de-at', :en, :'en-uk'] }
+      end
+
+      it 'shows a locale select with matching locales only' do
+        visit alchemy.edit_admin_language_path(language)
+
+        expect(page).to have_select('language_locale', options: ['de', 'de-at'])
+      end
+    end
+
+    context 'when selected locale has one matching locale file' do
+      before do
+        allow(::I18n).to receive(:available_locales) { [:de, :en, :'en-uk'] }
+      end
+
+      it 'shows a locale select with matching locale only' do
+        visit alchemy.edit_admin_language_path(language)
+
+        expect(page).to have_select('language_locale', options: %w(de))
+      end
+    end
+
+    context 'when selected locale has no matching locale files' do
+      before do
+        allow(::I18n).to receive(:available_locales) { [:jp, :es] }
+      end
+
+      it 'shows a locale select with all available locales' do
+        visit alchemy.edit_admin_language_path(language)
+
+        expect(page).to have_select('language_locale', options: %w(jp es))
+      end
+    end
+  end
+end

--- a/spec/models/alchemy/language_spec.rb
+++ b/spec/models/alchemy/language_spec.rb
@@ -93,7 +93,7 @@ module Alchemy
       end
     end
 
-    context 'validations' do
+    describe 'validations' do
       let(:language) { Language.new(default: true, public: false) }
 
       describe 'publicity_of_default_language' do
@@ -117,6 +117,105 @@ module Alchemy
             expect(language.errors.messages).to have_key(:default)
           end
         end
+      end
+
+      describe 'before' do
+        subject do
+          language.valid?
+          language.locale
+        end
+
+        before do
+          expect(::I18n).to receive(:available_locales) do
+            [:de, :'de-at', :en, :'en-uk']
+          end
+        end
+
+        context 'when code is an available locale' do
+          let(:language) do
+            build(:alchemy_language, language_code: 'de', country_code: 'at')
+          end
+
+          it 'sets the locale to code' do
+            is_expected.to eq('de-at')
+          end
+        end
+
+        context 'when code is not is an available locale, but language_code is' do
+          let(:language) do
+            build(:alchemy_language, language_code: 'de', country_code: 'ch')
+          end
+
+          it 'sets the locale to language code' do
+            is_expected.to eq('de')
+          end
+        end
+
+        context "when language_code is an available locale" do
+          let(:language) do
+            build(:alchemy_language, language_code: 'en')
+          end
+
+          it 'sets the locale to language_code' do
+            is_expected.to eq('en')
+          end
+        end
+
+        context "when neither language_code nor code is an available locale" do
+          it { is_expected.to be_nil }
+        end
+      end
+
+      describe 'presence_of_locale_file' do
+        context "when locale file is missing for selected language code" do
+          let(:language) do
+            build(:alchemy_language, language_code: 'jp')
+          end
+
+          it 'adds errors to locale attribute' do
+            expect(language).to_not be_valid
+            expect(language.errors).to have_key(:locale)
+          end
+        end
+
+        context "when locale file is present for selected language code" do
+          let(:language) do
+            build(:alchemy_language, :klingon)
+          end
+
+          it 'adds no errors to locale attribute' do
+            expect(language).to be_valid
+            expect(language.errors).to_not have_key(:locale)
+          end
+        end
+      end
+    end
+
+    describe '#matching_locales' do
+      let(:language) do
+        build(:alchemy_language, language_code: 'de')
+      end
+
+      subject do
+        language.matching_locales
+      end
+
+      before do
+        expect(::I18n).to receive(:available_locales) do
+          [:de, :'de-at', :'en-uk']
+        end
+      end
+
+      it 'returns locales matching the language code' do
+        is_expected.to eq [:de, :'de-at']
+      end
+
+      context 'when language code is not is an available locale' do
+        let(:language) do
+          build(:alchemy_language, language_code: 'jp')
+        end
+
+        it { is_expected.to eq [] }
       end
     end
   end

--- a/spec/models/alchemy/language_spec.rb
+++ b/spec/models/alchemy/language_spec.rb
@@ -7,6 +7,17 @@ module Alchemy
     let(:language)         { create(:alchemy_language, :klingon) }
     let(:page)             { create(:alchemy_page, language: language) }
 
+    it 'is valid with uppercase country code' do
+      language = Alchemy::Language.new(
+        country_code: 'AT',
+        language_code: 'de',
+        name: 'Österreich',
+        frontpage_name: 'Start',
+        page_layout: 'index'
+      )
+      expect(language).to be_valid
+    end
+
     it "should return a label for code" do
       expect(language.label(:code)).to eq('kl')
     end

--- a/spec/models/alchemy/language_spec.rb
+++ b/spec/models/alchemy/language_spec.rb
@@ -126,8 +126,18 @@ module Alchemy
         end
 
         before do
-          expect(::I18n).to receive(:available_locales) do
+          allow(::I18n).to receive(:available_locales) do
             [:de, :'de-at', :en, :'en-uk']
+          end
+        end
+
+        context 'when locale is already set' do
+          let(:language) do
+            build(:alchemy_language, language_code: 'de', locale: 'de')
+          end
+
+          it 'does not set the locale again' do
+            expect(language).to_not receive(:set_locale)
           end
         end
 

--- a/spec/routing/routing_spec.rb
+++ b/spec/routing/routing_spec.rb
@@ -23,6 +23,18 @@ describe "The Routing" do
           locale: 'en'
         )
       end
+
+      context 'that contains uppercase country code' do
+        it 'routes to pages_controller#index' do
+          expect({
+            get: '/en-UK'
+          }).to route_to(
+            controller: 'alchemy/pages',
+            action: 'index',
+            locale: 'en-UK'
+          )
+        end
+      end
     end
   end
 


### PR DESCRIPTION
As a follow up to #878 this adds a locale attribute to the current language that will be used as value for setting `I18n.locale`.

If a user creates a language for a language/-country code that does not exist as `I18n.available_locale` we display a select box that lets the user choose which of the `I18n.available_locales` should be used for this language.

<img width="448" alt="alchemy cms - languages 2016-04-07 14-44-06" src="https://cloud.githubusercontent.com/assets/42868/14351379/34daf722-fccf-11e5-8ec2-6242bc741927.png">

Closes #831 

### TODO

- [x] Translate `Alchemy::Language.locale` attribute