### PR TITLE
Use relative url for page preview frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ __Fixed Bugs__
 
 * Generators don't delete directories any more (#850)
 
+## 3.3.2 (unreleased)
+
+* Use relative url for page preview frame in order to prevent cross origin errors (#1076)
+
 ## 3.3.1 (2016-06-20)
 
 * Fix use of Alchemy::Resource with namespaced models (#729)

--- a/app/views/alchemy/admin/pages/edit.html.erb
+++ b/app/views/alchemy/admin/pages/edit.html.erb
@@ -117,7 +117,7 @@
     });
     Alchemy.Sitemap.watchPagePublicationState();
     Alchemy.PageLeaveObserver();
-    Alchemy.PreviewWindow.init('<%= admin_page_url(@page) %>');
+    Alchemy.PreviewWindow.init('<%= admin_page_path(@page) %>');
     Alchemy.ElementsWindow.init('<%= alchemy.admin_elements_path(page_id: @page.id) %>', {
       texts: {
         title: '<%= Alchemy.t("Elements") %>',

--- a/spec/features/admin/page_editing_feature_spec.rb
+++ b/spec/features/admin/page_editing_feature_spec.rb
@@ -10,6 +10,13 @@ describe 'Page editing feature' do
       visit alchemy.edit_admin_page_path(a_page)
       expect(page).to_not have_selector('#publish_page_form')
     end
+
+    describe "the preview frame", :js do
+      it "has relative url" do
+        visit alchemy.edit_admin_page_path(a_page)
+        expect(page).to have_selector("iframe[src='#{admin_page_path(a_page)}']")
+      end
+    end
   end
 
   context 'as editor' do


### PR DESCRIPTION
In order to prevent cross origin errors with multiple sites we
need to use a relative url for the preview frame.