### PR TITLE
Remove Actionpack Page Caching gem

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |gem|
   gem.executables           = 'alchemy'
   gem.require_paths         = ['lib']
 
-  gem.add_runtime_dependency 'actionpack-page_caching',          ['~> 1.0.0']
   gem.add_runtime_dependency 'active_model_serializers',         ['~> 0.9.0']
   gem.add_runtime_dependency 'acts_as_list',                     ['~> 0.3']
   gem.add_runtime_dependency 'acts-as-taggable-on',              ['~> 4.0']

--- a/lib/alchemy/engine.rb
+++ b/lib/alchemy/engine.rb
@@ -1,5 +1,4 @@
 # Require globally used external libraries
-require 'actionpack/page_caching'
 require 'acts_as_list'
 require 'acts-as-taggable-on'
 require 'action_view/dependency_tracker'


### PR DESCRIPTION
  - Page caching was used to cache the generated images from Dragonfly

  - as #1084 removed the controller, which was making use of the
    page caching, this gem is now not required