### PR TITLE
Adds required to belongs_to associations

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -40,7 +40,7 @@ namespace :alchemy do
   namespace :spec do
     desc "Prepares database for testing Alchemy"
     task :prepare do
-      system 'cd spec/dummy && RAILS_ENV=test bundle exec rake db:setup && cd -'
+      system 'cd spec/dummy && RAILS_ENV=test bundle exec rake db:drop db:create db:migrate:reset && cd -'
     end
   end
 end

--- a/app/models/alchemy/cell.rb
+++ b/app/models/alchemy/cell.rb
@@ -25,7 +25,7 @@ module Alchemy
   class Cell < ActiveRecord::Base
     include Alchemy::Logger
 
-    belongs_to :page
+    belongs_to :page, required: true
     validates_uniqueness_of :name, scope: 'page_id'
     validates_format_of :name, with: /\A[a-z0-9_-]+\z/
     has_many :elements, -> { where(parent_element_id: nil).order(:position) }, dependent: :destroy

--- a/app/models/alchemy/content.rb
+++ b/app/models/alchemy/content.rb
@@ -24,7 +24,7 @@ module Alchemy
     include Alchemy::Content::Factory
 
     belongs_to :essence, polymorphic: true, dependent: :destroy
-    belongs_to :element, touch: true
+    belongs_to :element, required: true, touch: true
     has_one :page, through: :element
 
     stampable stamper_class_name: Alchemy.user_class_name

--- a/app/models/alchemy/content.rb
+++ b/app/models/alchemy/content.rb
@@ -23,7 +23,7 @@ module Alchemy
     # Concerns
     include Alchemy::Content::Factory
 
-    belongs_to :essence, polymorphic: true, dependent: :destroy
+    belongs_to :essence, required: true, polymorphic: true, dependent: :destroy
     belongs_to :element, required: true, touch: true
     has_one :page, through: :element
 

--- a/app/models/alchemy/content/factory.rb
+++ b/app/models/alchemy/content/factory.rb
@@ -38,23 +38,26 @@ module Alchemy
         content
       end
 
-      # Makes a copy of source and also copies the associated essence.
+      # Creates a copy of source and also copies the associated essence.
       #
       # You can pass a differences hash to update the attributes of the copy.
       #
       # === Example
       #
-      #   @copy = Alchemy::Content.copy(@content, {:element_id => 3})
+      #   @copy = Alchemy::Content.copy(@content, {element_id: 3})
       #   @copy.element_id # => 3
       #
       def copy(source, differences = {})
-        attributes = source.attributes.except(*SKIPPED_ATTRIBUTES_ON_COPY).merge(differences.stringify_keys)
-        content = create!(attributes)
-        new_essence = content.essence.class.new(content.essence.attributes.except(*SKIPPED_ATTRIBUTES_ON_COPY))
-        new_essence.save!
-        raise "Essence not cloned" if new_essence.id == content.essence_id
-        content.update_attributes(essence_id: new_essence.id)
-        content
+        new_content = Content.new(
+          source.attributes.except(*SKIPPED_ATTRIBUTES_ON_COPY).merge(differences.stringify_keys)
+        )
+
+        new_essence = new_content.essence.class.create!(
+          new_content.essence.attributes.except(*SKIPPED_ATTRIBUTES_ON_COPY)
+        )
+
+        new_content.update!(essence_id: new_essence.id)
+        new_content
       end
 
       # Returns the content definition for building a content.

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -68,7 +68,7 @@ module Alchemy
       foreign_key: :parent_element_id,
       dependent: :destroy
 
-    belongs_to :cell
+    belongs_to :cell, required: false
     belongs_to :page
 
     # A nested element belongs to a parent element.

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -72,7 +72,10 @@ module Alchemy
     belongs_to :page, required: true
 
     # A nested element belongs to a parent element.
