### PR TITLE
Fix inability to add nested elements on pages with cells.

### DIFF
--- a/app/views/alchemy/admin/elements/_new_element_form.html.erb
+++ b/app/views/alchemy/admin/elements/_new_element_form.html.erb
@@ -6,7 +6,7 @@
 <%- else -%>
   <%= alchemy_form_for [:admin, @element] do |form| %>
     <%= form.hidden_field :page_id %>
-  <%- if @page.can_have_cells? -%>
+  <%- if @page.can_have_cells? && @parent_element.blank? -%>
     <%= form.input :name,
       label: Alchemy.t(:element_of_type),
       collection: grouped_elements_for_select(@elements),


### PR DESCRIPTION
When a page has cells, the cell version of the new element form is always shown. The non-cell version should be shown when adding nested elements.