### PR TITLE
Introduce new first_published_at page attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ __Notable Changes__
 * List pages from all sites in currently locked pages tabs and Dashboard widget (#1067)
 * The locked value on page is now a timestamp (`locked_at`), so we can order locked pages by (#1070)
 * Persist user in dummy app
+* When publishing a page with the publish button, `Page#public_on` does not get
+  reset to the current time when it is already set and in the past, and
+  `Page#public_until` does not get nilled when it is in the future.
 
 __Fixed Bugs__
 

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -115,7 +115,7 @@ module Alchemy
       unless: :systempage?
 
     before_save :set_published_at,
-      if: -> { public? && published_at.nil? },
+      if: -> { public_on.present? && published_at.nil? },
       unless: :systempage?
 
     before_create :set_language_from_parent_or_default,
@@ -382,8 +382,8 @@ module Alchemy
       current_time = Time.current
       update_columns(
         published_at: current_time,
-        public_on: current_time,
-        public_until: nil
+        public_on: already_public_for?(current_time) ? public_on : current_time,
+        public_until: still_public_for?(current_time) ? public_until : nil
       )
     end
 


### PR DESCRIPTION
As described in https://github.com/AlchemyCMS/alchemy_cms/issues/1085, people might be interested in when a page has been first published.
Right now the `published_at` attribute only stores the last time the
page has been published.
In analogy to the `created_at`/ `updated_at` timestamps this introduces
a `first_published_at` timestamp to keep the record of this event.

This might be helpful, if you want to order your pages by initial
publication date.