### PR TITLE
Fix table width for resources on small window sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ __Notable Changes__
 
 __Fixed Bugs__
 
+* Fix table width for attachments and resources on small window sizes.
 * Generators don't delete directories any more (#850)
 
 ## 3.3.2 (unreleased)

--- a/app/assets/stylesheets/alchemy/frame.scss
+++ b/app/assets/stylesheets/alchemy/frame.scss
@@ -155,11 +155,22 @@ div#overlay_text_box {
   padding-bottom: 60px;
 
   &.with_tag_filter {
-    padding-right: 230px;
+
+    table {
+      padding-right: 230px;
+    }
+
+    > .info {
+      margin-right: 230px;
+    }
   }
 
   &.resources-table-wrapper {
     padding-top: 47px;
+
+    > table {
+      padding-bottom: 60px;
+    }
   }
 }
 


### PR DESCRIPTION
When having a filter or tag bar, the table width is set so that
you can't scroll horizontally to the edit and delete buttons.
This fixes it.

Before (please notice the scroll bar already having scrolled to the left max):
![Before](https://cloud.githubusercontent.com/assets/1218622/17216928/e6a43d9a-54e2-11e6-90ce-13b0591b7f03.png)


After:
![After](https://cloud.githubusercontent.com/assets/1218622/17216873/b1d3cec8-54e2-11e6-9b65-fb73d6abcc95.png)