### PR TITLE
Add complete uploads folder to git ignore template

### DIFF
--- a/bin/alchemy
+++ b/bin/alchemy
@@ -113,7 +113,7 @@ EOF
       <<-GITIGNORE
 
 # Ignore Alchemy uploads folder
-uploads/*
+/uploads
 
 # Ignore sensitive data
 config/database.yml
@@ -123,7 +123,6 @@ GITIGNORE
     `
       cd #{@application}
       mkdir -p ./uploads
-      touch ./uploads/.gitkeep
     `
   end
 


### PR DESCRIPTION
The alchemy installer executable only ignored the contents
of the uploads folder and even adds a .gitkeep into it.

As since https://github.com/AlchemyCMS/capistrano-alchemy/pull/13
we symlink the complete uploads folder, we should not to keep it in the
repository at all.