-    belongs_to :parent_element, class_name: 'Alchemy::Element', touch: true
+    belongs_to :parent_element,
+      class_name: 'Alchemy::Element',
+      required: false,
+      touch: true
 
     has_and_belongs_to_many :touchable_pages, -> { uniq },
       class_name: 'Alchemy::Page',

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -69,7 +69,7 @@ module Alchemy
       dependent: :destroy
 
     belongs_to :cell, required: false
-    belongs_to :page
+    belongs_to :page, required: true
 
     # A nested element belongs to a parent element.
     belongs_to :parent_element, class_name: 'Alchemy::Element', touch: true

--- a/app/models/alchemy/essence_file.rb
+++ b/app/models/alchemy/essence_file.rb
@@ -15,7 +15,7 @@
 
 module Alchemy
   class EssenceFile < ActiveRecord::Base
-    belongs_to :attachment
+    belongs_to :attachment, required: false
     acts_as_essence ingredient_column: 'attachment'
 
     def attachment_url

--- a/app/models/alchemy/essence_picture.rb
+++ b/app/models/alchemy/essence_picture.rb
@@ -25,7 +25,7 @@ module Alchemy
   class EssencePicture < ActiveRecord::Base
     acts_as_essence ingredient_column: 'picture'
 
-    belongs_to :picture
+    belongs_to :picture, required: false
     delegate :image_file_width, :image_file_height, :image_file, to: :picture
     before_save :fix_crop_values
     before_save :replace_newlines

--- a/app/models/alchemy/folded_page.rb
+++ b/app/models/alchemy/folded_page.rb
@@ -10,7 +10,8 @@
 
 module Alchemy
   class FoldedPage < ActiveRecord::Base
-    belongs_to :page
-    belongs_to :user, class_name: Alchemy.user_class_name
+    belongs_to :page, required: true
+    belongs_to :user, required: true,
+      class_name: Alchemy.user_class_name
   end
 end

--- a/app/models/alchemy/legacy_page_url.rb
+++ b/app/models/alchemy/legacy_page_url.rb
@@ -10,10 +10,10 @@
 #
 
 class Alchemy::LegacyPageUrl < ActiveRecord::Base
-  belongs_to :page, class_name: 'Alchemy::Page'
+  belongs_to :page,
+    class_name: 'Alchemy::Page',
+    required: true
 
-  validates :page_id,
-    presence: true
   validates :urlname,
     presence: true,
     format: {with: /\A[:\.\w\-+_\/\?&%;=]*\z/}

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -336,7 +336,7 @@ module Alchemy
     def fold!(user_id, status)
       folded_page = folded_pages.find_or_create_by(user_id: user_id)
       folded_page.folded = status
-      folded_page.save
+      folded_page.save!
     end
 
     def set_restrictions_to_child_pages

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -87,7 +87,7 @@ module Alchemy
 
     stampable stamper_class_name: Alchemy.user_class_name
 
-    belongs_to :language
+    belongs_to :language, required: false
 
     has_one :site, through: :language
     has_many :site_languages, through: :site, source: :languages

--- a/db/migrate/20160927205604_add_foreign_key_indices.rb
+++ b/db/migrate/20160927205604_add_foreign_key_indices.rb
@@ -8,6 +8,7 @@ class AddForeignKeyIndices < ActiveRecord::Migration
     change_column_null :alchemy_contents, :essence_type, false, 'Alchemy::EssenceText'
     add_index :alchemy_contents, [:essence_id, :essence_type], unique: true
 
+    change_column_null :alchemy_elements, :page_id, false, 0
     add_index :alchemy_elements, :cell_id
   end
 end

--- a/db/migrate/20160927205604_add_foreign_key_indices.rb
+++ b/db/migrate/20160927205604_add_foreign_key_indices.rb
@@ -1,16 +1,15 @@
 class AddForeignKeyIndices < ActiveRecord::Migration
   def change
     change_column_null :alchemy_cells, :page_id, false, 0
-    add_index :alchemy_cells, :page_id
-
     change_column_null :alchemy_contents, :element_id, false, 0
     change_column_null :alchemy_contents, :essence_id, false, 0
     change_column_null :alchemy_contents, :essence_type, false, 'Alchemy::EssenceText'
