### PR TITLE
Fixes the views generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ __Fixed Bugs__
   use the `alchemy:upgrade:fix_picture_format` rake task.
 * Don't overwrite the fallback options when rendering a picture
 
+## 3.4.1 (unreleased)
+
+__Fixed Bugs__
+
+* Fixes the messages mailer views generator (#1118)
+
 ## 3.4.0 (2016-08-02)
 
 __New Features__

--- a/lib/rails/generators/alchemy/views/views_generator.rb
+++ b/lib/rails/generators/alchemy/views/views_generator.rb
@@ -3,7 +3,7 @@ require 'rails'
 module Alchemy
   module Generators
     class ViewsGenerator < ::Rails::Generators::Base
-      ALCHEMY_VIEWS = %w(breadcrumb language_links messages navigation)
+      ALCHEMY_VIEWS = %w(breadcrumb language_links messages_mailer navigation)
 
       desc "Generates Alchemy views for #{ALCHEMY_VIEWS.to_sentence}."
 


### PR DESCRIPTION
In 591ec53efb1676cc1b1d15f7655f9cd211dccdc7 we renamed the messages mailer into messages_mailer to follow the rails naming convention. We forgot to also adjust the views generator.