### PR TITLE
Add nested page tree api endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 3.5.0 (unreleased)
 
+__New Features__
+
+* New API endpoint for retrieving a nested page tree (#1155)
+  `api/pages/nested` returns a nested JSON tree of all pages.
+
 __Notable Changes__
 
 * The essence view partials don't get cached anymore (#1099)

--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -24,7 +24,7 @@ module Alchemy
       render json: PageTreeSerializer.new(@page,
         ability: current_ability,
         user: current_alchemy_user,
-        elements: params[:elements] == 'true',
+        elements: params[:elements],
         full: true)
     end
 

--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -12,6 +12,17 @@ module Alchemy
       respond_with @pages
     end
 
+    # Returns all pages as nested json object for tree views
+    #
+    def nested
+      @page = Language.current_root_page
+
+      render json: PageTreeSerializer.new(@page,
+        ability: current_ability,
+        user: current_alchemy_user,
+        full: true)
+    end
+
     # Returns a json object for page
     #
     # You can either load the page via id or its urlname

--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -16,12 +16,15 @@ module Alchemy
     #
     # Pass a page_id param to only load tree for this page
     #
+    # Pass elements=true param to include elements for pages
+    #
     def nested
       @page = Page.find_by(id: params[:page_id]) || Language.current_root_page
 
       render json: PageTreeSerializer.new(@page,
         ability: current_ability,
         user: current_alchemy_user,
+        elements: params[:elements] == 'true',
         full: true)
     end
 

--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -14,8 +14,10 @@ module Alchemy
 
     # Returns all pages as nested json object for tree views
     #
+    # Pass a page_id param to only load tree for this page
+    #
     def nested
-      @page = Language.current_root_page
+      @page = Page.find_by(id: params[:page_id]) || Language.current_root_page
 
       render json: PageTreeSerializer.new(@page,
         ability: current_ability,

--- a/app/serializers/alchemy/page_tree_serializer.rb
+++ b/app/serializers/alchemy/page_tree_serializer.rb
@@ -64,7 +64,7 @@ module Alchemy
       }
 
       if opts[:elements]
-        p_hash.update(elements: ActiveModel::ArraySerializer.new(page.elements))
+        p_hash.update(elements: ActiveModel::ArraySerializer.new(page_elements(page)))
       end
 
       if opts[:ability].can?(:index, :alchemy_admin_pages)
@@ -77,6 +77,14 @@ module Alchemy
         })
       else
         p_hash
+      end
+    end
+
+    def page_elements(page)
+      if opts[:elements] == 'true'
+        page.elements
+      else
+        page.elements.named(opts[:elements].split(',') || [])
       end
     end
 

--- a/app/serializers/alchemy/page_tree_serializer.rb
+++ b/app/serializers/alchemy/page_tree_serializer.rb
@@ -46,27 +46,34 @@ module Alchemy
     protected
 
     def page_hash(page, has_children, level, folded)
-      {
+      p_hash = {
         id: page.id,
         name: page.name,
-        permissions: page_permissions(page, opts[:ability]),
         public: page.public?,
         visible: page.visible?,
         restricted: page.restricted?,
-        status_titles: page_status_titles(page),
         page_layout: page.page_layout,
         slug: page.slug,
         redirects_to_external: page.redirects_to_external?,
-        locked: page.locked?,
-        definition_missing: page.definition.blank?,
         urlname: page.urlname,
-        external_urlname: page.external_urlname,
+        external_urlname: page.redirects_to_external? ? page.external_urlname : nil,
         level: level,
         root: level == 1,
-        folded: folded,
         root_or_leaf: level == 1 || !has_children,
         children: []
       }
+
+      if opts[:ability].can?(:index, :alchemy_admin_pages)
+        p_hash.merge({
+          definition_missing: page.definition.blank?,
+          folded: folded,
+          locked: page.locked?,
+          permissions: page_permissions(page, opts[:ability]),
+          status_titles: page_status_titles(page)
+        })
+      else
+        p_hash
+      end
     end
 
     def page_permissions(page, ability)

--- a/app/serializers/alchemy/page_tree_serializer.rb
+++ b/app/serializers/alchemy/page_tree_serializer.rb
@@ -63,6 +63,10 @@ module Alchemy
         children: []
       }
 
+      if opts[:elements]
+        p_hash.update(elements: ActiveModel::ArraySerializer.new(page.elements))
+      end
+
       if opts[:ability].can?(:index, :alchemy_admin_pages)
         p_hash.merge({
           definition_missing: page.definition.blank?,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,6 +139,9 @@ Alchemy::Engine.routes.draw do
     resources :pages, only: [:index] do
       get 'elements' => 'elements#index', as: 'elements'
       get 'elements/:named' => 'elements#index', as: 'named_elements'
+      collection do
+        get :nested
+      end
     end
 
     get '/pages/*urlname(.:format)' => 'pages#show', as: 'page'

--- a/spec/controllers/alchemy/api/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/api/pages_controller_spec.rb
@@ -102,6 +102,20 @@ module Alchemy
           expect(child).to have_key('status_titles')
         end
       end
+
+      context "when a page_id is passed" do
+        it 'returns all pages as nested json from this page only' do
+          alchemy_get :nested, page_id: page.id, format: :json
+
+          expect(response.status).to eq(200)
+          expect(response.content_type).to eq('application/json')
+
+          result = JSON.parse(response.body)
+
+          expect(result).to have_key('pages')
+          expect(result['pages'][0]['name']).to eq(page.name)
+        end
+      end
     end
 
     describe '#show' do

--- a/spec/controllers/alchemy/api/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/api/pages_controller_spec.rb
@@ -116,6 +116,20 @@ module Alchemy
           expect(result['pages'][0]['name']).to eq(page.name)
         end
       end
+
+      context "when `elements` is passed" do
+        it 'returns all pages as nested json tree with elements included' do
+          alchemy_get :nested, elements: 'true', format: :json
+
+          expect(response.status).to eq(200)
+          expect(response.content_type).to eq('application/json')
+
+          result = JSON.parse(response.body)
+
+          expect(result).to have_key('pages')
+          expect(result['pages'][0]).to have_key('elements')
+        end
+      end
     end
 
     describe '#show' do


### PR DESCRIPTION
Make the admin page tree api endpoint available in the front end, so you can get a nested JSON representation of the current public page tree.