### PR TITLE
Customizable upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ __Notable Changes__
 * Display download information on the Attachment Modal Dialog (#1137)
 * Added foreign keys to important associations (#1149)
 * Also destroy trashed elements when page gets destroyed (#1149)
+* Upgrade tasks can now be run separately (#1152)
 
 __Fixed Bugs__
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,8 @@ http://markevans.github.io/dragonfly/cache/
 
 ## Upgrading
 
-The Alchemy team takes upgrades very seriously and tries to make them as smooth as we can. Therefore we have build in upgrade tasks, that try to automate as much as possible.
+The Alchemy team takes upgrades very seriously and tries to make them as smooth as we can.
+Therefore we have build in upgrade tasks, that try to automate as much as possible.
 
 That's why after updating the Alchemy gem you should **always run the upgrader**:
 
@@ -216,12 +217,29 @@ $ bundle update alchemy_cms
 $ bin/rake alchemy:upgrade
 ```
 
-Alchemy will print out useful information after running the automated tasks that help a smooth upgrade path. So please **take your time and read them**.
+Alchemy will print out useful information after running the automated tasks that help a smooth upgrade path.
+So please **take your time and read them**.
 
 Always be sure to keep an eye on the `config/alchemy/config.yml.defaults` file and update your `config/alchemy/config.yml` accordingly.
 
 Also, `git diff` is your friend.
 
+### Customize the upgrade process
+
+Alchemy upgrader runs several rake tasks in a specific order. This is sometimes not what you want or could even break upgrades.
+In order to customize the upgrade process you can instead run each of the tasks on their own.
+
+```shell
+$ bin/rake alchemy:install:migrations
+$ bin/rake db:migrate
+$ bin/rake alchemy:db:seed
+$ bin/rake alchemy:upgrade:config
+$ bin/rake alchemy:upgrade:run
+```
+
+**WARNING:** This is only recommended, if you have problems with the default `rake alchemy:upgrade` task and need to
+repair your data in between. The upgrader depends on these upgrade tasks running in this specific order, otherwise
+we can't ensure smooth upgrades for you.
 
 ## Deployment
 

--- a/lib/alchemy/upgrader.rb
+++ b/lib/alchemy/upgrader.rb
@@ -50,15 +50,6 @@ module Alchemy
         private_methods - Object.private_methods - superclass.private_methods
       end
 
-      private
-
-      # Setup task
-      def setup
-        Rake::Task['alchemy:install:migrations'].invoke
-        Rake::Task['db:migrate'].invoke
-        Seeder.seed!
-      end
-
       def copy_new_config_file
         desc "Copy configuration file."
         config_file = Rails.root.join('config/alchemy/config.yml')

--- a/lib/tasks/alchemy/db.rake
+++ b/lib/tasks/alchemy/db.rake
@@ -1,9 +1,15 @@
 require 'shellwords'
+require 'alchemy/seeder'
 require 'alchemy/tasks/helpers'
 include Alchemy::Tasks::Helpers
 
 namespace :alchemy do
   namespace :db do
+    desc "Seeds the database with Alchemy defaults"
+    task seed: [:environment] do
+      Alchemy::Seeder.seed!
+    end
+
     desc "Dumps the database to STDOUT (Pass DUMP_FILENAME to store the dump into a file)."
     task dump: :environment do
       dump_store = ENV['DUMP_FILENAME'] ? " > #{ENV['DUMP_FILENAME']}" : ""

--- a/lib/tasks/alchemy/upgrade.rake
+++ b/lib/tasks/alchemy/upgrade.rake
@@ -2,13 +2,27 @@ require 'alchemy/upgrader'
 require 'alchemy/version'
 
 namespace :alchemy do
-  desc "Upgrades database content to Alchemy CMS v#{Alchemy::VERSION} (Set UPGRADE env variable to only run a specific task)."
-  task upgrade: :environment do
-    Alchemy::Upgrader.run!
-  end
+  desc "Upgrades your app to Alchemy CMS v#{Alchemy::VERSION} (Set UPGRADE env variable to only run a specific task)."
+  task upgrade: [
+    'alchemy:install:migrations',
+    'db:migrate',
+    'alchemy:db:seed',
+    'alchemy:upgrade:config',
+    'alchemy:upgrade:run'
+  ]
 
   namespace :upgrade do
-    desc "List all available upgrade tasks."
+    desc "Alchemy Upgrader: Run only the upgrader tasks without preparation"
+    task run: [:environment] do
+      Alchemy::Upgrader.run!
+    end
+
+    desc "Alchemy Upgrader: Copy configuration file."
+    task config: [:environment] do |t|
+      Alchemy::Upgrader.copy_new_config_file
+    end
+
+    desc "Alchemy Upgrader: List all upgrade tasks."
     task list: [:environment] do
       puts "\nAvailable upgrade tasks"
       puts "-----------------------\n"


### PR DESCRIPTION
Alchemy upgrader runs several rake tasks in a specific order.
This is sometimes not what you want or even breaks upgrades.
In order to customize the upgrade process you can now run each of tasks seperately.