### PR TITLE
Update acts-as-taggable-on to v4.0

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'actionpack-page_caching',          ['~> 1.0.0']
   gem.add_runtime_dependency 'active_model_serializers',         ['~> 0.9.0']
   gem.add_runtime_dependency 'acts_as_list',                     ['~> 0.3']
-  gem.add_runtime_dependency 'acts-as-taggable-on',              ['~> 3.1']
+  gem.add_runtime_dependency 'acts-as-taggable-on',              ['~> 4.0']
   gem.add_runtime_dependency 'awesome_nested_set',               ['~> 3.0.0']
   gem.add_runtime_dependency 'bourbon',                          ['~> 4.2']
   gem.add_runtime_dependency 'cancancan',                        ['~> 1.9']

--- a/spec/dummy/db/migrate/20160912194430_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/spec/dummy/db/migrate/20160912194430_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,10 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+class ChangeCollationForTagNames < ActiveRecord::Migration
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20160912194431_add_missing_indexes.acts_as_taggable_on_engine.rb
+++ b/spec/dummy/db/migrate/20160912194431_add_missing_indexes.acts_as_taggable_on_engine.rb
@@ -1,0 +1,13 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+class AddMissingIndexes < ActiveRecord::Migration
+  def change
+    add_index :taggings, :tag_id
+    add_index :taggings, :taggable_id
+    add_index :taggings, :taggable_type
+    add_index :taggings, :tagger_id
+    add_index :taggings, :context
+
+    add_index :taggings, [:tagger_id, :tagger_type]
+    add_index :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160617224938) do
+ActiveRecord::Schema.define(version: 20160912194431) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string   "name"
@@ -317,8 +317,15 @@ ActiveRecord::Schema.define(version: 20160617224938) do
     t.datetime "created_at"
   end
 
+  add_index "taggings", ["context"], name: "index_taggings_on_context"
   add_index "taggings", ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+  add_index "taggings", ["tag_id"], name: "index_taggings_on_tag_id"
   add_index "taggings", ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context"
+  add_index "taggings", ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+  add_index "taggings", ["taggable_id"], name: "index_taggings_on_taggable_id"
+  add_index "taggings", ["taggable_type"], name: "index_taggings_on_taggable_type"
+  add_index "taggings", ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+  add_index "taggings", ["tagger_id"], name: "index_taggings_on_tagger_id"
 
   create_table "tags", force: :cascade do |t|
     t.string  "name"


### PR DESCRIPTION
On the way to Rails 5 we make this useful upgrade