-    add_index :alchemy_contents, [:essence_id, :essence_type], unique: true
-
     change_column_null :alchemy_elements, :page_id, false, 0
-    add_index :alchemy_elements, :cell_id
 
+    add_index :alchemy_cells, :page_id
+    add_index :alchemy_contents, [:essence_id, :essence_type], unique: true
+    add_index :alchemy_elements, :cell_id
     add_index :alchemy_essence_files, :attachment_id
+    add_index :alchemy_essence_pictures, :picture_id
   end
 end

--- a/db/migrate/20160927205604_add_foreign_key_indices.rb
+++ b/db/migrate/20160927205604_add_foreign_key_indices.rb
@@ -7,5 +7,7 @@ class AddForeignKeyIndices < ActiveRecord::Migration
     change_column_null :alchemy_contents, :essence_id, false, 0
     change_column_null :alchemy_contents, :essence_type, false, 'Alchemy::EssenceText'
     add_index :alchemy_contents, [:essence_id, :essence_type], unique: true
+
+    add_index :alchemy_elements, :cell_id
   end
 end

--- a/db/migrate/20160927205604_add_foreign_key_indices.rb
+++ b/db/migrate/20160927205604_add_foreign_key_indices.rb
@@ -1,0 +1,8 @@
+class AddForeignKeyIndices < ActiveRecord::Migration
+  def change
+    change_column_null :alchemy_cells, :page_id, false, 0
+    add_index :alchemy_cells, :page_id
+
+    change_column_null :alchemy_contents, :element_id, false, 0
+  end
+end

--- a/db/migrate/20160927205604_add_foreign_key_indices.rb
+++ b/db/migrate/20160927205604_add_foreign_key_indices.rb
@@ -10,5 +10,7 @@ class AddForeignKeyIndices < ActiveRecord::Migration
 
     change_column_null :alchemy_elements, :page_id, false, 0
     add_index :alchemy_elements, :cell_id
+
+    add_index :alchemy_essence_files, :attachment_id
   end
 end

--- a/db/migrate/20160927205604_add_foreign_key_indices.rb
+++ b/db/migrate/20160927205604_add_foreign_key_indices.rb
@@ -4,5 +4,8 @@ class AddForeignKeyIndices < ActiveRecord::Migration
     add_index :alchemy_cells, :page_id
 
     change_column_null :alchemy_contents, :element_id, false, 0
+    change_column_null :alchemy_contents, :essence_id, false, 0
+    change_column_null :alchemy_contents, :essence_type, false, 'Alchemy::EssenceText'
+    add_index :alchemy_contents, [:essence_id, :essence_type], unique: true
   end
 end

--- a/db/migrate/20160927205604_add_foreign_key_indices_and_null_constraints.rb
+++ b/db/migrate/20160927205604_add_foreign_key_indices_and_null_constraints.rb
@@ -7,6 +7,7 @@ class AddForeignKeyIndicesAndNullConstraints < ActiveRecord::Migration
     change_column_null :alchemy_elements, :page_id, false, 0
     change_column_null :alchemy_folded_pages, :page_id, false, 0
     change_column_null :alchemy_folded_pages, :user_id, false, 0
+    change_column_null :alchemy_languages, :site_id, false, 0
 
     add_index :alchemy_cells, :page_id
     add_index :alchemy_contents, [:essence_id, :essence_type], unique: true

--- a/db/migrate/20160927205604_add_foreign_key_indices_and_null_constraints.rb
+++ b/db/migrate/20160927205604_add_foreign_key_indices_and_null_constraints.rb
@@ -15,5 +15,6 @@ class AddForeignKeyIndicesAndNullConstraints < ActiveRecord::Migration
     add_index :alchemy_essence_files, :attachment_id
     add_index :alchemy_essence_pictures, :picture_id
     add_index :alchemy_folded_pages, [:page_id, :user_id], unique: true
+    add_index :alchemy_legacy_page_urls, :page_id
   end
 end

