### PR TITLE
Ignore the require_ssl setting in development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ __Notable Changes__
 * The essence view partials don't get cached anymore (#1099)
 * Removes update_essence_select_elements (#1103)
 * The admin resource form now uses the datetime-picker instead of the date-picker for datetime fields.
+* `require_ssl` setting is now ignored in development mode
 
 __Fixed Bugs__
 

--- a/lib/alchemy/ssl_protection.rb
+++ b/lib/alchemy/ssl_protection.rb
@@ -19,7 +19,7 @@ module Alchemy
     # if you want to use the ssl protection.
     #
     def ssl_required?
-      !Rails.env.test? && Config.get(:require_ssl)
+      %w(development test).exclude?(Rails.env) && Config.get(:require_ssl)
     end
 
     # Redirects current request to https.


### PR DESCRIPTION
As most development servers don't support SSL anyway and it can get
tedious to set/unset require_ssl in development mode, just ignore it
entirely. It was already ignored in test mode before.