### PR TITLE
Ignore the require_ssl setting in development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 3.4.1 (unreleased)
 
+__Notable Changes__
+
+* `require_ssl` setting is now ignored in development mode
+
 __Fixed Bugs__
 
 * Remove trailing new lines in the AddImageFileFormatToAlchemyPictures migration. If you migrated already,

--- a/lib/alchemy/ssl_protection.rb
+++ b/lib/alchemy/ssl_protection.rb
@@ -19,7 +19,7 @@ module Alchemy
     # if you want to use the ssl protection.
     #
     def ssl_required?
-      !Rails.env.test? && Config.get(:require_ssl)
+      %w(development test).exclude?(Rails.env) && Config.get(:require_ssl)
     end
 
     # Redirects current request to https.


### PR DESCRIPTION
As most development servers don't support SSL anyway and it can get
tedious to set/unset require_ssl in development mode, just ignore it
entirely. It was already ignored in test mode before.