### PR TITLE
Make `has_tinymce?` resilient to missing essence.

### DIFF
--- a/app/models/alchemy/content.rb
+++ b/app/models/alchemy/content.rb
@@ -241,7 +241,7 @@ module Alchemy
     # Returns true if there is a tinymce setting defined on the content definiton
     # or if the +essence.has_tinymce?+ returns true.
     def has_tinymce?
-      settings[:tinymce].present? || essence.has_tinymce?
+      settings[:tinymce].present? || (essence.present? && essence.has_tinymce?)
     end
 
     # Returns true if there is a tinymce setting defined that contains settings.

--- a/spec/models/alchemy/content_spec.rb
+++ b/spec/models/alchemy/content_spec.rb
@@ -322,6 +322,14 @@ module Alchemy
 
         it { is_expected.to eq(true) }
       end
+
+      context 'having nil essence' do
+        before do
+          content.essence = nil
+        end
+
+        it { is_expected.to eq(false) }
+      end
     end
 
     describe '#has_custom_tinymce_config?' do


### PR DESCRIPTION
This ensures that the admin page still loads, and shows the "Missing essence"
error in the specific spot in the editor rather than a full page 500 error.