### PR TITLE
Replace attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ __New Features__
 * New API endpoint for retrieving a nested page tree (#1155)
   `api/pages/nested` returns a nested JSON tree of all pages.
 * Add page and user seeding support (#1160)
+* Files of attachments are replaceable now (#1167)
 
 __Notable Changes__
 

--- a/app/assets/javascripts/alchemy/alchemy.uploader.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.uploader.js.coffee
@@ -10,6 +10,9 @@ window.Alchemy = {} if typeof(window.Alchemy) is 'undefined'
 Alchemy.Uploader = (settings) ->
   totalFilesCount = 0
   completedUploads = 0
+  $filesContainer = $('.upload-progress-container')
+  selector = settings.selector || '.fileupload'
+  $fields = $(selector)
   $dropZone = $(settings.dropzone)
 
   # Normalize file types regex
@@ -22,79 +25,107 @@ Alchemy.Uploader = (settings) ->
   $dropZone.on 'dragleave', ->
     $dropZone.removeClass('dragover')
 
-  # Init jquery.fileupload
-  $(".fileupload").fileupload
-    dropZone: $dropZone
-    dataType: 'json'
-    filesContainer: $('.upload-progress-container')
-    acceptFileTypes: new RegExp("(.|/)(#{file_types})", "i")
-    maxNumberOfFiles: Alchemy.uploader_defaults.file_upload_limit
-    maxFileSize: Alchemy.uploader_defaults.file_size_limit * 1000000
-    getNumberOfFiles: ->
-      @filesContainer
-        .children()
-        .not('.progress-bar-in-progress').length - 1
-    dragover: ->
-      $dropZone.addClass('dragover')
-    add: (e, data) ->
-      $this = $(this)
-      data.context = new Alchemy.FileProgress(data.files[0])
-      totalFilesCount = data.originalFiles.length
-      $('.total-files-count').text(totalFilesCount)
-      $dropZone.removeClass('dragover').addClass('upload-in-progress')
-      $('.overall-upload').addClass('visible')
-      # trigger validations
-      data.process -> $this.fileupload('process', data)
-      if data.files.error
-        data.context.setError()
-        data.context.setStatus(data.files[0].error)
-        data.context.$fileProgressCancel.click (e) ->
-          e.preventDefault()
-          data.context.setCancelled()
-          data.context.setStatus('cancelled')
-          false
-        false
-      else
-        xhr = data.submit()
-        data.context.$fileProgressCancel.click (e) ->
-          e.preventDefault()
-          xhr.abort()
-          data.context.setCancelled()
-          data.context.setStatus('cancelled')
-          false
-        xhr
-    progress: (e, data) ->
-      progress = parseInt(data.loaded / data.total * 100, 10)
-      data.context.setProgress(progress)
-    progressall: (e, data) ->
-      progress = parseInt(data.loaded / data.total * 100, 10)
-      bar = $('.overall-upload .progress')
-      bar.css width: "#{progress}%"
-      $('.progress-status').text("#{progress}%")
-    done: (e, data) ->
-      completedUploads += 1
-      $('.uploaded-files-count').text(completedUploads)
-      data.context.setComplete()
-      data.context.setStatus('complete')
-      response_data = data.xhr().response
-      if completedUploads == totalFilesCount
-        completedUploads = 0
-        totalFilesCount = 0
-        $('.overall-upload').removeClass('visible')
-        settings.complete()
-    fail: (e, data) ->
+  getNumberOfFiles = ->
+    $filesContainer
+      .children()
+      .not('.progress-bar-in-progress').length - 1
+
+  dragover = ->
+    $dropZone.addClass('dragover')
+    return
+
+  add = (e, data) ->
+    $this = $(this)
+    data.context = new Alchemy.FileProgress(data.files[0])
+    totalFilesCount = data.originalFiles.length
+    $('.total-files-count').text(totalFilesCount)
+    $dropZone.removeClass('dragover').addClass('upload-in-progress')
+    $('.overall-upload').addClass('visible')
+    # trigger validations
+    data.process -> $this.fileupload('process', data)
+    if data.files.error
       data.context.setError()
-      response_data = data.xhr().response
-      if response_data
-        response = JSON.parse(response_data)
-        error = response.files[0].error
-      data.context.setStatus(error || data.textStatus)
-    always: (e, data) ->
-      xhr = data.xhr()
-      response_data = xhr.response
-      if response_data
-        response = JSON.parse(response_data)
-        if response.growl_message
-          Alchemy.growl(response.growl_message, if xhr.status == 422 then 'alert' else 'notice')
+      data.context.setStatus(data.files[0].error)
+      data.context.$fileProgressCancel.click (e) ->
+        data.context.setCancelled()
+        data.context.setStatus('cancelled')
+        return false
+      return false
+    else
+      xhr = data.submit()
+      data.context.$fileProgressCancel.click (e) ->
+        xhr.abort()
+        data.context.setCancelled()
+        data.context.setStatus('cancelled')
+        return false
+      return xhr
+
+  progress = (e, data) ->
+    progress = parseInt(data.loaded / data.total * 100, 10)
+    data.context.setProgress(progress)
+    return
+
+  progressall = (e, data) ->
+    progress = parseInt(data.loaded / data.total * 100, 10)
+    bar = $('.overall-upload .progress')
+    bar.css width: "#{progress}%"
+    $('.progress-status').text("#{progress}%")
+    return
+
+  done = (e, data) ->
+    completedUploads += 1
+    $('.uploaded-files-count').text(completedUploads)
+    data.context.setComplete()
+    data.context.setStatus('complete')
+    response_data = data.xhr().response
+    if completedUploads == totalFilesCount
+      completedUploads = 0
+      totalFilesCount = 0
+      $('.overall-upload').removeClass('visible')
+      settings.complete()
+    return
+
+  fail = (e, data) ->
+    data.context.setError()
+    response_data = data.xhr().response
+    if response_data
+      response = JSON.parse(response_data)
+      error = response.files[0].error
+    data.context.setStatus(error || data.textStatus)
+    return
+
+  always = (e, data) ->
+    xhr = data.xhr()
+    response_data = xhr.response
+    if response_data
+      response = JSON.parse(response_data)
+      if response.growl_message
+        Alchemy.growl(response.growl_message, if xhr.status == 422 then 'alert' else 'notice')
+    return
+
+  $fields.each ->
+    $field = $(this)
+    $form = $field.parents('form')
+    url = $form.attr('action')
+    http_method = $form.find('[name="_method"]').val()
+    # Init jquery.fileupload
+    $field.fileupload
+      url: url
+      type: if http_method then http_method.toUpperCase() else 'POST'
+      dropZone: $dropZone
+      dataType: 'json'
+      filesContainer: $filesContainer
+      acceptFileTypes: new RegExp("(.|/)(#{file_types})", "i")
+      maxNumberOfFiles: Alchemy.uploader_defaults.file_upload_limit
+      maxFileSize: Alchemy.uploader_defaults.file_size_limit * 1000000
+      getNumberOfFiles: getNumberOfFiles
+      dragover: dragover
+      add: add
+      progress: progress
+      progressall: progressall
+      done: done
+      fail: fail
+      always: always
+    return
 
   return

--- a/app/assets/stylesheets/alchemy/icons.scss
+++ b/app/assets/stylesheets/alchemy/icons.scss
@@ -154,6 +154,10 @@
     background-position: -32px -40px;
   }
 
+  &.file_change {
+    background-position: -512px -40px;
+  }
+
   &.flash {
     background-position: -256px -136px;
   }

--- a/app/assets/stylesheets/alchemy/tables.scss
+++ b/app/assets/stylesheets/alchemy/tables.scss
@@ -93,12 +93,6 @@ tr.even td {
   white-space: nowrap;
   @extend .disable-user-select;
 
-  a {
-    width: 19px;
-    height: 19px;
-    margin-right: 2px;
-  }
-
   &.long {
     width: 60px;
   }

--- a/app/assets/stylesheets/alchemy/upload.scss
+++ b/app/assets/stylesheets/alchemy/upload.scss
@@ -3,7 +3,7 @@
   vertical-align: top;
 }
 
-.fileupload {
+.fileupload--field {
   width: 0.1px;
   height: 0.1px;
   opacity: 0;

--- a/app/assets/stylesheets/alchemy/upload.scss
+++ b/app/assets/stylesheets/alchemy/upload.scss
@@ -1,6 +1,14 @@
 .upload-button {
   display: inline-block;
-  vertical-align: top;
+
+  #toolbar &,
+  #overlay_toolbar & {
+    vertical-align: top;
+  }
+
+  label {
+    cursor: pointer;
+  }
 }
 
 .fileupload--field {

--- a/app/controllers/alchemy/admin/attachments_controller.rb
+++ b/app/controllers/alchemy/admin/attachments_controller.rb
@@ -33,25 +33,25 @@ module Alchemy
       end
 
       def create
-        @attachment = Attachment.new(attachment_attributes)
-        if @attachment.save
-          render succesful_uploader_response(file: @attachment)
-        else
-          render failed_uploader_response(file: @attachment)
-        end
+        @attachment = Attachment.create(attachment_attributes)
+        handle_uploader_response(status: :created)
       end
 
       def update
-        @attachment.update_attributes(attachment_attributes)
-        render_errors_or_redirect(
-          @attachment,
-          admin_attachments_path(
-            per_page: params[:per_page],
-            page: params[:page],
-            q: params[:q]
-          ),
-          Alchemy.t("File successfully updated")
-        )
+        @attachment.update(attachment_attributes)
+        if attachment_attributes['file'].present?
+          handle_uploader_response(status: :accepted)
+        else
+          render_errors_or_redirect(
+            @attachment,
+            admin_attachments_path(
+              per_page: params[:per_page],
+              page: params[:page],
+              q: params[:q]
+            ),
+            Alchemy.t("File successfully updated")
+          )
+        end
       end
 
       def destroy
@@ -74,6 +74,14 @@ module Alchemy
       end
 
       private
+
+      def handle_uploader_response(status:)
+        if @attachment.valid?
+          render succesful_uploader_response(file: @attachment, status: status)
+        else
+          render failed_uploader_response(file: @attachment)
+        end
+      end
 
       def in_overlay?
         params[:content_id].present?

--- a/app/controllers/concerns/alchemy/admin/uploader_responses.rb
+++ b/app/controllers/concerns/alchemy/admin/uploader_responses.rb
@@ -3,7 +3,7 @@ module Alchemy
     module UploaderResponses
       extend ActiveSupport::Concern
 
-      def succesful_uploader_response(file:)
+      def succesful_uploader_response(file:, status: :created)
         message = Alchemy.t(:upload_success,
           scope: [:uploader, file.class.model_name.i18n_key],
           name: file.name
@@ -11,7 +11,7 @@ module Alchemy
 
         {
           json: uploader_response(file: file, message: message),
-          status: :created
+          status: status
         }
       end
 

--- a/app/models/alchemy/attachment.rb
+++ b/app/models/alchemy/attachment.rb
@@ -49,7 +49,6 @@ module Alchemy
     end
 
     validates_presence_of :file
-    validates_format_of :file_name, with: /\A[A-Za-z0-9\. \-_äÄöÖüÜß]+\z/, on: :update
     validates_size_of :file, maximum: Config.get(:uploader)['file_size_limit'].megabytes
     validates_property :ext, of: :file,
       in: allowed_filetypes,
@@ -57,9 +56,7 @@ module Alchemy
       message: Alchemy.t("not a valid file"),
       unless: -> { self.class.allowed_filetypes.include?('*') }
 
-    before_create do
-      write_attribute(:name, convert_to_humanized_name(file_name, file.ext))
-    end
+    before_save :set_name, if: :file_name_changed?
 
     after_update :touch_contents
 
@@ -122,6 +119,12 @@ module Alchemy
       else
         "file"
       end
+    end
+
+    private
+
+    def set_name
+      self.name = convert_to_humanized_name(file_name, file.ext)
     end
   end
 end

--- a/app/views/alchemy/admin/attachments/_archive_overlay.html.erb
+++ b/app/views/alchemy/admin/attachments/_archive_overlay.html.erb
@@ -1,7 +1,7 @@
 <div id="overlay_toolbar">
   <% if can? :create, Alchemy::Attachment %>
     <%= render 'alchemy/admin/uploader/button',
-      model_class: Alchemy::Attachment,
+      object: Alchemy::Attachment.new,
       dropzone: '#assign_file_list',
       file_attribute: 'file',
       in_dialog: true,

--- a/app/views/alchemy/admin/attachments/_attachment.html.erb
+++ b/app/views/alchemy/admin/attachments/_attachment.html.erb
@@ -46,6 +46,12 @@
       target: "_blank"
     ) %>
   <% end %>
+  <% if can?(:edit, attachment) %>
+    <%= render 'alchemy/admin/attachments/replace_button',
+      redirect_url: alchemy.admin_attachments_path,
+      object: attachment,
+      file_attribute: 'file' %>
+  <% end %>
   <% if can?(:destroy, attachment) %>
     <%= link_to_confirm_dialog(
       "",

--- a/app/views/alchemy/admin/attachments/_replace_button.html.erb
+++ b/app/views/alchemy/admin/attachments/_replace_button.html.erb
@@ -1,0 +1,26 @@
+<%= form_for [:admin, object], html: {multipart: true, class: 'upload-button'} do |f| %>
+  <%= f.file_field file_attribute,
+    class: 'fileupload--field',
+    name: "#{f.object_name}[#{file_attribute}]",
+    id: "replace_#{dom_id(object)}" %>
+  <%= label_tag "replace_#{dom_id(object)}", title: Alchemy.t(:replace_file) do %>
+    <%= render_icon :file_change %>
+  <% end %>
+<% end %>
+
+<% file_types = local_assigns[:file_types].presence ||
+  configuration(:uploader)['allowed_filetypes'][object.class.model_name.collection] || ['*'] %>
+
+<script type='text/javascript'>
+  $(function() {
+    var options = {
+      selector: '#replace_<%= dom_id(object) %>',
+      file_types: '<%= file_types.join("|") %>',
+      complete: function() {
+        Alchemy.pleaseWaitOverlay();
+        window.location.href = '<%= redirect_url.html_safe %>';
+      }
+    };
+    Alchemy.Uploader(options);
+  });
+</script>

--- a/app/views/alchemy/admin/attachments/index.html.erb
+++ b/app/views/alchemy/admin/attachments/index.html.erb
@@ -3,7 +3,7 @@
     <% if can? :create, Alchemy::Attachment %>
       <%= render 'alchemy/admin/uploader/button',
         redirect_url: alchemy.admin_attachments_path,
-        model_class: Alchemy::Attachment,
+        object: Alchemy::Attachment.new,
         file_attribute: 'file' %>
     <% end %>
   </div>

--- a/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
+++ b/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
@@ -1,7 +1,7 @@
 <div id="image_assign_filter_and_image_sizing">
   <% if can? :create, Alchemy::Picture %>
     <%= render 'alchemy/admin/uploader/button',
-      model_class: Alchemy::Picture,
+      object: Alchemy::Picture.new,
       dropzone: '#assign_image_list',
       file_attribute: 'image_file',
       in_dialog: true,

--- a/app/views/alchemy/admin/pictures/index.html.erb
+++ b/app/views/alchemy/admin/pictures/index.html.erb
@@ -2,7 +2,7 @@
   <div class="toolbar_buttons">
     <% if can? :create, Alchemy::Picture %>
       <%= render 'alchemy/admin/uploader/button',
-        model_class: Alchemy::Picture,
+        object: Alchemy::Picture.new,
         file_attribute: 'image_file',
         redirect_url: alchemy.admin_pictures_path(
           size: params[:size],

--- a/app/views/alchemy/admin/uploader/_button.html.erb
+++ b/app/views/alchemy/admin/uploader/_button.html.erb
@@ -1,4 +1,4 @@
-<%= form_for [:admin, model_class.new], html: {multipart: true, class: 'upload-button'} do |f| %>
+<%= form_for [:admin, object], html: {multipart: true, class: 'upload-button'} do |f| %>
   <%= f.file_field file_attribute,
     class: 'fileupload', multiple: true,
     name: "#{f.object_name}[#{file_attribute}]" %>
@@ -8,14 +8,14 @@
       <span class="icon_button"><%= render_icon :upload %></span>
       <label>
         <%= local_assigns[:label] ||
-          Alchemy.t(:button_label, scope: [:uploader, model_class.model_name.i18n_key]) %>
+          Alchemy.t(:button_label, scope: [:uploader, object.class.model_name.i18n_key]) %>
       </label>
     </div>
   <% end %>
 <% end %>
 
 <% file_types = local_assigns[:file_types].presence ||
-  configuration(:uploader)['allowed_filetypes'][model_class.model_name.collection] || ['*'] %>
+  configuration(:uploader)['allowed_filetypes'][object.class.model_name.collection] || ['*'] %>
 
 <script type='text/javascript'>
   $(function() {

--- a/app/views/alchemy/admin/uploader/_button.html.erb
+++ b/app/views/alchemy/admin/uploader/_button.html.erb
@@ -1,6 +1,6 @@
 <%= form_for [:admin, object], html: {multipart: true, class: 'upload-button'} do |f| %>
   <%= f.file_field file_attribute,
-    class: 'fileupload', multiple: true,
+    class: 'fileupload fileupload--field', multiple: true,
     name: "#{f.object_name}[#{file_attribute}]" %>
   <%= hidden_field_tag "#{f.object_name}[upload_hash]", Time.current.hash %>
   <%= f.label file_attribute, data: {alchemy_hotkey: 'alt+n'} do %>

--- a/config/locales/alchemy.de.yml
+++ b/config/locales/alchemy.de.yml
@@ -516,6 +516,7 @@ de:
     rename_file: "Datei umbenennen"
     rename: umbenennen
     replace: ersetzen
+    replace_file: Datei ersetzen
     'Replaced Tag': "Das Tag '%{old_tag}' wurde durch das Tag '%{new_tag}' ersetzt"
     resources:
       relation_select:

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -511,6 +511,7 @@ en:
     rename_file: "Rename this file."
     rename: "Rename"
     replace: replace
+    replace_file: Replace file
     'Replaced Tag': "Tag '%{old_tag}' was replaced with '%{new_tag}'"
     resources:
       relation_select:

--- a/config/locales/alchemy.es.yml
+++ b/config/locales/alchemy.es.yml
@@ -512,6 +512,7 @@ es:
     rename_file: "Renombrar este archivo."
     rename: "Renombrar"
     replace: Reemplazar
+    replace_file: Reemplazar el archivo
     'Replaced Tag': "La etiqueta '%{old_tag}' fue reemplazada por '%{new_tag}'"
     resources:
       relation_select:

--- a/config/locales/alchemy.fr.yml
+++ b/config/locales/alchemy.fr.yml
@@ -529,6 +529,7 @@ fr:
     rename_file: "Renommer un fichier"
     rename: rebaptiser
     replace: remplacer
+    replace_file: Remplacer le fichier
     'Replaced Tag %{old_tag} with %{new_tag}': "Le Tag '%{old_tag}' á été rmplacé par le Tag '%{new_tag}'"
     resources:
       relation_select:

--- a/config/locales/alchemy.it.yml
+++ b/config/locales/alchemy.it.yml
@@ -511,6 +511,7 @@ it:
     rename_file: "Rinomina questo file."
     rename: "Rinomina"
     replace: sostituisci
+    replace_file: Sostituire il file
     'Replaced Tag': "Il tag '%{old_tag}' è stato sostiuito con '%{new_tag}'"
     resources:
       relation_select:

--- a/config/locales/alchemy.nl.yml
+++ b/config/locales/alchemy.nl.yml
@@ -505,6 +505,7 @@ nl:
     rename_file: "Dit bestand hernoemen."
     rename: hernoemen
     replace: vervangen
+    replace_file: Vervang file
     'Replaced Tag': "De tag '%{old_tag}' wordt door de tag '%{new_tag}' vervangen"
     resources:
       relation_select:

--- a/config/locales/alchemy.ru.yml
+++ b/config/locales/alchemy.ru.yml
@@ -507,6 +507,7 @@ ru:
     rename_file: "Свойства файла"
     rename: "Переименовать"
     replace: "Заменить"
+    replace_file: "Заменить файл"
     'Replaced Tag': "Метка '%{old_tag}' заменена на '%{new_tag}'"
     resources:
       relation_select:

--- a/spec/models/alchemy/attachment_spec.rb
+++ b/spec/models/alchemy/attachment_spec.rb
@@ -13,14 +13,23 @@ module Alchemy
       end
     end
 
-    describe 'after create' do
-      before { attachment.save! }
+    describe 'after save' do
+      subject(:save) { attachment.save! }
 
       it "should have a humanized name" do
+        save
         expect(attachment.name).to eq("image with spaces")
       end
 
-      after { attachment.destroy }
+      context "when file_name has not changed" do
+        before do
+          attachment.update(name: 'image with spaces')
+        end
+
+        it "should not change name" do
+          expect { save }.to_not change { attachment.name }
+        end
+      end
     end
 
     describe 'urlname sanitizing' do
@@ -78,17 +87,6 @@ module Alchemy
 
         it "should be valid" do
           expect(attachment).to be_valid
-        end
-      end
-
-      context "having a filename with unallowed character" do
-        before do
-          attachment.file_name = 'my FileNämü?!.pdf'
-          attachment.save
-        end
-
-        it "should not be valid" do
-          expect(attachment).not_to be_valid
         end
       end
     end

--- a/vendor/assets/javascripts/fileupload/jquery.fileupload-process.js
+++ b/vendor/assets/javascripts/fileupload/jquery.fileupload-process.js
@@ -1,5 +1,5 @@
 /*
- * jQuery File Upload Processing Plugin 1.3.1
+ * jQuery File Upload Processing Plugin
  * https://github.com/blueimp/jQuery-File-Upload
  *
  * Copyright 2012, Sebastian Tschan
@@ -12,7 +12,7 @@
 /* jshint nomen:false */
 /* global define, require, window */
 
-(function (factory) {
+;(function (factory) {
     'use strict';
     if (typeof define === 'function' && define.amd) {
         // Register as an anonymous AMD module:
@@ -84,7 +84,7 @@
                         settings
                     );
                 };
-                chain = chain.pipe(func, settings.always && func);
+                chain = chain.then(func, settings.always && func);
             });
             chain
                 .done(function () {
@@ -151,7 +151,7 @@
                         };
                     opts.index = index;
                     that._processing += 1;
-                    that._processingQueue = that._processingQueue.pipe(func, func)
+                    that._processingQueue = that._processingQueue.then(func, func)
                         .always(function () {
                             that._processing -= 1;
                             if (that._processing === 0) {

--- a/vendor/assets/javascripts/fileupload/jquery.fileupload-validate.js
+++ b/vendor/assets/javascripts/fileupload/jquery.fileupload-validate.js
@@ -1,5 +1,5 @@
 /*
- * jQuery File Upload Validation Plugin 1.1.3
+ * jQuery File Upload Validation Plugin
  * https://github.com/blueimp/jQuery-File-Upload
  *
  * Copyright 2013, Sebastian Tschan
@@ -11,7 +11,7 @@
 
 /* global define, require, window */
 
-(function (factory) {
+;(function (factory) {
     'use strict';
     if (typeof define === 'function' && define.amd) {
         // Register as an anonymous AMD module:

--- a/vendor/assets/javascripts/fileupload/jquery.fileupload.js
+++ b/vendor/assets/javascripts/fileupload/jquery.fileupload.js
@@ -1,5 +1,5 @@
 /*
- * jQuery File Upload Plugin 5.42.3
+ * jQuery File Upload Plugin
  * https://github.com/blueimp/jQuery-File-Upload
  *
  * Copyright 2010, Sebastian Tschan
@@ -12,13 +12,13 @@
 /* jshint nomen:false */
 /* global define, require, window, document, location, Blob, FormData */
 
-(function (factory) {
+;(function (factory) {
     'use strict';
     if (typeof define === 'function' && define.amd) {
         // Register as an anonymous AMD module:
         define([
             'jquery',
-            'jquery.ui.widget'
+            'jquery-ui/widget'
         ], factory);
     } else if (typeof exports === 'object') {
         // Node/CommonJS:
@@ -277,7 +277,8 @@
             // The following are jQuery ajax settings required for the file uploads:
             processData: false,
             contentType: false,
-            cache: false
+            cache: false,
+            timeout: 0
         },
 
         // A list of options that require reinitializing event listeners and/or
@@ -651,7 +652,7 @@
             data.process = function (resolveFunc, rejectFunc) {
                 if (resolveFunc || rejectFunc) {
                     data._processQueue = this._processQueue =
-                        (this._processQueue || getPromise([this])).pipe(
+                        (this._processQueue || getPromise([this])).then(
                             function () {
                                 if (data.errorThrown) {
                                     return $.Deferred()
@@ -659,7 +660,7 @@
                                 }
                                 return getPromise(arguments);
                             }
-                        ).pipe(resolveFunc, rejectFunc);
+                        ).then(resolveFunc, rejectFunc);
                 }
                 return this._processQueue || getPromise([this]);
             };
@@ -944,9 +945,9 @@
                 if (this.options.limitConcurrentUploads > 1) {
                     slot = $.Deferred();
                     this._slots.push(slot);
-                    pipe = slot.pipe(send);
+                    pipe = slot.then(send);
                 } else {
-                    this._sequence = this._sequence.pipe(send, send);
+                    this._sequence = this._sequence.then(send, send);
                     pipe = this._sequence;
                 }
                 // Return the piped Promise object, enhanced with an abort method,
@@ -983,7 +984,10 @@
                 fileSet,
                 i,
                 j = 0;
-            if (limitSize && (!filesLength || files[0].size === undefined)) {
+            if (!filesLength) {
+                return false;
+            }
+            if (limitSize && files[0].size === undefined) {
                 limitSize = undefined;
             }
             if (!(options.singleFileUploads || limit || limitSize) ||
@@ -1042,13 +1046,19 @@
 
         _replaceFileInput: function (data) {
             var input = data.fileInput,
-                inputClone = input.clone(true);
+                inputClone = input.clone(true),
+                restoreFocus = input.is(document.activeElement);
             // Add a reference for the new cloned file input to the data argument:
             data.fileInputClone = inputClone;
             $('<form></form>').append(inputClone)[0].reset();
             // Detaching allows to insert the fileInput on another form
             // without loosing the file input value:
             input.after(inputClone).detach();
+            // If the fileInput had focus before it was detached,
+            // restore focus to the inputClone.
+            if (restoreFocus) {
+                inputClone.focus();
+            }
             // Avoid memory leaks with the detached file input:
             $.cleanData(input.unbind('remove'));
             // Replace the original file input element in the fileInput
@@ -1070,6 +1080,8 @@
         _handleFileTreeEntry: function (entry, path) {
             var that = this,
                 dfd = $.Deferred(),
+                entries = [],
+                dirReader,
                 errorHandler = function (e) {
                     if (e && !e.entry) {
                         e.entry = entry;
@@ -1097,8 +1109,7 @@
                             readEntries();
                         }
                     }, errorHandler);
-                },
-                dirReader, entries = [];
+                };
             path = path || '';
             if (entry.isFile) {
                 if (entry._file) {
@@ -1129,7 +1140,7 @@
                 $.map(entries, function (entry) {
                     return that._handleFileTreeEntry(entry, path);
                 })
-            ).pipe(function () {
+            ).then(function () {
                 return Array.prototype.concat.apply(
                     [],
                     arguments
@@ -1198,7 +1209,7 @@
             return $.when.apply(
                 $,
                 $.map(fileInput, this._getSingleFileInputFiles)
-            ).pipe(function () {
+            ).then(function () {
                 return Array.prototype.concat.apply(
                     [],
                     arguments
@@ -1299,6 +1310,10 @@
             this._off(this.options.dropZone, 'dragenter dragleave dragover drop');
             this._off(this.options.pasteZone, 'paste');
             this._off(this.options.fileInput, 'change');
+        },
+
+        _destroy: function () {
+            this._destroyEventHandlers();
         },
 
         _setOption: function (key, value) {

--- a/vendor/assets/javascripts/fileupload/jquery.iframe-transport.js
+++ b/vendor/assets/javascripts/fileupload/jquery.iframe-transport.js
@@ -1,5 +1,5 @@
 /*
- * jQuery Iframe Transport Plugin 1.8.3
+ * jQuery Iframe Transport Plugin
  * https://github.com/blueimp/jQuery-File-Upload
  *
  * Copyright 2011, Sebastian Tschan
@@ -11,7 +11,7 @@
 
 /* global define, require, window, document */
 
-(function (factory) {
+;(function (factory) {
     'use strict';
     if (typeof define === 'function' && define.amd) {
         // Register as an anonymous AMD module:


### PR DESCRIPTION
Attachment files can now be replaced by another file. Very useful, if you have published the url to a file and want to replace the file afterwards.