### PR TITLE
Add Tooltips js function

### DIFF
--- a/app/assets/javascripts/alchemy/admin.js
+++ b/app/assets/javascripts/alchemy/admin.js
@@ -50,5 +50,6 @@
 //= require alchemy/alchemy.sitemap
 //= require alchemy/alchemy.spinner
 //= require alchemy/alchemy.tinymce
+//= require alchemy/alchemy.tooltips
 //= require alchemy/alchemy.translations
 //= require alchemy/alchemy.trash_window

--- a/app/assets/javascripts/alchemy/alchemy.gui.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.gui.js.coffee
@@ -7,6 +7,7 @@ Alchemy.GUI =
   init: (scope) ->
     Alchemy.SelectBox(scope)
     Alchemy.Datepicker(scope)
+    Alchemy.Tooltips(scope)
     Alchemy.Buttons.observe(scope)
     Alchemy.watchForDialogs(scope)
     Alchemy.Hotkeys(scope)

--- a/app/assets/javascripts/alchemy/alchemy.tooltips.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.tooltips.coffee
@@ -1,0 +1,10 @@
+window.Alchemy = {} if typeof(window.Alchemy) is 'undefined'
+
+Alchemy.Tooltips = (scope) ->
+  $('[data-alchemy-tooltip]', scope).each ->
+    $el = $(this)
+    text = $el.data('alchemy-tooltip')
+    $el.wrap('<span class="with-hint"/>')
+    $el.after('<span class="hint-bubble">'+text+'</span>')
+    return
+  return


### PR DESCRIPTION
Transform all elements with `data-alchemy-tooltip` into tooltips by wrapping it in `with-hint` and append the text in a `hint-bubble`.