### PR TITLE
Adds feature to customize searchable attributes on a resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ when it is defined.
 * Adds an +EssencePictureView+ class responsible for rendering the `essence_picture_view` partial
 * Adds a file type filter to file archive
 * Allow setting the type of EssenceText input fields in the elements.yml via `settings[:input_type]`
+* Adds support for defining custom searchable attributes in resources
 
 __Notable Changes__
 

--- a/lib/alchemy/resource.rb
+++ b/lib/alchemy/resource.rb
@@ -44,6 +44,17 @@ module Alchemy
   #       %w(synced_at remote_record_id)
   #     end
   #
+  # == Searchable attributes
+  #
+  # By default all :text and :string based attributes are searchable in the admin interface.
+  # You can overwrite this behaviour by providing a set of attribute names that should be searchable instead.
+  #
+  # === Example
+  #
+  #    def self.searchable_alchemy_resource_attributes
+  #      %w(remote_record_id firstname lastname age)
+  #    end
+  #
   # == Resource relations
   #
   # Alchemy::Resource can take care of ActiveRecord relations.
@@ -159,19 +170,24 @@ module Alchemy
       attributes.reject { |h| restricted_attributes.map(&:to_s).include?(h[:name].to_s) }
     end
 
-    # Returns all columns that are searchable
+    # Returns all attribute names that are searchable in the admin interface
     #
-    def searchable_attributes
-      attributes.select { |a| searchable_attribute?(a) }
-        .concat(searchable_relation_attributes?(attributes))
+    def searchable_attribute_names
+      if model.respond_to?(:searchable_alchemy_resource_attributes)
+        model.searchable_alchemy_resource_attributes
+      else
+        attributes.select { |a| searchable_attribute?(a) }
+          .concat(searchable_relation_attributes?(attributes))
+          .collect { |h| h[:name] }
+      end
     end
 
     # Search field input name
     #
-    # Joins all searchable attributes into a Ransack compatible search query
+    # Joins all searchable attribute names into a Ransack compatible search query
     #
     def search_field_name
-      searchable_attributes.collect { |a| a[:name] }.join("_or_") + "_cont"
+      searchable_attribute_names.join("_or_") + "_cont"
     end
 
     def in_engine?

--- a/lib/alchemy/resource.rb
+++ b/lib/alchemy/resource.rb
@@ -177,7 +177,7 @@ module Alchemy
         model.searchable_alchemy_resource_attributes
       else
         attributes.select { |a| searchable_attribute?(a) }
-          .concat(searchable_relation_attributes?(attributes))
+          .concat(searchable_relation_attributes(attributes))
           .collect { |h| h[:name] }
       end
     end
@@ -245,7 +245,7 @@ module Alchemy
         SEARCHABLE_COLUMN_TYPES.include?(a[:relation][:attr_type].to_sym)
     end
 
-    def searchable_relation_attributes?(attrs)
+    def searchable_relation_attributes(attrs)
       attrs.select { |a| searchable_attribute_on_relation?(a) }.map { |a| searchable_relation_attribute(a) }
     end
 

--- a/spec/libraries/resource_spec.rb
+++ b/spec/libraries/resource_spec.rb
@@ -229,15 +229,23 @@ module Alchemy
       end
     end
 
-    describe "#searchable_attributes" do
-      subject { resource.searchable_attributes }
+    describe "#searchable_attribute_names" do
+      subject { resource.searchable_attribute_names }
 
-      it "returns all attributes of type string and text" do
-        is_expected.to eq([
-          {name: "name", type: :string},
-          {name: "hidden_value", type: :string},
-          {name: "description", type: :text}
-        ])
+      it "returns all attribute names of type string and text" do
+        is_expected.to eq(["name", "hidden_value", "description"])
+      end
+
+      context "when model provides custom defined searchable attribute names" do
+        before do
+          allow(Party).to receive(:searchable_alchemy_resource_attributes) do
+            %w(date venue age)
+          end
+        end
+
+        it "returns the custom defined attribute names from the model" do
+          is_expected.to eq(["date", "venue", "age"])
+        end
       end
 
       context "with an array attribute" do
@@ -249,7 +257,7 @@ module Alchemy
         end
 
         it "does not include this column" do
-          is_expected.to eq([{name: "name", type: :string}])
+          is_expected.to eq(["name"])
         end
       end
     end

--- a/spec/libraries/resource_spec.rb
+++ b/spec/libraries/resource_spec.rb
@@ -254,6 +254,14 @@ module Alchemy
       end
     end
 
+    describe "#search_field_name" do
+      subject { resource.search_field_name }
+
+      it "returns a ransack compatible search query" do
+        is_expected.to eq("name_or_hidden_value_or_description_cont")
+      end
+    end
+
     describe "#editable_attributes" do
       subject { resource.editable_attributes }
 

--- a/spec/libraries/resource_spec.rb
+++ b/spec/libraries/resource_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
-class Party
+class Party < ActiveRecord::Base
+  belongs_to :location
 end
 
 module Namespace1
@@ -245,6 +246,20 @@ module Alchemy
 
         it "returns the custom defined attribute names from the model" do
           is_expected.to eq(["date", "venue", "age"])
+        end
+      end
+
+      context "when model has a relation defined" do
+        before do
+          allow(Party).to receive(:alchemy_resource_relations) do
+            {
+              location: {attr_method: "name", attr_type: :string}
+            }
+          end
+        end
+
+        it "also includes the searchable attributes of the relation" do
+          is_expected.to eq(["name", "hidden_value", "description", "location_name"])
         end
       end
 


### PR DESCRIPTION
Example usage:

```
class Event < ActiveRecord::Base
  def self.searchable_alchemy_attributes
    %w(name date)
  end
end
```

Please see commit messages for further information.