### PR TITLE
New menu layout

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.initializer.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.initializer.js.coffee
@@ -15,8 +15,8 @@ Alchemy.Initializer = ->
     Alchemy.Growler.fade()
 
   # Add observer for please wait overlay.
-  $('a.please_wait, #main_navi a.main_navi_entry, div.button_with_label form :submit, #sub_navigation .subnavi_tab a, .pagination a')
-    .not('*[data-alchemy-confirm], #locked_pages .subnavi_tab button')
+  $('.please_wait, #main_navi a, .button_with_label form :submit, .locked_page a, .pagination a')
+    .not('*[data-alchemy-confirm], .locked_page button')
     .click ->
       unless Alchemy.isPageDirty()
         Alchemy.pleaseWaitOverlay()

--- a/app/assets/javascripts/alchemy/alchemy.preview_window.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.preview_window.js.coffee
@@ -2,8 +2,6 @@ window.Alchemy = {} if typeof(window.Alchemy) is 'undefined'
 
 Alchemy.PreviewWindow =
   MIN_WIDTH: 240
-  MINIMIZED_WIDTH: 149 # Main menu width - border
-  MAXIMIZED_WIDTH: 549 # Main menu width - border + element window width
   HEIGHT: 75 # Top menu height
 
   init: (url) ->
@@ -18,12 +16,8 @@ Alchemy.PreviewWindow =
     @resize()
 
   resize: ->
-    $window = $(window)
-    if Alchemy.ElementsWindow.hidden
-      width = $window.width() - @MINIMIZED_WIDTH
-    else
-      width = $window.width() - @MAXIMIZED_WIDTH
-    height = $window.height() - @HEIGHT
+    width = @_calculateWidth()
+    height = $(window).height() - @HEIGHT
     width = @MIN_WIDTH if width < @MIN_WIDTH
     @currentWidth = width
     @currentWindow.css
@@ -57,6 +51,12 @@ Alchemy.PreviewWindow =
       @refresh()
     $reload.click =>
       @refresh()
+
+  _calculateWidth: ->
+    width = $(window).width() - $('#left_menu').width()
+    unless Alchemy.ElementsWindow.hidden
+      width -= $('#alchemy_elements_window').width()
+    return width
 
 Alchemy.reloadPreview = ->
   Alchemy.PreviewWindow.refresh()

--- a/app/assets/javascripts/alchemy/alchemy.preview_window.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.preview_window.js.coffee
@@ -1,6 +1,10 @@
 window.Alchemy = {} if typeof(window.Alchemy) is 'undefined'
 
 Alchemy.PreviewWindow =
+  MIN_WIDTH: 240
+  MINIMIZED_WIDTH: 149 # Main menu width - border
+  MAXIMIZED_WIDTH: 549 # Main menu width - border + element window width
+  HEIGHT: 75 # Top menu height
 
   init: (url) ->
     $iframe = $("<iframe name=\"alchemy_preview_window\" src=\"#{url}\" id=\"alchemy_preview_window\" frameborder=\"0\"/>")
@@ -16,11 +20,11 @@ Alchemy.PreviewWindow =
   resize: ->
     $window = $(window)
     if Alchemy.ElementsWindow.hidden
-      width = $window.width() - 64
+      width = $window.width() - @MINIMIZED_WIDTH
     else
-      width = $window.width() - 466
-    height = $window.height() - 73
-    width = 240 if width < 240
+      width = $window.width() - @MAXIMIZED_WIDTH
+    height = $window.height() - @HEIGHT
+    width = @MIN_WIDTH if width < @MIN_WIDTH
     @currentWidth = width
     @currentWindow.css
       width: width

--- a/app/assets/stylesheets/alchemy/_extends.scss
+++ b/app/assets/stylesheets/alchemy/_extends.scss
@@ -87,7 +87,7 @@
 }
 
 %gradiated-toolbar {
-  background: $medium-gray;
+  background: $toolbar-bg-color;
   padding: 8px 4px;
   height: 29px;
 }

--- a/app/assets/stylesheets/alchemy/_mixins.scss
+++ b/app/assets/stylesheets/alchemy/_mixins.scss
@@ -187,3 +187,10 @@
   cursor: -moz-zoom-in;
   cursor: zoom-in;
 }
+
+@mixin truncate($max-width, $display: inline-block) {
+  display: $display;
+  max-width: $max-width;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/app/assets/stylesheets/alchemy/_variables.scss
+++ b/app/assets/stylesheets/alchemy/_variables.scss
@@ -62,4 +62,5 @@ $sitemap-line-height: 24px;
 
 $main-menu-width: 150px !default;
 $collapsed-main-menu-width: 48px !default;
+$main-menu-bg-color: $light-blue !default;
 $main-menu-active-bg-color: #baced9 !default;

--- a/app/assets/stylesheets/alchemy/_variables.scss
+++ b/app/assets/stylesheets/alchemy/_variables.scss
@@ -66,6 +66,7 @@ $collapsed-main-menu-width: 48px !default;
 $main-menu-bg-color: #baced9 !default;
 $main-menu-active-bg-color: $light-blue !default;
 $main-menu-text-color: #222 !default;
+$main-menu-entry-max-width: 100px !default;
 $toolbar-bg-color: $medium-gray !default;
 $header-height: 29px !default;
 $text-shadow-light: rgba($white, 0.5) 0 0 4px !default;

--- a/app/assets/stylesheets/alchemy/_variables.scss
+++ b/app/assets/stylesheets/alchemy/_variables.scss
@@ -59,3 +59,5 @@ $error_background_color: #efd3d3;
 $form-left-width: 35%;
 $form-right-width: 65%;
 $sitemap-line-height: 24px;
+
+$main-menu-width: 150px !default;

--- a/app/assets/stylesheets/alchemy/_variables.scss
+++ b/app/assets/stylesheets/alchemy/_variables.scss
@@ -61,4 +61,5 @@ $form-right-width: 65%;
 $sitemap-line-height: 24px;
 
 $main-menu-width: 150px !default;
+$collapsed-main-menu-width: 48px !default;
 $main-menu-active-bg-color: #baced9 !default;

--- a/app/assets/stylesheets/alchemy/_variables.scss
+++ b/app/assets/stylesheets/alchemy/_variables.scss
@@ -69,3 +69,5 @@ $main-menu-text-color: #222 !default;
 $toolbar-bg-color: $medium-gray !default;
 $header-height: 29px !default;
 $text-shadow-light: rgba($white, 0.5) 0 0 4px !default;
+$transition-duration: 200ms !default;
+$transition-easing: linear !default;

--- a/app/assets/stylesheets/alchemy/_variables.scss
+++ b/app/assets/stylesheets/alchemy/_variables.scss
@@ -61,3 +61,4 @@ $form-right-width: 65%;
 $sitemap-line-height: 24px;
 
 $main-menu-width: 150px !default;
+$main-menu-active-bg-color: #baced9 !default;

--- a/app/assets/stylesheets/alchemy/_variables.scss
+++ b/app/assets/stylesheets/alchemy/_variables.scss
@@ -1,4 +1,5 @@
 $text-color: #333333;
+$muted-text-color: rgba(0, 0, 0, 0.5);
 $light-blue: #cddce5; // #c6dbe7
 $blue: darken($light-blue, 15%);
 $very-light-blue: lighten($light-blue, 12%);
@@ -62,5 +63,9 @@ $sitemap-line-height: 24px;
 
 $main-menu-width: 150px !default;
 $collapsed-main-menu-width: 48px !default;
-$main-menu-bg-color: $light-blue !default;
-$main-menu-active-bg-color: #baced9 !default;
+$main-menu-bg-color: #baced9 !default;
+$main-menu-active-bg-color: $light-blue !default;
+$main-menu-text-color: #222 !default;
+$toolbar-bg-color: $medium-gray !default;
+$header-height: 29px !default;
+$text-shadow-light: rgba($white, 0.5) 0 0 4px !default;

--- a/app/assets/stylesheets/alchemy/admin.scss
+++ b/app/assets/stylesheets/alchemy/admin.scss
@@ -6,6 +6,7 @@
 
 @import "alchemy/defaults";
 @import "alchemy/archive";
+@import "alchemy/navigation";
 @import "alchemy/base";
 @import "alchemy/buttons";
 @import "alchemy/dialogs";

--- a/app/assets/stylesheets/alchemy/archive.scss
+++ b/app/assets/stylesheets/alchemy/archive.scss
@@ -6,7 +6,7 @@ div#image_assign_filter_and_image_sizing {
 #picture_archive {
 
   .selected_item_tools {
-    margin: -4*$default-padding;
+    margin: -2*$default-padding;
     border-bottom: 1px solid $default-border-color;
     margin-bottom: 4*$default-padding;
     padding: 4*$default-padding;

--- a/app/assets/stylesheets/alchemy/base.scss
+++ b/app/assets/stylesheets/alchemy/base.scss
@@ -523,6 +523,10 @@ div.browse {
   background: #fff;
   border-right: $default-border;
   @include transition(200ms ease-in-out);
+
+  .collapsed-menu & {
+    left: $collapsed-main-menu-width;
+  }
 }
 
 #error_trace {

--- a/app/assets/stylesheets/alchemy/base.scss
+++ b/app/assets/stylesheets/alchemy/base.scss
@@ -53,7 +53,7 @@ h1 {
     position: fixed;
     width: 100%;
     top: 75px;
-    left: 74px;
+    left: $main-menu-width + 9px;
     z-index: 2;
     margin: 0 -8px;
     padding: 16px;
@@ -515,12 +515,13 @@ div.browse {
 #alchemy_preview_window {
   box-sizing: border-box;
   position: absolute;
-  left: 66px;
-  top: 73px;
+  left: $main-menu-width;
+  top: 75px;
   width: auto;
   height: auto;
   border: 0 none;
   background: #fff;
+  border-right: $default-border;
   @include transition(200ms ease-in-out);
 }
 

--- a/app/assets/stylesheets/alchemy/dashboard.scss
+++ b/app/assets/stylesheets/alchemy/dashboard.scss
@@ -1,6 +1,6 @@
 #dashboard {
   overflow: auto;
-  padding: 4 * $default-padding;
+  padding: 4*$default-padding 2*$default-padding;
   width: 100%;
   position: relative;
   box-sizing: border-box;

--- a/app/assets/stylesheets/alchemy/frame.scss
+++ b/app/assets/stylesheets/alchemy/frame.scss
@@ -34,12 +34,14 @@ div#overlay_text_box {
 }
 
 #logout {
+  box-sizing: border-box;
   position: absolute;
   z-index: 1;
   bottom: 0;
   left: 0;
   width: $main-menu-width;
-  background: $light-blue;
+  background: $main-menu-bg-color;
+  border-right: $default-border;
 
   .collapsed-menu & {
     width: $collapsed-main-menu-width;
@@ -65,11 +67,10 @@ div#overlay_text_box {
 }
 
 #header {
-  height: 24px;
-  line-height: 23px;
+  height: $header-height;
+  line-height: $header-height;
   background: $light-blue;
   border-bottom: $default-border;
-  padding-top: 4px;
   position: relative;
 
   a {
@@ -84,37 +85,16 @@ div#overlay_text_box {
   .page_status_and_name {
     padding: 0 8px;
     background-color: $medium-gray;
-    text-shadow: 0px 1px 1px #FFFFFF;
+    text-shadow: $text-shadow-light;
     @extend .disable-user-select;
+    @extend .locked_page;
     cursor: default;
-    float: left;
-    @extend .top-rounded-border;
-    border: $default-border;
-    border-bottom-style: none;
-    height: 24px;
-    margin-right: 1px;
+    border-bottom-color: $toolbar-bg-color;
   }
 
   .page_name {
     margin-right: $default-margin;
-  }
-
-  .page_language {
-    float: none;
-    display: inline-block;
-    vertical-align: middle;
-    color: #3265b1;
-    margin-right: 2px;
-    font-size: 10px;
-    text-transform: uppercase;
-  }
-
-  .page_site {
-    float: none;
-    display: inline-block;
-    color: #847474;
-    margin-right: $default-margin;
-    font-size: 10px;
+    line-height: $header-height;
   }
 }
 
@@ -152,30 +132,62 @@ div#overlay_text_box {
   }
 }
 
