### PR TITLE
Move page_layouts_missing_warning helper

### DIFF
--- a/app/helpers/alchemy/admin/base_helper.rb
+++ b/app/helpers/alchemy/admin/base_helper.rb
@@ -450,6 +450,15 @@ module Alchemy
         end
       end
 
+      # Renders a warning icon with a hint
+      # that explains the user that the page layout is missing
+      def page_layout_missing_warning
+        hint_with_tooltip(
+          Alchemy.t(:page_definition_missing),
+          class: 'inline warning icon'
+        )
+      end
+
       private
 
       def permission_from_options(options)

--- a/app/helpers/alchemy/admin/pages_helper.rb
+++ b/app/helpers/alchemy/admin/pages_helper.rb
@@ -42,15 +42,6 @@ module Alchemy
           Alchemy.t(:page_type)
         end
       end
-
-      # Renders a warning icon with a hint
-      # that explains the user that the page layout is missing
-      def page_layout_missing_warning
-        hint_with_tooltip(
-          Alchemy.t(:page_definition_missing),
-          class: 'inline warning icon'
-        )
-      end
     end
   end
 end


### PR DESCRIPTION
The helper needs to be globally available, because everywhere we show the locked pages we need to have access to this helper.