### PR TITLE
Render 404 if unpublished index page has callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ __Fixed Bugs__
 * Eliminate an SQL lookup on frontend cached element partials
 * Add missing german and spanish translation for element toolbar
 * Use the site_id parameter and the session only in the Admin area
+* Render 404 if accessing an unpublished index page that has "on page layout" callbacks
 
 [Full Change Log](https://github.com/AlchemyCMS/alchemy_cms/compare/v3.2.0...HEAD)
 

--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -9,8 +9,13 @@ module Alchemy
     before_action :load_index_page, only: [:index]
     before_action :load_page, only: [:show]
 
-    # Page redirects need to run after the page was loaded. Order is important here!
+    # Legacy page redirects need to run after the page was loaded and before we render 404.
     include LegacyPageRedirects
+
+    # From here on, we need a +@page+ to work with!
+    before_action :page_not_found!, if: -> { @page.blank? }, only: [:index, :show]
+
+    # Page redirects need to run after the page was loaded and we're sure to have a +@page+ set.
     include PageRedirects
 
     # We only need to set the +@root_page+ if we are sure that no more redirects happen.
@@ -35,8 +40,6 @@ module Alchemy
     # If no public page can be found it renders a 404 error.
     #
     def index
-      @page || page_not_found!
-
       if Alchemy::Config.get(:redirect_index)
         ActiveSupport::Deprecation.warn("The configuration option `redirect_index` is deprecated and will be removed with the release of Alchemy v4.0")
         raise "Remove deprecated `redirect_index` configuration!" if Alchemy.version == "4.0.0.rc1"

--- a/app/controllers/concerns/alchemy/page_redirects.rb
+++ b/app/controllers/concerns/alchemy/page_redirects.rb
@@ -7,13 +7,6 @@ module Alchemy
   module PageRedirects
     extend ActiveSupport::Concern
 
-    included do
-      # We need a +@page+ to work with
-      before_action :page_not_found!,
-        if: -> { @page.blank? },
-        only: [:show]
-    end
-
     private
 
     # Returns an URL to redirect the request to.

--- a/spec/controllers/alchemy/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/pages_controller_spec.rb
@@ -66,6 +66,21 @@ module Alchemy
                 alchemy_get :index
               }.to raise_error(ActionController::RoutingError)
             end
+
+            context "when a page layout callback is set" do
+              before do
+                ApplicationController.send(:extend, Alchemy::OnPageLayout)
+                ApplicationController.class_eval do
+                  on_page_layout('index') { "do something" }
+                end
+              end
+
+              it 'raises routing error (404) and no "undefined method for nil" error' do
+                expect {
+                  alchemy_get :index
+                }.to raise_error(ActionController::RoutingError)
+              end
+            end
           end
 
           context 'and redirect_to_public_child is set to true' do


### PR DESCRIPTION
If a "on page layout" is set and we request an unpublished index
page, we get an "undefined method page_layout for NilClass" error.

This fixes this as it ensures that we render 404 errors before
running any "on page layout" callbacks.