### PR TITLE
Enable use of Turbolinks 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
 sudo: false
-cache: bundler
+cache:
+  bundler: true
+  directories:
+    - "travis_phantomjs"
 rvm:
 - 2.1
 - 2.2
@@ -8,7 +11,15 @@ rvm:
 branches:
   only:
     - master
+
 before_install:
+  - "phantomjs --version"
+  - "export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH"
+  - "phantomjs --version"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then wget https://assets.membergetmember.co/software/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
+  - "phantomjs --version"
   - gem install bundler
 before_script: bundle exec rake alchemy:spec:prepare
 script: bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ __Notable Changes__
 * The view helpers `preview_mode_code`, `render_meta_data`, `render_meta_tag`, `render_page_title`, `render_title_tag` are now deprecated. (#1110)
 * An easy way to include several edit mode related partials is now available (#1120):
   `render 'alchemy/edit_mode'` loads `menubar` and `preview_mode_code` at once
+* Add support for Turbolinks 5.0 (#1095)
 
 __Fixed Bugs__
 

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ group :development, :test do
   gem 'capybara', '~> 2.4'
   gem 'database_cleaner', '~> 1.3'
   gem 'factory_girl_rails', '~> 4.5'
-  gem 'poltergeist', '~> 1.5'
+  gem 'poltergeist', '~> 1.10'
   gem 'rspec-activemodel-mocks', '~> 1.0'
   gem 'rspec-rails', '~> 3.0'
   gem 'shoulda-matchers', '~> 3.1'

--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'responders',                       ['~> 2.0']
   gem.add_runtime_dependency 'select2-rails',                    ['>= 3.5.9.1', '< 4.0']
   gem.add_runtime_dependency 'simple_form',                      ['~> 3.0']
-  gem.add_runtime_dependency 'turbolinks',                       ['~> 2.5']
+  gem.add_runtime_dependency 'turbolinks',                       ['>= 2.5']
 
   gem.post_install_message = <<-MSG
 -------------------------------------------------------------

--- a/app/assets/javascripts/alchemy/alchemy.initializer.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.initializer.js.coffee
@@ -55,16 +55,18 @@ Alchemy.Initializer = ->
     scrollingTop: 122,
     zIndex: 1
 
-# Enabling the Turbolinks Progress Bar
-Turbolinks.enableProgressBar()
+# Enabling the Turbolinks Progress Bar for v2.5
+Turbolinks.enableProgressBar() if Turbolinks.enableProgressBar
 
-# Turbolinks DOM Ready
-$(document).on 'page:change', ->
+# Turbolinks DOM Ready.
+# Handle both v2.5(page:change), and v.5.0 (turbolinks:load)
+$(document).on 'page:change turbolinks:load', ->
   Alchemy.Initializer()
   return
 
 # Turbolinks before parsing a new page
-$(document).on 'page:receive', ->
+# Handle both v2.5(page:receive), and v.5.0 (turbolinks:request-end)
+$(document).on 'page:receive turbolinks:request-end', ->
   # Ensure that all tinymce editors get removed before parsing a new page
   Alchemy.Tinymce.removeFrom $('.has_tinymce')
   return

--- a/app/assets/javascripts/alchemy/alchemy.tinymce.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.tinymce.js.coffee
@@ -77,6 +77,7 @@ $.extend Alchemy.Tinymce,
   # Remove all tinymce instances for given selector
   removeFrom: (selector) ->
     $(selector).each ->
-      tinymce.get(this.id).remove()
+      elem = tinymce.get(this.id)
+      elem.remove() if elem
       return
     return

--- a/app/assets/stylesheets/alchemy/base.scss
+++ b/app/assets/stylesheets/alchemy/base.scss
@@ -1,7 +1,8 @@
 html {
   height: 100%;
 
-  &.turbolinks-progress-bar::before {
+  &.turbolinks-progress-bar::before,
+  .turbolinks-progress-bar {
     background-color: $blue !important;
     height: 3px !important;
     z-index: 400001;

--- a/app/views/alchemy/admin/pages/edit.html.erb
+++ b/app/views/alchemy/admin/pages/edit.html.erb
@@ -107,6 +107,11 @@
 <% if Alchemy::Tinymce.custom_config_contents(@page).present? %>
   <%= render 'tinymce_custom_config' %>
 <% end %>
+
+<% content_for :javascript_includes do %>
+  <meta name="turbolinks-cache-control" content="no-cache">
+<% end %>
+
 <script type="text/javascript" charset="utf-8">
 
   $(function() {


### PR DESCRIPTION
- Allow for events from both Turbolinks 2.5 and 5.0 to be handled correctly
- Fixes back button problem as of current when used with Turbolinks 2.5

addresses #939