### PR TITLE
Fixes the locked page notice in sitemap

### DIFF
--- a/app/serializers/alchemy/page_tree_serializer.rb
+++ b/app/serializers/alchemy/page_tree_serializer.rb
@@ -72,6 +72,7 @@ module Alchemy
           definition_missing: page.definition.blank?,
           folded: folded,
           locked: page.locked?,
+          locked_notice: page.locked? ? Alchemy.t('This page is locked', name: page.locker_name) : nil,
           permissions: page_permissions(page, opts[:ability]),
           status_titles: page_status_titles(page)
         })

--- a/app/views/alchemy/admin/pages/_page.html.erb
+++ b/app/views/alchemy/admin/pages/_page.html.erb
@@ -21,7 +21,7 @@
         <div class="page icon<% if @sorting %>{{#unless root}} handle{{/unless}}<% end %>{{#if locked}} with-hint{{/if}}">
         {{#if locked}}
           <span class="hint-bubble">
-            <%= Alchemy.t('This page is locked', name: page.locker_name) %>
+            {{locked_notice}}
           </span>
         {{/if}}
         </div>

--- a/spec/dummy/app/models/dummy_user.rb
+++ b/spec/dummy/app/models/dummy_user.rb
@@ -12,4 +12,8 @@ class DummyUser < ActiveRecord::Base
   def alchemy_roles
     @alchemy_roles || %w(admin)
   end
+
+  def name
+    @name || email
+  end
 end


### PR DESCRIPTION
Since the template gets compiled once into a Handlebars template, the only page that gets hit by ruby on template compile time is the root page. The sitemap renderer replaces all accurances of this id with the actual page id [1] to make the links work.

The "page locked by" notice also only gets rendered once, but since this is always the root page it happens that all other pages have the name of the user on all other pages as well (or 'unknown', if the root page is not locked).

This fixes it by putting the "page locked by" notice into the serializer.

[1] https://github.com/AlchemyCMS/alchemy_cms/blob/5dc29f5b88ee9f7dece474dc2c1de25b12204df7/app/assets/javascripts/alchemy/alchemy.sitemap.js.coffee#L15-L16