### PR TITLE
Rename Klingonian into Klingon

### DIFF
--- a/lib/alchemy/test_support/factories/language_factory.rb
+++ b/lib/alchemy/test_support/factories/language_factory.rb
@@ -11,8 +11,8 @@ FactoryGirl.define do
     public true
     site { Alchemy::Site.first || FactoryGirl.create(:site) }
 
-    trait :klingonian do
-      name 'Klingonian'
+    trait :klingon do
+      name 'Klingon'
       code 'kl'
       frontpage_name 'Tuq'
       default false

--- a/spec/controllers/alchemy/admin/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/pages_controller_spec.rb
@@ -541,7 +541,7 @@ module Alchemy
       end
 
       describe "#switch_language" do
-        let(:language) { build_stubbed(:alchemy_language, :klingonian) }
+        let(:language) { build_stubbed(:alchemy_language, :klingon) }
 
         before do
           allow(Language).to receive(:find_by).and_return(language)

--- a/spec/controllers/alchemy/api/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/api/pages_controller_spec.rb
@@ -139,17 +139,17 @@ module Alchemy
       end
 
       context 'in an environment with multiple languages' do
-        let(:klingonian) { create(:alchemy_language, :klingonian) }
+        let(:klingon) { create(:alchemy_language, :klingon) }
 
         context 'having two pages with the same url names in different languages' do
           let!(:english_page) { create(:alchemy_page, :public, language: Language.default, name: "same-name") }
-          let!(:klingonian_page) { create(:alchemy_page, :public, language: klingonian, name: "same-name") }
+          let!(:klingon_page) { create(:alchemy_page, :public, language: klingon, name: "same-name") }
 
           context 'when a locale is given' do
             it 'renders the page related to its language' do
-              alchemy_get :show, {urlname: "same-name", locale: klingonian_page.language_code, format: :json}
+              alchemy_get :show, {urlname: "same-name", locale: klingon_page.language_code, format: :json}
               result = JSON.parse(response.body)
-              expect(result['id']).to eq(klingonian_page.id)
+              expect(result['id']).to eq(klingon_page.id)
             end
           end
 

--- a/spec/controllers/alchemy/base_controller_spec.rb
+++ b/spec/controllers/alchemy/base_controller_spec.rb
@@ -4,7 +4,7 @@ module Alchemy
   describe BaseController do
     describe '#set_locale' do
       context 'with Language.current set' do
-        let(:language) { create(:alchemy_language, :klingonian) }
+        let(:language) { create(:alchemy_language, :klingon) }
 
         before { Alchemy::Language.current = language }
 

--- a/spec/controllers/alchemy/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/pages_controller_spec.rb
@@ -297,22 +297,22 @@ module Alchemy
     end
 
     context 'in an environment with multiple languages' do
-      let(:klingonian) { create(:alchemy_language, :klingonian) }
+      let(:klingon) { create(:alchemy_language, :klingon) }
 
       context 'having two pages with the same url names in different languages' do
         render_views
 
-        let!(:klingonian_page) { create(:alchemy_page, :public, language: klingonian, name: "same-name", do_not_autogenerate: false) }
+        let!(:klingon_page) { create(:alchemy_page, :public, language: klingon, name: "same-name", do_not_autogenerate: false) }
         let!(:english_page) { create(:alchemy_page, :public, language: default_language, name: "same-name") }
 
         before do
           # Set a text in an essence rendered on the page so we can match against that
-          klingonian_page.essence_texts.first.update_column(:body, 'klingonian page')
+          klingon_page.essence_texts.first.update_column(:body, 'klingon page')
         end
 
         it 'renders the page related to its language' do
-          alchemy_get :show, {urlname: "same-name", locale: klingonian_page.language_code}
-          expect(response.body).to have_content("klingonian page")
+          alchemy_get :show, {urlname: "same-name", locale: klingon_page.language_code}
+          expect(response.body).to have_content("klingon page")
         end
       end
     end

--- a/spec/features/admin/language_tree_feature_spec.rb
+++ b/spec/features/admin/language_tree_feature_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Language tree feature', type: :feature, js: true do
-  let(:klingonian) { create(:alchemy_language, :klingonian) }
+  let(:klingon) { create(:alchemy_language, :klingon) }
 
   before do
     create(:alchemy_page, :language_root)
@@ -10,22 +10,22 @@ describe 'Language tree feature', type: :feature, js: true do
 
   context "in a multilangual environment" do
     before do
-      create(:alchemy_page, :language_root, name: 'Klingonian', language: klingonian)
+      create(:alchemy_page, :language_root, name: 'Klingon', language: klingon)
     end
 
     it "one should be able to switch the language tree" do
       visit('/admin/pages')
-      page.select 'Klingonian', from: 'language_id'
-      expect(page).to have_selector('#sitemap', text: 'Klingonian')
+      page.select 'Klingon', from: 'language_id'
+      expect(page).to have_selector('#sitemap', text: 'Klingon')
     end
   end
 
   context "with no language root page" do
