### PR TITLE
Add foreign keys

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -10,6 +10,7 @@ engines:
     enabled: true
     exclude_paths:
     - "lib/alchemy/permissions.rb"
+    - "lib/tasks/alchemy/tidy.rake"
     config:
       languages:
       - ruby

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ __Notable Changes__
 * `image_size` option is now deprecated. Please use just `size` (#1084)
 * `show_alchemy_picture_path` helper is now deprecated. Please use `picture.url` instead (#1084)
 * Display download information on the Attachment Modal Dialog (#1137)
+* Added foreign keys to important associations (#1149)
 
 __Fixed Bugs__
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ __Notable Changes__
 * `show_alchemy_picture_path` helper is now deprecated. Please use `picture.url` instead (#1084)
 * Display download information on the Attachment Modal Dialog (#1137)
 * Added foreign keys to important associations (#1149)
+* Also destroy trashed elements when page gets destroyed (#1149)
 
 __Fixed Bugs__
 

--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -24,13 +24,6 @@ module Alchemy
       after_create :autogenerate_elements, unless: -> { systempage? || do_not_autogenerate }
       after_update :trash_not_allowed_elements!, if: :page_layout_changed?
       after_update :autogenerate_elements, if: :page_layout_changed?
-
-      after_destroy do
-        elements.each do |element|
-          next if element.trashed?
-          element.destroy
-        end
-      end
     end
 
     module ClassMethods

--- a/config/locales/alchemy.de.yml
+++ b/config/locales/alchemy.de.yml
@@ -326,7 +326,7 @@ de:
     confirm_to_delete_image: "Wollen Sie dieses Bild wirklich löschen?"
     confirm_to_delete_image_from_server: "Wollen Sie dieses Bild wirklich vom Server löschen?"
     confirm_to_delete_images_from_server: "Wollen Sie diese Bilder wirklich vom Server löschen?"
-    confirm_to_delete_page: "Wollen Sie diese Seite wirklich löschen? Alle Inhalte gehen dabei unwiderruflich verloren!"
+    confirm_to_delete_page: "Wollen Sie diese Seite wirklich löschen? Alle Inhalte (auch die aus dem Papierkorb) gehen dabei unwiderruflich verloren!"
     content_essence_not_found: "Essenz wurde nicht gefunden"
     content_not_found: "Das Feld für diesen Inhalt ist nicht vorhanden."
     content_validations_headline: "Bitte überprüfen Sie die markierten Felder."

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -324,7 +324,7 @@ en:
     confirm_to_delete_image: "Do you really want to delete this image from server?"
     confirm_to_delete_image_from_server: "Do you really want to delete this image from the server?"
     confirm_to_delete_images_from_server: "Do you really want to delete these images from the server?"
-    confirm_to_delete_page: "Do you really want to delete this page? All its elements will get lost!"
+    confirm_to_delete_page: "Do you really want to delete this page? All its elements (even trashed ones) will get lost!"
     content_essence_not_found: "Content essence not found"
     content_not_found: "Field for content not present."
     content_validations_headline: "Please check marked fields below"

--- a/db/migrate/20160928080104_add_foreign_keys.rb
+++ b/db/migrate/20160928080104_add_foreign_keys.rb
@@ -1,0 +1,27 @@
+class AddForeignKeys < ActiveRecord::Migration
+  def change
+    add_foreign_key :alchemy_cells, :alchemy_pages,
+      column: :page_id,
+      on_update: :cascade,
+      on_delete: :cascade,
+      name: :alchemy_cells_page_id_fkey
+
+    add_foreign_key :alchemy_contents, :alchemy_elements,
+      column: :element_id,
+      on_update: :cascade,
+      on_delete: :cascade,
+      name: :alchemy_contents_element_id_fkey
+
+    add_foreign_key :alchemy_elements, :alchemy_pages,
+      column: :page_id,
+      on_update: :cascade,
+      on_delete: :cascade,
+      name: :alchemy_elements_page_id_fkey
+
+    add_foreign_key :alchemy_elements, :alchemy_cells,
+      column: :cell_id,
+      on_update: :cascade,
+      on_delete: :cascade,
+      name: :alchemy_elements_cell_id_fkey
+  end
+end

--- a/lib/tasks/alchemy/tidy.rake
+++ b/lib/tasks/alchemy/tidy.rake
@@ -7,6 +7,7 @@ namespace :alchemy do
       Rake::Task['alchemy:tidy:cells'].invoke
       Rake::Task['alchemy:tidy:element_positions'].invoke
       Rake::Task['alchemy:tidy:content_positions'].invoke
+      Rake::Task['alchemy:tidy:remove_orphaned_records'].invoke
     end
 
     desc "Creates missing cells for pages."
@@ -32,6 +33,28 @@ namespace :alchemy do
     desc "Fixes content positions."
     task content_positions: [:environment] do
       Alchemy::Tidy.update_content_positions
+    end
+
+    desc "Remove orphaned records (cells, elements, contents)."
+    task remove_orphaned_records: [:environment] do
+      Rake::Task['alchemy:tidy:remove_orphaned_cells'].invoke
+      Rake::Task['alchemy:tidy:remove_orphaned_elements'].invoke
+      Rake::Task['alchemy:tidy:remove_orphaned_contents'].invoke
+    end
+
+    desc "Remove orphaned cells."
+    task remove_orphaned_cells: [:environment] do
+      Alchemy::Tidy.remove_orphaned_cells
+    end
+
+    desc "Remove orphaned elements."
+    task remove_orphaned_elements: [:environment] do
+      Alchemy::Tidy.remove_orphaned_elements
+    end
+
+    desc "Remove orphaned contents."
+    task remove_orphaned_contents: [:environment] do
+      Alchemy::Tidy.remove_orphaned_contents
     end
   end
 end
@@ -95,6 +118,68 @@ module Alchemy
             end
           end
         end
+      end
+    end
+
+    def self.remove_orphaned_cells
+      puts "\n## Removing orphaned cells"
+      cells = Alchemy::Cell.unscoped.all
+      if cells.any?
+        orphaned_cells = cells.select do |cell|
+          cell.page.nil? && cell.page_id.present?
+        end
+        if orphaned_cells.any?
+          destroy_orphaned_records(orphaned_cells, 'cell')
+        else
+          log "No orphaned cells found", :skip
+        end
+      else
+        log "No cells found", :skip
+      end
+    end
+
+    def self.remove_orphaned_elements
+      puts "\n## Removing orphaned elements"
+      elements = Alchemy::Element.unscoped.all
+      if elements.any?
+        orphaned_elements = elements.select do |element|
+          element.page.nil? && element.page_id.present? ||
+            element.cell.nil? && element.cell_id.present?
+        end
+        if orphaned_elements.any?
+          destroy_orphaned_records(orphaned_elements, 'element')
+        else
+          log "No orphaned elements found", :skip
+        end
+      else
+        log "No elements found", :skip
+      end
+    end
+
+    def self.remove_orphaned_contents
+      puts "\n## Removing orphaned contents"
+      contents = Alchemy::Content.unscoped.all
+      if contents.any?
+        orphaned_contents = contents.select do |content|
+          content.essence.nil? && content.essence_id.present? ||
+            content.element.nil? && content.element_id.present?
+        end
+        if orphaned_contents.any?
+          destroy_orphaned_records(orphaned_contents, 'content')
+        else
+          log "No orphaned contents found", :skip
+        end
+      else
+        log "No contents found", :skip
+      end
+    end
+
+    private
+
+    def self.destroy_orphaned_records(records, class_name)
+      records.each do |record|
+        log "Destroy orphaned #{class_name}: #{record.id}"
+        record.destroy
       end
     end
   end

--- a/spec/controllers/alchemy/admin/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/elements_controller_spec.rb
@@ -131,16 +131,28 @@ module Alchemy
           expect(trashed_element.position).to_not be_nil
         end
 
-        it "should assign the (new) page_id to the element" do
-          alchemy_xhr :post, :order, element_ids: [trashed_element.id], page_id: 1, cell_id: nil
-          trashed_element.reload
-          expect(trashed_element.page_id).to be 1
+        context "with new page_id present" do
+          let(:page) { create(:alchemy_page) }
+
+          it "should assign the (new) page_id to the element" do
+            alchemy_xhr :post, :order, element_ids: [trashed_element.id], page_id: page.id
+            trashed_element.reload
+            expect(trashed_element.page_id).to be page.id
+          end
         end
 
-        it "should assign the (new) cell_id to the element" do
-          alchemy_xhr :post, :order, element_ids: [trashed_element.id], page_id: 1, cell_id: 5
-          trashed_element.reload
-          expect(trashed_element.cell_id).to be 5
+        context "with cell_id present" do
+          let(:cell) { create(:alchemy_cell) }
+
+          it "should assign the (new) cell_id to the element" do
+            alchemy_xhr :post, :order,
+              element_ids: [trashed_element.id],
+              page_id: trashed_element.page_id,
+              cell_id: cell.id
+
+            trashed_element.reload
+            expect(trashed_element.cell_id).to be cell.id
+          end
         end
       end
     end

--- a/spec/dummy/db/migrate/20160928080104_add_foreign_keys.rb
+++ b/spec/dummy/db/migrate/20160928080104_add_foreign_keys.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20160928080104_add_foreign_keys.rb

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160927205604) do
+ActiveRecord::Schema.define(version: 20160928080104) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string   "name"

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -166,10 +166,13 @@ module Alchemy
     end
 
     describe '.not_in_cell' do
-      it "should return all elements that are not in a cell" do
+      before do
         Element.delete_all
-        create(:alchemy_element, cell_id: 6)
-        create(:alchemy_element, cell_id: nil)
+        create(:alchemy_element, cell: create(:alchemy_cell))
+        create(:alchemy_element)
+      end
+
+      it "should return all elements that are not in a cell" do
         expect(Element.not_in_cell.size).to eq(1)
       end
     end

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -925,17 +925,6 @@ module Alchemy
       end
     end
 
-    describe '#destroy' do
-      context "with trashed but still assigned elements" do
-        before { news_page.elements.map(&:trash!) }
-
-        it "should not delete the trashed elements" do
-          news_page.destroy
-          expect(Element.trashed).not_to be_empty
-        end
-      end
-    end
-
     describe "#elements" do
       let(:page) { create(:alchemy_page) }
       let!(:element_1) { create(:alchemy_element, page: page) }


### PR DESCRIPTION
As discussed in #1133 #1148 and #1066 we need foreign keys to ensure data integrity.

### Adds a cleanup task

Run

    rake alchemy:tidy:remove_orphaned_records

to remove all orphaned records at once, or

    rake alchemy:tidy:remove_orphaned_cells
    rake alchemy:tidy:remove_orphaned_elements
    rake alchemy:tidy:remove_orphaned_contents

to remove orphaned records from a certain type from the database.

This task also runs if you invoke

    rake alchemy:tidy:up

to clean up the complete database.