### PR TITLE
Keep filter and tag scope when editing resource

### DIFF
--- a/lib/alchemy/resources_helper.rb
+++ b/lib/alchemy/resources_helper.rb
@@ -165,7 +165,9 @@ module Alchemy
     def current_location_params
       {
         q: params[:q],
-        page: params[:page]
+        page: params[:page],
+        tagged_with: params[:tagged_with],
+        filter: params[:filter]
       }
     end
 

--- a/spec/features/admin/resources_integration_spec.rb
+++ b/spec/features/admin/resources_integration_spec.rb
@@ -156,8 +156,14 @@ describe "Resources" do
         end
       end
 
-      it "filters the events when clicking a tag" do
+      it "filters the events when clicking a tag", aggregate_failures: true do
         click_link "Matinee"
+        expect(page).to have_content("Casablanca")
+        expect(page).to_not have_content("Die Hard IX")
+
+        # Keep the tags when editing an event
+        click_link "Edit"
+        click_button "Save"
         expect(page).to have_content("Casablanca")
         expect(page).to_not have_content("Die Hard IX")
       end
@@ -196,6 +202,13 @@ describe "Resources" do
       expect(page).to_not have_content("Horse Expo")
 
       visit "/admin/events?filter=future"
+      expect(page).to     have_content("Hovercar Expo")
+      expect(page).to_not have_content("Car Expo")
+      expect(page).to_not have_content("Horse Expo")
+
+      # Keep the filter when editing an event
+      click_link "Edit"
+      click_button "Save"
       expect(page).to     have_content("Hovercar Expo")
       expect(page).to_not have_content("Car Expo")
       expect(page).to_not have_content("Horse Expo")

--- a/spec/libraries/resources_helper_spec.rb
+++ b/spec/libraries/resources_helper_spec.rb
@@ -176,14 +176,24 @@ describe Alchemy::ResourcesHelper do
   end
 
   describe '#current_location_params' do
-    let(:params) { {q: "some_query", page: 6, action: "some_action"} }
+    let(:params) do
+      {
+        q: "some_query",
+        page: 6,
+        action: "some_action",
+        filter: "some_filter",
+        tagged_with: "some_tag"
+      }
+    end
 
     before do
       allow(controller).to receive(:params) { params }
     end
 
     it 'returns the current location params' do
-      expect(controller.current_location_params).to eq({q: "some_query", page: 6})
+      expect(controller.current_location_params).to eq(
+        {q: "some_query", page: 6, filter: "some_filter", tagged_with: "some_tag"}
+      )
     end
 
     it 'only includes the q and page parameters' do


### PR DESCRIPTION
https://github.com/AlchemyCMS/alchemy_cms/pull/1053 and
https://github.com/AlchemyCMS/alchemy_cms/pull/1057 introduced
automatical resource filters and tags. When filtering the resource
and editing, the filter has not been kept after save.

This changes it, so the filters and tags are kept.