### PR TITLE
Don't overwrite DEFAULT_OPTIONS in EssencePictureView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ __Fixed Bugs__
 * Fix setting of locale when `current_alchemy_user.language` doesn't return a Symbol (#1097)
 * Remove trailing new lines in the AddImageFileFormatToAlchemyPictures migration. If you migrated already,
   use the `alchemy:upgrade:fix_picture_format` rake task.
+* Don't overwrite the fallback options when rendering a picture
 
 ## 3.4.0 (2016-08-02)
 

--- a/app/models/alchemy/essence_picture_view.rb
+++ b/app/models/alchemy/essence_picture_view.rb
@@ -14,7 +14,7 @@ module Alchemy
 
     def initialize(content, options = {}, html_options = {})
       @content = content
-      @options = DEFAULT_OPTIONS.update(content.settings).update(options)
+      @options = DEFAULT_OPTIONS.merge(content.settings).merge(options)
       @html_options = html_options
       @essence = content.essence
       @picture = essence.picture

--- a/spec/models/alchemy/essence_picture_view_spec.rb
+++ b/spec/models/alchemy/essence_picture_view_spec.rb
@@ -138,4 +138,19 @@ describe Alchemy::EssencePictureView, type: :model do
       end
     end
   end
+
+  context "with multiple instances" do
+    let(:options) do
+      {}
+    end
+
+    subject(:picture_view) do
+      Alchemy::EssencePictureView.new(content, options)
+    end
+
+    it "does not overwrite DEFAULT_OPTIONS" do
+      Alchemy::EssencePictureView.new(content, {my_custom_option: true})
+      expect(picture_view.options).to_not have_key(:my_custom_option)
+    end
+  end
 end


### PR DESCRIPTION
Previously invoking EssencePictureView.new would update
`EssencePictureView::DEFAULT_OPTIONS` and therefore all later pictures had
wrong `DEFAULT_OPTIONS`. That led to problems when those later pictures
had not explicitly set the options. The spec should make it clear what
happens. Ultimatively you could end up with images in the wrong
resolutions or formats.