### PR TITLE
Use Rails' HTML sanitizer to strip tags

### DIFF
--- a/app/models/alchemy/essence_richtext.rb
+++ b/app/models/alchemy/essence_richtext.rb
@@ -25,26 +25,7 @@ module Alchemy
     private
 
     def strip_content
-      self.stripped_body = strip_tags(body)
-    end
-
-    # Stripping HTML Tags and only returns plain text.
-    def strip_tags(html)
-      return html if html.blank?
-      if html.index("<")
-        text = ""
-        tokenizer = ::HTML::Tokenizer.new(html)
-        while token = tokenizer.next
-          node = ::HTML::Node.parse(nil, 0, 0, token, false)
-          # result is only the content of any Text nodes
-          text << node.to_s if node.class == ::HTML::Text
-        end
-        # strip any comments, and if they have a newline at the end (ie. line with
-        # only a comment) strip that too
-        text.gsub(/<!--(.*?)-->[\n]?/m, "")
-      else
-        html # already plain text
-      end
+      self.stripped_body = Rails::Html::FullSanitizer.new.sanitize(body)
     end
   end
 end


### PR DESCRIPTION
We used to have a custom HTML sanitizer that does not work
any more with Rails 4.2

Now we use the default html sanitizer shipped with rails.

Fixes #1017