### PR TITLE
Move `current_ability` into it's own module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ __Notable Changes__
 * Thumbnails now render in original file format, but GIFs will always be flattened
 * Pictures will be rendered in original file format by default
 * Allow SVG files to be rendered as EssencePicture
+* When using Alchemy content outside of Alchemy, `current_ability` is no longer
+  included with `Alchemy::ControllerActions` to prevent method clashes. If you
+  need access to `current_ability` you also need to include `Alchemy::AbilityHelper`
 
 ## 3.3.0 (2016-05-18)
 

--- a/app/controllers/alchemy/base_controller.rb
+++ b/app/controllers/alchemy/base_controller.rb
@@ -3,6 +3,7 @@
 module Alchemy
   class BaseController < ApplicationController
     include Alchemy::ConfigurationMethods
+    include Alchemy::AbilityHelper
     include Alchemy::ControllerActions
     include Alchemy::Modules
     include Alchemy::SSLProtection

--- a/lib/alchemy/ability_helper.rb
+++ b/lib/alchemy/ability_helper.rb
@@ -1,0 +1,23 @@
+module Alchemy::AbilityHelper
+  # Ensures usage of Alchemy's permissions class.
+  #
+  # == Register custom Abilities
+  #
+  # If your app has a CanCan Ability class with rules you want to be aviable in an Alchemy context
+  # you need to register it. Or if you have an engine with it's own CanCan abilities you want to
+  # add to Alchemy you must register them first.
+  #
+  #     Alchemy.register_ability MyCustom::Permisson
+  #
+  def current_ability
+    @current_ability ||= begin
+      alchemy_permissions = Alchemy::Permissions.new(current_alchemy_user)
+      Alchemy.registered_abilities.each do |klass|
+        # Ensure to avoid issues with Rails constant lookup.
+        klass = "::#{klass}".constantize
+        alchemy_permissions.merge(klass.new(current_alchemy_user))
+      end
+      alchemy_permissions
+    end
+  end
+end

--- a/lib/alchemy/controller_actions.rb
+++ b/lib/alchemy/controller_actions.rb
@@ -49,28 +49,6 @@ module Alchemy
       @current_alchemy_site ||= Site.find_for_host(request.host)
     end
 
-    # Ensures usage of Alchemy's permissions class.
-    #
-    # == Register custom Abilities
-    #
-    # If your app has a CanCan Ability class with rules you want to be aviable in an Alchemy context
-    # you need to register it. Or if you have an engine with it's own CanCan abilities you want to
-    # add to Alchemy you must register them first.
-    #
-    #     Alchemy.register_ability MyCustom::Permisson
-    #
-    def current_ability
-      @current_ability ||= begin
-        alchemy_permissions = Alchemy::Permissions.new(current_alchemy_user)
-        Alchemy.registered_abilities.each do |klass|
-          # Ensure to avoid issues with Rails constant lookup.
-          klass = "::#{klass}".constantize
-          alchemy_permissions.merge(klass.new(current_alchemy_user))
-        end
-        alchemy_permissions
-      end
-    end
-
     # Sets the current site in a cvar so the Language model
     # can be scoped against it.
     #

--- a/lib/alchemy/engine.rb
+++ b/lib/alchemy/engine.rb
@@ -23,6 +23,7 @@ require 'turbolinks'
 require 'userstamp'
 
 # Require globally used Alchemy mixins
+require_relative './ability_helper'
 require_relative './auth_accessors'
 require_relative './cache_digests/template_tracker'
 require_relative './config'


### PR DESCRIPTION
A common need is to render alchemy content within the another context (the app or another engine). An example of this would be the alchemy-solidus gem. We do this by included `Alchemy::ControllerActions` into the controllers for the context we want to use the Alchemy content in.

The problem is when this is done IF that gem is also using cancancan (like Solidus does) then the `current_ability` method from Alchemy can end up overwritting the `current_ability` of the controller doing the including.

By moving `current_ability` to it's own module it allows the including controller to decide if that method is desired or not.

Motivation for this commit is driven from AlchemyCMS/alchemy-solidus#6 to simplify that PR.