### PR TITLE
Adds an edit_mode partial for easy preview mode access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ __Notable Changes__
 * The `preview_mode_code` helper is moved to a partial in `alchemy/preview_mode_code`. (#1110)
 * The `render_meta_data` helper is moved to a partial in `alchemy/pages/meta_data` and can be rendered with the same options as before but now passed in as locals. (#1110)
 * The view helpers `preview_mode_code`, `render_meta_data`, `render_meta_tag`, `render_page_title`, `render_title_tag` are now deprecated. (#1110)
+* An easy way to include several edit mode related partials is now available (#1120):
+  `render 'alchemy/edit_mode'` loads `menubar` and `preview_mode_code` at once
 
 __Fixed Bugs__
 

--- a/app/views/alchemy/_edit_mode.html.erb
+++ b/app/views/alchemy/_edit_mode.html.erb
@@ -1,0 +1,2 @@
+<%= render 'alchemy/menubar' %>
+<%= render "alchemy/preview_mode_code" %>

--- a/app/views/alchemy/_menubar.html.erb
+++ b/app/views/alchemy/_menubar.html.erb
@@ -1,4 +1,4 @@
-<% if !@preview_mode && can?(:edit_content, @page) %>
+<% if !@preview_mode && @page && can?(:edit_content, @page) %>
   <div id="alchemy_menubar" style="display: none">
     <ul>
       <li><%= link_to Alchemy.t(:to_alchemy), alchemy.admin_dashboard_url %></li>

--- a/lib/rails/generators/alchemy/install/files/application.html.erb
+++ b/lib/rails/generators/alchemy/install/files/application.html.erb
@@ -8,7 +8,6 @@
 </head>
 <body>
   <%= yield %>
-  <%= render "alchemy/preview_mode_code" %>
-  <%= render "alchemy/menubar" %>
+  <%= render "alchemy/edit_mode" %>
 </body>
 </html>

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -11,7 +11,6 @@
   <div id="navigation">
     <%= render_navigation(:all_sub_menues => true) %>
   </div>
-  <%= render "alchemy/preview_mode_code" %>
-  <%= render "alchemy/menubar" %>
+  <%= render "alchemy/edit_mode" %>
 </body>
 </html>


### PR DESCRIPTION
An easy way to include several edit mode related partials:

`render 'alchemy/edit_mode'` loads 

* `menubar`
* `preview_mode_code`

partials at once