### PR TITLE
Fixes 995

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.dialog.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.dialog.js.coffee
@@ -248,19 +248,19 @@ window.Alchemy.openDialog = (url, options) ->
 #
 # See Alchemy.Dialog for further options you can add to the data attribute
 #
-window.Alchemy.watchForDialogs = (scope) ->
-  $('a[data-alchemy-dialog]', scope).click (e) ->
+window.Alchemy.watchForDialogs = (scope = '#alchemy') ->
+  $(scope).on 'click', '[data-alchemy-dialog]', (e) ->
     $this = $(this)
     url = $this.attr('href')
     options = $this.data('alchemy-dialog')
     Alchemy.openDialog(url, options)
     false
-  $('a[data-alchemy-confirm-delete]', scope).click (event) ->
+  $(scope).on 'click', '[data-alchemy-confirm-delete]', (event) ->
     $this = $(this)
     options = $this.data('alchemy-confirm-delete')
     Alchemy.confirmToDeleteDialog($this.attr('href'), options)
     false
-  $('input[data-alchemy-confirm], button[data-alchemy-confirm]', scope).click (event) ->
+  $(scope).on 'click', '[data-alchemy-confirm]', (event) ->
     options = $(this).data('alchemy-confirm')
     Alchemy.openConfirmDialog options.message, $.extend options,
       ok_label: options.ok_label

--- a/app/assets/javascripts/alchemy/alchemy.sitemap.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.sitemap.js.coffee
@@ -49,8 +49,6 @@ Alchemy.Sitemap =
       self.items = $(".sitemap_page", '#sitemap')
       self._observe()
 
-      Alchemy.watchForDialogs('#sitemap')
-
       if self.options.ready
         self.options.ready()
 

--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -36,9 +36,7 @@ module Alchemy
       def tree
         authorize! :tree, :alchemy_admin_pages
 
-        render json: PageTreeSerializer.new(@page, ability: current_ability,
-                                            user: current_alchemy_user,
-                                            full: params[:full] == 'true')
+        render json: serialized_page_tree
       end
 
       # Used by page preview iframe in Page#edit view.
@@ -103,6 +101,10 @@ module Alchemy
         if @page.update_attributes(page_params)
           @notice = Alchemy.t("Page saved", name: @page.name)
           @while_page_edit = request.referer.include?('edit')
+
+          unless @while_page_edit
+            @tree = serialized_page_tree
+          end
         else
           configure
         end
@@ -371,6 +373,12 @@ module Alchemy
 
       def set_root_page
         @page_root = Language.current_root_page
+      end
+
+      def serialized_page_tree
+        PageTreeSerializer.new(@page, ability: current_ability,
+                                      user: current_alchemy_user,
+                                      full: params[:full] == 'true')
       end
     end
   end

--- a/app/views/alchemy/admin/attachments/archive_overlay.js.erb
+++ b/app/views/alchemy/admin/attachments/archive_overlay.js.erb
@@ -2,6 +2,5 @@
   var dialog = Alchemy.currentDialog();
   dialog.dialog_body.html('<%= j render("archive_overlay") %>');
   Alchemy.SelectBox('#filter_bar');
-  Alchemy.watchForDialogs(dialog.dialog_body);
   Alchemy.ListFilter(dialog.dialog_body);
 })();

--- a/app/views/alchemy/admin/contents/create.js.erb
+++ b/app/views/alchemy/admin/contents/create.js.erb
@@ -53,4 +53,3 @@ Alchemy.Tinymce.initEditor(<%= @content.id %>);
 Alchemy.reloadPreview();
 Alchemy.closeCurrentDialog();
 Alchemy.SelectBox("#element_<%= @element.id %>");
-Alchemy.watchForDialogs('#<%= @content.dom_id %>');

--- a/app/views/alchemy/admin/essence_files/assign.js.erb
+++ b/app/views/alchemy/admin/essence_files/assign.js.erb
@@ -6,4 +6,3 @@ $('#<%= @content.dom_id %>').replaceWith('<%= j(
 ) %>');
 Alchemy.closeCurrentDialog();
 Alchemy.setElementDirty($('#element_<%= @content.element.id %>'));