-    before { klingonian }
+    before { klingon }
 
     it "it should display the form for creating language root" do
       visit('/admin/pages')
-      page.select 'Klingonian', from: 'language_id'
+      page.select 'Klingon', from: 'language_id'
       expect(page).to have_content('This language tree does not exist')
     end
   end

--- a/spec/features/page_redirects_spec.rb
+++ b/spec/features/page_redirects_spec.rb
@@ -258,7 +258,7 @@ module Alchemy
         end
 
         it "should render 404 if urlname and lang parameter do not belong to same page" do
-          create(:alchemy_language, :klingonian)
+          create(:alchemy_language, :klingon)
           expect {
             visit "/kl/#{public_page.urlname}"
           }.to raise_error(ActionController::RoutingError)

--- a/spec/helpers/alchemy/pages_helper_spec.rb
+++ b/spec/helpers/alchemy/pages_helper_spec.rb
@@ -13,9 +13,9 @@ module Alchemy
     let(:level_2_page)             { create(:alchemy_page, :public, parent_id: visible_page.id, visible: true, name: 'Level 2') }
     let(:level_3_page)             { create(:alchemy_page, :public, parent_id: level_2_page.id, visible: true, name: 'Level 3') }
     let(:level_4_page)             { create(:alchemy_page, :public, parent_id: level_3_page.id, visible: true, name: 'Level 4') }
-    let(:klingonian)               { create(:alchemy_language, :klingonian) }
-    let(:klingonian_language_root) { create(:alchemy_page, :language_root, language: klingonian) }
-    let(:klingonian_public_page)   { create(:alchemy_page, :public, language: klingonian, parent_id: klingonian_language_root.id) }
+    let(:klingon)                  { create(:alchemy_language, :klingon) }
+    let(:klingon_language_root)    { create(:alchemy_page, :language_root, language: klingon) }
+    let(:klingon_public_page)      { create(:alchemy_page, :public, language: klingon, parent_id: klingon_language_root.id) }
 
     before do
       helper.controller.class_eval { include Alchemy::ConfigurationMethods }
@@ -375,7 +375,7 @@ module Alchemy
     describe "#language_links" do
       context "with two public languages" do
         # Always create second language
-        before { klingonian }
+        before { klingon }
 
         context "with only one language root page" do
           it "should return nil" do
@@ -384,29 +384,29 @@ module Alchemy
         end
 
         context "with two language root pages" do
-          # Always create a language root page for klingonian
-          before { klingonian_language_root }
+          # Always create a language root page for klingon
+          before { klingon_language_root }
 
           it "should render two language links" do
             expect(helper.language_links).to have_selector('a', count: 2)
           end
 
           it "should render language links referring to their language root page" do
-            code = klingonian_language_root.language_code
-            urlname = klingonian_language_root.urlname
+            code = klingon_language_root.language_code
+            urlname = klingon_language_root.urlname
             expect(helper.language_links).to have_selector("a.#{code}[href='/#{code}/#{urlname}']")
           end
 
           context "with options[:linkname]" do
             context "set to 'name'" do
               it "should render the name of the language" do
-                expect(helper.language_links(linkname: 'name')).to have_selector("span[contains('#{klingonian_language_root.language.name}')]")
+                expect(helper.language_links(linkname: 'name')).to have_selector("span[contains('#{klingon_language_root.language.name}')]")
               end
             end
 
             context "set to 'code'" do
               it "should render the code of the language" do
-                expect(helper.language_links(linkname: 'code')).to have_selector("span[contains('#{klingonian_language_root.language.code}')]")
+                expect(helper.language_links(linkname: 'code')).to have_selector("span[contains('#{klingon_language_root.language.code}')]")
               end
             end
           end

--- a/spec/libraries/controller_actions_spec.rb
+++ b/spec/libraries/controller_actions_spec.rb
@@ -53,7 +53,7 @@ describe 'Alchemy::ControllerActions', type: 'controller' do
 
   describe "#set_alchemy_language" do
     let(:default_language) { Alchemy::Language.default }
-    let(:klingonian)       { create(:alchemy_language, :klingonian) }
+    let(:klingon)          { create(:alchemy_language, :klingon) }
 
     after do
       # We must never change the app's locale
@@ -62,25 +62,25 @@ describe 'Alchemy::ControllerActions', type: 'controller' do
 
     context "with a Language argument" do
       it "should set the language to the passed Language instance" do
-        controller.send :set_alchemy_language, klingonian
-        expect(assigns(:language)).to eq(klingonian)
-        expect(Alchemy::Language.current).to eq(klingonian)
+        controller.send :set_alchemy_language, klingon
+        expect(assigns(:language)).to eq(klingon)
+        expect(Alchemy::Language.current).to eq(klingon)
       end
     end
 
     context "with a language id argument" do
       it "should set the language to the language specified by the passed id" do
-        controller.send :set_alchemy_language, klingonian.id
-        expect(assigns(:language)).to eq(klingonian)
-        expect(Alchemy::Language.current).to eq(klingonian)
+        controller.send :set_alchemy_language, klingon.id
+        expect(assigns(:language)).to eq(klingon)
+        expect(Alchemy::Language.current).to eq(klingon)
       end
     end
 
     context "with a language code argument" do
       it "should set the language to the language specified by the passed code" do
