### PR TITLE
Always set file_types to an array

### DIFF
--- a/app/views/alchemy/admin/uploader/_button.html.erb
+++ b/app/views/alchemy/admin/uploader/_button.html.erb
@@ -17,7 +17,7 @@
 <% file_types = (
   local_assigns.fetch(:file_types, []).presence ||
     configuration(:uploader)['allowed_filetypes'][model_class.model_name.collection]
-) %>
+) || [] %>
 
 <script type='text/javascript'>
   $(function() {


### PR DESCRIPTION
With the current code, file_types can end up as nil, causing an exception further down the page. This fixes that. I'm not sure where an appropriate spec for this would be.