-div#user_info {
+#user_info {
   position: absolute;
   top: 0;
-  right: $main-menu-width;
+  right: 0;
+  height: $header-height;
   font-size: 11px;
-  padding: 0 8px;
+  padding-left: 2*$default-padding;
   background-color: $light-blue;
-
-  .collapsed-menu & {
-    right: $collapsed-main-menu-width;
-  }
+  border-bottom: $default-border;
 
   .select2-container {
-    margin-top: -2px;
-    margin-right: $default-margin;
+    margin-top: -3px;
+    padding-right: 2*$default-padding;
+  }
+
+  .select2-choice {
+    padding-right: 0;
+    background: transparent;
+    box-shadow: none;
+    border: none;
+    border-radius: 0;
+    border-left: $default-border;
+    height: $header-height + 1;
+    line-height: $header-height;
+    text-shadow: $text-shadow-light;
+
+    .select2-arrow {
+      width: 14px;
+      border-left: none;
+
+      b {
+        color: $muted-text-color;
+
+        &:before {
+          position: absolute;
+          top: 50%;
+          transform: translateY(-50%);
+        }
+      }
+    }
+  }
+
+  .select2-dropdown-open {
+    background-color: $main-menu-bg-color;
+
+    .select2-choice .select2-arrow b {
+      background-position: -20px -5px;
+    }
   }
 
   .current-user-name {
-    padding-right: $default-padding;
+    padding-right: 2*$default-padding;
   }
 }
 
 #locked_pages {
-  height: 25px;
   overflow: hidden;
 
   label {

--- a/app/assets/stylesheets/alchemy/frame.scss
+++ b/app/assets/stylesheets/alchemy/frame.scss
@@ -60,6 +60,60 @@ div#overlay_text_box {
   }
 }
 
+#header {
+  height: 24px;
+  line-height: 23px;
+  background: $light-blue;
+  border-bottom: $default-border;
+  padding-top: 4px;
+  position: relative;
+
+  a {
+    display: inline-block;
+    vertical-align: middle;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  .page_status_and_name {
+    padding: 0 8px;
+    background-color: $medium-gray;
+    text-shadow: 0px 1px 1px #FFFFFF;
+    @extend .disable-user-select;
+    cursor: default;
+    float: left;
+    @extend .top-rounded-border;
+    border: $default-border;
+    border-bottom-style: none;
+    height: 24px;
+    margin-right: 1px;
+  }
+
+  .page_name {
+    margin-right: $default-margin;
+  }
+
+  .page_language {
+    float: none;
+    display: inline-block;
+    vertical-align: middle;
+    color: #3265b1;
+    margin-right: 2px;
+    font-size: 10px;
+    text-transform: uppercase;
+  }
+
+  .page_site {
+    float: none;
+    display: inline-block;
+    color: #847474;
+    margin-right: $default-margin;
+    font-size: 10px;
+  }
+}
+
 #main_content {
   box-sizing: border-box;
   background-color: $light-gray;

--- a/app/assets/stylesheets/alchemy/frame.scss
+++ b/app/assets/stylesheets/alchemy/frame.scss
@@ -41,6 +41,10 @@ div#overlay_text_box {
   width: $main-menu-width;
   background: $light-blue;
 
+  .collapsed-menu & {
+    width: $collapsed-main-menu-width;
+  }
+
   a {
     display: block;
     padding-left: 3 * $default-padding;
@@ -155,6 +159,10 @@ div#user_info {
   font-size: 11px;
   padding: 0 8px;
   background-color: $light-blue;
+
+  .collapsed-menu & {
+    right: $collapsed-main-menu-width;
+  }
 
   .select2-container {
     margin-top: -2px;

--- a/app/assets/stylesheets/alchemy/frame.scss
+++ b/app/assets/stylesheets/alchemy/frame.scss
@@ -40,8 +40,13 @@ div#overlay_text_box {
   bottom: 0;
   left: 0;
   width: $main-menu-width;
-  background: $main-menu-bg-color;
+  background-color: $main-menu-bg-color;
   border-right: $default-border;
+  transition: background-color $transition-duration $transition-easing;
+
+  &:hover {
+    background-color: $main-menu-active-bg-color;
+  }
 
   .collapsed-menu & {
     width: $collapsed-main-menu-width;

--- a/app/assets/stylesheets/alchemy/frame.scss
+++ b/app/assets/stylesheets/alchemy/frame.scss
@@ -1,86 +1,3 @@
-#top_menu {
-  box-sizing: border-box;
-  position: fixed;
-  top: 0;
-  margin-left: 65px;
-  padding-right: 65px;
-  z-index: 30;
-  width: 100%;
-  @extend .disable-user-select;
-}
-
-#left_menu {
-  white-space: nowrap;
-  z-index: 20;
-  height: 100%;
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 65px;
-  overflow: hidden;
-  border-right: $default-border;
-  background: $light-blue;
-  font-size: 10px;
-  @extend .disable-user-select;
-
-  label {
-    display: block;
-  }
-
-  a {
-    text-shadow: #fff 0 0px 4px;
-  }
-}
-
-#main_navi {
-  padding-top: 20px;
-  padding-left: 4px;
-  padding-bottom: 80px;
-
-  .main_navi_entry {
-    color: #444;
-    position: relative;
-    text-align: center;
-    overflow: hidden;
-    display: block;
-    padding-top: 7px;
-    @extend .left-rounded-border;
-    border: 1px none #afafaf;
-    border-right-style: none;
-    padding-bottom: 6px;
-    padding-left: 1px;
-    width: 60px;
-
-    &:hover {
-      cursor: pointer;
-      text-decoration: none;
-      color: $text-color;
-    }
-
-    &.active {
-      background: #baced9;
-      color: $text-color;
-      cursor: default;
-      text-shadow: #fff 0 1px 2px;
-      border: $default-border;
-      padding-left: 0;
-      border-right-style: none;
-      padding-top: 6px;
-      padding-bottom: 5px;
-    }
-
-    img {
-      border-style: none;
-      height: 24px;
-      width: 24px;
-      display: inline-block;
-      vertical-align: middle;
-      margin-bottom: 4px;
-      margin-top: 2px;
-    }
-  }
-}
-
 div#overlay {
   display: none;
   position: fixed;
@@ -121,17 +38,20 @@ div#overlay_text_box {
   z-index: 1;
   bottom: 0;
   left: 0;
-  text-align: center;
-  width: 65px;
+  width: $main-menu-width;
   background: $light-blue;
 
   a {
     display: block;
-    padding-top: 4px;
-    padding-bottom: 8px;
+    padding-left: 3 * $default-padding;
+    line-height: 45px;
 
     &:hover {
       text-decoration: none;
+    }
+
+    label {
+      padding-left: 2 * $default-padding;
     }
   }
 
