### PR TITLE
Use datetimepicker for datetime fields in admin resource forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ __Notable Changes__
 
 * The essence view partials don't get cached anymore (#1099)
 * Removes update_essence_select_elements (#1103)
+* The admin resource form now uses the datetime-picker instead of the date-picker for datetime fields.
 
 __Fixed Bugs__
 

--- a/lib/alchemy/resources_helper.rb
+++ b/lib/alchemy/resources_helper.rb
@@ -96,8 +96,10 @@ module Alchemy
       when 'date', 'datetime'
         options.merge as: 'string',
           input_html: {
-            type: 'date',
-            value: l(resource_instance_variable.send(attribute[:name]) || Time.current, format: :datepicker)
+            type: attribute[:type].to_s,
+            value: l(resource_instance_variable.send(attribute[:name]) || Time.current,
+              format: "#{attribute[:type]}picker".to_sym
+            )
           }
       when 'time'
         options.merge(as: 'time')

--- a/spec/features/admin/resources_integration_spec.rb
+++ b/spec/features/admin/resources_integration_spec.rb
@@ -37,7 +37,7 @@ describe "Resources" do
     it "renders an input field according to the attribute's type" do
       visit '/admin/events/new'
       expect(page).to have_selector('input#event_name[type="text"]')
-      expect(page).to have_selector('input#event_starts_at[type="date"]')
+      expect(page).to have_selector('input#event_starts_at[type="datetime"]')
       expect(page).to have_selector('textarea#event_description')
       expect(page).to have_selector('input#event_published[type="checkbox"]')
       expect(page).to have_selector('input#event_lunch_starts_at_1i[type="hidden"]')


### PR DESCRIPTION
This introduces that the newly introduced datetime-picker will also be used for admin resource forms.