### PR TITLE
Adds page and user seeders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ __New Features__
 
 * New API endpoint for retrieving a nested page tree (#1155)
   `api/pages/nested` returns a nested JSON tree of all pages.
+* Add page and user seeding support (#1160)
 
 __Notable Changes__
 

--- a/lib/alchemy/seeder.rb
+++ b/lib/alchemy/seeder.rb
@@ -13,6 +13,7 @@ module Alchemy
         create_default_site
         create_root_page
         seed_pages if page_seeds_file.file?
+        seed_users if user_seeds_file.file?
       end
 
       protected
@@ -62,6 +63,15 @@ module Alchemy
         end
       end
 
+      def seed_users
+        desc "Seeding Alchemy users from #{user_seeds_file}"
+        users = YAML.load_file(user_seeds_file)
+        users.each do |draft|
+          user = Alchemy.user_class.create!(draft)
+          log "Created user: #{user.try(:email) || user.try(:login) || user.id}"
+        end
+      end
+
       private
 
       def site_config
@@ -70,6 +80,10 @@ module Alchemy
 
       def page_seeds_file
         @_page_seeds_file ||= Rails.root.join('db', 'seeds', 'alchemy', 'pages.yml')
+      end
+
+      def user_seeds_file
+        @_user_seeds_file ||= Rails.root.join('db', 'seeds', 'alchemy', 'users.yml')
       end
 
       def create_page(draft, attributes = {})

--- a/spec/features/page_seeder_spec.rb
+++ b/spec/features/page_seeder_spec.rb
@@ -12,24 +12,39 @@ RSpec.describe 'Page seeding' do
       Alchemy::Seeder.instance_variable_set(:@_page_yml, nil)
     end
 
-    it 'seeds pages' do
-      Alchemy::Seeder.seed!
-      expect(Alchemy::Page.find_by(name: 'Index')).to be_present
-      expect(Alchemy::Page.find_by(name: 'Home')).to be_present
-      expect(Alchemy::Page.find_by(name: 'About')).to be_present
-      expect(Alchemy::Page.find_by(name: 'Contact')).to be_present
-      expect(Alchemy::Page.find_by(name: 'Footer')).to be_present
-    end
+    subject(:seed) { Alchemy::Seeder.seed! }
 
-    context 'when more then one content root page is present' do
-      let(:seeds_file) do
-        'spec/fixtures/pages_with_two_roots.yml'
+    context 'when no pages are present yet' do
+      before do
+        Alchemy::Page.delete_all
       end
 
-      it 'aborts' do
-        expect {
-          expect { Alchemy::Seeder.seed! }.to output.to_stderr
-        }.to raise_error(SystemExit)
+      it 'seeds pages', :aggregate_failures do
+        seed
+        expect(Alchemy::Page.find_by(name: 'Index')).to be_present
+        expect(Alchemy::Page.find_by(name: 'Home')).to be_present
+        expect(Alchemy::Page.find_by(name: 'About')).to be_present
+        expect(Alchemy::Page.find_by(name: 'Contact')).to be_present
+        expect(Alchemy::Page.find_by(name: 'Footer')).to be_present
+      end
+
+      context 'when more then one content root page is present' do
+        let(:seeds_file) do
+          'spec/fixtures/pages_with_two_roots.yml'
+        end
+
+        it 'aborts' do
+          expect {
+            expect { seed }.to output.to_stderr
+          }.to raise_error(SystemExit)
+        end
+      end
+    end
+
+    context "when pages are already present" do
+      it 'does not seed' do
+        seed
+        expect(Alchemy::Page.find_by(name: 'Home')).to_not be_present
       end
     end
 

--- a/spec/features/page_seeder_spec.rb
+++ b/spec/features/page_seeder_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'Page seeding' do
     before do
       FileUtils.mkdir_p(Rails.root.join('db/seeds/alchemy'))
       FileUtils.cp(seeds_file, Rails.root.join('db/seeds/alchemy/pages.yml'))
+      Alchemy::Seeder.instance_variable_set(:@_page_yml, nil)
     end
 
     it 'seeds pages' do
@@ -17,9 +18,10 @@ RSpec.describe 'Page seeding' do
       expect(Alchemy::Page.find_by(name: 'Home')).to be_present
       expect(Alchemy::Page.find_by(name: 'About')).to be_present
       expect(Alchemy::Page.find_by(name: 'Contact')).to be_present
+      expect(Alchemy::Page.find_by(name: 'Footer')).to be_present
     end
 
-    context 'when more then one root page is present' do
+    context 'when more then one content root page is present' do
       let(:seeds_file) do
         'spec/fixtures/pages_with_two_roots.yml'
       end

--- a/spec/features/page_seeder_spec.rb
+++ b/spec/features/page_seeder_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+RSpec.describe 'Page seeding' do
+  context 'when db/seeds/alchemy/pages.yml file is present' do
+    let(:seeds_file) do
+      'spec/fixtures/pages.yml'
+    end
+
+    before do
+      FileUtils.mkdir_p(Rails.root.join('db/seeds/alchemy'))
+      FileUtils.cp(seeds_file, Rails.root.join('db/seeds/alchemy/pages.yml'))
+    end
+
+    it 'seeds pages' do
+      Alchemy::Seeder.seed!
+      expect(Alchemy::Page.find_by(name: 'Index')).to be_present
+      expect(Alchemy::Page.find_by(name: 'Home')).to be_present
+      expect(Alchemy::Page.find_by(name: 'About')).to be_present
+      expect(Alchemy::Page.find_by(name: 'Contact')).to be_present
+    end
+
+    context 'when more then one root page is present' do
+      let(:seeds_file) do
+        'spec/fixtures/pages_with_two_roots.yml'
+      end
+
+      it 'aborts' do
+        expect {
+          expect { Alchemy::Seeder.seed! }.to output.to_stderr
+        }.to raise_error(SystemExit)
+      end
+    end
+
+    after do
+      FileUtils.rm_rf(Rails.root.join('db/seeds'))
+    end
+  end
+end

--- a/spec/features/user_seeder_spec.rb
+++ b/spec/features/user_seeder_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.describe 'User seeding' do
+  context 'when db/seeds/alchemy/users.yml file is present' do
+    let(:seeds_file) do
+      'spec/fixtures/users.yml'
+    end
+
+    before do
+      FileUtils.mkdir_p(Rails.root.join('db/seeds/alchemy'))
+      FileUtils.cp(seeds_file, Rails.root.join('db/seeds/alchemy/users.yml'))
+    end
+
+    it 'seeds users' do
+      Alchemy::Seeder.seed!
+      expect(DummyUser.find_by(email: 'admin@example.com')).to be_present
+      expect(DummyUser.find_by(email: 'member@example.com')).to be_present
+    end
+
+    after do
+      FileUtils.rm_rf(Rails.root.join('db/seeds'))
+    end
+  end
+end

--- a/spec/fixtures/pages.yml
+++ b/spec/fixtures/pages.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Index
+  page_layout: index
+  children:
+    - name: Home
+      page_layout: standard
+    - name: About
+      page_layout: about
+    - name: Contact
+      page_layout: contact

--- a/spec/fixtures/pages.yml
+++ b/spec/fixtures/pages.yml
@@ -9,3 +9,7 @@
       page_layout: about
     - name: Contact
       page_layout: contact
+
+- name: Footer
+  layoutpage: true
+  page_layout: footer

--- a/spec/fixtures/pages_with_two_roots.yml
+++ b/spec/fixtures/pages_with_two_roots.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Index1
+  page_layout: index
+
+- name: Index2
+  page_layout: index

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -1,0 +1,9 @@
+- email: admin@example.com
+  password: test123
+  alchemy_roles:
+    - admin
+
+- email: member@example.com
+  password: test123
+  alchemy_roles:
+    - member


### PR DESCRIPTION
In order to be able to better seed Alchemy sites the `Alchemy::Seeder` now supports:

* `db/seeds/alchemy/pages.yml`
* `db/seeds/alchemy/users.yml`

as fixtures.

### Page seeds example

```yml
# db/seeds/alchemy/pages.yml
- name: Index
  page_layout: index
  children:
  - name: Home
    page_layout: standard
    visible: true
    public_on: 2016-10-18
  - name: About
    page_layout: about
    visible: true
    public_on: 2016-10-18
  - name: Contact
    page_layout: contact
    visible: true
    public_on: 2016-10-18

- name: Footer
  page_layout: footer
  layoutpage: true
```

### User seeds example

```yml
# db/seeds/alchemy/users.yml
- email: admin@example.com
  password: test123
  password_confirmation: test123
  confirmed_at: 2016-10-18
  alchemy_roles:
    - admin
```