### PR TITLE
Redirect to page sites host when visiting from Admin

### DIFF
--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -171,9 +171,10 @@ module Alchemy
 
       def visit
         @page.unlock!
-        redirect_to show_page_path(
+        redirect_to show_page_url(
           urlname: @page.urlname,
-          locale: prefix_locale? ? @page.language_code : nil
+          locale: prefix_locale? ? @page.language_code : nil,
+          host: @page.site.host == "*" ? request.host : @page.site.host
         )
       end
 


### PR DESCRIPTION
Currently, with a multi-site setup, when visiting a page from
the edit page view in the admin, the admin user gets redirected to
a page's path - however, every page has a site, too, and that site
should be visited so that we don't get 404s.