--- a/db/migrate/20160927205604_add_foreign_key_indices_and_null_constraints.rb
+++ b/db/migrate/20160927205604_add_foreign_key_indices_and_null_constraints.rb
@@ -1,15 +1,18 @@
-class AddForeignKeyIndices < ActiveRecord::Migration
+class AddForeignKeyIndicesAndNullConstraints < ActiveRecord::Migration
   def change
     change_column_null :alchemy_cells, :page_id, false, 0
     change_column_null :alchemy_contents, :element_id, false, 0
     change_column_null :alchemy_contents, :essence_id, false, 0
     change_column_null :alchemy_contents, :essence_type, false, 'Alchemy::EssenceText'
     change_column_null :alchemy_elements, :page_id, false, 0
+    change_column_null :alchemy_folded_pages, :page_id, false, 0
+    change_column_null :alchemy_folded_pages, :user_id, false, 0
 
     add_index :alchemy_cells, :page_id
     add_index :alchemy_contents, [:essence_id, :essence_type], unique: true
     add_index :alchemy_elements, :cell_id
     add_index :alchemy_essence_files, :attachment_id
     add_index :alchemy_essence_pictures, :picture_id
+    add_index :alchemy_folded_pages, [:page_id, :user_id], unique: true
   end
 end

--- a/lib/alchemy/test_support/essence_shared_examples.rb
+++ b/lib/alchemy/test_support/essence_shared_examples.rb
@@ -6,6 +6,8 @@ shared_examples_for "an essence" do
   let(:content_definition) { {'name' => 'foo'} }
 
   it "touches the content after update" do
+    element = create(:alchemy_element)
+    content = create(:alchemy_content, element: element)
     essence.save
     content.update(essence: essence, essence_type: essence.class.name)
     date = content.updated_at

--- a/lib/alchemy/test_support/factories/content_factory.rb
+++ b/lib/alchemy/test_support/factories/content_factory.rb
@@ -6,5 +6,6 @@ FactoryGirl.define do
     name "text"
     essence_type "Alchemy::EssenceText"
     association :essence, factory: :alchemy_essence_text
+    association :element, factory: :alchemy_element
   end
 end

--- a/lib/alchemy/test_support/factories/element_factory.rb
+++ b/lib/alchemy/test_support/factories/element_factory.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
   factory :alchemy_element, class: 'Alchemy::Element' do
     name 'article'
     create_contents_after_create false
+    association :page, factory: :alchemy_page
 
     trait :unique do
       unique true

--- a/spec/controllers/alchemy/admin/contents_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/contents_controller_spec.rb
@@ -29,8 +29,18 @@ module Alchemy
       end
 
       context 'inside a picture gallery' do
+        let(:element) { create(:alchemy_element) }
+
         let(:attributes) do
-          {content: {element_id: element.id, essence_type: 'Alchemy::EssencePicture'}, options: {grouped: 'true'}}
+          {
+            content: {
+              element_id: element.id,
+              essence_type: 'Alchemy::EssencePicture'
+            },
+            options: {
+              grouped: 'true'
+            }
+          }
         end
 
         it "adds it into the gallery editor" do

--- a/spec/controllers/alchemy/admin/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/pages_controller_spec.rb
@@ -91,6 +91,7 @@ module Alchemy
       end
 
       describe '#tree' do
+        let(:user)   { create(:alchemy_dummy_user, :as_editor) }
         let(:page_1) { create(:alchemy_page, visible: true, name: 'one') }
         let(:page_2) { create(:alchemy_page, visible: true, name: 'two', parent_id: page_1.id) }
         let(:page_3) { create(:alchemy_page, visible: true, name: 'three', parent_id: page_2.id) }

--- a/spec/dummy/db/migrate/20160927205604_add_foreign_key_indices.rb
+++ b/spec/dummy/db/migrate/20160927205604_add_foreign_key_indices.rb
@@ -1,1 +1,0 @@
-../../../../db/migrate/20160927205604_add_foreign_key_indices.rb

