### PR TITLE
Tag lists layout fixes

### DIFF
--- a/app/assets/stylesheets/alchemy/archive.scss
+++ b/app/assets/stylesheets/alchemy/archive.scss
@@ -198,7 +198,7 @@ div#filter_bar {
   }
 }
 
-#tag_list {
+.tag-list {
   @include box-sizing(border-box);
   height: 100%;
   padding-bottom: 138px;
@@ -281,22 +281,22 @@ div#filter_bar {
 #assign_image_list {
   padding-right: 244px;
 
-  #tag_list ul {
+  .tag-list ul {
     height: 316px;
   }
 
-  &.filtered #tag_list ul {
+  &.filtered .tag-list ul {
     height: 292px;
   }
 }
 
 #assign_file_list {
 
-  #tag_list ul {
+  .tag-list ul {
     height: 396px;
   }
 
-  &.filtered #tag_list ul {
+  &.filtered .tag-list ul {
     height: 372px;
   }
 }
@@ -374,6 +374,6 @@ div#filter_bar {
   }
 }
 
-table.list#tag_list .tag {
+.tags .list .tag {
   padding: 0;
 }

--- a/app/views/alchemy/admin/attachments/_archive_overlay.html.erb
+++ b/app/views/alchemy/admin/attachments/_archive_overlay.html.erb
@@ -16,7 +16,7 @@
 <div id="assign_file_list" class="with_padding<%= params[:tagged_with].present? ? ' filtered' : '' %>">
   <% if any_tags = Alchemy::Attachment.tag_counts.any? %>
   <div id="library_sidebar">
-    <div id="tag_list">
+    <div class="tag-list">
       <%= render 'tag_list' %>
     </div>
   </div>

--- a/app/views/alchemy/admin/attachments/_tag_list.html.erb
+++ b/app/views/alchemy/admin/attachments/_tag_list.html.erb
@@ -1,6 +1,6 @@
 <% p = params.dup %>
 <h2><%= Alchemy.t("Filter by tag") %></h2>
-<%= js_filter_field '#tag_list li' %>
+<%= js_filter_field '.tag-list li' %>
 <ul>
   <%= render_tag_list('Alchemy::Attachment', p) %>
 </ul>

--- a/app/views/alchemy/admin/attachments/index.html.erb
+++ b/app/views/alchemy/admin/attachments/index.html.erb
@@ -17,7 +17,7 @@
   <%= render partial: 'files_list' %>
   <% if any_tags %>
   <div id="library_sidebar">
-    <div id="tag_list" class="<%= params[:tagged_with].present? ? 'filtered' : '' %>">
+    <div class="<%= params[:tagged_with].present? ? 'tag-list filtered' : 'tag-list' %>">
       <%= render partial: 'tag_list' %>
     </div>
   </div>

--- a/app/views/alchemy/admin/pictures/_archive.html.erb
+++ b/app/views/alchemy/admin/pictures/_archive.html.erb
@@ -1,6 +1,6 @@
 <div id="library_sidebar">
   <%= render :partial => 'filter_bar' %>
-  <div id="tag_list" class="with_filter_bar<%= params[:tagged_with].present? ? ' filtered' : '' %>">
+  <div class="tag-list with_filter_bar<%= params[:tagged_with].present? ? ' filtered' : '' %>">
     <%= render :partial => 'tag_list' %>
   </div>
 </div>

--- a/app/views/alchemy/admin/pictures/_archive_overlay.html.erb
+++ b/app/views/alchemy/admin/pictures/_archive_overlay.html.erb
@@ -4,7 +4,7 @@
 <div id="assign_image_list" class="with_padding<%= params[:tagged_with].present? ? ' filtered' : '' %>">
   <div id="library_sidebar">
     <%= render 'filter_bar' %>
-    <div id="tag_list">
+    <div class="tag-list">
       <%= render 'tag_list' %>
     </div>
   </div>

--- a/app/views/alchemy/admin/pictures/_tag_list.html.erb
+++ b/app/views/alchemy/admin/pictures/_tag_list.html.erb
@@ -1,7 +1,7 @@
 <% p = params.dup %>
 <% if Alchemy::Picture.tag_counts.any? %>
   <h2><%= Alchemy.t("Filter by tag") %></h2>
-  <%= js_filter_field '#tag_list li' %>
+  <%= js_filter_field '.tag-list li' %>
   <ul>
     <%= render_tag_list('Alchemy::Picture', p) %>
   </ul>

--- a/app/views/alchemy/admin/tags/edit.html.erb
+++ b/app/views/alchemy/admin/tags/edit.html.erb
@@ -13,8 +13,8 @@
     <div class="input tags">
       <label class="control-label"><%= Alchemy.t('Tags') %></label>
       <div class="control_group" id="tags_tag_list">
-        <%= js_filter_field '#tag_list li' %>
-        <ul id="tag_list" class="tags">
+        <%= js_filter_field '.tag-list li' %>
+        <ul class="tags tag-list">
           <%= render partial: "radio_tag", collection: @tags, locals: {name: "tag"} %>
         </ul>
       </div>

--- a/app/views/alchemy/admin/tags/index.html.erb
+++ b/app/views/alchemy/admin/tags/index.html.erb
@@ -22,7 +22,7 @@
   </h1>
   <% if @tags.any? %>
 
-  <table class="list" id="tag_list">
+  <table class="list">
     <thead>
       <tr>
         <th class="icon"></th>


### PR DESCRIPTION
Due to duplicated ids the tags table layout was broken.

**Before**

![alchemy cms - tags before](https://cloud.githubusercontent.com/assets/42868/15196226/a64d2274-17cb-11e6-901e-64208fa38d13.jpg)

**After**

![alchemy cms - tags after](https://cloud.githubusercontent.com/assets/42868/15196230/ab370d7c-17cb-11e6-9606-8edb025ad19b.jpg)
