### PR TITLE
Allow setting the input type for EssenceText editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ when it is defined.
 * Send page expiration cache headers
 * Adds an +EssencePictureView+ class responsible for rendering the `essence_picture_view` partial
 * Adds a file type filter to file archive
+* Allow setting the type of EssenceText input fields in the elements.yml via `settings[:input_type]`
 
 __Notable Changes__
 

--- a/app/views/alchemy/essences/_essence_text_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_text_editor.html.erb
@@ -5,7 +5,8 @@
       content.form_field_name,
       content.ingredient,
       class: ["thin_border #{content.settings[:linkable] ? ' text_with_icon' : ''}", html_options[:class]].join(' '),
-      style: html_options[:style]
+      style: html_options[:style],
+      type: content.settings_value(:input_type) || "text"
     ) %>
     <% if content.settings[:linkable] %>
       <%= hidden_field_tag content.form_field_name(:link), content.essence.link %>

--- a/spec/views/essences/essence_text_editor_spec.rb
+++ b/spec/views/essences/essence_text_editor_spec.rb
@@ -4,6 +4,18 @@ describe 'alchemy/essences/_essence_text_editor' do
   let(:essence) { Alchemy::EssenceText.new(body: '1234') }
   let(:content) { Alchemy::Content.new(essence: essence) }
 
+  context 'with no input type set' do
+    before do
+      allow(view).to receive(:content_label).and_return("1e Zahl")
+      allow(content).to receive(:settings).and_return({})
+    end
+
+    it "renders an input field of type number" do
+      render partial: "alchemy/essences/essence_text_editor", locals: {content: content, options: {}, html_options: {}}
+      expect(rendered).to have_selector('input[type="text"]')
+    end
+  end
+
   context 'with a different input type set' do
     before do
       allow(view).to receive(:content_label).and_return("1e Zahl")

--- a/spec/views/essences/essence_text_editor_spec.rb
+++ b/spec/views/essences/essence_text_editor_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'alchemy/essences/_essence_text_editor' do
+  let(:essence) { Alchemy::EssenceText.new(body: '1234') }
+  let(:content) { Alchemy::Content.new(essence: essence) }
+
+  context 'with a different input type set' do
+    before do
+      allow(view).to receive(:content_label).and_return("1e Zahl")
+      allow(content).to receive(:settings).and_return({input_type: "number"})
+    end
+
+    it "renders an input field of type number" do
+      render partial: "alchemy/essences/essence_text_editor", locals: {content: content, options: {}, html_options: {}}
+      expect(rendered).to have_selector('input[type="number"]')
+    end
+  end
+end


### PR DESCRIPTION
Now you can set which input field type should be used
for a particular EssenceText. Good for colors,
telephone numbers, E-Mails.