### PR TITLE
Element content order

### DIFF
--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -57,7 +57,9 @@ module Alchemy
 
     stampable stamper_class_name: Alchemy.user_class_name
 
-    has_many :contents, -> { order(:position) }, dependent: :destroy
+    # Content positions are scoped by their essence_type, so positions can be the same for different contents.
+    # In order to get contents in creation order we also order them by id.
+    has_many :contents, -> { order(:position, :id) }, dependent: :destroy
 
     # Elements can have other elements nested inside
     has_many :nested_elements,

--- a/app/models/alchemy/element/element_contents.rb
+++ b/app/models/alchemy/element/element_contents.rb
@@ -137,13 +137,8 @@ module Alchemy
 
     # creates the contents for this element as described in the elements.yml
     def create_contents
-      contents = []
-      if definition["contents"].blank?
-        log_warning "Could not find any content definitions for element: #{name}"
-      else
-        definition["contents"].each do |content_hash|
-          contents << Content.create_from_scratch(self, content_hash.symbolize_keys)
-        end
+      definition.fetch("contents", []).each do |content_hash|
+        Content.create_from_scratch(self, content_hash.symbolize_keys)
       end
     end
   end

--- a/app/models/alchemy/element/presenters.rb
+++ b/app/models/alchemy/element/presenters.rb
@@ -80,8 +80,15 @@ module Alchemy
       "#{name}_#{id}"
     end
 
+    # The content that's used for element's preview text.
+    #
+    # It tries to find one of element's contents that is defined +as_element_title+.
+    # Takes element's first content if no content is defined +as_element_title+.
+    #
+    # @return (Alchemy::Content)
+    #
     def preview_content
-      @_preview_content ||= contents.detect(&:preview_content?)
+      @_preview_content ||= contents.detect(&:preview_content?) || contents.first
     end
 
     private
@@ -92,7 +99,7 @@ module Alchemy
     end
 
     def preview_text_from_preview_content(maxlength)
-      (preview_content || contents.first).try(:preview_text, maxlength)
+      preview_content.try!(:preview_text, maxlength)
     end
   end
 end

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -412,16 +412,18 @@ module Alchemy
         mock_model(Content, preview_text: 'Content 2', preview_content?: false)
       end
 
+      let(:contents) { [] }
+
       let(:preview_content) do
         mock_model(Content, preview_text: 'Preview Content', preview_content?: true)
       end
 
+      before do
+        allow(element).to receive(:contents).and_return(contents)
+      end
+
       context "without a content marked as preview" do
         let(:contents) { [content, content_2] }
-
-        before do
-          allow(element).to receive(:contents).and_return(contents)
-        end
 
         it "returns the preview text of first content found" do
           expect(content).to receive(:preview_text).with(30)
@@ -432,10 +434,6 @@ module Alchemy
       context "with a content marked as preview" do
         let(:contents) { [content, preview_content] }
 
-        before do
-          allow(element).to receive(:contents).and_return(contents)
-        end
-
         it "should return the preview_text of this content" do
           expect(preview_content).to receive(:preview_text).with(30)
           element.preview_text
@@ -443,10 +441,6 @@ module Alchemy
       end
 
       context "without any contents present" do
-        before do
-          allow(element).to receive(:contents).and_return([])
-        end
-
         it "should return nil" do
           expect(element.preview_text).to be_nil
         end


### PR DESCRIPTION
Element's contents are ordered by position, but the position of contents are scoped by its essence type. So different contents can have the same position on the same element.

In order to be sure we always talk about the same content, if we ask for the first one (ie. in `Element#preview_text`), we additionally order the contents by id.