--- a/spec/dummy/db/migrate/20160927205604_add_foreign_key_indices.rb
+++ b/spec/dummy/db/migrate/20160927205604_add_foreign_key_indices.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20160927205604_add_foreign_key_indices.rb

--- a/spec/dummy/db/migrate/20160927205604_add_foreign_key_indices_and_null_constraints.rb
+++ b/spec/dummy/db/migrate/20160927205604_add_foreign_key_indices_and_null_constraints.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20160927205604_add_foreign_key_indices_and_null_constraints.rb

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -68,6 +68,7 @@ ActiveRecord::Schema.define(version: 20160927205604) do
     t.integer  "parent_element_id"
   end
 
+  add_index "alchemy_elements", ["cell_id"], name: "index_alchemy_elements_on_cell_id"
   add_index "alchemy_elements", ["page_id", "parent_element_id"], name: "index_alchemy_elements_on_page_id_and_parent_element_id"
   add_index "alchemy_elements", ["page_id", "position"], name: "index_elements_on_page_id_and_position"
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -182,10 +182,12 @@ ActiveRecord::Schema.define(version: 20160927205604) do
   end
 
   create_table "alchemy_folded_pages", force: :cascade do |t|
-    t.integer "page_id"
-    t.integer "user_id"
+    t.integer "page_id",                 null: false
+    t.integer "user_id",                 null: false
     t.boolean "folded",  default: false
   end
+
+  add_index "alchemy_folded_pages", ["page_id", "user_id"], name: "index_alchemy_folded_pages_on_page_id_and_user_id", unique: true
 
   create_table "alchemy_languages", force: :cascade do |t|
     t.string   "name"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -39,8 +39,8 @@ ActiveRecord::Schema.define(version: 20160927205604) do
 
   create_table "alchemy_contents", force: :cascade do |t|
     t.string   "name"
-    t.string   "essence_type"
-    t.integer  "essence_id"
+    t.string   "essence_type", null: false
+    t.integer  "essence_id",   null: false
     t.integer  "element_id",   null: false
     t.integer  "position"
     t.datetime "created_at",   null: false
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 20160927205604) do
   end
 
   add_index "alchemy_contents", ["element_id", "position"], name: "index_contents_on_element_id_and_position"
+  add_index "alchemy_contents", ["essence_id", "essence_type"], name: "index_alchemy_contents_on_essence_id_and_essence_type", unique: true
 
   create_table "alchemy_elements", force: :cascade do |t|
     t.string   "name"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -106,6 +106,8 @@ ActiveRecord::Schema.define(version: 20160927205604) do
     t.string   "link_text"
   end
 
+  add_index "alchemy_essence_files", ["attachment_id"], name: "index_alchemy_essence_files_on_attachment_id"
+
   create_table "alchemy_essence_htmls", force: :cascade do |t|
     t.text     "source"
     t.integer  "creator_id"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -216,6 +216,7 @@ ActiveRecord::Schema.define(version: 20160927205604) do
     t.datetime "updated_at", null: false
   end
 
+  add_index "alchemy_legacy_page_urls", ["page_id"], name: "index_alchemy_legacy_page_urls_on_page_id"
   add_index "alchemy_legacy_page_urls", ["urlname"], name: "index_alchemy_legacy_page_urls_on_urlname"
 
   create_table "alchemy_pages", force: :cascade do |t|

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -146,6 +146,8 @@ ActiveRecord::Schema.define(version: 20160927205604) do
     t.string   "render_size"
   end
 
+  add_index "alchemy_essence_pictures", ["picture_id"], name: "index_alchemy_essence_pictures_on_picture_id"
+
   create_table "alchemy_essence_richtexts", force: :cascade do |t|
     t.text     "body"
     t.text     "stripped_body"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -55,7 +55,7 @@ ActiveRecord::Schema.define(version: 20160927205604) do
   create_table "alchemy_elements", force: :cascade do |t|
     t.string   "name"
     t.integer  "position"
