### PR TITLE
Check if user language is of type String or Symbol, fixes #1097

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ __Notable Changes__
 
 * The essence view partials don't get cached anymore (#1099)
 
+__Fixed Bugs__
+
+* Fix setting of locale when `current_alchemy_user.language` doesn't return a Symbol (#1097)
+
 ## 3.4.0 (2016-08-02)
 
 __New Features__

--- a/lib/alchemy/admin/locale.rb
+++ b/lib/alchemy/admin/locale.rb
@@ -38,15 +38,15 @@ module Alchemy
       #  * the locale of the browser
       #
       def available_locale
-        locales = [params[:admin_locale], locale_from_user, locale_from_browser].compact
-        locales.detect { |locale| ::I18n.available_locales.include?(locale.to_sym) }
+        locales = [params[:admin_locale], locale_from_user, locale_from_browser].compact.map(&:to_sym)
+        locales.detect { |locale| ::I18n.available_locales.include?(locale) }
       end
 
       # Try to get the locale from user settings.
       def locale_from_user
         return if !current_alchemy_user
         if user_has_preferred_language?
-          current_alchemy_user.language.to_sym
+          current_alchemy_user.language
         end
       end
 

--- a/lib/alchemy/admin/locale.rb
+++ b/lib/alchemy/admin/locale.rb
@@ -46,7 +46,7 @@ module Alchemy
       def locale_from_user
         return if !current_alchemy_user
         if user_has_preferred_language?
-          current_alchemy_user.language
+          current_alchemy_user.language.to_sym
         end
       end
 
@@ -55,7 +55,7 @@ module Alchemy
         return if !current_alchemy_user
         current_alchemy_user.respond_to?(:language) &&
           current_alchemy_user.language.present? &&
-          [String, Symbol].include?(current_alchemy_user.language.class)
+          current_alchemy_user.language.respond_to?(:to_sym)
       end
 
       # Try to get the locale from browser headers.

--- a/lib/alchemy/admin/locale.rb
+++ b/lib/alchemy/admin/locale.rb
@@ -54,7 +54,8 @@ module Alchemy
       def user_has_preferred_language?
         return if !current_alchemy_user
         current_alchemy_user.respond_to?(:language) &&
-          current_alchemy_user.language.present?
+          current_alchemy_user.language.present? &&
+          [String, Symbol].include?(current_alchemy_user.language.class)
       end
 
       # Try to get the locale from browser headers.

--- a/spec/features/admin/translation_spec.rb
+++ b/spec/features/admin/translation_spec.rb
@@ -46,6 +46,28 @@ describe "Translation integration" do
           expect(page).to have_content('Bienvenido')
         end
       end
+
+      context "if user language is an instance of a model" do
+        let(:language) { create(:alchemy_language) }
+        let(:dummy_user) { mock_model(Alchemy.user_class, alchemy_roles: %w(admin), language: language) }
+
+        context "if language doesn't return a valid locale symbol" do
+          it "should use the browsers language setting" do
+            page.driver.header 'ACCEPT-LANGUAGE', 'es-ES'
+            visit admin_dashboard_path
+            expect(page).to have_content('Bienvenido')
+          end
+        end
+
+        context "if language returns a valid locale symbol" do
+          before { allow(language).to receive(:to_sym).and_return(:nl) }
+
+          it "should use the locale of the user language" do
+            visit admin_dashboard_path
+            expect(page).to have_content('Welkom')
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
We check if the return of `current_alchemy_user.language` is valid. 
Like this we ensure to not break any existing setups, for example alchemy-devise. 