### PR TITLE
Fix alchemy_language factory to use the right site factory

### DIFF
--- a/lib/alchemy/test_support/factories/language_factory.rb
+++ b/lib/alchemy/test_support/factories/language_factory.rb
@@ -9,7 +9,7 @@ FactoryGirl.define do
     frontpage_name 'Intro'
     page_layout { Alchemy::Config.get(:default_language)['page_layout'] }
     public true
-    site { Alchemy::Site.first || FactoryGirl.create(:site) }
+    site { Alchemy::Site.first || FactoryGirl.create(:alchemy_site) }
 
     trait :klingon do
       name 'Klingon'


### PR DESCRIPTION
There must have been slipped one `site` when namespacing the factories.