### PR TITLE
Display locked pages ordered by `locked_at` time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ __Notable Changes__
 * Removes the `Language.get_default` method alias for `Language.default`
 * Move site select into pages and languages module to avoid confusion about curent site (#1067)
 * List pages from all sites in currently locked pages tabs and Dashboard widget (#1067)
+* The locked value on page is now a timestamp (`locked_at`), so we can order locked pages by (#1070)
 
 __Fixed Bugs__
 

--- a/app/controllers/alchemy/admin/base_controller.rb
+++ b/app/controllers/alchemy/admin/base_controller.rb
@@ -165,7 +165,7 @@ module Alchemy
       end
 
       def load_locked_pages
-        @locked_pages = Page.locked_by(current_alchemy_user)
+        @locked_pages = Page.locked_by(current_alchemy_user).order(:locked_at)
       end
 
       # Returns the current site for admin controllers.

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -17,7 +17,7 @@
 #  depth            :integer
 #  visible          :boolean          default(FALSE)
 #  public           :boolean          default(FALSE)
-#  locked           :boolean          default(FALSE)
+#  locked_at        :datetime
 #  locked_by        :integer
 #  restricted       :boolean          default(FALSE)
 #  robot_index      :boolean          default(TRUE)
@@ -47,7 +47,7 @@ module Alchemy
       visible: false,
       public_on: nil,
       public_until: nil,
-      locked: false,
+      locked_at: nil,
       locked_by: nil
     }
 
@@ -319,16 +319,16 @@ module Alchemy
     end
     alias_method :next_page, :next
 
-    # Locks the page to given user without updating the timestamps
+    # Locks the page to given user
     #
     def lock_to!(user)
-      update_columns(locked: true, locked_by: user.id)
+      update_columns(locked_at: Time.current, locked_by: user.id)
     end
 
     # Unlocks the page without updating the timestamps
     #
     def unlock!
-      if update_columns(locked: false, locked_by: nil)
+      if update_columns(locked_at: nil, locked_by: nil)
         Page.current_preview = nil
       end
     end

--- a/app/models/alchemy/page/page_natures.rb
+++ b/app/models/alchemy/page/page_natures.rb
@@ -42,6 +42,11 @@ module Alchemy
       !PageLayout.get(page_layout).nil? && !PageLayout.get(page_layout)["controller"].blank?
     end
 
+    # True if page locked_at timestamp and locked_by id are set
+    def locked?
+      locked_by? && locked_at?
+    end
+
     def controller_and_action
       if has_controller?
         {

--- a/app/models/alchemy/page/page_scopes.rb
+++ b/app/models/alchemy/page/page_scopes.rb
@@ -15,7 +15,7 @@ module Alchemy
 
       # All locked pages
       #
-      scope :locked, -> { where(locked: true) }
+      scope :locked, -> { where.not(locked_at: nil, locked_by: nil) }
 
       # All pages locked by given user
       #
@@ -27,7 +27,7 @@ module Alchemy
 
       # All not locked pages
       #
-      scope :not_locked, -> { where(locked: false) }
+      scope :not_locked, -> { where(locked_at: nil, locked_by: nil) }
 
       # All visible pages
       #

--- a/app/serializers/alchemy/page_tree_serializer.rb
+++ b/app/serializers/alchemy/page_tree_serializer.rb
@@ -57,7 +57,7 @@ module Alchemy
         page_layout: page.page_layout,
         slug: page.slug,
         redirects_to_external: page.redirects_to_external?,
-        locked: page.locked,
+        locked: page.locked?,
         definition_missing: page.definition.blank?,
         urlname: page.urlname,
         external_urlname: page.external_urlname,

--- a/app/views/alchemy/admin/layoutpages/_layoutpage.html.erb
+++ b/app/views/alchemy/admin/layoutpages/_layoutpage.html.erb
@@ -1,5 +1,5 @@
 <li class="page_level_<%= layoutpage.level %>" id="page_<%= layoutpage.id %>">
-  <div class="sitemap_page<%= layoutpage.locked ? ' locked' : '' %>">
+  <div class="sitemap_page<%= layoutpage.locked? ? ' locked' : '' %>">
     <div class="sitemap_left_images">
     <% if layoutpage.definition.blank? %>
       <span class="inline warning icon" title="<%= Alchemy.t(:page_definition_missing) %>"></span>

--- a/db/migrate/20160617224938_change_alchemy_pages_locked_to_locked_at.rb
+++ b/db/migrate/20160617224938_change_alchemy_pages_locked_to_locked_at.rb
@@ -1,0 +1,22 @@
+class ChangeAlchemyPagesLockedToLockedAt < ActiveRecord::Migration
+  def up
+    add_column :alchemy_pages, :locked_at, :datetime
+    update <<-SQL.strip_heredoc
+      UPDATE alchemy_pages
+      SET locked_at = updated_at
+      WHERE locked=#{ActiveRecord::Base.connection.quoted_true}
+    SQL
+    remove_column :alchemy_pages, :locked
+    add_index :alchemy_pages, [:locked_at, :locked_by]
+  end
+
+  def down
+    add_column :alchemy_pages, :locked, :boolean
+    update <<-SQL.strip_heredoc
+      UPDATE alchemy_pages
+      SET locked=#{ActiveRecord::Base.connection.quoted_true}
+      WHERE locked_at IS NOT NULL
+    SQL
+    remove_column :alchemy_pages, :locked_at
+  end
+end

--- a/lib/alchemy/test_support/factories/page_factory.rb
+++ b/lib/alchemy/test_support/factories/page_factory.rb
@@ -47,5 +47,10 @@ FactoryGirl.define do
       name "Restricted page"
       restricted true
     end
+
+    trait :locked do
+      locked_at { Time.current }
+      locked_by { SecureRandom.random_number(1_000_000_000) }
+    end
   end
 end

--- a/spec/controllers/alchemy/admin/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/pages_controller_spec.rb
@@ -540,7 +540,7 @@ module Alchemy
 
         context 'if page is locked by myself' do
           before do
-            expect_any_instance_of(Page).to receive(:locker).and_return(user)
+            expect_any_instance_of(Page).to receive(:locker).at_least(:once) { user }
             expect(user).to receive(:logged_in?).and_return(true)
           end
 
@@ -548,11 +548,16 @@ module Alchemy
             alchemy_get :edit, id: page.id
             expect(response).to render_template(:edit)
           end
+
+          it 'does not lock the page again' do
+            expect_any_instance_of(Alchemy::Page).to_not receive(:lock_to!)
+            alchemy_get :edit, id: page.id
+          end
         end
 
         context 'if page is not locked' do
           before do
-            expect_any_instance_of(Page).to receive(:locker).and_return(nil)
+            expect_any_instance_of(Page).to receive(:locker).at_least(:once) { nil }
           end
 
           it 'renders the edit view' do

--- a/spec/dummy/db/migrate/20160617224938_change_alchemy_pages_locked_to_locked_at.rb
+++ b/spec/dummy/db/migrate/20160617224938_change_alchemy_pages_locked_to_locked_at.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20160617224938_change_alchemy_pages_locked_to_locked_at.rb

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160422195310) do
+ActiveRecord::Schema.define(version: 20160617224938) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string   "name"
@@ -222,7 +222,6 @@ ActiveRecord::Schema.define(version: 20160422195310) do
     t.integer  "parent_id"
     t.integer  "depth"
     t.boolean  "visible",          default: false
-    t.boolean  "locked",           default: false
     t.integer  "locked_by"
     t.boolean  "restricted",       default: false
     t.boolean  "robot_index",      default: true
@@ -238,9 +237,11 @@ ActiveRecord::Schema.define(version: 20160422195310) do
     t.datetime "published_at"
     t.datetime "public_on"
     t.datetime "public_until"
+    t.datetime "locked_at"
   end
 
   add_index "alchemy_pages", ["language_id"], name: "index_pages_on_language_id"
+  add_index "alchemy_pages", ["locked_at", "locked_by"], name: "index_alchemy_pages_on_locked_at_and_locked_by"
   add_index "alchemy_pages", ["parent_id", "lft"], name: "index_pages_on_parent_id_and_lft"
   add_index "alchemy_pages", ["public_on", "public_until"], name: "index_alchemy_pages_on_public_on_and_public_until"
   add_index "alchemy_pages", ["urlname"], name: "index_pages_on_urlname"

--- a/spec/helpers/alchemy/admin/pages_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/pages_helper_spec.rb
@@ -9,7 +9,7 @@ describe Alchemy::Admin::PagesHelper do
   end
 
   describe '#combined_page_status' do
-    let(:page) { build_stubbed(:alchemy_page, :public, :restricted, visible: true, locked: true) }
+    let(:page) { build_stubbed(:alchemy_page, :public, :restricted, :locked, visible: true) }
     subject { helper.combined_page_status(page) }
 
     context 'when page is locked' do


### PR DESCRIPTION
In order to ensure the exact order of locked pages tabs we order them by the time they got locked.

This prevents the UI from being jumpy and confusing to the user. Without an explicit order the database can't ensure us exact ordering.