@@ -143,7 +63,7 @@ div#overlay_text_box {
 #main_content {
   box-sizing: border-box;
   background-color: $light-gray;
-  padding: 75px 8px 8px 74px;
+  padding: 84px 8px 8px $main-menu-width + 10px;
   z-index: 0;
   width: 100%;
   height: 100%;
@@ -177,7 +97,7 @@ div#overlay_text_box {
 div#user_info {
   position: absolute;
   top: 0;
-  right: 65px;
+  right: $main-menu-width;
   font-size: 11px;
   padding: 0 8px;
   background-color: $light-blue;
@@ -189,109 +109,6 @@ div#user_info {
 
   .current-user-name {
     padding-right: $default-padding;
-  }
-}
-
-#sub_navigation {
-  height: 24px;
-  line-height: 23px;
-  background: $light-blue;
-  border-bottom: $default-border;
-  padding-top: 4px;
-  position: relative;
-
-  a {
-    display: inline-block;
-    vertical-align: middle;
-
-    &:hover {
-      text-decoration: none;
-    }
-  }
-
-  .page_status_and_name {
-    padding: 0 8px;
-    background-color: $medium-gray;
-    text-shadow: 0px 1px 1px #FFFFFF;
-    @extend .disable-user-select;
-    cursor: default;
-    float: left;
-    @extend .top-rounded-border;
-    border: $default-border;
-    border-bottom-style: none;
-    height: 24px;
-    margin-right: 1px;
-  }
-
-  .page_name {
-    margin-right: $default-margin;
-  }
-
-  .page_language {
-    float: none;
-    display: inline-block;
-    vertical-align: middle;
-    color: #3265b1;
-    margin-right: 2px;
-    font-size: 10px;
-    text-transform: uppercase;
-  }
-
-  .page_site {
-    float: none;
-    display: inline-block;
-    color: #847474;
-    margin-right: $default-margin;
-    font-size: 10px;
-  }
-
-  .subnavi_tab {
-    float: left;
-    line-height: 21px;
-    height: 23px;
-    text-shadow: #fff 0 0px 4px;
-    background: #d6e0e6;
-    color: #444;
-    @extend .top-rounded-border;
-    border: $default-border;
-    border-bottom-style: none;
-    margin-right: 1px;
-
-    &.wide {
-      position: relative;
-      padding-right: 24px;
-
-      form {
-        position: absolute;
-        right: $default-padding;
-        top: $default-padding;
-        line-height: 1;
-      }
-    }
-
-    &:hover {
-      color: $text-color;
-      text-decoration: none;
-    }
-
-    &.active {
-      position: relative;
-      height: 24px;
-      color: $text-color;
-      background-color: $medium-gray;
-      text-shadow: #fff 0 1px 2px;
-      @extend .disable-user-select;
-      cursor: default;
-      z-index: 10;
-    }
-
-    > a {
-      padding: 0px 8px;
-    }
-
-    .inline.icon {
-      vertical-align: text-bottom;
-    }
   }
 }
 

--- a/app/assets/stylesheets/alchemy/modules.scss
+++ b/app/assets/stylesheets/alchemy/modules.scss
@@ -1,9 +1,3 @@
-span.icon.module {
-  width: 24px;
-  height: 24px;
-  margin-bottom: 4px;
-}
-
 span.module.dashboard {
   background-position: -240px 0;
 }

--- a/app/assets/stylesheets/alchemy/navigation.scss
+++ b/app/assets/stylesheets/alchemy/navigation.scss
@@ -4,7 +4,7 @@
   top: 0;
   margin-left: $main-menu-width;
   padding-right: $main-menu-width;
-  z-index: 30;
+  z-index: 20;
   width: 100%;
   @extend .disable-user-select;
 
@@ -16,7 +16,7 @@
 
 #left_menu {
   box-sizing: border-box;
-  z-index: 20;
+  z-index: 30;
   height: 100%;
   position: fixed;
   top: 0;
