### PR TITLE
Add tag management in admin module views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ when it is defined.
 * Adds a file type filter to file archive
 * Allow setting the type of EssenceText input fields in the elements.yml via `settings[:input_type]`
 * Adds support for defining custom searchable attributes in resources
+* Automatically add tag management to admin module views when the resource model has been set to `acts_as_taggable`.
 
 __Notable Changes__
 

--- a/app/controllers/alchemy/admin/resources_controller.rb
+++ b/app/controllers/alchemy/admin/resources_controller.rb
@@ -7,7 +7,7 @@ module Alchemy
     class ResourcesController < Alchemy::Admin::BaseController
       include Alchemy::ResourcesHelper
 
-      helper Alchemy::ResourcesHelper
+      helper Alchemy::ResourcesHelper, TagsHelper
       helper_method :resource_handler
 
       before_filter :load_resource,
@@ -20,9 +20,15 @@ module Alchemy
       def index
         @query = resource_handler.model.ransack(params[:q])
         items = @query.result
+
         if contains_relations?
           items = items.includes(*resource_relations_names)
         end
+
+        if params[:tagged_with].present?
+          items = items.tagged_with(params[:tagged_with])
+        end
+
         respond_to do |format|
           format.html {
             items = items.page(params[:page] || 1).per(per_page_value_for_screen_size)

--- a/app/views/alchemy/admin/resources/_form.html.erb
+++ b/app/views/alchemy/admin/resources/_form.html.erb
@@ -9,5 +9,11 @@
       <%= f.input attribute[:name], resource_attribute_field_options(attribute) %>
     <% end %>
   <% end %>
+  <% if f.object.respond_to?(:tag_list) %>
+    <div class="input string">
+      <%= f.label :tag_list %>
+      <%= render 'alchemy/admin/partials/autocomplete_tag_list', f: f %>
+    </div>
+  <% end %>
   <%= f.submit Alchemy.t(:save) %>
 <% end %>

--- a/app/views/alchemy/admin/resources/_tag_list.html.erb
+++ b/app/views/alchemy/admin/resources/_tag_list.html.erb
@@ -1,0 +1,16 @@
+<div class="<%= params[:tagged_with].present? ? 'tag-list filtered' : 'tag-list' %>">
+  <% p = params.dup %>
+  <h2><%= Alchemy.t("Filter by tag") %></h2>
+  <%= js_filter_field '.tag-list li' %>
+  <ul>
+    <%= render_tag_list(resource_model.name, p) %>
+  </ul>
+  <% if p[:tagged_with].present? %>
+    <%= link_to(
+      render_icon('delete-small') + Alchemy.t('Remove tag filter'),
+      url_for(p.delete_if { |k, v| k == "tagged_with" }.merge(action: 'index')),
+      remote: request.xhr?,
+      class: 'button small with_icon please_wait'
+    ) %>
+  <% end %>
+</div>

--- a/app/views/alchemy/admin/resources/index.html.erb
+++ b/app/views/alchemy/admin/resources/index.html.erb
@@ -26,7 +26,15 @@
   ]
 ) %>
 
-<div id="archive_all" class="resources-table-wrapper">
+<% resource_has_tags = resource_model.respond_to?(:tag_counts) && resource_model.tag_counts.any? %>
+
+<div id="archive_all" class="resources-table-wrapper<%= ' with_tag_filter' if resource_has_tags %>">
   <%= resources_header %>
   <%= render 'table' %>
+
+  <% if resource_has_tags %>
+    <div id="library_sidebar">
+      <%= render 'tag_list' %>
+    </div>
+  <% end %>
 </div>


### PR DESCRIPTION
As tags used on module resources are a very common pattern,
when the resource model has been set to `acts_as_taggable`,
this adds the following:

- an autocomplete tag field on the resource form
- a tag filter sidebar on the resource index view