### PR TITLE
Removes update_essence_select_elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 __Notable Changes__
 
 * The essence view partials don't get cached anymore (#1099)
+* Removes update_essence_select_elements (#1103)
 
 __Fixed Bugs__
 

--- a/app/helpers/alchemy/admin/elements_helper.rb
+++ b/app/helpers/alchemy/admin/elements_helper.rb
@@ -94,25 +94,6 @@ module Alchemy
         end
       end
 
-      # This helper loads all elements from page that have EssenceSelects in them.
-      #
-      # It returns a javascript function that replaces all editor partials of this elements.
-      #
-      # We need this while updating, creating or trashing an element,
-      # because another element on the same page could have a element selector in it.
-      #
-      # In cases like this one wants Ember.js databinding!
-      #
-      def update_essence_select_elements(page, element)
-        elements = page.elements.not_trashed.joins(:contents)
-          .where(["#{Content.table_name}.element_id != ?", element.id])
-          .where(Content.table_name => {essence_type: "Alchemy::EssenceSelect"})
-        return if elements.blank?
-        elements.collect do |el|
-          render 'alchemy/admin/elements/refresh_editor', element: el
-        end.join.html_safe
-      end
-
       # CSS classes for the element editor partial.
       def element_editor_classes(element, local_assigns)
         [

--- a/app/views/alchemy/admin/elements/_refresh_editor.js.erb
+++ b/app/views/alchemy/admin/elements/_refresh_editor.js.erb
@@ -1,8 +1,0 @@
-<%- rtfs = element.richtext_contents_ids -%>
-(function() {
-  var $element = $('#element_<%= element.id %>_content');
-  Alchemy.Tinymce.remove(<%= rtfs.to_json %>);
-  $element.html('<%= j render_editor(element) %>');
-  Alchemy.GUI.init($element);
-  Alchemy.Tinymce.init(<%= rtfs.to_json %>);
-})();

--- a/app/views/alchemy/admin/elements/create.js.erb
+++ b/app/views/alchemy/admin/elements/create.js.erb
@@ -46,6 +46,4 @@
 <%- if @clipboard.blank? -%>
   $('#clipboard_button .icon.clipboard').removeClass('full');
 <%- end -%>
-
-  <%= update_essence_select_elements(@page, @element) -%>
 })();

--- a/app/views/alchemy/admin/elements/trash.js.erb
+++ b/app/views/alchemy/admin/elements/trash.js.erb
@@ -8,5 +8,4 @@ $('#element_<%= @element.id %>').hide(200, function() {
   <% @element.richtext_contents_ids.each do |id| %>
   tinymce.get('tinymce_<%= id %>').remove();
   <% end %>
-  <%= update_essence_select_elements(@page, @element) -%>
 });

--- a/app/views/alchemy/admin/elements/update.js.erb
+++ b/app/views/alchemy/admin/elements/update.js.erb
@@ -11,7 +11,6 @@
   Alchemy.PreviewWindow.refresh(function() {
     Alchemy.ElementEditors.selectElementInPreview(<%= @element.id %>);
   });
-  <%= update_essence_select_elements(@page, @element) -%>
 
 <%- else -%>
 
@@ -22,5 +21,4 @@
   Alchemy.Buttons.enable($el);
 
 <%- end -%>
-
 })();


### PR DESCRIPTION
See #1101 why we decided to remove this code without replacement.

This will actually speed up saving elements for lots of people.

The rare case, where an essence_select on the same page references the updated element needs to be solved in a better manner.