### PR TITLE
Fix selectCellForElement to respect nested elements DOM levels

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.element_editors.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.element_editors.js.coffee
@@ -72,7 +72,7 @@ Alchemy.ElementEditors =
   selectCellForElement: ($element) ->
     $cells = $("#cells .sortable_cell")
     if $cells.size() > 0
-      $cell = $element.parent(".sortable_cell")
+      $cell = $element.closest(".sortable_cell")
       $("#cells").tabs("option", "active", $cells.index($cell))
 
   # Marks an element as selected in the element window and scrolls to it.


### PR DESCRIPTION
### Overview
We recently switched over to `3.3-stable` and using the editor I noticed that some of the existing JavaScript is not compatible with the introduced nested elements

### Reproduce
1. Create or use an existing page with at least two Cells
2. Make sure the first Cell (e.g. `Main content`) has an element that allows adding nested elements
3. Add a nested element to any element in your `Main content` Cell.
4. See that after adding the element the last Cell (as in most right) gets selected

### Details
I had a look into why that happens on my fork. It seems like the existing JavaScript that is supposed to select a Cell for any given element can't deal with the (newly introduced) multiple levels of elements. It inspects the DOM only one level up (see [alchemy.element_editors.js.coffee](https://github.com/AlchemyCMS/alchemy_cms/blob/master/app/assets/javascripts/alchemy/alchemy.element_editors.js.coffee#L75)) which worked fine in the past.

I'm not 100% sure if there are any other situations where my fix would cause issues. But looking on the existing code it shouldn't make any difference to use `$.fn.closest`.