### PR TITLE
Do not namespace generated essences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ __New Features__
 
 __Notable Changes__
 
+* Essence generator does not namespace the model into `Alchemy` namespace anymore
 * New simplified uploader that allows to drag and drop images onto the archive everywhere in your app
   - Model names in uploader `allowed_filetypes` setting are now namespaced.
     Please be sure to run `rake alchemy:upgrade` to update your settings.

--- a/lib/rails/generators/alchemy/essence/essence_generator.rb
+++ b/lib/rails/generators/alchemy/essence/essence_generator.rb
@@ -8,7 +8,7 @@ module Alchemy
       source_root File.expand_path('templates', File.dirname(__FILE__))
 
       def init
-        @essence_name = Alchemy::Content.normalize_essence_type(essence_name).underscore
+        @essence_name = essence_name.underscore
         @essence_view_path = Rails.root.join('app/views/alchemy/essences')
       end
 


### PR DESCRIPTION
The `alchemy:essence` generator puts the model into the Alchemy namespace,
but maybe someone wants to have it's own model to be an essence outside
of the Alchemy namespace.