-    t.integer  "page_id"
+    t.integer  "page_id",                           null: false
     t.boolean  "public",            default: true
     t.boolean  "folded",            default: false
     t.boolean  "unique",            default: false

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -201,7 +201,7 @@ ActiveRecord::Schema.define(version: 20160927205604) do
     t.integer  "updater_id"
     t.boolean  "default",        default: false
     t.string   "country_code",   default: "",      null: false
-    t.integer  "site_id"
+    t.integer  "site_id",                          null: false
     t.string   "locale"
   end
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160912223112) do
+ActiveRecord::Schema.define(version: 20160927205604) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string   "name"
@@ -29,17 +29,19 @@ ActiveRecord::Schema.define(version: 20160912223112) do
   add_index "alchemy_attachments", ["file_uid"], name: "index_alchemy_attachments_on_file_uid"
 
   create_table "alchemy_cells", force: :cascade do |t|
-    t.integer  "page_id"
+    t.integer  "page_id",    null: false
     t.string   "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
+  add_index "alchemy_cells", ["page_id"], name: "index_alchemy_cells_on_page_id"
+
   create_table "alchemy_contents", force: :cascade do |t|
     t.string   "name"
     t.string   "essence_type"
     t.integer  "essence_id"
-    t.integer  "element_id"
+    t.integer  "element_id",   null: false
     t.integer  "position"
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false

--- a/spec/models/alchemy/content_spec.rb
+++ b/spec/models/alchemy/content_spec.rb
@@ -108,15 +108,16 @@ module Alchemy
       it "should create a new record with all attributes of source except given differences" do
         copy = Content.copy(content, {name: 'foobar', element_id: new_element.id})
         expect(copy.name).to eq('foobar')
+        expect(copy.element_id).to eq(new_element.id)
       end
 
       it "should make a new record for essence of source" do
-        copy = Content.copy(content, {element_id: new_element.id})
+        copy = Content.copy(content)
         expect(copy.essence_id).not_to eq(content.essence_id)
       end
 
       it "should copy source essence attributes" do
-        copy = Content.copy(content, {element_id: new_element.id})
+        copy = Content.copy(content)
         copy.essence.body == content.essence.body
       end
     end

--- a/spec/models/alchemy/content_spec.rb
+++ b/spec/models/alchemy/content_spec.rb
@@ -91,24 +91,33 @@ module Alchemy
     end
 
     describe '.copy' do
-      before(:each) do
-        @element = create(:alchemy_element, name: 'text', create_contents_after_create: true)
-        @content = @element.contents.first
+      let(:element) do
+        create :alchemy_element,
+          name: 'text',
+          create_contents_after_create: true
+      end
+
+      let(:new_element) do
+        create(:alchemy_element, name: 'text')
+      end
+
+      let(:content) do
+        element.contents.first
       end
 
       it "should create a new record with all attributes of source except given differences" do
-        copy = Content.copy(@content, {name: 'foobar', element_id: @element.id + 1})
+        copy = Content.copy(content, {name: 'foobar', element_id: new_element.id})
         expect(copy.name).to eq('foobar')
       end
 
       it "should make a new record for essence of source" do
-        copy = Content.copy(@content, {element_id: @element.id + 1})
-        expect(copy.essence_id).not_to eq(@content.essence_id)
+        copy = Content.copy(content, {element_id: new_element.id})
+        expect(copy.essence_id).not_to eq(content.essence_id)
       end
 
       it "should copy source essence attributes" do
-        copy = Content.copy(@content, {element_id: @element.id + 1})
-        copy.essence.body == @content.essence.body
+        copy = Content.copy(content, {element_id: new_element.id})
+        copy.essence.body == content.essence.body
       end
     end
 

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -11,7 +11,8 @@ module Alchemy
     describe '.new_from_scratch' do
       it "should initialize an element by name from scratch" do
         el = Element.new_from_scratch(name: 'article')
-        expect(el).to be_valid
+        expect(el).to be_an(Alchemy::Element)
+        expect(el.name).to eq('article')
       end
 
       it "should raise an error if the given name is not defined in the elements.yml" do
