### PR TITLE
Remove default language scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ __Notable Changes__
   need access to `current_ability` you also need to include `Alchemy::AbilityHelper`
 * Asset manifests are now installed into `vendor/assets` folder in order to provide easy customization
   Please don't use alchemy/custom files any more. Instead require your customizations in the manifests.
+* Removes the default_scope from Language on_site current
 
 __Fixed Bugs__
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,9 @@ __Notable Changes__
   need access to `current_ability` you also need to include `Alchemy::AbilityHelper`
 * Asset manifests are now installed into `vendor/assets` folder in order to provide easy customization
   Please don't use alchemy/custom files any more. Instead require your customizations in the manifests.
-* Removes the default_scope from Language on_site current
+* Removes the default_scope from Language on_site current while ensuring to load languages by code
+  from current site only.
+* Removes the `Language.get_default` method alias for `Language.default`
 
 __Fixed Bugs__
 

--- a/app/models/alchemy/language.rb
+++ b/app/models/alchemy/language.rb
@@ -52,9 +52,10 @@ module Alchemy
     before_destroy :check_for_default
     after_destroy :delete_language_root_page
 
-    scope :published,      -> { where(public: true) }
-    scope :with_root_page, -> { joins(:pages).where(Page.table_name => {language_root: true}) }
-    scope :on_site,        ->(s) { s.present? ? where(site_id: s.id) : all }
+    scope :published,       -> { where(public: true) }
+    scope :with_root_page,  -> { joins(:pages).where(Page.table_name => {language_root: true}) }
+    scope :on_site,         ->(s) { s ? where(site_id: s.id) : all }
+    scope :on_current_site, -> { on_site(Site.current) }
 
     class << self
       # Store the current language in the current thread.
@@ -72,11 +73,10 @@ module Alchemy
         current.pages.language_roots.first
       end
 
-      # Default language
+      # Default language for current site
       def default
-        find_by(default: true)
+        on_current_site.find_by(default: true)
       end
-      alias_method :get_default, :default
     end
 
     def label(attrib)

--- a/app/models/alchemy/language.rb
+++ b/app/models/alchemy/language.rb
@@ -52,8 +52,6 @@ module Alchemy
     before_destroy :check_for_default
     after_destroy :delete_language_root_page
 
-    default_scope { on_site(Site.current) }
-
     scope :published,      -> { where(public: true) }
     scope :with_root_page, -> { joins(:pages).where(Page.table_name => {language_root: true}) }
     scope :on_site,        ->(s) { s.present? ? where(site_id: s.id) : all }

--- a/app/models/alchemy/language/code.rb
+++ b/app/models/alchemy/language/code.rb
@@ -13,7 +13,10 @@ module Alchemy::Language::Code
     def find_by_code(code)
       codes = code.split('-')
       codes << '' if codes.length == 1
-      find_by_language_code_and_country_code(*codes)
+      on_current_site.find_by(
+        language_code: codes[0],
+        country_code: codes[1]
+      )
     end
   end
 end

--- a/app/models/alchemy/site.rb
+++ b/app/models/alchemy/site.rb
@@ -44,6 +44,14 @@ module Alchemy
       "alchemy/site_layouts/#{partial_name}"
     end
 
+    # The default language for this site
+    #
+    # There can only be one default language per site.
+    #
+    def default_language
+      languages.find_by(default: true)
+    end
+
     class << self
       def current=(v)
         RequestStore.store[:alchemy_current_site] = v

--- a/spec/controllers/alchemy/admin/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/pages_controller_spec.rb
@@ -42,14 +42,12 @@ module Alchemy
         context 'without language root page' do
           before do
             expect(Language).to receive(:current_root_page).and_return(nil)
-            expect(Language).to receive(:find_by).and_return(language)
-            expect(Language).to receive(:all).and_return([language])
-            expect(Language).to receive(:with_root_page).and_return([language])
+            allow(Language).to receive(:current).and_return(language)
           end
 
           it "it assigns current language" do
             alchemy_get :index
-            expect(assigns(:language)).to be(language)
+            expect(assigns(:language)).to eq(language)
           end
         end
       end

--- a/spec/models/alchemy/language_spec.rb
+++ b/spec/models/alchemy/language_spec.rb
@@ -96,10 +96,67 @@ module Alchemy
       end
     end
 
+    describe '.default' do
+      let!(:site_1) do
+        create(:alchemy_site, host: 'site-one.com')
+      end
+
+      let!(:site_2) do
+        create(:alchemy_site, host: 'site-two.com')
+      end
+
+      let!(:default_language) do
+        site_2.default_language
+      end
+
+      subject do
+        Language.default
+      end
+
+      it 'returns the default language of current site' do
+        expect(Site).to receive(:current) { site_2 }
+        is_expected.to eq(default_language)
+      end
+    end
+
     describe '.find_by_code' do
-      context "with only the language code given" do
+      subject do
+        Language.find_by_code(code)
+      end
+
+      let(:code) do
+        language.language_code
+      end
+
+      it "should find the language by language code" do
+        is_expected.to eq(language)
+      end
+
+      context "with language code and country code given" do
+        let(:code) do
+          "#{language.language_code}-#{language.country_code}"
+        end
+
         it "should find the language" do
-          expect(Language.find_by_code(language.code)).to eq(language)
+          is_expected.to eq(language)
+        end
+      end
+
+      context "with multiple sites having languages with same code" do
+        let!(:current_site) do
+          create(:alchemy_site, host: 'other.com')
+        end
+
+        let!(:other_language) do
+          create(:alchemy_language, site: current_site, code: language.code)
+        end
+
+        before do
+          expect(Site).to receive(:current) { current_site }
+        end
+
+        it "loads the language from current site" do
+          is_expected.to eq(other_language)
         end
       end
     end

--- a/spec/models/alchemy/site_spec.rb
+++ b/spec/models/alchemy/site_spec.rb
@@ -154,5 +154,25 @@ module Alchemy
         expect(site.definition).to eq(definitions.first)
       end
     end
+
+    describe '#default_language' do
+      let(:default_language) do
+        site.default_language
+      end
+
+      let!(:other_language) do
+        create(:alchemy_language, site: site)
+      end
+
+      subject do
+        site.default_language
+      end
+
+      it 'returns the default language of site' do
+        expect(site.languages.count).to eq(2)
+        is_expected.to eq(default_language)
+        is_expected.to_not eq(other_language)
+      end
+    end
   end
 end

--- a/spec/models/alchemy/site_spec.rb
+++ b/spec/models/alchemy/site_spec.rb
@@ -78,18 +78,8 @@ module Alchemy
     end
 
     describe '.current' do
-      context 'when set to a site' do
-        before { Site.current = site }
-        specify "Language should be scoped to that site" do
-          expect(Language.all.to_sql).to match(/alchemy_languages.+site_id.+#{site.id}/)
-        end
-      end
-
       context 'when set to nil' do
         before { Site.current = nil }
-        specify "Language should not be scoped to a site" do
-          expect(Language.all.to_sql).not_to match(/alchemy_languages.+site_id.+#{site.id}/)
-        end
 
         it "should return default site" do
           expect(Site.current).not_to be_nil


### PR DESCRIPTION
The default_scope in language model causes errors when accessing the language of a page from another site then the current site. This happens if a user selects another site with the site select.

And as default_scopes are evil we remove this while ensuring that loading languages by code or beeing the default is always scope to the current site.

As this is actually a bug, we should consider to release this with 3.3.1 instead of with 3.4.0