### PR TITLE
Make default site in seeder configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,10 @@ __New Features__
 * Resource forms can now have Tinymce enabled by adding `.tinymce` class
 * `Alchemy::EssenceFile` now has a `link_text` attribute, so the editor is able to change the linked text of the download link.
 * Enable to pass multiple page layout names to `on_page_layout` callbacks
-* Client side rendering of the pages admin _(not merged yet)_
-* Deprecate `redirect_index` configuration _(not merged yet)_
+* Client side rendering of the pages admin
+* Deprecate `redirect_index` configuration
 * Add Nestable elements feature
+* Default site in seeder is now configurable
 
 __Notable Changes__
 

--- a/config/alchemy/config.yml
+++ b/config/alchemy/config.yml
@@ -77,7 +77,12 @@ output_image_jpg_quality: 85
 preprocess_image_resize:
 image_output_format: jpg
 
-# This is the default language for new sites.
+# This is used by the seeder to create the default site.
+default_site:
+  name: Default Site
+  host: '*'
+
+# This is the default language when a new site gets created.
 default_language:
   code: en
   name: English

--- a/lib/alchemy/seeder.rb
+++ b/lib/alchemy/seeder.rb
@@ -7,7 +7,7 @@ module Alchemy
     class << self
       # This seed builds the necessary page structure for Alchemy in your database.
       #
-      # Call this from your db/seeds.rb file with the rake db:seed task.
+      # Call this from your +db/seeds.rb+ file with the `rake db:seed task'.
       #
       def seed!
         create_default_site
@@ -20,8 +20,8 @@ module Alchemy
         desc "Creating default Alchemy site"
         if Alchemy::Site.count == 0
           site = Alchemy::Site.new(
-            name: 'Default Site',
-            host: '*'
+            name: site_config['name'],
+            host: site_config['host']
           )
           if Alchemy::Language.any?
             site.languages = Alchemy::Language.all
@@ -44,6 +44,12 @@ module Alchemy
         else
           log "Alchemy root page was already present.", :skip
         end
+      end
+
+      private
+
+      def site_config
+        @_site_config ||= Alchemy::Config.get(:default_site)
       end
     end
   end


### PR DESCRIPTION
The values for the seeded default site are currently hard coded.
This makes them configurable.