### PR TITLE
Only update expanded elements with essence selects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ __Notable Changes__
 __Fixed Bugs__
 
 * Fix setting of locale when `current_alchemy_user.language` doesn't return a Symbol (#1097)
+* Only update elements with essence selects that are expanded (#1101)
 
 ## 3.4.0 (2016-08-02)
 

--- a/app/helpers/alchemy/admin/elements_helper.rb
+++ b/app/helpers/alchemy/admin/elements_helper.rb
@@ -103,14 +103,17 @@ module Alchemy
       #
       # In cases like this one wants Ember.js databinding!
       #
-      def update_essence_select_elements(page, element)
-        elements = page.elements.not_trashed.joins(:contents)
-          .where(["#{Content.table_name}.element_id != ?", element.id])
-          .where(Content.table_name => {essence_type: "Alchemy::EssenceSelect"})
+      def update_essence_select_elements(element)
+        elements = Element.not_trashed.expanded.joins(:contents)
+          .where(page_id: element.page_id)
+          .where.not(Content.table_name => {element_id: element.id})
+          .merge(Content.essence_selects).distinct
+
         return if elements.blank?
+
         elements.collect do |el|
           render 'alchemy/admin/elements/refresh_editor', element: el
-        end.join.html_safe
+        end.join
       end
 
       # CSS classes for the element editor partial.

--- a/app/views/alchemy/admin/elements/_refresh_editor.js.erb
+++ b/app/views/alchemy/admin/elements/_refresh_editor.js.erb
@@ -1,8 +1,10 @@
 <%- rtfs = element.richtext_contents_ids -%>
-(function() {
-  var $element = $('#element_<%= element.id %>_content');
-  Alchemy.Tinymce.remove(<%= rtfs.to_json %>);
-  $element.html('<%= j render_editor(element) %>');
-  Alchemy.GUI.init($element);
-  Alchemy.Tinymce.init(<%= rtfs.to_json %>);
-})();
+
+  // Refreshing element editors with essence selects
+  (function() {
+    var $element = $('#element_<%= element.id %>_content');
+    Alchemy.Tinymce.remove(<%= rtfs.to_json %>);
+    $element.html('<%= j render_editor(element) %>');
+    Alchemy.GUI.init($element);
+    Alchemy.Tinymce.init(<%= rtfs.to_json %>);
+  })();

--- a/app/views/alchemy/admin/elements/create.js.erb
+++ b/app/views/alchemy/admin/elements/create.js.erb
@@ -47,5 +47,5 @@
   $('#clipboard_button .icon.clipboard').removeClass('full');
 <%- end -%>
 
-  <%= update_essence_select_elements(@page, @element) -%>
+  <%== update_essence_select_elements(@element) -%>
 })();

--- a/app/views/alchemy/admin/elements/trash.js.erb
+++ b/app/views/alchemy/admin/elements/trash.js.erb
@@ -8,5 +8,5 @@ $('#element_<%= @element.id %>').hide(200, function() {
   <% @element.richtext_contents_ids.each do |id| %>
   tinymce.get('tinymce_<%= id %>').remove();
   <% end %>
-  <%= update_essence_select_elements(@page, @element) -%>
+  <%== update_essence_select_elements(@element) -%>
 });

--- a/app/views/alchemy/admin/elements/update.js.erb
+++ b/app/views/alchemy/admin/elements/update.js.erb
@@ -11,7 +11,7 @@
   Alchemy.PreviewWindow.refresh(function() {
     Alchemy.ElementEditors.selectElementInPreview(<%= @element.id %>);
   });
-  <%= update_essence_select_elements(@page, @element) -%>
+  <%== update_essence_select_elements(@element) -%>
 
 <%- else -%>
 

--- a/spec/helpers/alchemy/admin/elements_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/elements_helper_spec.rb
@@ -310,5 +310,60 @@ module Alchemy
         end
       end
     end
+
+    describe "#update_essence_select_elements" do
+      let!(:element) do
+        create(:alchemy_element, page: create(:alchemy_page))
+      end
+
+      let!(:folded_element) do
+        create(:alchemy_element,
+          name: 'contactform',
+          folded: true,
+          page: element.page,
+          create_contents_after_create: true)
+      end
+
+      let!(:trashed_element) do
+        el = create(:alchemy_element,
+          name: 'contactform',
+          page: element.page,
+          create_contents_after_create: true)
+        el.trash!
+        el
+      end
+
+      let!(:select_element) do
+        create(:alchemy_element,
+          name: 'contactform',
+          page: element.page,
+          create_contents_after_create: true)
+      end
+
+      let!(:element_from_another_page) do
+        create(:alchemy_element,
+          name: 'contactform',
+          create_contents_after_create: true)
+      end
+
+      let!(:non_select_element) do
+        create(:alchemy_element,
+          name: 'article',
+          page: element.page,
+          create_contents_after_create: true)
+      end
+
+      it 'updates all other elements on the same page that are' \
+         'not folded, not trashed and have essence selects', :aggregate_failures do
+        result = update_essence_select_elements(element)
+
+        expect(result).to have_content("$('#element_#{select_element.id}_content');")
+        expect(result).to_not have_content("$('#element_#{element.id}_content');")
+        expect(result).to_not have_content("$('#element_#{folded_element.id}_content');")
+        expect(result).to_not have_content("$('#element_#{trashed_element.id}_content');")
+        expect(result).to_not have_content("$('#element_#{non_select_element.id}_content');")
+        expect(result).to_not have_content("$('#element_#{element_from_another_page.id}_content');")
+      end
+    end
   end
 end


### PR DESCRIPTION
If we save an element we need to update elements that have essence selects in them, because maybe this select references the updated element. A very rare case, but unfortunately we need to take care.

In order to make this fast and only when these conditions are met:

1. The element needs to be on the same page
2. The element needs to be expanded (not folded)
3. The element must not be trashed
4. The element needs to have at least one essence select

I hope we can remove this in a future version, but without a reference to an element we can't know if an element needs to be updated or not.