### PR TITLE
Fixes the image file format migration

### DIFF
--- a/db/migrate/20160422195310_add_image_file_format_to_alchemy_pictures.rb
+++ b/db/migrate/20160422195310_add_image_file_format_to_alchemy_pictures.rb
@@ -2,9 +2,16 @@ class AddImageFileFormatToAlchemyPictures < ActiveRecord::Migration
   def up
     add_column :alchemy_pictures, :image_file_format, :string
 
-    Alchemy::Picture.all.each do |pic|
-      format = pic.image_file.identify('-ping -format "%m"')
-      pic.update_column('image_file_format', format.downcase)
+    say_with_time "Storing file format of existing pictures" do
+      Alchemy::Picture.all.each do |pic|
+        begin
+          format = pic.image_file.identify('-ping -format "%m"')
+          pic.update_column('image_file_format', format.to_s.downcase)
+        rescue Dragonfly::Job::Fetch::NotFound => e
+          say(e.message, true)
+        end
+      end
+      Alchemy::Picture.count
     end
   end
 


### PR DESCRIPTION
If an image file is missing we now ignore this image instead of aborting
the migration.

Also adds a nice status message