### PR TITLE
Include attributes of type text to resource search

### DIFF
--- a/lib/alchemy/resource.rb
+++ b/lib/alchemy/resource.rb
@@ -90,6 +90,7 @@ module Alchemy
 
     DEFAULT_SKIPPED_ATTRIBUTES = %w(id updated_at created_at creator_id updater_id)
     DEFAULT_SKIPPED_ASSOCIATIONS = %w(creator updater)
+    SEARCHABLE_COLUMN_TYPES = [:string, :text]
 
     def initialize(controller_path, module_definition = nil, custom_model = nil)
       @controller_path = controller_path
@@ -160,10 +161,9 @@ module Alchemy
 
     # Returns all columns that are searchable
     #
-    # For now it only uses string type columns
-    #
     def searchable_attributes
-      attributes.select { |a| string_attribute?(a) } + searchable_relation_attributes?(attributes)
+      attributes.select { |a| searchable_attribute?(a) }
+        .concat(searchable_relation_attributes?(attributes))
     end
 
     # Search field input name
@@ -220,16 +220,17 @@ module Alchemy
 
     private
 
-    def string_attribute?(a)
-      a[:type].to_sym == :string && !a.key?(:relation)
+    def searchable_attribute?(a)
+      SEARCHABLE_COLUMN_TYPES.include?(a[:type].to_sym) && !a.key?(:relation)
     end
 
-    def string_attribute_on_relation?(a)
-      a.key?(:relation) && a[:relation][:attr_type].to_sym == :string
+    def searchable_attribute_on_relation?(a)
+      a.key?(:relation) &&
+        SEARCHABLE_COLUMN_TYPES.include?(a[:relation][:attr_type].to_sym)
     end
 
     def searchable_relation_attributes?(attrs)
-      attrs.select { |a| string_attribute_on_relation?(a) }.map { |a| searchable_relation_attribute(a) }
+      attrs.select { |a| searchable_attribute_on_relation?(a) }.map { |a| searchable_relation_attribute(a) }
     end
 
     def searchable_relation_attribute(a)

--- a/spec/libraries/resource_spec.rb
+++ b/spec/libraries/resource_spec.rb
@@ -42,7 +42,7 @@ module Alchemy
       [
         double(:column, {name: 'name', type: :string, array: false}),
         double(:column, {name: 'hidden_value', type: :string, array: false}),
-        double(:column, {name: 'description', type: :string, array: false}),
+        double(:column, {name: 'description', type: :text, array: false}),
         double(:column, {name: 'id', type: :integer, array: false}),
         double(:column, {name: 'starts_at', type: :datetime, array: false}),
         double(:column, {name: 'location_id', type: :integer, array: false}),
@@ -176,7 +176,7 @@ module Alchemy
         expect(subject).to eq([
           {name: "name", type: :string},
           {name: "hidden_value", type: :string},
-          {name: "description", type: :string},
+          {name: "description", type: :text},
           {name: "starts_at", type: :datetime},
           {name: "location_id", type: :integer},
           {name: "organizer_id", type: :integer}
@@ -232,11 +232,11 @@ module Alchemy
     describe "#searchable_attributes" do
       subject { resource.searchable_attributes }
 
-      it "returns all attributes of type string" do
+      it "returns all attributes of type string and text" do
         is_expected.to eq([
           {name: "name", type: :string},
           {name: "hidden_value", type: :string},
-          {name: "description", type: :string}
+          {name: "description", type: :text}
         ])
       end
 


### PR DESCRIPTION
Right now only the string attributes of a resource are searched
by the default search field.
This also includes the attributes of type text to the default search.

I'm not sure why this has been implemented like that before. Maybe for performance reasons. If you don't approve of my solution, I could also image a solution where the method `Alchemy::Resource#search_field_name` may be overridden by the module's resource. What do you think?

And of course I will be happy to write tests for the addition, once the direction is decided.