-        controller.send :set_alchemy_language, klingonian.code
-        expect(assigns(:language)).to eq(klingonian)
-        expect(Alchemy::Language.current).to eq(klingonian)
+        controller.send :set_alchemy_language, klingon.code
+        expect(assigns(:language)).to eq(klingon)
+        expect(Alchemy::Language.current).to eq(klingon)
       end
     end
 
@@ -96,24 +96,24 @@ describe 'Alchemy::ControllerActions', type: 'controller' do
 
     context "with language in the session" do
       before do
-        allow(controller).to receive(:session).and_return(alchemy_language_id: klingonian.id)
-        allow(Alchemy::Language).to receive(:current).and_return(klingonian)
+        allow(controller).to receive(:session).and_return(alchemy_language_id: klingon.id)
+        allow(Alchemy::Language).to receive(:current).and_return(klingon)
       end
 
       it "should use the language from the session" do
         controller.send :set_alchemy_language
-        expect(assigns(:language)).to eq(klingonian)
-        expect(Alchemy::Language.current).to eq(klingonian)
+        expect(assigns(:language)).to eq(klingon)
+        expect(Alchemy::Language.current).to eq(klingon)
       end
     end
 
     context "with lang param" do
       it "should set the language" do
-        allow(controller).to receive(:params).and_return(locale: klingonian.code)
+        allow(controller).to receive(:params).and_return(locale: klingon.code)
         controller.send :set_alchemy_language
-        expect(assigns(:language)).to eq(klingonian)
-        expect(Alchemy::Language.current).to eq(klingonian)
-        expect(controller.session).to include_language_information_for(klingonian)
+        expect(assigns(:language)).to eq(klingon)
+        expect(Alchemy::Language.current).to eq(klingon)
+        expect(controller.session).to include_language_information_for(klingon)
       end
 
       context "for language that does not exist" do

--- a/spec/models/alchemy/language_spec.rb
+++ b/spec/models/alchemy/language_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 module Alchemy
   describe Language do
     let(:default_language) { Alchemy::Language.default }
-    let(:language)         { create(:alchemy_language, :klingonian) }
+    let(:language)         { create(:alchemy_language, :klingon) }
     let(:page)             { create(:alchemy_page, language: language) }
 
     it "should return a label for code" do
@@ -12,7 +12,7 @@ module Alchemy
     end
 
     it "should return a label for name" do
-      expect(language.label(:name)).to eq('Klingonian')
+      expect(language.label(:name)).to eq('Klingon')
     end
 
     context "with language_code and empty country_code" do

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -6,7 +6,7 @@ module Alchemy
   describe Page do
     let(:rootpage)      { Page.root }
     let(:language)      { Language.default }
-    let(:klingonian)    { create(:alchemy_language, :klingonian) }
+    let(:klingon)       { create(:alchemy_language, :klingon) }
     let(:language_root) { create(:alchemy_page, :language_root) }
     let(:page)          { mock_model(Page, page_layout: 'foo') }
     let(:public_page)   { create(:alchemy_page, :public) }
@@ -226,7 +226,7 @@ module Alchemy
 
       context "Saving a normal page" do
         let(:page) do
-          build(:alchemy_page, language_code: nil, language: klingonian, do_not_autogenerate: false)
+          build(:alchemy_page, language_code: nil, language: klingon, do_not_autogenerate: false)
         end
 
         it "sets the language code" do
@@ -454,7 +454,7 @@ module Alchemy
 
     describe '.contentpages' do
       let!(:layoutroot) do
-        Page.find_or_create_layout_root_for(klingonian.id)
+        Page.find_or_create_layout_root_for(klingon.id)
       end
 
       let!(:layoutpage) do
@@ -462,15 +462,15 @@ module Alchemy
           name: 'layoutpage',
           layoutpage: true,
           parent_id: layoutroot.id,
-          language: klingonian
+          language: klingon
         }
       end
 
-      let!(:klingonian_lang_root) do
+      let!(:klingon_lang_root) do
         create :alchemy_page, :language_root, {
-          name: 'klingonian_lang_root',
+          name: 'klingon_lang_root',
           layoutpage: nil,
-          language: klingonian
+          language: klingon
         }
       end
 
@@ -485,7 +485,7 @@ module Alchemy
       it "returns a collection of contentpages" do
         expect(Page.contentpages.to_a).to include(
           language_root,
-          klingonian_lang_root,
+          klingon_lang_root,
           contentpage
         )
       end
@@ -497,7 +497,7 @@ module Alchemy
       it "contains pages with attribute :layoutpage set to nil" do
         expect(Page.contentpages.to_a.select do |page|
           page.layoutpage.nil?
-        end).to include(klingonian_lang_root)
+        end).to include(klingon_lang_root)
       end
     end
 


### PR DESCRIPTION
There is no language called Klingonian. It's called Klingon.

Prerequisite for #974