### PR TITLE
Limit active model serializers version to 0.9.x

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.require_paths         = ['lib']
 
   gem.add_runtime_dependency 'actionpack-page_caching',          ['~> 1.0.0']
-  gem.add_runtime_dependency 'active_model_serializers',         ['~> 0.9']
+  gem.add_runtime_dependency 'active_model_serializers',         ['~> 0.9.0']
   gem.add_runtime_dependency 'acts_as_list',                     ['~> 0.3']
   gem.add_runtime_dependency 'acts-as-taggable-on',              ['~> 3.1']
   gem.add_runtime_dependency 'awesome_nested_set',               ['~> 3.0.0']


### PR DESCRIPTION
ActiveModelSerializers v0.10 breaks several things. This limits the version to 0.9.x so everything works fine.