### PR TITLE
Add default for uploader allowed_filetypes setting

### DIFF
--- a/app/models/alchemy/attachment.rb
+++ b/app/models/alchemy/attachment.rb
@@ -34,14 +34,21 @@ module Alchemy
     has_many :elements, through: :contents
     has_many :pages, through: :elements
 
+    # We need to define this method here to have it available in the validations below.
+    class << self
+      def allowed_filetypes
+        Config.get(:uploader).fetch('allowed_filetypes', {}).fetch('alchemy/attachments', [])
+      end
+    end
+
     validates_presence_of :file
     validates_format_of :file_name, with: /\A[A-Za-z0-9\. \-_äÄöÖüÜß]+\z/, on: :update
     validates_size_of :file, maximum: Config.get(:uploader)['file_size_limit'].megabytes
     validates_property :ext, of: :file,
-      in: Config.get(:uploader)['allowed_filetypes']['alchemy/attachments'],
+      in: allowed_filetypes,
       case_sensitive: false,
       message: Alchemy.t("not a valid file"),
-      unless: -> { Config.get(:uploader)['allowed_filetypes']['alchemy/attachments'].include?('*') }
+      unless: -> { self.class.allowed_filetypes.include?('*') }
 
     before_create do
       write_attribute(:name, convert_to_humanized_name(file_name, file.ext))

--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -49,11 +49,18 @@ module Alchemy
       end
     end
 
+    # We need to define this method here to have it available in the validations below.
+    class << self
+      def allowed_filetypes
+        Config.get(:uploader).fetch('allowed_filetypes', {}).fetch('alchemy/pictures', [])
+      end
+    end
+
     validates_presence_of :image_file
     validates_size_of :image_file, maximum: Config.get(:uploader)['file_size_limit'].megabytes
     validates_property :format,
       of: :image_file,
-      in: Config.get(:uploader)['allowed_filetypes']['alchemy/pictures'],
+      in: allowed_filetypes,
       case_sensitive: false,
       message: Alchemy.t("not a valid image")
 


### PR DESCRIPTION
If we don't have a default (empty array) for this setting upgrading
Alchemy install without the new config won't be able to upgrade.