@@ -204,7 +205,7 @@ module Alchemy
     end
 
     context 'trash' do
-      let(:element) { create(:alchemy_element, page_id: 1) }
+      let(:element) { create(:alchemy_element) }
 
       describe '.not_trashed' do
         before { element }
@@ -688,22 +689,30 @@ module Alchemy
     end
 
     describe '#trash!' do
-      let(:element)         { create(:alchemy_element, page_id: 1, cell_id: 1) }
-      let(:trashed_element) { element.trash!; element }
-      subject               { trashed_element }
+      let(:element) { create(:alchemy_element) }
 
-      it             { is_expected.not_to be_public }
-      it             { is_expected.to be_folded }
+      let(:trashed_element) do
+        element.trash!
+        element
+      end
+
+      subject { trashed_element }
+
+      it { is_expected.not_to be_public }
+      it { is_expected.to be_folded }
 
       describe '#position' do
         subject { super().position }
         it { is_expected.to be_nil }
       end
-      specify        { expect { element.trash! }.to_not change(element, :page_id) }
-      specify        { expect { element.trash! }.to_not change(element, :cell_id) }
+
+      specify { expect { element.trash! }.to_not change(element, :page_id) }
+      specify { expect { element.trash! }.to_not change(element, :cell_id) }
 
       context "with already one trashed element on the same page" do
-        let(:element_2) { create(:alchemy_element, page_id: 1) }
+        let(:element_2) do
+          create(:alchemy_element, page: trashed_element.page)
+        end
 
         before do
           trashed_element

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1299,7 +1299,7 @@ module Alchemy
     end
 
     context 'folding' do
-      let(:user) { mock_model('DummyUser') }
+      let(:user) { create(:alchemy_dummy_user) }
 
       describe '#fold!' do
         context "with folded status set to true" do
@@ -1315,7 +1315,7 @@ module Alchemy
 
         context 'with user is a active record model' do
           before do
-            expect(Alchemy.user_class).to receive(:'<').and_return(true)
+            allow(Alchemy.user_class).to receive(:'<').and_return(true)
           end
 
           context 'if page is folded' do

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -971,15 +971,15 @@ module Alchemy
       end
 
       let!(:element_1) do
-        create(:alchemy_element, page_id: page.id)
+        create(:alchemy_element, page: page)
       end
 
       let!(:element_2) do
-        create(:alchemy_element, :with_nestable_elements, page_id: page.id, parent_element_id: element_1.id)
+        create(:alchemy_element, :with_nestable_elements, page: page, parent_element_id: element_1.id)
       end
 
       let!(:element_3) do
-        create(:alchemy_element, page_id: page.id)
+        create(:alchemy_element, page: page)
       end
 
       it 'returns an active record collection of all elements including nested elements on that page' do
@@ -993,20 +993,25 @@ module Alchemy
       end
 
       let!(:element_1) do
-        create(:alchemy_element, :with_nestable_elements, :with_contents, name: 'slider', page_id: page.id)
+        create :alchemy_element,
+          :with_nestable_elements,
+          :with_contents, {
+            name: 'slider',
+            page: page
+          }
       end
 
       let!(:element_2) do
         create :alchemy_element,
           :with_contents, {
             name: 'slide',
-            page_id: page.id,
+            page: page,
             parent_element_id: element_1.id
           }
       end
 
       let!(:element_3) do
-        create(:alchemy_element, :with_contents, name: 'slide', page_id: page.id)
+        create(:alchemy_element, :with_contents, name: 'slide', page: page)
       end
 
       it 'returns an active record collection of all content including nested elements on that page' do


### PR DESCRIPTION
In order to achieve better database consistency (to avoid errors like in #1066) and because Rails 5 has `belongs_to` associations required per default, we set `required: true` (and `required: false` for optional associations, like element <=> cell) for all these associations.

This also adds lots of missing foreign key indices and not null constraints for these columns.