### PR TITLE
fix: copy_templates method

### DIFF
--- a/lib/rails/generators/alchemy/module/module_generator.rb
+++ b/lib/rails/generators/alchemy/module/module_generator.rb
@@ -20,7 +20,7 @@ module Alchemy
 
       def copy_templates
         template "controller.rb.tt", "app/controllers/admin/#{@controller_name}_controller.rb"
-        template "ability.rb.tt", 'app/models', "alchemy_#{@module_name}_ability.rb"
+        template "ability.rb.tt", "app/models/alchemy_#{@module_name}_ability.rb"
         template "module_config.rb.tt", "config/initializers/alchemy_#{@module_name}.rb"
       end
     end

--- a/lib/rails/generators/alchemy/module/module_generator.rb
+++ b/lib/rails/generators/alchemy/module/module_generator.rb
@@ -20,7 +20,7 @@ module Alchemy
 
       def copy_templates
         template "controller.rb.tt", "app/controllers/admin/#{@controller_name}_controller.rb"
-        template "ability.rb.tt", "app/models/alchemy_#{@module_name}_ability.rb"
+        template "ability.rb.tt", "app/models/#{@module_name}_ability.rb"
         template "module_config.rb.tt", "config/initializers/alchemy_#{@module_name}.rb"
       end
     end


### PR DESCRIPTION
according to ~~http://apidock.com/rails/Rails/Generator/Commands/Create/template~~ http://www.rubydoc.info/github/wycats/thor/Thor/Actions#template-instance_method `template` expects `source, *args, &block` as arguments, where source is the source file to render, and args.first could define a destination or the source bath will be used as relative destination path. 
# 47358c974d3ebd5ac9758f7e0f256384ceb76bff fix: copy_templates method

```
$ rails generate alchemy:module Example
Running via Spring preloader in process 73144
       route  namespace :admin do
    resources :examples
  end
      create  app/controllers/admin/examples_controller.rb
…/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/thor-0.19.1/lib/thor/actions/create_file.rb:46:in `binread': Is a directory @ io_fread - …/app/models (Errno::EISDIR)
```
# 9ed9fb767eb184543f67b2e5d65f4d474d2cb3c4 fix: remove alchemy prefix from ability file name

```
$ rails generate alchemy:module Example
Running via Spring preloader in process 72950
       route  namespace :admin do
    resources :examples
  end
      create  app/controllers/admin/examples_controller.rb
      create  app/models/alchemy_example_ability.rb
      create  config/initializers/alchemy_example.rb

$ rails server
=> Booting WEBrick
=> Rails 4.2.5 application starting in development on http://localhost:3000
=> Run `rails server -h` for more startup options
=> Ctrl-C to shutdown server
Exiting
…/config/initializers/alchemy_example.rb:17:in `<top (required)>': uninitialized constant ExampleAbility (NameError)
```

File app/models/alchemy_example_ability.rb contains the class ExampleAbility, but can't be autoloaded cause of the missmatch of class and file name. 
