### PR TITLE
Fix file preview

### DIFF
--- a/app/assets/stylesheets/alchemy/frame.scss
+++ b/app/assets/stylesheets/alchemy/frame.scss
@@ -292,3 +292,11 @@ div#user_info {
     float: left;
   }
 }
+
+.full-iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}

--- a/app/views/alchemy/admin/attachments/show.html.erb
+++ b/app/views/alchemy/admin/attachments/show.html.erb
@@ -1,3 +1,3 @@
-<iframe src="<%= alchemy.show_attachment_path(@attachment) %>" frameborder=0 style="width: 100%; min-height: 90%">
+<iframe src="<%= alchemy.show_attachment_path(@attachment) %>" frameborder=0 class="full-iframe">
   Your browser does not support frames.
 </iframe>

--- a/config/locales/alchemy.de.yml
+++ b/config/locales/alchemy.de.yml
@@ -141,6 +141,7 @@ de:
       image/gif: 'GIF-Bild'
       image/jpeg: 'JPG-Bild'
       image/png: 'PNG-Bild'
+      image/svg+xml: SVG-Grafik
       video/x-msvideo: 'AVI-Video'
       video/x-ms-wmv: 'Windows Media Video'
       image/tiff: 'TIFF-Bild'

--- a/lib/alchemy/filetypes.rb
+++ b/lib/alchemy/filetypes.rb
@@ -13,6 +13,7 @@ module Alchemy
       "image/gif",
       "image/jpeg",
       "image/png",
+      "image/svg+xml",
       "image/tiff"
     ]
 


### PR DESCRIPTION
The iframe in the file preview overlay is too small, the former fix with `min-height` does not work any more. Using `position: absolute` fixes this.