### PR TITLE
Use a query to update public_on

### DIFF
--- a/db/migrate/20160108174834_add_timebased_publishing_columns_to_pages.rb
+++ b/db/migrate/20160108174834_add_timebased_publishing_columns_to_pages.rb
@@ -4,11 +4,7 @@ class AddTimebasedPublishingColumnsToPages < ActiveRecord::Migration
     add_column :alchemy_pages, :public_until, :datetime
     add_index :alchemy_pages, [:public_on, :public_until]
 
-    Alchemy::Page.each do |page|
-      next unless page.published_at
-      page.update_column(public_on: page.published_at)
-      say "Updated #{page.name} public state"
-    end
+    execute "UPDATE alchemy_pages SET public_on = published_at WHERE published_at IS NOT NULL"
 
     remove_column :alchemy_pages, :public
   end
@@ -16,25 +12,10 @@ class AddTimebasedPublishingColumnsToPages < ActiveRecord::Migration
   def down
     add_column :alchemy_pages, :public, :boolean, default: false
 
-    Alchemy::Page.each do |page|
-      next unless page_public?(page)
-      page.update_column(public: true)
-      say "Updated #{page.name} public state"
-    end
+    execute "UPDATE alchemy_pages SET public = (public_on IS NOT NULL AND public_on < NOW() AND (public_until > NOW() OR public_until IS NULL))"
 
+    remove_index :alchemy_pages, [:public_on, :public_until]
     remove_column :alchemy_pages, :public_on
     remove_column :alchemy_pages, :public_until
-    remove_index :alchemy_pages, [:public_on, :public_until]
-  end
-
-  private
-
-  def page_public?(page)
-    page.public_on && page.public_on < current_time &&
-      page.public_until && page.public_until > current_time
-  end
-
-  def current_time
-    @_current_time ||= Time.current
   end
 end


### PR DESCRIPTION
Because #1024 introduced a bug (`Alchemy::Page.each` is not defined) I took the occasion to rewrite the migration so it does not rely on classes any more. This makes it independent from the implementation and faster.

I could only test it with Postgres, but it should work with MySQL also. I will try in the next few days when I have time. Feedback is appreciated!