### PR TITLE
Allow users to explicitely publish global pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ __Fixed Bugs__
 * Fix setting of locale when `current_alchemy_user.language` doesn't return a Symbol (#1097)
 * Presence validation of EssenceFile is not working (#1096)
 
+## 3.4.2 (unreleased)
+
+__Notable Changes__
+
+* Allow users to manually publish changes on global pages
+
 ## 3.4.1 (2016-08-31)
 
 __Fixed Bugs__

--- a/app/views/alchemy/admin/pages/edit.html.erb
+++ b/app/views/alchemy/admin/pages/edit.html.erb
@@ -65,7 +65,7 @@
     <% end %>
     <label><%= Alchemy.t(:page_properties) %></label>
   </div>
-  <% if can?(:publish, @page) && !@page.layoutpage? %>
+  <% if can?(:publish, @page) %>
     <div class="button_with_label">
       <%= form_tag alchemy.publish_admin_page_path(@page), id: 'publish_page_form' do %>
         <%= button_tag class: 'icon_button', title: Alchemy.t(:explain_publishing) do %>

--- a/spec/features/admin/page_editing_feature_spec.rb
+++ b/spec/features/admin/page_editing_feature_spec.rb
@@ -31,9 +31,9 @@ describe 'Page editing feature' do
     context 'while editing a global page' do
       let(:a_page) { create(:alchemy_page, layoutpage: true) }
 
-      it 'cannot publish page.' do
+      it 'can publish page.' do
         visit alchemy.edit_admin_page_path(a_page)
-        expect(page).to_not have_selector('#publish_page_form')
+        expect(page).to have_selector('#publish_page_form')
       end
     end
   end


### PR DESCRIPTION
Previously only pages inside the page tree had a publish-button. That
led to problems with elements from global pages like footers. Their
cache key consists mainly of their page's published_at date and since
one could not directly publish a (locked) global page, these elements
would keep their old, cached state. Even more problematic: users would
see the new version in the backend but only the cached version in the
frontend.

By adding the publish button, we allow the user to explicitely publish
the changes to elements on the global page. By generating a new
identifier (`page.published_at`), the element will be rendered as the
new version on *all* pages.