### PR TITLE
Fixes name of alchemy_preview_mode_code helper

### DIFF
--- a/app/helpers/alchemy/deprecated_pages_helper.rb
+++ b/app/helpers/alchemy/deprecated_pages_helper.rb
@@ -3,8 +3,8 @@ module Alchemy
     # All these helper methods are deprecated.
     # They are mixed into Alchemy::PagesHelper but will be removed in the future.
 
-    def preview_mode_code
-      ActiveSupport::Deprecation.warn('PageHelper `preview_mode_code` is deprecated and will be removed with Alchemy v4.0. Please use `render "alchemy/preview_mode_code"` in your layout instead.')
+    def alchemy_preview_mode_code
+      ActiveSupport::Deprecation.warn('PageHelper `alchemy_preview_mode_code` is deprecated and will be removed with Alchemy v4.0. Please use `render "alchemy/preview_mode_code"` in your layout instead.')
       render "alchemy/preview_mode_code"
     end
 


### PR DESCRIPTION
In 40cec4cfb00150125047b08f56462fbcd64ded51 we accidentally renamed the `alchemy_preview_mode_code` helper into `preview_mode_code`.