### PR TITLE
Introduce automatical module scope filters in admin view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ when it is defined.
 * Adds a file type filter to file archive
 * Allow setting the type of EssenceText input fields in the elements.yml via `settings[:input_type]`
 * Adds support for defining custom searchable attributes in resources
-* Automatically add tag management to admin module views when the resource model has been set to `acts_as_taggable`.
+* Automatically add tag management to admin module views, when the resource model
+  has been set to `acts_as_taggable`.
+* Automatically add scope filters to admin module views, when the resource model
+  has the class method `alchemy_resource_filters` defined.
 
 __Notable Changes__
 

--- a/app/controllers/alchemy/admin/resources_controller.rb
+++ b/app/controllers/alchemy/admin/resources_controller.rb
@@ -29,6 +29,10 @@ module Alchemy
           items = items.tagged_with(params[:tagged_with])
         end
 
+        if params[:filter].present?
+          items = items.public_send(sanitized_filter_params)
+        end
+
         respond_to do |format|
           format.html {
             items = items.page(params[:page] || 1).per(per_page_value_for_screen_size)
@@ -118,6 +122,12 @@ module Alchemy
       #
       def resource_params
         params.require(resource_handler.namespaced_resource_name).permit!
+      end
+
+      def sanitized_filter_params
+        resource_model.alchemy_resource_filters.detect do |filter|
+          filter == params[:filter]
+        end || :all
       end
     end
   end

--- a/app/views/alchemy/admin/resources/_filter_bar.html.erb
+++ b/app/views/alchemy/admin/resources/_filter_bar.html.erb
@@ -1,0 +1,31 @@
+<% params_to_keep = [:tagged_with, :q] %>
+
+<div id="filter_bar">
+  <h2><%= Alchemy.t('Filter') %></h2>
+  <%= select_tag(
+    'resource_filter',
+    options_for_select(
+      resource_filter_select, params[:filter]
+    ),
+    include_blank: Alchemy.t(:all, scope: ['resources', resource_name, 'filters']),
+    data: { remote: !!request.xhr? },
+    class: 'alchemy_selectbox'
+  ) %>
+</div>
+
+<script type="text/javascript">
+  $(function() {
+    $('#resource_filter').on('change', function(e) {
+      var $this = $(this);
+      var url = '<%= resources_path(resource_handler.namespaced_resources_name, merge_params_only(params_to_keep)).html_safe %>';
+      if ($this.data('remote') === true) {
+        $.get(url, {filter: $this.val()}, null, 'script');
+      } else {
+        Alchemy.pleaseWaitOverlay();
+        delimiter = url.match(/\?/) ? '&' : '?';
+        window.location = url + delimiter + 'filter=' + encodeURIComponent($this.val());
+      }
+      return false;
+    });
+  });
+</script>

--- a/app/views/alchemy/admin/resources/index.html.erb
+++ b/app/views/alchemy/admin/resources/index.html.erb
@@ -26,15 +26,19 @@
   ]
 ) %>
 
-<% resource_has_tags = resource_model.respond_to?(:tag_counts) && resource_model.tag_counts.any? %>
-
-<div id="archive_all" class="resources-table-wrapper<%= ' with_tag_filter' if resource_has_tags %>">
+<div id="archive_all" class="resources-table-wrapper<%= ' with_tag_filter' if resource_has_tags || resource_has_filters %>">
   <%= resources_header %>
   <%= render 'table' %>
 
-  <% if resource_has_tags %>
+  <% if resource_has_tags || resource_has_filters %>
     <div id="library_sidebar">
-      <%= render 'tag_list' %>
+      <% if resource_has_filters %>
+        <%= render 'filter_bar' %>
+      <% end %>
+
+      <% if resource_has_tags %>
+        <%= render 'tag_list' %>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/lib/alchemy/resources_helper.rb
+++ b/lib/alchemy/resources_helper.rb
@@ -168,5 +168,22 @@ module Alchemy
         page: params[:page]
       }
     end
+
+    def resource_has_tags
+      resource_model.respond_to?(:tag_counts) && resource_model.tag_counts.any?
+    end
+
+    def resource_has_filters
+      resource_model.respond_to?(:alchemy_resource_filters)
+    end
+
+    def resource_filter_select
+      resource_model.alchemy_resource_filters.map do |filter_scope|
+        [
+          Alchemy.t(filter_scope.to_sym, scope: ['resources', resource_name, 'filters']),
+          filter_scope
+        ]
+      end
+    end
   end
 end


### PR DESCRIPTION
When a modules resource provides a `alchemy_resource_filters` class method providing
an array of strings, this will automatically show a select filter
with the strings as options that link to according scopes in the
module admin view.

**Example**
Given a module resource Event with the following code:

    class Event < ActiveRecord::Base
      def self.alchemy_resource_filters
        %w(released unreleased)
      end

      scope :released, -> { where(released: true) }
      scope :unreleased, -> { where(released: false) }
    end

The module admin view will show a select filter with the values
_all_, _released_ and _unreleased_ that link to the index page
with the according scope applied.