-Alchemy.watchForDialogs($('#<%= @content.dom_id %>'));

--- a/app/views/alchemy/admin/essence_pictures/assign.js.erb
+++ b/app/views/alchemy/admin/essence_pictures/assign.js.erb
@@ -15,4 +15,3 @@ Alchemy.SortableContents('#<%= @content.element.id -%>_contents', '<%= form_auth
 
 Alchemy.closeCurrentDialog();
 Alchemy.setElementDirty('#element_<%= @content.element.id %>');
-Alchemy.watchForDialogs('#<%= @content.dom_id %>');

--- a/app/views/alchemy/admin/legacy_page_urls/create.js.erb
+++ b/app/views/alchemy/admin/legacy_page_urls/create.js.erb
@@ -4,7 +4,6 @@
   $('#legacy_page_url_urlname').val('');
   $('#no_page_links_notice').hide();
   $('#legacy_page_urls').append('<%=j render "legacy_page_url", legacy_page_url: @legacy_page_url %>');
-  Alchemy.watchForDialogs('#<%= dom_id(@legacy_page_url) %>');
 <% else %>
   $('#new_legacy_page_url').replaceWith('<%=j render("new") %>');
 <% end %>

--- a/app/views/alchemy/admin/pages/destroy.js.erb
+++ b/app/views/alchemy/admin/pages/destroy.js.erb
@@ -8,7 +8,6 @@ window.location.href = '<%= alchemy.admin_layoutpages_path %>';
 
 $('#sitemap').replaceWith('<%= j render("sitemap") %>');
 Alchemy.growl('<%= j @message %>');
-Alchemy.watchForDialogs('#sitemap');
 
 <% else -%>
 

--- a/app/views/alchemy/admin/pages/update.js.erb
+++ b/app/views/alchemy/admin/pages/update.js.erb
@@ -1,8 +1,6 @@
 (function() {
   var $page;
 
-  Alchemy.growl("<%= j @notice %>");
-
 <% if @old_page_layout != @page.page_layout -%>
   Alchemy.ElementsWindow.reload();
   Alchemy.growl('<%= j Alchemy.t(:page_layout_changed_notice) %>');
@@ -15,7 +13,11 @@
 
 <% else -%>
 
-  $('#page_<%= @page.id %>').replaceWith('<%= j render("page", page: @page) %>');
+  var page_html = "<%= j render('page', page: @page) %>";
+  var compiler = Handlebars.compile(page_html);
+  var tree = JSON.parse('<%== @tree.to_json %>');
+  var html = compiler(tree.pages[0]);
+  $('#page_<%= @page.id %>').replaceWith(html);
   $page = $('#page_<%= @page.id %>');
   Alchemy.watchForDialogs($page);
 
@@ -33,5 +35,6 @@
 
 <% end -%>
 
+  Alchemy.growl("<%= j @notice %>");
   Alchemy.closeCurrentDialog();
 })()

--- a/app/views/alchemy/admin/pages/update.js.erb
+++ b/app/views/alchemy/admin/pages/update.js.erb
@@ -19,7 +19,6 @@
   var html = compiler(tree.pages[0]);
   $('#page_<%= @page.id %>').replaceWith(html);
   $page = $('#page_<%= @page.id %>');
-  Alchemy.watchForDialogs($page);
 
   <% if @page.locked? && @page.locker == current_alchemy_user -%>
     $('#locked_page_<%= @page.id %> > a').html('<%= @page.name %>');

--- a/app/views/alchemy/admin/pictures/archive_overlay.js.erb
+++ b/app/views/alchemy/admin/pictures/archive_overlay.js.erb
@@ -2,7 +2,6 @@
   var dialog = Alchemy.currentDialog();
   dialog.dialog_body.html('<%= j render("archive_overlay") %>');
   Alchemy.SelectBox('#filter_bar');
-  Alchemy.watchForDialogs(dialog.dialog_body);
   Alchemy.ImageLoader('#assign_image_list');
   Alchemy.ListFilter(dialog.dialog_body);
 })();


### PR DESCRIPTION
- Use handlebars template for replacing updated page in tree
- Uses event delegation to avoid the need to re-attach click events for replaced dom nodes.