### PR TITLE
Properly escape preview text on update

### DIFF
--- a/app/views/alchemy/admin/elements/update.js.erb
+++ b/app/views/alchemy/admin/elements/update.js.erb
@@ -6,7 +6,7 @@
 <%- if @element_validated -%>
 
   $errors.hide();
-  $el.trigger('SaveElement.Alchemy', {previewText: '<%= sanitize(@element.preview_text) %>'});
+  $el.trigger('SaveElement.Alchemy', {previewText: '<%= j sanitize(@element.preview_text) %>'});
   Alchemy.growl('<%= Alchemy.t(:element_saved) %>');
   Alchemy.PreviewWindow.refresh(function() {
     Alchemy.ElementEditors.selectElementInPreview(<%= @element.id %>);


### PR DESCRIPTION
Since the `preview_text` can contain `\r` (as `&#13;`) and `\n`, it can break
the JS response that places the new preview text. That results in an
unresponsive admin view although the content was saved successfully.

This happens for example in EssenceRichtext with a short headline,
followed by a newline.