### PR TITLE
Adds editable fields to create language tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ __New Features__
 * Deprecate `redirect_index` configuration
 * Add Nestable elements feature
 * Default site in seeder is now configurable
+* Frontpage name and page layout are now editable when creating new language trees
 
 __Notable Changes__
 

--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -28,6 +28,7 @@ module Alchemy
         if !@page_root
           @language = Language.current
           @languages_with_page_tree = Language.with_root_page
+          @page_layouts = PageLayout.layouts_for_select(@language.id)
         end
       end
 

--- a/app/views/alchemy/admin/pages/_create_language_form.html.erb
+++ b/app/views/alchemy/admin/pages/_create_language_form.html.erb
@@ -21,22 +21,26 @@
   <%- end -%>
 
   <%- if params[:action] == "index" -%>
-
-  <%= form_for([:admin, Alchemy::Page.new]) do |form| %>
-    <h3><%= Alchemy.t(:create_language_tree_heading) %></h3>
-    <p><%= Alchemy.t(:want_to_create_new_language) %></p>
-    <%= form.hidden_field :name, value: @language.frontpage_name %>
-    <%= form.hidden_field :language_id, value: @language.id %>
-    <%= form.hidden_field :language_code, value: @language.code %>
-    <%= form.hidden_field :page_layout, value: @language.page_layout %>
-    <%= form.hidden_field :language_root, value: true %>
-    <%= form.hidden_field :parent_id, value: root.id %>
-    <%= form.hidden_field :public, value: Alchemy::Language.all.size == 1 %>
-    <div class="submit">
-      <%= form.button Alchemy.t("create_tree_as_new_language", language: @language.name), autofocus: true %>
-    </div>
-  <% end %>
-
+    <%= alchemy_form_for([:admin, Alchemy::Page.new], id: 'create_language_tree') do |form| %>
+      <% if @languages_with_page_tree.size >= 1 %>
+        <h3><%= Alchemy.t(:create_language_tree_heading) %></h3>
+        <p><%= Alchemy.t(:want_to_create_new_language) %></p>
+      <% end %>
+      <%= form.input :name, input_html: {value: @language.frontpage_name} %>
+      <%= form.input :page_layout,
+        collection: @page_layouts,
+        selected: @language.page_layout,
+        label: Alchemy.t(:page_type),
+        include_blank: false,
+        required: true,
+        input_html: {class: 'alchemy_selectbox'} %>
+      <%= form.hidden_field :language_id, value: @language.id %>
+      <%= form.hidden_field :language_code, value: @language.code %>
+      <%= form.hidden_field :language_root, value: true %>
+      <%= form.hidden_field :parent_id, value: root.id %>
+      <%= form.hidden_field :public, value: Alchemy::Language.all.size == 1 %>
+      <%= form.submit Alchemy.t("create_tree_as_new_language", language: @language.name), autofocus: true %>
+    <% end %>
   <%- end -%>
 
 <%- else -%>

--- a/app/views/alchemy/admin/pages/_new_page_form.html.erb
+++ b/app/views/alchemy/admin/pages/_new_page_form.html.erb
@@ -5,6 +5,7 @@
     collection: @page_layouts,
     label: Alchemy.t(:page_type),
     include_blank: false,
+    required: true,
     input_html: {class: 'alchemy_selectbox'} %>
   <%= f.input :name %>
   <%= f.submit Alchemy.t(:create) %>

--- a/spec/features/admin/language_tree_feature_spec.rb
+++ b/spec/features/admin/language_tree_feature_spec.rb
@@ -23,10 +23,16 @@ describe 'Language tree feature', type: :feature, js: true do
   context "with no language root page" do
     before { klingon }
 
-    it "it should display the form for creating language root" do
+    it "displays a form for creating language root with preselected page layout and front page name" do
       visit('/admin/pages')
       page.select 'Klingon', from: 'language_id'
       expect(page).to have_content('This language tree does not exist')
+
+      within('form#create_language_tree') do
+        expect(page).to \
+          have_selector('input[type="text"][value="' + klingon.frontpage_name + '"]')
+        expect(page).to have_selector('option[selected="selected"][value="' + klingon.page_layout + '"]')
+      end
     end
   end
 end


### PR DESCRIPTION
All attributes needed to create a new page tree where hidden form fields. So, new language trees always got created by their default values from the language settings.

If, for instance because a site has not the page layout set in tthe defaults, a user creates a new language treee, this leads to wrong page setup.

This change converts the `name` and `page_layout` fields into normal form fields that the user can change. These fields get populated with their default values, so for "normal use case" nothing changed.

**Before**

![alchemy cms - create language tree before](https://cloud.githubusercontent.com/assets/42868/15323809/00714d30-1c44-11e6-88d6-1fb5498806a1.jpg)

**After**

![alchemy cms - language tree after](https://cloud.githubusercontent.com/assets/42868/15323808/004ca494-1c44-11e6-85b1-35268ceaa762.jpg)
