### PR TITLE
Add lost search form back to file archive

### DIFF
--- a/app/views/alchemy/admin/attachments/index.html.erb
+++ b/app/views/alchemy/admin/attachments/index.html.erb
@@ -1,4 +1,5 @@
 <% any_tags = Alchemy::Attachment.tag_counts.any? %>
+
 <% content_for(:toolbar) do %>
   <div class="toolbar_buttons">
     <% if can? :create, Alchemy::Attachment %>
@@ -8,7 +9,9 @@
         file_attribute: 'file' %>
     <% end %>
   </div>
+  <%= render 'alchemy/admin/partials/search_form' %>
 <% end %>
+
 <div id="archive_all" class="<%= any_tags ? 'with_tag_filter ' : nil %>resources-table-wrapper">
   <%= resources_header %>
   <%= render partial: 'files_list' %>


### PR DESCRIPTION
Since fadf052a101567ab7967fc23a91392e82b2c046d the search form is missing from file archive.

Fixes #1004