### PR TITLE
Do not cache the essence view partials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 3.5.0 (unreleased)
 
+__Notable Changes__
+
+* The essence view partials don't get cached anymore (#1099)
+
 ## 3.4.0 (2016-08-02)
 
 __New Features__

--- a/app/views/alchemy/essences/_essence_boolean_view.html.erb
+++ b/app/views/alchemy/essences/_essence_boolean_view.html.erb
@@ -1,3 +1,1 @@
-<%- cache(content) do -%>
 <%= Alchemy.t(content.ingredient) -%>
-<%- end -%>

--- a/app/views/alchemy/essences/_essence_date_view.html.erb
+++ b/app/views/alchemy/essences/_essence_date_view.html.erb
@@ -1,4 +1,3 @@
-<%- cache(content) do -%>
 <%- date_format = content.settings_value(:date_format,
   local_assigns.fetch(:options, {})) -%>
 <%- if content.ingredient.present? -%>
@@ -6,6 +5,5 @@
 <%= content.ingredient.to_s(:rfc822) %>
 <%- else -%>
 <%= l(content.ingredient, format: date_format) %>
-<%- end -%>
 <%- end -%>
 <%- end -%>

--- a/app/views/alchemy/essences/_essence_file_view.html.erb
+++ b/app/views/alchemy/essences/_essence_file_view.html.erb
@@ -1,4 +1,3 @@
-<%- cache(content) do -%>
 <%- if attachment = content.ingredient -%>
 <%= link_to(
   content.essence.link_text.presence ||
@@ -12,5 +11,4 @@
   class: content.essence.css_class.presence,
   title: content.essence.title.presence
 ) -%>
-<%- end -%>
 <%- end -%>

--- a/app/views/alchemy/essences/_essence_html_view.html.erb
+++ b/app/views/alchemy/essences/_essence_html_view.html.erb
@@ -1,3 +1,1 @@
-<% cache(content) do %>
 <%= raw content.ingredient -%>
-<% end %>

--- a/app/views/alchemy/essences/_essence_link_view.html.erb
+++ b/app/views/alchemy/essences/_essence_link_view.html.erb
@@ -1,4 +1,3 @@
-<%- cache(content) do -%>
 <%- if content.ingredient.present? -%>
 <%- html_options = {
   target: content.essence.link_target == "blank" ? "_blank" : nil
@@ -6,6 +5,5 @@
 <%= link_to(content.ingredient, html_options) do -%>
 <%= content.settings_value(:text, local_assigns.fetch(:options, {})) ||
   content.ingredient -%>
-<%- end -%>
 <%- end -%>
 <%- end -%>

--- a/app/views/alchemy/essences/_essence_picture_view.html.erb
+++ b/app/views/alchemy/essences/_essence_picture_view.html.erb
@@ -1,7 +1,5 @@
-<% cache(content) do %>
 <%= Alchemy::EssencePictureView.new(
   content,
   local_assigns[:options],
   local_assigns[:html_options]
 ).render %>
-<% end %>

--- a/app/views/alchemy/essences/_essence_richtext_view.html.erb
+++ b/app/views/alchemy/essences/_essence_richtext_view.html.erb
@@ -1,5 +1,3 @@
-<%- cache(content) do -%>
 <%- options = local_assigns.fetch(:options, {}) -%>
 <%- plain_text = !!content.settings_value(:plain_text, options) -%>
-<%= raw content.essence.send(plain_text ? :stripped_body : :body) -%>
-<%- end -%>
+<%= raw content.essence.public_send(plain_text ? :stripped_body : :body) -%>

--- a/app/views/alchemy/essences/_essence_select_view.html.erb
+++ b/app/views/alchemy/essences/_essence_select_view.html.erb
@@ -1,3 +1,1 @@
-<% cache(content) do %>
 <%= content.ingredient %>
-<% end %>

--- a/app/views/alchemy/essences/_essence_text_view.html.erb
+++ b/app/views/alchemy/essences/_essence_text_view.html.erb
@@ -1,4 +1,3 @@
-<%- cache(content) do -%>
 <%- options = local_assigns.fetch(:options, {}) -%>
 <%- html_options = local_assigns.fetch(:html_options, {}) -%>
 <%- if content.essence.link.blank? ||
@@ -14,5 +13,4 @@
     'data-link-target' => content.essence.link_target
   }.merge(html_options)
 ) -%>
-<%- end -%>
 <%- end -%>


### PR DESCRIPTION
Caching the essence view partials does not make any sense, when the element is already cached. The essence views has no complex computation or DB queries, but lots of moving parts (`html_options`, `options`).

Caching them is more harmful then helpful.