### PR TITLE
Do not empty directory in generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ __Notable Changes__
   included with `Alchemy::ControllerActions` to prevent method clashes. If you
   need access to `current_ability` you also need to include `Alchemy::AbilityHelper`
 
+__Fixed Bugs__
+
+* Generators don't delete directories any more (#850)
+
 ## 3.3.1 (unreleased)
 
 * Fix use of Alchemy::Resource with namespaced models (#729)

--- a/lib/rails/generators/alchemy/elements/elements_generator.rb
+++ b/lib/rails/generators/alchemy/elements/elements_generator.rb
@@ -6,11 +6,6 @@ module Alchemy
       desc "This generator generates your elements view partials."
       source_root File.expand_path('templates', File.dirname(__FILE__))
 
-      def create_directory
-        @elements_dir = "#{Rails.root}/app/views/alchemy/elements"
-        empty_directory @elements_dir
-      end
-
       def create_partials
         @elements = load_alchemy_yaml('elements.yml')
         @elements.each do |element|
@@ -22,9 +17,15 @@ module Alchemy
             raise "Element name '#{element['name']}' has wrong format. Only lowercase and non whitespace characters allowed."
           end
 
-          conditional_template "editor.html.#{template_engine}", "#{@elements_dir}/_#{@element_name}_editor.html.#{template_engine}"
-          conditional_template "view.html.#{template_engine}", "#{@elements_dir}/_#{@element_name}_view.html.#{template_engine}"
+          conditional_template "editor.html.#{template_engine}", "#{elements_dir}/_#{@element_name}_editor.html.#{template_engine}"
+          conditional_template "view.html.#{template_engine}", "#{elements_dir}/_#{@element_name}_view.html.#{template_engine}"
         end if @elements
+      end
+
+      private
+
+      def elements_dir
+        @_elements_dir ||= "app/views/alchemy/elements"
       end
     end
   end

--- a/lib/rails/generators/alchemy/essence/essence_generator.rb
+++ b/lib/rails/generators/alchemy/essence/essence_generator.rb
@@ -9,19 +9,15 @@ module Alchemy
 
       def init
         @essence_name = essence_name.underscore
-        @essence_view_path = Rails.root.join('app/views/alchemy/essences')
+        @essence_view_path = 'app/views/alchemy/essences'
       end
 
       def create_model
         invoke("model", [@essence_name])
       end
 
-      def create_directory
-        empty_directory @essence_view_path
-      end
-
       def act_as_essence
-        essence_class_file = Rails.root.join('app/models', "#{@essence_name}.rb")
+        essence_class_file = "app/models/#{@essence_name}.rb"
         essence_class = @essence_name.classify
         inject_into_class essence_class_file, essence_class, <<-CLASSMETHOD
   acts_as_essence(

--- a/lib/rails/generators/alchemy/install/install_generator.rb
+++ b/lib/rails/generators/alchemy/install/install_generator.rb
@@ -12,12 +12,6 @@ module Alchemy
 
       source_root File.expand_path('files', File.dirname(__FILE__))
 
-      def create_view_dirs
-        %w(elements page_layouts).each do |dir|
-          empty_directory Rails.root.join("app/views/alchemy/#{dir}")
-        end
-      end
-
       def copy_config
         copy_file "#{config_path}/config.yml",
           Rails.root.join("config/alchemy/config.yml")

--- a/lib/rails/generators/alchemy/module/module_generator.rb
+++ b/lib/rails/generators/alchemy/module/module_generator.rb
@@ -19,11 +19,9 @@ module Alchemy
       end
 
       def copy_templates
-        empty_directory Rails.root.join("app/controllers/admin")
-
-        template "controller.rb.tt", Rails.root.join("app/controllers/admin/#{@controller_name}_controller.rb")
-        template "ability.rb.tt", Rails.root.join('app/models', "alchemy_#{@module_name}_ability.rb")
-        template "module_config.rb.tt", Rails.root.join("config/initializers/alchemy_#{@module_name}.rb")
+        template "controller.rb.tt", "app/controllers/admin/#{@controller_name}_controller.rb"
+        template "ability.rb.tt", 'app/models', "alchemy_#{@module_name}_ability.rb"
+        template "module_config.rb.tt", "config/initializers/alchemy_#{@module_name}.rb"
       end
     end
   end

--- a/lib/rails/generators/alchemy/page_layouts/page_layouts_generator.rb
+++ b/lib/rails/generators/alchemy/page_layouts/page_layouts_generator.rb
@@ -6,18 +6,19 @@ module Alchemy
       desc "This generator generates your page_layouts view partials."
       source_root File.expand_path('templates', File.dirname(__FILE__))
 
-      def create_directory
-        @page_layouts_dir = "#{Rails.root}/app/views/alchemy/page_layouts"
-        empty_directory @page_layouts_dir
-      end
-
       def create_partials
         @page_layouts = load_alchemy_yaml('page_layouts.yml')
         @page_layouts.each do |page_layout|
           next if page_layout['redirects_to_external']
           @page_layout_name = page_layout["name"].underscore
-          conditional_template "layout.html.#{template_engine}", "#{@page_layouts_dir}/_#{@page_layout_name}.html.#{template_engine}"
+          conditional_template "layout.html.#{template_engine}", "#{page_layouts_dir}/_#{@page_layout_name}.html.#{template_engine}"
         end if @page_layouts
+      end
+
+      private
+
+      def page_layouts_dir
+        @_page_layouts_dir ||= "app/views/alchemy/page_layouts"
       end
     end
   end

--- a/lib/rails/generators/alchemy/site_layouts/site_layouts_generator.rb
+++ b/lib/rails/generators/alchemy/site_layouts/site_layouts_generator.rb
@@ -6,17 +6,18 @@ module Alchemy
       desc "This generator generates your site layouts view partials."
       source_root File.expand_path('templates', File.dirname(__FILE__))
 
-      def create_directory
-        @site_layouts_dir = "#{Rails.root}/app/views/alchemy/site_layouts"
-        empty_directory @site_layouts_dir
-      end
-
       def create_partials
         @sites = Alchemy::Site.all
         @sites.each do |site|
           @site_name = site.name.parameterize.underscore
-          conditional_template "layout.html.#{template_engine}", "#{@site_layouts_dir}/_#{@site_name}.html.#{template_engine}"
+          conditional_template "layout.html.#{template_engine}", "#{site_layouts_dir}/_#{@site_name}.html.#{template_engine}"
         end if @sites
+      end
+
+      private
+
+      def site_layouts_dir
+        @_site_layouts_dir ||= "app/views/alchemy/site_layouts"
       end
     end
   end


### PR DESCRIPTION
Thor automatically creates a missing directory while copying files or templates.

By explicitly calling `empty_directory` we enforced to remove this directory on the reverse generator call `rails destroy alchemy:something`. This is dangerous in that we could remove files we don't to be removed.

Closes #850