### PR TITLE
Touch parent while sorting nestable elements

### DIFF
--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -90,6 +90,7 @@ module Alchemy
 
       def order
         @trashed_element_ids = Element.trashed.where(id: params[:element_ids]).pluck(:id)
+        parent_element = Element.find_by(id: params[:parent_element_id])
         Element.transaction do
           params.fetch(:element_ids, []).each_with_index do |element_id, idx|
             # Ensure to set page_id, cell_id and parent_element_id to the current page and
@@ -101,6 +102,7 @@ module Alchemy
               position: idx + 1
             )
           end
+          parent_element.try!(:touch)
         end
       end
 

--- a/spec/controllers/alchemy/admin/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/elements_controller_spec.rb
@@ -87,6 +87,23 @@ module Alchemy
         end
       end
 
+      context "when nested inside parent element" do
+        let(:parent) { create(:alchemy_element) }
+
+        it 'touches the cache key of parent element' do
+          expect(Element).to receive(:find_by) { parent }
+          expect(parent).to receive(:touch) { true }
+          alchemy_xhr :post, :order, element_ids: element_ids, parent_element_id: parent.id
+        end
+
+        it 'assigns parent element id to each element' do
+          alchemy_xhr :post, :order, element_ids: element_ids, parent_element_id: parent.id
+          [element_1, element_2, element_3].each do |element|
+            expect(element.reload.parent_element_id).to eq parent.id
+          end
+        end
+      end
+
       context "untrashing" do
         let(:trashed_element) { create(:alchemy_element, public: false, position: nil, page_id: 58, cell_id: 32) }
 


### PR DESCRIPTION
For performance reasons we update the position of elements
directly into database and skip activerecord callbacks.

This breaks the touching mechanisms of activerecord. We need
to ensure that the parent element (if any) gets touched to
invalidate it's cache key.

Fixes #991