### PR TITLE
Sort admin locales

### DIFF
--- a/app/helpers/alchemy/admin/base_helper.rb
+++ b/app/helpers/alchemy/admin/base_helper.rb
@@ -58,7 +58,7 @@ module Alchemy
 
       # Used for translations selector in Alchemy cockpit user settings.
       def translations_for_select
-        Alchemy::I18n.available_locales.map do |locale|
+        Alchemy::I18n.available_locales.sort.map do |locale|
           [Alchemy.t(locale, scope: :translations), locale]
         end
       end


### PR DESCRIPTION
The tiny locale select on the top right of the screen has now sorted entries.

### Before:

![alchemy cms - files 2016-09-29 15-27-34](https://cloud.githubusercontent.com/assets/42868/18955820/4683a352-8659-11e6-9218-443b664a31e3.jpg)

### After:

![alchemy cms - dashboard 2016-09-29 15-26-46](https://cloud.githubusercontent.com/assets/42868/18955781/287af2ca-8659-11e6-8e32-ca99817c2c6a.jpg)
