### PR TITLE
Fixes use of Alchemy::Resource with namespaced models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 3.3.1 (unreleased)
+
+* Fix use of Alchemy::Resource with namespaced models (#729)
+
 ## 3.3.0 (2016-05-18)
 
 __New Features__

--- a/lib/alchemy/resource.rb
+++ b/lib/alchemy/resource.rb
@@ -117,10 +117,15 @@ module Alchemy
     end
 
     def namespaced_resource_name
-      return @_namespaced_resource_name unless @_namespaced_resource_name.nil?
-      resource_name_array = resource_array
-      resource_name_array.delete(engine_name) if in_engine?
-      @_namespaced_resource_name = resource_name_array.join('_').singularize
+      @_namespaced_resource_name ||= namespaced_resources_name.singularize
+    end
+
+    def namespaced_resources_name
+      @_namespaced_resources_name ||= begin
+        resource_name_array = resource_array.dup
+        resource_name_array.delete(engine_name) if in_engine?
+        resource_name_array.join('_')
+      end
     end
 
     def namespace_for_scope

--- a/lib/alchemy/resources_helper.rb
+++ b/lib/alchemy/resources_helper.rb
@@ -31,11 +31,11 @@ module Alchemy
       @_resource_scope ||= [resource_url_proxy].concat(resource_handler.namespace_for_scope)
     end
 
-    def resources_path(resource_or_name = resource_handler.resources_name, options = {})
+    def resources_path(resource_or_name = resource_handler.namespaced_resources_name, options = {})
       polymorphic_path (resource_scope + [resource_or_name]), options
     end
 
-    def resource_path(resource = resource_handler.resource_name, options = {})
+    def resource_path(resource = resource_handler.namespaced_resource_name, options = {})
       resources_path(resource, options)
     end
 

--- a/spec/libraries/resources_helper_spec.rb
+++ b/spec/libraries/resources_helper_spec.rb
@@ -65,14 +65,14 @@ describe Alchemy::ResourcesHelper do
       end
 
       it "uses resource_name when no object is given" do
-        expect(controller).to receive(:polymorphic_path).with(["main_app_proxy", "admin", "my_resource"], {})
+        expect(controller).to receive(:polymorphic_path).with(["main_app_proxy", "admin", "namespace_my_resource"], {})
         controller.resource_path
       end
     end
 
     describe "#resources_path" do
       it "invokes polymorphic-path with correct scope and resources_name" do
-        expect(controller).to receive(:polymorphic_path).with(["main_app_proxy", "admin", "my_resources"], {})
+        expect(controller).to receive(:polymorphic_path).with(["main_app_proxy", "admin", "namespace_my_resources"], {})
         controller.resources_path
       end
     end


### PR DESCRIPTION
When using a namespaced base model for an Alchemy module,
there used to be confusion as to how to name paths. This commit
assumes that the models namespaces will be used also in the controller
world, ie: If your model is "MySite::Party", your resource controller
will be called "Admin::MySite::PartiesController", and the respective path
helpers will be called "admin_my_site_parties_path" (and so on).

The Generator is not yet up to date with this.

Fixes #729