@@ -29,15 +29,23 @@
   .collapsed-menu & {
     width: $collapsed-main-menu-width;
 
-    label {
+    .main_navi_entry.has_sub_navigation label {
       display: none;
-      background-color: $main-menu-active-bg-color;
     }
 
-    .main_navi_entry:not(.has_sub_navigation) {
+    label {
+      visibility: hidden;
+      opacity: 0;
+      background-color: $main-menu-active-bg-color;
+      transition: opacity $transition-duration $transition-easing;
+    }
+
+    .main_navi_entry:not(.has_sub_navigation),
+    #logout {
 
       &:hover label {
-        display: block;
+        visibility: visible;
+        opacity: 1;
       }
 
       label {
@@ -81,6 +89,9 @@
   position: relative;
   display: block;
   line-height: 46px;
+  margin-bottom: 3*$default-padding;
+  background-color: transparent;
+  transition: background-color $transition-duration $transition-easing;
 
   &:hover {
     background-color: $main-menu-active-bg-color;
@@ -89,7 +100,8 @@
     .collapsed-menu & {
 
       .sub_navigation {
-        display: block;
+        visibility: visible;
+        opacity: 1;
         background-color: $main-menu-active-bg-color;
       }
     }
@@ -104,11 +116,12 @@
   a {
     display: block;
     padding-left: 3 * $default-padding;
+    transition: color $transition-duration $transition-easing;
 
     &:hover {
-      cursor: pointer;
       text-decoration: none;
-      color: $text-color;
+      color: #000;
+      text-shadow: none;
     }
   }
 }
@@ -117,16 +130,13 @@ body:not(.collapsed-menu) .main_navi_entry.active {
 
   .sub_navigation {
     position: static;
-    display: block;
+    visibility: visible;
+    opacity: 1;
     width: auto;
   }
 
   .subnavi_tab {
     line-height: 24px;
-
-    &:last-of-type {
-      padding-bottom: $default-padding;
-    }
 
     a {
       padding: 8px 4px 8px 44px;
@@ -136,28 +146,38 @@ body:not(.collapsed-menu) .main_navi_entry.active {
 
 .sub_navigation {
   position: absolute;
-  width: $main-menu-width + 1;
-  left: $main-menu-width - 1;
+  width: $main-menu-width;
+  left: $main-menu-width;
   top: 0;
-  display: none;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity $transition-duration $transition-easing;
 
   .collapsed-menu & {
-    left: $collapsed-main-menu-width - 1;
+    left: $collapsed-main-menu-width;
   }
 }
 
 .subnavi_tab {
 
+  &:first-of-type {
+    border-left: 1px solid $main-menu-active-bg-color;
+    margin-left: -1px;
+  }
+
   a {
     padding-left: 4*$default-padding;
+    background-color: transparent;
+    transition: background-color $transition-duration $transition-easing;
 
     &:hover {
-      text-decoration: underline;
+      background-color: rgba(255,255,255,0.2);
     }
   }
 
-  &.active {
-    text-decoration: underline;
+  &.active a {
+    font-weight: bold;
+    color: $main-menu-text-color;
   }
 }
 

--- a/app/assets/stylesheets/alchemy/navigation.scss
+++ b/app/assets/stylesheets/alchemy/navigation.scss
@@ -7,6 +7,11 @@
   z-index: 30;
   width: 100%;
   @extend .disable-user-select;
+
+  .collapsed-menu & {
+    margin-left: $collapsed-main-menu-width;
+    padding-right: $collapsed-main-menu-width;
+  }
 }
 
 #left_menu {
@@ -19,6 +24,14 @@
   border-right: $default-border;
   background: $light-blue;
   @extend .disable-user-select;
+
+  .collapsed-menu & {
+    width: $collapsed-main-menu-width;
+
+    label {
+      display: none;
+    }
+  }
 
   label {
     padding-left: $default-padding;
@@ -54,9 +67,13 @@
   &:hover {
     background-color: $main-menu-active-bg-color;
 
-    &:not(.active) .sub_navigation {
-      display: block;
-      background-color: $main-menu-active-bg-color;
+    &:not(.active),
+    .collapsed-menu & {
+
+      .sub_navigation {
+        display: block;
+        background-color: $main-menu-active-bg-color;
+      }
     }
   }
 
@@ -64,12 +81,6 @@
     background-color: $main-menu-active-bg-color;
     color: $text-color;
     cursor: default;
-
-    .sub_navigation {
-      position: static;
-      display: block;
-      width: auto;
-    }
   }
 
   a {
@@ -84,17 +95,15 @@
   }
 }
 
-.sub_navigation {
-  position: absolute;
-  width: $main-menu-width;
-  left: $main-menu-width;
-  top: 0;
-  display: none;
-}
+body:not(.collapsed-menu) .main_navi_entry.active {
 
-.subnavi_tab {
+  .sub_navigation {
+    position: static;
+    display: block;
+    width: auto;
+  }
 
-  .active.main_navi_entry & {
+  .subnavi_tab {
     line-height: 24px;
 
     &:last-of-type {
@@ -105,6 +114,21 @@
       padding: 8px 4px 8px 44px;
     }
   }
+}
+
+.sub_navigation {
+  position: absolute;
+  width: $main-menu-width;
+  left: $main-menu-width;
+  top: 0;
+  display: none;
+
+  .collapsed-menu & {
+    left: $collapsed-main-menu-width;
+  }
+}
+
+.subnavi_tab {
 
   a {
     padding-left: 4*$default-padding;

--- a/app/assets/stylesheets/alchemy/navigation.scss
+++ b/app/assets/stylesheets/alchemy/navigation.scss
@@ -1,0 +1,170 @@
+#top_menu {
+  box-sizing: border-box;
+  position: fixed;
+  top: 0;
+  margin-left: $main-menu-width;
+  padding-right: $main-menu-width;
+  z-index: 30;
+  width: 100%;
+  @extend .disable-user-select;
+}
+
+#left_menu {
+  white-space: nowrap;
+  z-index: 20;
+  height: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: $main-menu-width;
+  overflow: hidden;
+  border-right: $default-border;
+  background: $light-blue;
+  @extend .disable-user-select;
+
+  label {
+    padding-left: $default-padding;
+    vertical-align: middle;
+  }
+
+  a {
+    text-shadow: #fff 0 0px 4px;
+  }
+
+  img, .icon {
+    border-style: none;
+    height: 24px;
+    width: 24px;
+    display: inline-block;
+    vertical-align: middle;
+  }
+}
+
+#main_navi {
+  padding-top: 29px;
+  padding-bottom: 80px;
+}
+
+.main_navi_entry {
+  color: #444;
+  position: relative;
+  overflow: hidden;
+  display: block;
+  padding-left: 3 * $default-padding;
+  line-height: 45px;
+
+  &:hover {
+    cursor: pointer;
+    text-decoration: none;
+    color: $text-color;
+  }
+
+  &.active {
+    background: #baced9;
+    color: $text-color;
+    cursor: default;
+  }
+}
+
+#sub_navigation {
+  height: 24px;
+  line-height: 23px;
+  background: $light-blue;
+  border-bottom: $default-border;
+  padding-top: 4px;
+  position: relative;
+
+  a {
+    display: inline-block;
+    vertical-align: middle;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  .page_status_and_name {
+    padding: 0 8px;
+    background-color: $medium-gray;
+    text-shadow: 0px 1px 1px #FFFFFF;
+    @extend .disable-user-select;
+    cursor: default;
+    float: left;
+    @extend .top-rounded-border;
+    border: $default-border;
+    border-bottom-style: none;
+    height: 24px;
+    margin-right: 1px;
+  }
+
+  .page_name {
+    margin-right: $default-margin;
+  }
+
+  .page_language {
+    float: none;
+    display: inline-block;
+    vertical-align: middle;
+    color: #3265b1;
+    margin-right: 2px;
+    font-size: 10px;
+    text-transform: uppercase;
+  }
+
+  .page_site {
+    float: none;
+    display: inline-block;
+    color: #847474;
+    margin-right: $default-margin;
+    font-size: 10px;
+  }
+
+  .subnavi_tab {
+    float: left;
+    line-height: 21px;
+    height: 23px;
+    text-shadow: #fff 0 0px 4px;
+    background: #d6e0e6;
+    color: #444;
+    @extend .top-rounded-border;
+    border: $default-border;
+    border-bottom-style: none;
+    margin-right: 1px;
+
+    &.wide {
+      position: relative;
+      padding-right: 24px;
+
+      form {
+        position: absolute;
+        right: $default-padding;
+        top: $default-padding;
+        line-height: 1;
+      }
+    }
+
+    &:hover {
+      color: $text-color;
+      text-decoration: none;
+    }
+
+    &.active {
+      position: relative;
+      height: 24px;
+      color: $text-color;
+      background-color: $medium-gray;
+      text-shadow: #fff 0 1px 2px;
+      @extend .disable-user-select;
+      cursor: default;
+      z-index: 10;
+    }
+
+    > a {
+      padding: 0px 8px;
+    }
+
+    .inline.icon {
+      vertical-align: text-bottom;
+    }
+  }
+}

--- a/app/assets/stylesheets/alchemy/navigation.scss
+++ b/app/assets/stylesheets/alchemy/navigation.scss
@@ -60,8 +60,10 @@
   }
 
   label {
+    vertical-align: middle;
     padding-left: $default-padding;
     cursor: pointer;
+    @include truncate($main-menu-entry-max-width);
   }
 
   a {
@@ -69,13 +71,11 @@
   }
 
   img, .module.icon {
-    position: relative;
-    top: 2*$default-padding;
     border-style: none;
     height: 24px;
     width: 24px;
     display: inline-block;
-    vertical-align: baseline;
+    vertical-align: middle;
   }
 }
 
@@ -126,20 +126,27 @@
   }
 }
 
-body:not(.collapsed-menu) .main_navi_entry.active {
+body:not(.collapsed-menu) {
 
-  .sub_navigation {
-    position: static;
-    visibility: visible;
-    opacity: 1;
-    width: auto;
+  .subnavi_tab a {
+    padding-top: 1px;
   }
 
-  .subnavi_tab {
-    line-height: 24px;
+  .main_navi_entry.active {
 
-    a {
-      padding: 8px 4px 8px 44px;
+    .sub_navigation {
+      position: static;
+      visibility: visible;
+      opacity: 1;
+      width: auto;
+    }
+
+    .subnavi_tab {
+      line-height: 24px;
+
+      a {
+        padding: 8px 4px 8px 44px;
+      }
     }
   }
 }
@@ -169,6 +176,7 @@ body:not(.collapsed-menu) .main_navi_entry.active {
     padding-left: 4*$default-padding;
     background-color: transparent;
     transition: background-color $transition-duration $transition-easing;
+    @include truncate($main-menu-width, $display: block);
 
     &:hover {
       background-color: rgba(255,255,255,0.2);

--- a/app/assets/stylesheets/alchemy/navigation.scss
+++ b/app/assets/stylesheets/alchemy/navigation.scss
@@ -16,14 +16,12 @@
   top: 0;
   left: 0;
   width: $main-menu-width;
-  overflow: hidden;
   border-right: $default-border;
   background: $light-blue;
   @extend .disable-user-select;
 
   label {
     padding-left: $default-padding;
-    vertical-align: middle;
     cursor: pointer;
   }
 
@@ -31,12 +29,14 @@
     text-shadow: #fff 0 0px 4px;
   }
 
-  img, .icon {
+  img, .module.icon {
+    position: relative;
+    top: 2*$default-padding;
     border-style: none;
     height: 24px;
     width: 24px;
     display: inline-block;
-    vertical-align: middle;
+    vertical-align: baseline;
   }
 }
 
@@ -48,18 +48,28 @@
 .main_navi_entry {
   color: #444;
   position: relative;
-  overflow: hidden;
   display: block;
   line-height: 46px;
 
   &:hover {
     background-color: $main-menu-active-bg-color;
+
+    &:not(.active) .sub_navigation {
+      display: block;
+      background-color: $main-menu-active-bg-color;
+    }
   }
 
   &.active {
     background-color: $main-menu-active-bg-color;
     color: $text-color;
     cursor: default;
+
+    .sub_navigation {
+      position: static;
+      display: block;
+      width: auto;
+    }
   }
 
   a {
@@ -74,25 +84,38 @@
   }
 }
 
-.subnavi_tab {
-  line-height: 24px;
-  padding: 8px 4px 8px 32px;
+.sub_navigation {
+  position: absolute;
+  width: $main-menu-width;
+  left: $main-menu-width;
+  top: 0;
+  display: none;
+}
 
-  a:hover {
-    text-decoration: underline;
+.subnavi_tab {
+
+  .active.main_navi_entry & {
+    line-height: 24px;
+
+    &:last-of-type {
+      padding-bottom: $default-padding;
+    }
+
+    a {
+      padding: 8px 4px 8px 44px;
+    }
+  }
+
+  a {
+    padding-left: 4*$default-padding;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 
   &.active {
-    position: relative;
-    color: $text-color;
-    text-shadow: #fff 0 1px 2px;
-    @extend .disable-user-select;
-    cursor: default;
-    z-index: 10;
-  }
-
-  &:last-of-type {
-    padding-bottom: $default-padding;
+    text-decoration: underline;
   }
 }
 

--- a/app/assets/stylesheets/alchemy/navigation.scss
+++ b/app/assets/stylesheets/alchemy/navigation.scss
@@ -22,7 +22,7 @@
   left: 0;
   width: $main-menu-width;
   border-right: $default-border;
-  background: $light-blue;
+  background-color: $main-menu-bg-color;
   @extend .disable-user-select;
 
   .collapsed-menu & {
@@ -30,6 +30,23 @@
 
     label {
       display: none;
+      background-color: $main-menu-active-bg-color;
+    }
+
+    .main_navi_entry:not(.has_sub_navigation) {
+
+      &:hover label {
+        display: block;
+      }
+
+      label {
+        box-sizing: border-box;
+        position: absolute;
+        top: 0;
+        left: $collapsed-main-menu-width;
+        width: $main-menu-width;
+        padding-left: 4*$default-padding;
+      }
     }
   }
 

--- a/app/assets/stylesheets/alchemy/navigation.scss
+++ b/app/assets/stylesheets/alchemy/navigation.scss
@@ -15,6 +15,7 @@
 }
 
 #left_menu {
+  box-sizing: border-box;
   z-index: 20;
   height: 100%;
   position: fixed;
@@ -43,8 +44,8 @@
         box-sizing: border-box;
         position: absolute;
         top: 0;
-        left: $collapsed-main-menu-width;
-        width: $main-menu-width;
+        left: $collapsed-main-menu-width - 1;
+        width: $main-menu-width + 1;
         padding-left: 4*$default-padding;
       }
     }
@@ -56,7 +57,7 @@
   }
 
   a {
-    text-shadow: #fff 0 0px 4px;
+    text-shadow: $text-shadow-light;
   }
 
   img, .module.icon {
@@ -71,12 +72,12 @@
 }
 
 #main_navi {
-  padding-top: 28px;
+  padding-top: 30px;
   padding-bottom: 80px;
 }
 
 .main_navi_entry {
-  color: #444;
+  color: $main-menu-text-color;
   position: relative;
   display: block;
   line-height: 46px;
@@ -135,13 +136,13 @@ body:not(.collapsed-menu) .main_navi_entry.active {
 
 .sub_navigation {
   position: absolute;
-  width: $main-menu-width;
-  left: $main-menu-width;
+  width: $main-menu-width + 1;
+  left: $main-menu-width - 1;
   top: 0;
   display: none;
 
   .collapsed-menu & {
-    left: $collapsed-main-menu-width;
+    left: $collapsed-main-menu-width - 1;
   }
 }
 
@@ -161,43 +162,24 @@ body:not(.collapsed-menu) .main_navi_entry.active {
 }
 
 .locked_page {
+  position: relative;
   float: left;
-  line-height: 21px;
-  height: 23px;
-  text-shadow: #fff 0 0px 4px;
-  background: #d6e0e6;
+  line-height: $header-height - 1;
   color: #444;
-  @extend .top-rounded-border;
-  border: $default-border;
-  border-bottom-style: none;
-  margin-right: 1px;
+  border-right: $default-border;
+  border-bottom: $default-border;
+  padding-right: 24px;
+
+  form {
+    position: absolute;
+    right: $default-padding;
+    top: 7px;
+    line-height: 1;
+  }
 
   &:hover {
     color: $text-color;
     text-decoration: none;
-  }
-
-  &.active {
-    position: relative;
-    height: 24px;
-    color: $text-color;
-    background-color: $medium-gray;
-    text-shadow: #fff 0 1px 2px;
-    @extend .disable-user-select;
-    cursor: default;
-    z-index: 10;
-  }
-
-  &.wide {
-    position: relative;
-    padding-right: 24px;
-
-    form {
-      position: absolute;
-      right: $default-padding;
-      top: $default-padding;
-      line-height: 1;
-    }
   }
 
   > a {
@@ -205,28 +187,27 @@ body:not(.collapsed-menu) .main_navi_entry.active {
     padding: 0px 8px;
   }
 
-  .inline.icon {
+  .icon.close {
     vertical-align: text-bottom;
+    text-shadow: $text-shadow-light;
   }
 
   .page_name {
     margin-right: $default-margin;
+    text-shadow: $text-shadow-light;
   }
 
   .page_language {
-    float: none;
     display: inline-block;
-    vertical-align: middle;
-    color: #3265b1;
+    color: $muted-text-color;
     margin-right: 2px;
     font-size: 10px;
     text-transform: uppercase;
   }
 
   .page_site {
-    float: none;
     display: inline-block;
-    color: #847474;
+    color: $muted-text-color;
     margin-right: $default-margin;
     font-size: 10px;
   }

--- a/app/assets/stylesheets/alchemy/navigation.scss
+++ b/app/assets/stylesheets/alchemy/navigation.scss
@@ -10,7 +10,6 @@
 }
 
 #left_menu {
-  white-space: nowrap;
   z-index: 20;
   height: 100%;
   position: fixed;
@@ -25,6 +24,7 @@
   label {
     padding-left: $default-padding;
     vertical-align: middle;
+    cursor: pointer;
   }
 
   a {
@@ -41,7 +41,7 @@
 }
 
 #main_navi {
-  padding-top: 29px;
+  padding-top: 28px;
   padding-bottom: 80px;
 }
 
@@ -50,51 +50,99 @@
   position: relative;
   overflow: hidden;
   display: block;
-  padding-left: 3 * $default-padding;
-  line-height: 45px;
+  line-height: 46px;
 
   &:hover {
-    cursor: pointer;
-    text-decoration: none;
-    color: $text-color;
+    background-color: $main-menu-active-bg-color;
   }
 
   &.active {
-    background: #baced9;
+    background-color: $main-menu-active-bg-color;
     color: $text-color;
     cursor: default;
   }
-}
-
-#sub_navigation {
-  height: 24px;
-  line-height: 23px;
-  background: $light-blue;
-  border-bottom: $default-border;
-  padding-top: 4px;
-  position: relative;
 
   a {
-    display: inline-block;
-    vertical-align: middle;
+    display: block;
+    padding-left: 3 * $default-padding;
 
     &:hover {
+      cursor: pointer;
       text-decoration: none;
+      color: $text-color;
+    }
+  }
+}
+
+.subnavi_tab {
+  line-height: 24px;
+  padding: 8px 4px 8px 32px;
+
+  a:hover {
+    text-decoration: underline;
+  }
+
+  &.active {
+    position: relative;
+    color: $text-color;
+    text-shadow: #fff 0 1px 2px;
+    @extend .disable-user-select;
+    cursor: default;
+    z-index: 10;
+  }
+
+  &:last-of-type {
+    padding-bottom: $default-padding;
+  }
+}
+
+.locked_page {
+  float: left;
+  line-height: 21px;
+  height: 23px;
+  text-shadow: #fff 0 0px 4px;
+  background: #d6e0e6;
+  color: #444;
+  @extend .top-rounded-border;
+  border: $default-border;
+  border-bottom-style: none;
+  margin-right: 1px;
+
+  &:hover {
+    color: $text-color;
+    text-decoration: none;
+  }
+
+  &.active {
+    position: relative;
+    height: 24px;
+    color: $text-color;
+    background-color: $medium-gray;
+    text-shadow: #fff 0 1px 2px;
+    @extend .disable-user-select;
+    cursor: default;
+    z-index: 10;
+  }
+
+  &.wide {
+    position: relative;
+    padding-right: 24px;
+
+    form {
+      position: absolute;
+      right: $default-padding;
+      top: $default-padding;
+      line-height: 1;
     }
   }
 
-  .page_status_and_name {
-    padding: 0 8px;
-    background-color: $medium-gray;
-    text-shadow: 0px 1px 1px #FFFFFF;
-    @extend .disable-user-select;
-    cursor: default;
-    float: left;
-    @extend .top-rounded-border;
-    border: $default-border;
-    border-bottom-style: none;
-    height: 24px;
-    margin-right: 1px;
+  > a {
+    cursor: pointer;
+    padding: 0px 8px;
+  }
+
+  .inline.icon {
+    vertical-align: text-bottom;
   }
 
   .page_name {
@@ -117,54 +165,5 @@
     color: #847474;
     margin-right: $default-margin;
     font-size: 10px;
-  }
-
-  .subnavi_tab {
-    float: left;
-    line-height: 21px;
-    height: 23px;
-    text-shadow: #fff 0 0px 4px;
-    background: #d6e0e6;
-    color: #444;
-    @extend .top-rounded-border;
-    border: $default-border;
-    border-bottom-style: none;
-    margin-right: 1px;
-
-    &.wide {
-      position: relative;
-      padding-right: 24px;
-
-      form {
-        position: absolute;
-        right: $default-padding;
-        top: $default-padding;
-        line-height: 1;
-      }
-    }
-
-    &:hover {
-      color: $text-color;
-      text-decoration: none;
-    }
-
-    &.active {
-      position: relative;
-      height: 24px;
-      color: $text-color;
-      background-color: $medium-gray;
-      text-shadow: #fff 0 1px 2px;
-      @extend .disable-user-select;
-      cursor: default;
-      z-index: 10;
-    }
-
-    > a {
-      padding: 0px 8px;
-    }
-
-    .inline.icon {
-      vertical-align: text-bottom;
-    }
   }
 }

--- a/app/assets/stylesheets/alchemy/pagination.scss
+++ b/app/assets/stylesheets/alchemy/pagination.scss
@@ -8,8 +8,8 @@
   width: 100%;
   left: 0px;
   height: 50px;
-  padding: 2*$default-padding $default-padding;
-  padding-left: 76px;
+  padding: 2*$default-padding;
+  padding-left: $main-menu-width + 10px;
   text-align: left;
   border-top: $default-border;
   z-index: 10;

--- a/app/assets/stylesheets/alchemy/selects.scss
+++ b/app/assets/stylesheets/alchemy/selects.scss
@@ -47,38 +47,6 @@ select {
       }
     }
 
-    &.tiny {
-      padding-top: 6px;
-
-      .select2-choice {
-        height: 18px;
-        line-height: 18px;
-        padding-right: 0;
-
-        .select2-arrow {
-          width: 14px;
-          height: 14px;
-
-          b {
-            line-height: 4px;
-            width: 12px;
-            font-size: 10px;
-
-            &:before {
-              top: 0px;
-              left: 0px;
-            }
-          }
-        }
-      }
-
-      &.select2-dropdown-open {
-        .select2-choice .select2-arrow b {
-          background-position: -20px -5px;
-        }
-      }
-    }
-
     &.medium {
       width: 90px;
     }

--- a/app/assets/stylesheets/alchemy/sitemap.scss
+++ b/app/assets/stylesheets/alchemy/sitemap.scss
@@ -216,7 +216,7 @@ ul.list .sitemap_sitename {
   }
 }
 
-#sub_navigation .page_status_and_name .page_status {
+#header .page_status_and_name .page_status {
   float: none;
   display: inline-block;
   vertical-align: -3px;

--- a/app/assets/stylesheets/alchemy/sitemap.scss
+++ b/app/assets/stylesheets/alchemy/sitemap.scss
@@ -9,12 +9,11 @@
   border-bottom: $default-border;
 
   div.info {
-    margin: 8px 8px 8px 78px;
-    width: 720px;
+    margin: 16px 12px 8px 163px;
   }
 
   .buttons {
-    margin-left: 78px;
+    margin-left: 163px;
   }
 }
 

--- a/app/assets/stylesheets/alchemy/toolbar.scss
+++ b/app/assets/stylesheets/alchemy/toolbar.scss
@@ -2,9 +2,7 @@
   z-index: 10;
   @extend %gradiated-toolbar;
   margin-right: 0px;
-  border: $default-border;
-  border-top-style: none;
-  border-right-style: none;
+  border-bottom: $default-border;
   position: relative;
 
   .button_with_label {

--- a/app/helpers/alchemy/admin/base_helper.rb
+++ b/app/helpers/alchemy/admin/base_helper.rb
@@ -406,7 +406,11 @@ module Alchemy
 
       # Appends the current controller and action to body as css class.
       def alchemy_body_class
-        "#{controller_name} #{action_name}"
+        [
+          controller_name,
+          action_name,
+          content_for(:main_menu_style)
+        ]
       end
 
       # (internal) Returns options for the clipboard select tag

--- a/app/helpers/alchemy/admin/navigation_helper.rb
+++ b/app/helpers/alchemy/admin/navigation_helper.rb
@@ -11,22 +11,9 @@ module Alchemy
       def alchemy_main_navigation_entry(alchemy_module)
         render(
           'alchemy/admin/partials/main_navigation_entry',
-          alchemy_module: alchemy_module.stringify_keys,
-          navigation: module_main_navigation(alchemy_module)
+          alchemy_module: alchemy_module,
+          navigation: alchemy_module['navigation']
         )
-      end
-
-      # Renders the subnavigation from current module
-      #
-      # We find the module from current controller and index action.
-      #
-      def admin_subnavigation
-        if current_alchemy_module.present?
-          render(
-            'alchemy/admin/partials/sub_navigation',
-            entries: current_sub_navigation
-          )
-        end
       end
 
       # Used for checking the main navi permissions
@@ -46,7 +33,6 @@ module Alchemy
       #   can :index, :my_admin_posts
       #
       def navigate_module(navigation)
-        navigation.stringify_keys!
         [
           navigation['action'].to_sym,
           navigation['controller'].to_s.gsub(/\A\//, '').gsub(/\//, '_').to_sym
@@ -149,7 +135,7 @@ module Alchemy
       #   A Alchemy module definition
       #
       def url_options_for_module(alchemy_module)
-        url_options_for_navigation_entry(module_main_navigation(alchemy_module))
+        url_options_for_navigation_entry(alchemy_module['navigation'] || {})
       end
 
       # Returns a url options hash for given navigation entry.
@@ -158,7 +144,6 @@ module Alchemy
       #   A Alchemy module navigation entry
       #
       def url_options_for_navigation_entry(entry)
-        entry.stringify_keys!
         {
           controller: entry['controller'],
           action: entry['action'],
@@ -173,40 +158,15 @@ module Alchemy
         module_definition_for(controller: params[:controller], action: 'index')
       end
 
-      # Returns the sub navigation for current Alchemy module.
-      #
-      def current_sub_navigation
-        module_sub_navigation(module_main_navigation(current_alchemy_module))
-      end
-
-      # Returns navigation entries from given module.
-      #
-      def module_main_navigation(alchemy_module)
-        alchemy_module.fetch('navigation', {}).stringify_keys
-      end
-
-      # Returns sub navigation entries from given module.
-      #
-      def module_sub_navigation(alchemy_module)
-        alchemy_module.fetch('sub_navigation', []).map(&:stringify_keys)
-      end
-
-      # Returns nested navigation entries for given module.
-      #
-      def module_nested_navigation(alchemy_module)
-        alchemy_module.fetch('nested', []).map(&:stringify_keys)
-      end
-
       # Returns true if the current controller and action is in a modules navigation definition.
       #
-      def admin_mainnavi_active?(main_navigation)
-        main_navigation.stringify_keys!
+      def admin_mainnavi_active?(navigation)
         # Has the given navigation entry a active sub navigation?
-        has_active_entry?(module_sub_navigation(main_navigation)) ||
+        has_active_entry?(navigation['sub_navigation'] || []) ||
           # Has the given navigation entry a active nested navigation?
-          has_active_entry?(module_nested_navigation(main_navigation)) ||
+          has_active_entry?(navigation['nested'] || []) ||
           # Is the navigation entry active?
-          entry_active?(main_navigation)
+          entry_active?(navigation || {})
       end
 
       # Returns true if the given entry's controller is current controller
@@ -220,7 +180,8 @@ module Alchemy
       # Also checks if given entry has a +nested_actions+ key, if so it checks if one of them is current controller's action
       #
       def is_entry_action_active?(entry)
-        entry['action'] == params[:action] || entry['nested_actions'].to_a.include?(params[:action])
+        entry['action'] == params[:action] ||
+          entry.fetch('nested_actions', []).include?(params[:action])
       end
 
       # Returns true if an entry of given entries is active.
@@ -229,7 +190,7 @@ module Alchemy
       #   Alchemy module navigation entries.
       #
       def has_active_entry?(entries)
-        !entries.detect { |entry| entry_active?(entry) }.nil?
+        entries.any? { |entry| entry_active?(entry) }
       end
     end
   end

--- a/app/helpers/alchemy/admin/navigation_helper.rb
+++ b/app/helpers/alchemy/admin/navigation_helper.rb
@@ -58,8 +58,9 @@ module Alchemy
       def main_navigation_css_classes(navigation)
         [
           'main_navi_entry',
-          admin_mainnavi_active?(navigation) ? 'active' : nil
-        ].compact.join(' ')
+          admin_mainnavi_active?(navigation) ? 'active' : nil,
+          navigation.key?('sub_navigation') ? 'has_sub_navigation' : nil
+        ].compact
       end
 
       # Returns true if given navi entry is in params controller and action

--- a/app/views/alchemy/admin/pages/_locked_page.html.erb
+++ b/app/views/alchemy/admin/pages/_locked_page.html.erb
@@ -1,7 +1,7 @@
 <% if @page == locked_page %>
   <%= render 'alchemy/admin/pages/current_page', current_page: @page %>
 <% else %>
-  <div class="subnavi_tab wide" id="locked_page_<%= locked_page.id %>">
+  <div class="locked_page wide" id="locked_page_<%= locked_page.id %>">
     <%= link_to alchemy.edit_admin_page_path(locked_page) do %>
       <%= render 'alchemy/admin/pages/page_status', page: locked_page, truncate: true %>
     <% end %>

--- a/app/views/alchemy/admin/pages/edit.html.erb
+++ b/app/views/alchemy/admin/pages/edit.html.erb
@@ -1,5 +1,7 @@
 <% content_for(:title) { @page.name } %>
 
+<% content_for(:main_menu_style) { 'collapsed-menu' } %>
+
 <% content_for(:toolbar) do %>
 <div class="toolbar_buttons">
   <div class="button_with_label">
@@ -122,7 +124,6 @@
     });
     Alchemy.Sitemap.watchPagePublicationState();
     Alchemy.PageLeaveObserver();
-    Alchemy.PreviewWindow.init('<%= admin_page_path(@page) %>');
     Alchemy.ElementsWindow.init('<%= alchemy.admin_elements_path(page_id: @page.id) %>', {
       texts: {
         title: '<%= Alchemy.t("Elements") %>',
@@ -180,6 +181,8 @@
         $(window.location.hash).trigger('FocusElementEditor.Alchemy');
       }
     });
+
+    Alchemy.PreviewWindow.init('<%= admin_page_path(@page) %>');
 
     $('#preview_size').bind('open.selectBoxIt', function (e) {
       $('#top_menu').css('z-index', 5000);

--- a/app/views/alchemy/admin/partials/_main_navigation_entry.html.erb
+++ b/app/views/alchemy/admin/partials/_main_navigation_entry.html.erb
@@ -1,12 +1,17 @@
 <% if can? *navigate_module(navigation) %>
-  <%= link_to url_for_module(alchemy_module), class: main_navigation_css_classes(navigation) do %>
-    <% if navigation["image"] %>
-    <%= image_tag(navigation["image"]) %>
-    <% elsif navigation["icon"] %>
-    <span class="module icon <%= navigation["icon"] %>"></span>
-    <% else %>
-    <span class="module icon"></span>
+  <%= content_tag :div, class: main_navigation_css_classes(navigation) do %>
+    <%= link_to url_for_module(alchemy_module) do %>
+      <% if navigation["image"] %>
+        <%= image_tag(navigation["image"]) %>
+      <% elsif navigation["icon"] %>
+        <span class="module icon <%= navigation["icon"] %>"></span>
+      <% else %>
+        <span class="module icon"></span>
+      <% end %>
+      <label><%= truncate Alchemy.t(navigation["name"]), length: 10 %></label>
     <% end %>
-    <label><%= truncate Alchemy.t(navigation["name"]), length: 10 %></label>
+    <% if admin_mainnavi_active?(navigation) %>
+      <%= admin_subnavigation %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/alchemy/admin/partials/_main_navigation_entry.html.erb
+++ b/app/views/alchemy/admin/partials/_main_navigation_entry.html.erb
@@ -8,7 +8,7 @@
       <% else %>
         <span class="module icon"></span>
       <% end %>
-      <label><%= truncate Alchemy.t(navigation["name"]), length: 10 %></label>
+      <label><%= Alchemy.t(navigation['name']) %></label>
     <% end %>
     <%= render 'alchemy/admin/partials/sub_navigation',
       entries: navigation['sub_navigation'] %>

--- a/app/views/alchemy/admin/partials/_main_navigation_entry.html.erb
+++ b/app/views/alchemy/admin/partials/_main_navigation_entry.html.erb
@@ -10,8 +10,7 @@
       <% end %>
       <label><%= truncate Alchemy.t(navigation["name"]), length: 10 %></label>
     <% end %>
-    <% if admin_mainnavi_active?(navigation) %>
-      <%= admin_subnavigation %>
-    <% end %>
+    <%= render 'alchemy/admin/partials/sub_navigation',
+      entries: module_sub_navigation(alchemy_module['navigation']) %>
   <% end %>
 <% end %>

--- a/app/views/alchemy/admin/partials/_main_navigation_entry.html.erb
+++ b/app/views/alchemy/admin/partials/_main_navigation_entry.html.erb
@@ -11,6 +11,6 @@
       <label><%= truncate Alchemy.t(navigation["name"]), length: 10 %></label>
     <% end %>
     <%= render 'alchemy/admin/partials/sub_navigation',
-      entries: module_sub_navigation(alchemy_module['navigation']) %>
+      entries: navigation['sub_navigation'] %>
   <% end %>
 <% end %>

--- a/app/views/alchemy/admin/partials/_sub_navigation.html.erb
+++ b/app/views/alchemy/admin/partials/_sub_navigation.html.erb
@@ -1,10 +1,11 @@
-<div class="sub_navigation">
-<% entries.each do |entry| %>
-  <% entry.stringify_keys! %>
-  <% if can? *navigate_module(entry) %>
-  <div class="subnavi_tab<%= entry_active?(entry) ? ' active' : nil %>">
-    <%= link_to Alchemy.t(entry['name']), url_for_module_sub_navigation(entry) %>
+<% if entries.present? %>
+  <div class="sub_navigation">
+    <% entries.each do |entry| %>
+      <% if can? *navigate_module(entry) %>
+        <div class="subnavi_tab<%= entry_active?(entry) ? ' active' : nil %>">
+          <%= link_to Alchemy.t(entry['name']), url_for_module_sub_navigation(entry) %>
+        </div>
+      <% end %>
+    <% end %>
   </div>
-  <% end %>
 <% end %>
-</div>

--- a/app/views/alchemy/admin/partials/_sub_navigation.html.erb
+++ b/app/views/alchemy/admin/partials/_sub_navigation.html.erb
@@ -1,3 +1,4 @@
+<div class="sub_navigation">
 <% entries.each do |entry| %>
   <% entry.stringify_keys! %>
   <% if can? *navigate_module(entry) %>
@@ -6,3 +7,4 @@
   </div>
   <% end %>
 <% end %>
+</div>

--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -37,7 +37,7 @@
     <%= javascript_include_tag('alchemy/admin/all', 'data-turbolinks-track' => true) %>
     <%= yield :javascript_includes %>
   </head>
-  <body id="alchemy" class="<%= alchemy_body_class %>">
+  <%= content_tag :body, id: 'alchemy', class: alchemy_body_class do %>
     <noscript>
       <h1><%= Alchemy.t(:javascript_disabled_headline) %></h1>
       <p><%= Alchemy.t(:javascript_disabled_text) %></p>
@@ -102,5 +102,5 @@
     </script>
     <%= render 'alchemy/admin/uploader/setup' %>
     <%= yield(:javascripts) %>
-  </body>
+  <% end %>
 </html>

--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -72,11 +72,9 @@
     </div>
     <% if current_alchemy_user %>
     <div id="top_menu">
-      <div id="sub_navigation">
-        <%= admin_subnavigation %>
+      <div id="header">
         <% if @locked_pages.present? %>
           <div id="locked_pages">
-            <label><%= Alchemy.t(:locked_pages) %> &raquo;</label>
             <%= render partial: 'alchemy/admin/pages/locked_page', collection: @locked_pages %>
           </div>
         <% end %>

--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -78,15 +78,15 @@
             <%= render partial: 'alchemy/admin/pages/locked_page', collection: @locked_pages %>
           </div>
         <% end %>
+        <div id="user_info">
+          <%= current_alchemy_user_name %>
+          <%= select_tag 'change_locale',
+            options_for_select(translations_for_select, ::I18n.locale),
+            class: 'alchemy_selectbox tiny' %>
+        </div>
       </div>
       <div id="toolbar">
         <%= yield(:toolbar) %>
-      </div>
-      <div id="user_info">
-        <%= current_alchemy_user_name %>
-        <%= select_tag 'change_locale',
-          options_for_select(translations_for_select, ::I18n.locale),
-          class: 'alchemy_selectbox tiny' %>
       </div>
     </div>
     <% end %>

--- a/config/alchemy/modules.yml
+++ b/config/alchemy/modules.yml
@@ -8,10 +8,6 @@
     controller: 'alchemy/admin/dashboard'
     action: index
     image: 'alchemy/icon.svg'
-    sub_navigation:
-      - name: 'modules.dashboard'
-        controller: 'alchemy/admin/dashboard'
-        action: index
 
 - name: pages
   engine_name: alchemy
@@ -40,10 +36,6 @@
     controller: 'alchemy/admin/languages'
     action: index
     icon: languages
-    sub_navigation:
-      - name: 'modules.languages'
-        controller: 'alchemy/admin/languages'
-        action: index
 
 - name: sites
   engine_name: alchemy
@@ -53,10 +45,6 @@
     controller: 'alchemy/admin/sites'
     action: index
     icon: sites
-    sub_navigation:
-    - name: 'modules.sites'
-      controller: 'alchemy/admin/sites'
-      action: index
 
 - name: tags
   engine_name: alchemy
@@ -66,10 +54,6 @@
     controller: 'alchemy/admin/tags'
     action: index
     icon: tags
-    sub_navigation:
-    - name: 'modules.tags'
-      controller: 'alchemy/admin/tags'
-      action: index
 
 - name: archive
   engine_name: alchemy

--- a/lib/alchemy/modules.rb
+++ b/lib/alchemy/modules.rb
@@ -22,7 +22,7 @@ module Alchemy
     #     }
     #
     def self.register_module(module_definition)
-      @@alchemy_modules << module_definition.stringify_keys
+      @@alchemy_modules << module_definition.deep_stringify_keys
     end
 
     # Get the module definition for given module name
@@ -30,51 +30,47 @@ module Alchemy
     # You can also pass a hash of an module definition.
     # It then tries to find the module defintion from controller name and action name
     #
-    def module_definition_for(name)
-      case name
+    def module_definition_for(name_or_params)
+      case name_or_params
       when String
-        alchemy_modules.detect { |p| p['name'] == name }
+        alchemy_modules.detect { |m| m['name'] == name_or_params }
       when Hash
+        name_or_params.stringify_keys!
         alchemy_modules.detect do |alchemy_module|
-          module_navi = alchemy_module_navigation(alchemy_module)
-          definition_from_mainnavi(module_navi, name.symbolize_keys) ||
-            definition_from_subnavi(module_navi, name.symbolize_keys)
+          module_navi = alchemy_module.fetch('navigation', {})
+          definition_from_mainnavi(module_navi, name_or_params) ||
+            definition_from_subnavi(module_navi, name_or_params)
         end
       else
-        raise ArgumentError, "Could not find module definition for #{name}"
+        raise ArgumentError, "Could not find module definition for #{name_or_params}"
       end
     end
 
     private
 
-    def alchemy_module_navigation(alchemy_module)
-      alchemy_module.stringify_keys!
-      alchemy_module.fetch('navigation', {}).stringify_keys
+    def definition_from_mainnavi(module_navi, params)
+      controller_matches?(module_navi, params) && action_matches?(module_navi, params)
     end
 
-    def definition_from_mainnavi(module_navi, name)
-      controller_matches?(module_navi, name) && action_matches?(module_navi, name)
-    end
-
-    def definition_from_subnavi(module_navi, name)
+    def definition_from_subnavi(module_navi, params)
       subnavi = module_navi['sub_navigation']
       return if subnavi.nil?
 
-      subnavi.map(&:stringify_keys).any? do |sn|
-        controller_matches?(sn, name) && action_matches?(sn, name)
+      subnavi.any? do |navi|
+        controller_matches?(navi, params) && action_matches?(navi, params)
       end
     end
 
-    def controller_matches?(subnavi, name)
-      remove_slash(subnavi['controller']) == remove_slash(name[:controller])
+    def controller_matches?(navi, params)
+      remove_slash(navi['controller']) == remove_slash(params['controller'])
     end
 
-    def action_matches?(subnavi, name)
-      subnavi['action'] == name[:action]
+    def action_matches?(navi, params)
+      navi['action'] == params['action']
     end
 
-    def remove_slash(name)
-      name.gsub(/^\//, '')
+    def remove_slash(str)
+      str.gsub(/^\//, '')
     end
   end
 end

--- a/lib/alchemy/modules.rb
+++ b/lib/alchemy/modules.rb
@@ -36,7 +36,9 @@ module Alchemy
         alchemy_modules.detect { |p| p['name'] == name }
       when Hash
         alchemy_modules.detect do |alchemy_module|
-          definition_from_subnavi(alchemy_module, name.symbolize_keys)
+          module_navi = alchemy_module_navigation(alchemy_module)
+          definition_from_mainnavi(module_navi, name.symbolize_keys) ||
+            definition_from_subnavi(module_navi, name.symbolize_keys)
         end
       else
         raise ArgumentError, "Could not find module definition for #{name}"
@@ -50,12 +52,15 @@ module Alchemy
       alchemy_module.fetch('navigation', {}).stringify_keys
     end
 
-    def definition_from_subnavi(alchemy_module, name)
-      module_navi = alchemy_module_navigation(alchemy_module)
+    def definition_from_mainnavi(module_navi, name)
+      controller_matches?(module_navi, name) && action_matches?(module_navi, name)
+    end
+
+    def definition_from_subnavi(module_navi, name)
       subnavi = module_navi['sub_navigation']
       return if subnavi.nil?
 
-      subnavi.map(&:stringify_keys).detect do |sn|
+      subnavi.map(&:stringify_keys).any? do |sn|
         controller_matches?(sn, name) && action_matches?(sn, name)
       end
     end

--- a/spec/helpers/alchemy/admin/navigation_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/navigation_helper_spec.rb
@@ -65,7 +65,7 @@ describe Alchemy::Admin::NavigationHelper do
       end
 
       it "renders the main navigation entry partial" do
-        expect(helper.alchemy_main_navigation_entry(alchemy_module)).to match /<a.+class="main_navi_entry/
+        expect(helper.alchemy_main_navigation_entry(alchemy_module)).to match /<div.+class="main_navi_entry/
       end
     end
 

--- a/spec/helpers/alchemy/admin/navigation_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/navigation_helper_spec.rb
@@ -9,9 +9,26 @@ describe Alchemy::Admin::NavigationHelper do
         'name' => 'modules.dashboard',
         'controller' => 'alchemy/admin/dashboard',
         'action' => 'index',
-        'icon' => 'dashboard',
+        'icon' => 'dashboard'
+      }
+    }
+  end
+
+  let(:module_with_subnavigation) do
+    {
+      'name' => 'library',
+      'engine_name' => 'alchemy',
+      'navigation' => {
+        'name' => 'modules.library',
+        'controller' => 'alchemy/admin/pictures',
+        'action' => 'index',
         'sub_navigation' => [{
-          'controller' => 'alchemy/admin/layoutpages',
+          'name' => 'modules.pictures',
+          'controller' => 'alchemy/admin/pictures',
+          'action' => 'index'
+        }, {
+          'name' => 'modules.files',
+          'controller' => 'alchemy/admin/attachments',
           'action' => 'index'
         }]
       }
@@ -37,14 +54,14 @@ describe Alchemy::Admin::NavigationHelper do
         'controller' => '/admin/events',
         'action' => 'index',
         'params' => {
-            'key' => 'value'
+          'key' => 'value'
         },
         'sub_navigation' => [{
           'controller' => '/admin/events',
           'action' => 'index',
           'params' => {
-             'key' => 'value',
-             'key2' => 'value2'
+            'key' => 'value',
+            'key2' => 'value2'
           }
        }]
       }
@@ -61,11 +78,29 @@ describe Alchemy::Admin::NavigationHelper do
 
     context "with permission" do
       before do
-        expect(helper).to receive(:can?).and_return(true)
+        allow(helper).to receive(:can?).and_return(true)
       end
 
       it "renders the main navigation entry partial" do
-        expect(helper.alchemy_main_navigation_entry(alchemy_module)).to match /<div.+class="main_navi_entry/
+        expect(helper.alchemy_main_navigation_entry(alchemy_module)).
+          to have_selector '.main_navi_entry'
+      end
+
+      context "when module has sub navigation" do
+        let(:alchemy_module) do
+          module_with_subnavigation
+        end
+
+        before do
+          allow(helper).to receive(:module_definition_for) do
+            alchemy_module
+          end
+        end
+
+        it 'includes the sub navigation' do
+          expect(helper.alchemy_main_navigation_entry(alchemy_module)).
+            to have_selector '.main_navi_entry .sub_navigation'
+        end
       end
     end
 
@@ -80,61 +115,28 @@ describe Alchemy::Admin::NavigationHelper do
     end
   end
 
-  describe '#admin_subnavigation' do
-    before do
-      allow(helper).to receive(:current_alchemy_module).and_return(alchemy_module)
-      allow(helper).to receive(:url_for_module_sub_navigation).and_return('')
-      allow(Alchemy).to receive(:t).and_return(alchemy_module['name'])
-    end
-
-    context "with permission" do
-      before do
-        expect(helper).to receive(:can?).and_return(true)
-      end
-
-      it "renders the sub navigation for current module" do
-        expect(helper.admin_subnavigation).to match /<div.+class="subnavi_tab/
-      end
-    end
-
-    context "without permission" do
-      before do
-        expect(helper).to receive(:can?).and_return(false)
-      end
-
-      it "renders the sub navigation for current module" do
-        expect(helper.admin_subnavigation).to be_empty
-      end
-    end
-
-    context "without a module present" do
-      before do
-        expect(helper).to receive(:current_alchemy_module).and_return(nil)
-      end
-
-      it "returns nil" do
-        expect(helper.admin_subnavigation).to be_nil
-      end
-    end
-  end
-
   describe '#navigate_module' do
     it "returns array with symbolized action and controller name" do
       expect(helper.navigate_module(navigation)).to eq([:index, :alchemy_admin_dashboard])
     end
 
-    it "stringifies keys" do
-      expect(helper.navigate_module({action: 'index', controller: 'alchemy/admin/pictures'})).to eq([:index, :alchemy_admin_pictures])
-    end
+    context "when controller name has a leading slash" do
+      let(:navigation) do
+        {
+          'action' => 'index',
+          'controller' => '/admin/pictures'
+        }
+      end
 
-    it "removes leading slash" do
-      expect(helper.navigate_module({action: 'index', controller: '/admin/pictures'})).to eq([:index, :admin_pictures])
+      it "removes leading slash" do
+        expect(helper.navigate_module(navigation)).to eq([:index, :admin_pictures])
+      end
     end
   end
 
   describe '#main_navigation_css_classes' do
     it "returns string with css classes for main navigation entry" do
-      expect(helper.main_navigation_css_classes(navigation)).to eq("main_navi_entry")
+      expect(helper.main_navigation_css_classes(navigation)).to eq(%w(main_navi_entry))
     end
 
     context "with active entry" do
@@ -146,7 +148,7 @@ describe Alchemy::Admin::NavigationHelper do
       end
 
       it "includes active class" do
-        expect(helper.main_navigation_css_classes(navigation)).to eq("main_navi_entry active")
+        expect(helper.main_navigation_css_classes(navigation)).to eq(%w(main_navi_entry active))
       end
     end
   end
@@ -158,10 +160,12 @@ describe Alchemy::Admin::NavigationHelper do
 
     context "with active entry" do
       before do
-        allow(helper).to receive(:params).and_return({
-          controller: 'alchemy/admin/dashboard',
-          action: 'index'
-        })
+        allow(helper).to receive(:params) do
+          {
+            controller: 'alchemy/admin/dashboard',
+            action: 'index'
+          }
+        end
       end
 
       it "returns true" do
@@ -190,10 +194,12 @@ describe Alchemy::Admin::NavigationHelper do
 
     context "with inactive entry" do
       before do
-        expect(helper).to receive(:params).and_return({
-          controller: 'alchemy/admin/users',
-          action: 'index'
-        })
+        expect(helper).to receive(:params) do
+          {
+            controller: 'alchemy/admin/users',
+            action: 'index'
+          }
+        end
       end
 
       it "returns false" do
@@ -221,10 +227,15 @@ describe Alchemy::Admin::NavigationHelper do
   end
 
   describe '#url_for_module_sub_navigation' do
-    subject { helper.url_for_module_sub_navigation(navigation) }
+    let(:current_module) do
+      module_with_subnavigation
+    end
 
-    let(:current_module) { alchemy_module }
-    let(:navigation)     { current_module['navigation']['sub_navigation'].first }
+    let(:navigation) do
+      current_module['navigation']['sub_navigation'].first
+    end
+
+    subject { helper.url_for_module_sub_navigation(navigation) }
 
     context 'with module found' do
       before do
@@ -232,10 +243,8 @@ describe Alchemy::Admin::NavigationHelper do
       end
 
       context "with module within an engine" do
-        let(:current_module) { alchemy_module }
-
         it "returns correct url string" do
-          is_expected.to eq('/admin/layoutpages')
+          is_expected.to eq('/admin/pictures')
         end
       end
 


### PR DESCRIPTION
## Introducing a new main menu

It's time for a new and more efficient main menu.

This is a first in many to follow PRs that clean the admin I step by step. 

### 1. The main menu now includes the sub navigation tabs:

![alchemy cms - pages 2016-09-07 12-49-07](https://cloud.githubusercontent.com/assets/42868/18309380/7a6cb5bc-74f9-11e6-92c9-a330bdcbc79d.jpg)

### 2. The sub navigation of non active tabs are accessible via hover

![monosnap 2016-09-07 12-51-11](https://cloud.githubusercontent.com/assets/42868/18309467/dec11e2c-74f9-11e6-9160-aa6b20098801.jpg)

### 3. A new collapsed main menu in page edit mode for maximum screen size usage

![monosnap 2016-09-07 12-54-24](https://cloud.githubusercontent.com/assets/42868/18309538/39d15610-74fa-11e6-8495-89d04fe6fd48.jpg)

### 4. The new top menu only shows locked pages and removed visual distraction

![alchemy cms - contact 2016-09-07 12-56-19](https://cloud.githubusercontent.com/assets/42868/18309587/7e5d4960-74fa-11e6-8aa2-825f7bb1bb16.jpg)

Please test this and provide feedback.