### PR TITLE
Scoped users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ __New Features__
 * Files of attachments are replaceable now (#1167)
 * Add fixed page attributes (#1168)
   Page attributes can be defined as fixed_attributes to prevent changes by the user.
+* Allow to declare which user role can edit page content on the page layout level.
 
 __Notable Changes__
 

--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -81,7 +81,7 @@ module Alchemy
       def edit
         # fetching page via before filter
         if page_is_locked?
-          flash[:notice] = Alchemy.t('This page is locked', name: @page.locker_name)
+          flash[:warning] = Alchemy.t('This page is locked', name: @page.locker_name)
           redirect_to admin_pages_path
         elsif page_needs_lock?
           @page.lock_to!(current_alchemy_user)
@@ -348,7 +348,7 @@ module Alchemy
       end
 
       def redirect_path_after_create_page
-        if @page.redirects_to_external?
+        if @page.redirects_to_external? || !@page.editable_by?(current_alchemy_user)
           admin_pages_path
         else
           params[:redirect_to] || edit_admin_page_path(@page)

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -419,6 +419,16 @@ module Alchemy
       fixed_attributes.fixed?(name)
     end
 
+    # Checks the current page's list of editors, if defined.
+    #
+    # This allows us to pass in a user and see if any of their roles are enable
+    # them to make edits
+    #
+    def editable_by?(user)
+      return true unless has_limited_editors?
+      (editor_roles & user.alchemy_roles).any?
+    end
+
     private
 
     def set_fixed_attributes

--- a/app/models/alchemy/page/page_natures.rb
+++ b/app/models/alchemy/page/page_natures.rb
@@ -33,6 +33,25 @@ module Alchemy
       definition["feed"]
     end
 
+    # Returns an Array of Alchemy roles which are able to edit this template
+    #
+    #     # config/alchemy/page_layouts.yml
+    #     - name: contact
+    #       editable_by:
+    #         - freelancer
+    #         - admin
+    #
+    # @returns Array
+    #
+    def has_limited_editors?
+      definition["editable_by"].present?
+    end
+
+    def editor_roles
+      return unless has_limited_editors?
+      definition["editable_by"]
+    end
+
     # Returns true or false if the pages definition for config/alchemy/page_layouts.yml contains redirects_to_external: true
     def redirects_to_external?
       !!definition["redirects_to_external"]

--- a/app/serializers/alchemy/page_tree_serializer.rb
+++ b/app/serializers/alchemy/page_tree_serializer.rb
@@ -95,7 +95,8 @@ module Alchemy
         configure: ability.can?(:configure, page),
         copy: ability.can?(:copy, page),
         destroy: ability.can?(:destroy, page),
-        create: ability.can?(:create, Alchemy::Page)
+        create: ability.can?(:create, Alchemy::Page),
+        edit_content: ability.can?(:edit_content, page)
       }
     end
 

--- a/app/views/alchemy/admin/pages/_page.html.erb
+++ b/app/views/alchemy/admin/pages/_page.html.erb
@@ -18,13 +18,20 @@
       {{#if definition_missing}}
         <%= page_layout_missing_warning %>
       {{else}}
-        <div class="page icon<% if @sorting %>{{#unless root}} handle{{/unless}}<% end %>{{#if locked}} with-hint{{/if}}">
-        {{#if locked}}
-          <span class="hint-bubble">
-            {{locked_notice}}
-          </span>
+        {{#if permissions.edit_content}}
+          <div class="page icon<% if @sorting %>{{#unless root}} handle{{/unless}}<% end %>{{#if locked}} with-hint{{/if}}">
+            {{#if locked}}
+              <span class="hint-bubble">
+                {{locked_notice}}
+              </span>
+            {{/if}}
+          </div>
+        {{else}}
+          <%= hint_with_tooltip(
+                'Your user role does not allow you to edit this page.',
+                class: 'inline warning icon'
+          ) %>
         {{/if}}
-        </div>
       {{/if}}
     </div>
     <div class="sitemap_right_tools">
@@ -113,13 +120,17 @@
         {{ external_urlname }}
       </span>
       {{else}}
-        <%= link_to_unless(
-          @sorting,
-          '{{name}}',
-          alchemy.edit_admin_page_path(page),
-          title: Alchemy.t(:edit_page),
-          class: "sitemap_pagename_link"
-        ) { content_tag('span', '{{name}}', class: "sitemap_pagename_link") } -%>
+        {{#if permissions.edit_content}}
+          <%= link_to_unless(
+            @sorting,
+            '{{name}}',
+            alchemy.edit_admin_page_path(page),
+            title: Alchemy.t(:edit_page),
+            class: "sitemap_pagename_link"
+          ) { content_tag('span', '{{name}}', class: "sitemap_pagename_link") } -%>
+        {{else}}
+          <%= content_tag('span', '{{name}}', class: "sitemap_pagename_link") %>
+        {{/if}}
       {{/if}}
     </div>
   </div>

--- a/lib/alchemy/permissions.rb
+++ b/lib/alchemy/permissions.rb
@@ -113,9 +113,9 @@ module Alchemy
         can :manage,                Alchemy::EssenceFile
         can :manage,                Alchemy::EssencePicture
         can :manage,                Alchemy::LegacyPageUrl
-        can :edit_content,          Alchemy::Page
         can :read,                  Alchemy::Picture
         can [:read, :autocomplete], Alchemy::Tag
+        can(:edit_content,          Alchemy::Page) { |p| p.editable_by?(@user) }
       end
     end
 
@@ -142,14 +142,25 @@ module Alchemy
         can [
           :copy,
           :copy_language_tree,
-          :create,
-          :destroy,
           :flush,
           :order,
-          :publish,
           :sort,
           :switch_language
         ], Alchemy::Page
+
+        # Resources which may be locked via template permissions
+        #
+        #     # config/alchemy/page_layouts.yml
+        #     - name: contact
+        #       editable_by:
+        #         - freelancer
+        #         - admin
+        #
+        can([
+          :create,
+          :destroy,
+          :publish
+        ], Alchemy::Page) { |p| p.editable_by?(@user) }
 
         can :manage, Alchemy::Picture
         can :manage, Alchemy::Attachment

--- a/spec/features/admin/locked_page_feature_spec.rb
+++ b/spec/features/admin/locked_page_feature_spec.rb
@@ -12,7 +12,7 @@ describe 'Locked pages feature' do
     authorize_user(user)
   end
 
-  it 'displays tab for each locekd page' do
+  it 'displays tab for each locked page' do
     visit alchemy.admin_pages_path
 
     within '#locked_pages' do

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1485,6 +1485,69 @@ module Alchemy
       end
     end
 
+    describe '#editable_by?' do
+      subject { page.editable_by?(user) }
+
+      let(:user) { mock_model('DummyUser') }
+      let(:page) { create(:alchemy_page) }
+
+      context "template defines one alchemy role" do
+        before do
+          allow(page).to receive(:definition).and_return({"editable_by" => ["freelancer"]})
+        end
+
+        context 'user has matching alchemy role' do
+          before do
+            allow(user).to receive(:alchemy_roles).at_least(:once) { ["freelancer"] }
+          end
+
+          it { is_expected.to be(true) }
+        end
+        context 'user has a different alchemy role' do
+          before do
+            allow(user).to receive(:alchemy_roles).at_least(:once) { ["editor"] }
+          end
+
+          it { is_expected.to be(false) }
+        end
+      end
+
+      context "template defines multiple alchemy roles" do
+        before do
+          allow(page).to receive(:definition).and_return({"editable_by" => ["freelancer", "admin"]})
+        end
+
+        context 'user has matching alchemy role' do
+          before do
+            allow(user).to receive(:alchemy_roles).at_least(:once) { ["freelancer", "member"] }
+          end
+
+          it { is_expected.to be(true) }
+        end
+        context 'user has a different alchemy role' do
+          before do
+            allow(user).to receive(:alchemy_roles).at_least(:once) { ["editor", "leader"] }
+          end
+
+          it { is_expected.to be(false) }
+        end
+      end
+
+      context "template has no alchemy role defined" do
+        before do
+          allow(page).to receive(:definition).and_return({})
+        end
+
+        context 'user has matching alchemy role' do
+          before do
+            allow(user).to receive(:alchemy_roles).at_least(:once) { ["freelancer", "member"] }
+          end
+
+          it { is_expected.to be(true) }
+        end
+      end
+    end
+
     describe '#public?' do
       subject { page.public? }
 


### PR DESCRIPTION
This feature allows administrators to scope a template to `alchemy_roles`. A use case for this would be if you wanted specific teams or individuals to only be able to make changes to specific templates.