### PR TITLE
Pass options around while uploading images

### DIFF
--- a/app/controllers/alchemy/admin/pictures_controller.rb
+++ b/app/controllers/alchemy/admin/pictures_controller.rb
@@ -133,6 +133,7 @@ module Alchemy
         @content = Content.select('id').find_by(id: params[:content_id])
         @element = Element.select('id').find_by(id: params[:element_id])
         @options = options_from_params
+
         respond_to do |format|
           format.html { render partial: 'archive_overlay' }
           format.js   { render action:  'archive_overlay' }

--- a/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
+++ b/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
@@ -9,7 +9,8 @@
         size: params[:size],
         filter: 'last_upload',
         content_id: @content.try(:id),
-        element_id: @element.try(:id)
+        element_id: @element.try(:id),
+        options: @options
       ) %>
     <div class="toolbar_spacer"></div>
   <% end %>

--- a/app/views/alchemy/admin/pictures/_picture_to_assign.html.erb
+++ b/app/views/alchemy/admin/pictures/_picture_to_assign.html.erb
@@ -1,5 +1,5 @@
 <div class="picture_thumbnail assign_image_list_detail <%= size.blank? ? 'medium' : size %>" name="<%= picture_to_assign.name %>" id="picture_to_assign_<%= picture_to_assign.id %>">
-<% unless params[:image_assign_url].blank? %>
+<% if params[:image_assign_url].present? %>
   <% action_url = params[:image_assign_url] + "?picture_id=#{picture_to_assign.id}" %>
   <% action_method = params[:image_assign_method] %>
 <% else %>

--- a/app/views/alchemy/admin/pictures/_picture_to_assign.html.erb
+++ b/app/views/alchemy/admin/pictures/_picture_to_assign.html.erb
@@ -1,11 +1,5 @@
 <div class="picture_thumbnail assign_image_list_detail <%= size.blank? ? 'medium' : size %>" name="<%= picture_to_assign.name %>" id="picture_to_assign_<%= picture_to_assign.id %>">
-<% if params[:image_assign_url].present? %>
-  <% action_url = params[:image_assign_url] + "?picture_id=#{picture_to_assign.id}" %>
-  <% action_method = params[:image_assign_method] %>
-<% else %>
   <% action_url = create_or_assign_url(picture_to_assign, @options.to_json) %>
-  <% action_method = @content.blank? ? 'post' : 'put' %>
-<% end %>
   <%= link_to(
     image_tag(
       alchemy.thumbnail_path(
@@ -18,7 +12,7 @@
     action_url,
     remote: true,
     onclick: '$(self).attr("href", "#").off("click"); return false',
-    method: action_method,
+    method: @content.blank? ? 'post' : 'put',
     title: Alchemy.t(:assign_image),
     class: 'thumbnail_background'
   ) %>

--- a/spec/features/admin/picture_overlay_spec.rb
+++ b/spec/features/admin/picture_overlay_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.feature "Picture overlay" do
+  before do
+    authorize_user(:as_admin)
+  end
+
+  describe "Upload button" do
+    let(:element) { create(:alchemy_element) }
+
+    let(:options) do
+      {grouped: true}
+    end
+
+    scenario 'passes options params to the uploader script' do
+      visit alchemy.admin_pictures_path(element_id: element.id, options: options)
+
+      expect(page.find('form#new_picture + script').text).to \
+        match /#{Regexp.escape({options: options}.to_param)}/
+    end
+  end
+end

--- a/spec/features/admin/picture_overlay_spec.rb
+++ b/spec/features/admin/picture_overlay_spec.rb
@@ -5,9 +5,9 @@ RSpec.feature "Picture overlay" do
     authorize_user(:as_admin)
   end
 
-  describe "Upload button" do
-    let(:element) { create(:alchemy_element) }
+  let(:element) { create(:alchemy_element) }
 
+  describe "Upload button" do
     let(:options) do
       {grouped: true}
     end
@@ -17,6 +17,17 @@ RSpec.feature "Picture overlay" do
 
       expect(page.find('form#new_picture + script').text).to \
         match /#{Regexp.escape({options: options}.to_param)}/
+    end
+  end
+
+  describe "assigning an image" do
+    let!(:picture) { create(:alchemy_picture) }
+
+    context 'when no content is present' do
+      scenario 'it has link to create a content' do
+        visit alchemy.admin_pictures_path(element_id: element.id)
+        expect(page).to have_selector('a[data-method="post"][href*="/admin/contents"]')
+      end
     end
   end
 end


### PR DESCRIPTION
These options are important to decide if an essence picture should be created
in a gallery after uploading an image or not.

Fixes #987