### PR TITLE
Do not cache essence editor partials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ __New Features__
 __Notable Changes__
 
 * The essence view partials don't get cached anymore (#1099)
+* The essence editor partials don't get cached anymore (#1171)
 * Removes update_essence_select_elements (#1103)
 * The admin resource form now uses the datetime-picker instead of the date-picker for datetime fields.
 * The `preview_mode_code` helper is moved to a partial in `alchemy/preview_mode_code`. (#1110)

--- a/app/views/alchemy/essences/_essence_boolean_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_boolean_editor.html.erb
@@ -1,15 +1,13 @@
-<% cache(content) do %>
-  <div class="content_editor essence_boolean" id="<%= content.dom_id %>" data-content-id="<%= content.id %>">
-    <input type="hidden" value="0" name="<%= content.form_field_name %>">
-    <%= check_box_tag content.form_field_name, 1,
-      content.ingredient.presence || content.settings_value(
-        :default_value, local_assigns.fetch(:options, {})
-      ),
-      class: local_assigns.fetch(:html_options, {})[:class],
-      style: local_assigns.fetch(:html_options, {})[:style] %>
-    <label for="<%= content.form_field_id %>" style="display: inline">
-      <%= render_content_name(content) %>
-    </label>
-    <%= render_hint_for(content) %>
-  </div>
-<% end %>
+<div class="content_editor essence_boolean" id="<%= content.dom_id %>" data-content-id="<%= content.id %>">
+  <input type="hidden" value="0" name="<%= content.form_field_name %>">
+  <%= check_box_tag content.form_field_name, 1,
+    content.ingredient.presence || content.settings_value(
+      :default_value, local_assigns.fetch(:options, {})
+    ),
+    class: local_assigns.fetch(:html_options, {})[:class],
+    style: local_assigns.fetch(:html_options, {})[:style] %>
+  <label for="<%= content.form_field_id %>" style="display: inline">
+    <%= render_content_name(content) %>
+  </label>
+  <%= render_hint_for(content) %>
+</div>

--- a/app/views/alchemy/essences/_essence_date_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_date_editor.html.erb
@@ -1,4 +1,3 @@
-<% cache(content) do %>
 <div class="content_editor essence_date" id="<%= content.dom_id %>" data-content-id="<%= content.id %>">
   <%= content_label(content) %>
   <%= alchemy_datepicker(
@@ -12,4 +11,3 @@
     <span class="ui-icon ui-icon-calendar"></span>
   </label>
 </div>
-<% end %>

--- a/app/views/alchemy/essences/_essence_file_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_file_editor.html.erb
@@ -1,5 +1,3 @@
-<% cache(content) do %>
-
 <% dialog_link = link_to_dialog('',
   alchemy.admin_attachments_path(
     content_id: content.id,
@@ -50,4 +48,3 @@
       content.ingredient && content.ingredient.id %>
   </div>
 </div>
-<% end %>

--- a/app/views/alchemy/essences/_essence_html_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_html_editor.html.erb
@@ -1,4 +1,3 @@
-<% cache(content) do %>
 <div class="content_editor essence_html_editor" data-content-id="<%= content.id %>">
   <%= content_label(content) %>
   <%= text_area_tag(
@@ -6,4 +5,3 @@
     content.ingredient
   ) %>
 </div>
-<% end %>

--- a/app/views/alchemy/essences/_essence_link_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_link_editor.html.erb
@@ -1,4 +1,3 @@
-<% cache(content) do %>
 <div class="content_editor essence_link" id="<%= content.dom_id %>" data-content-id="<%= content.id %>">
   <%= content_label(content) %>
   <%= text_field_tag '', content.ingredient,
@@ -22,4 +21,3 @@
     $('#<%= content.dom_id %> input.text_with_icon').val($(this).val());
   });
 </script>
-<% end %>

--- a/app/views/alchemy/essences/_essence_picture_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_picture_editor.html.erb
@@ -1,54 +1,52 @@
-<% cache(content) do %>
-  <%= content_tag :div, id: content.dom_id, data: {"content-id" => content.id}, class: [
-      "essence_picture_editor",
-      options[:dragable] ? "dragable_picture" : nil,
-      options[:grouped] ? nil : "content_editor"
-    ].compact.join(" ") do %>
-    <% unless options[:grouped] %><%= content_label(content) %><% end %>
-    <div class="picture_thumbnail">
-      <span class="picture_tool delete">
-        <% if options[:grouped] %>
-          <%= link_to_confirm_dialog "", Alchemy.t(:confirm_to_delete_image),
-            alchemy.admin_essence_picture_path(
-              id: content,
-              options: options
-            ), {title: Alchemy.t(:delete_image)} %>
-        <% else %>
-          <%= link_to '', '#',
-            onclick: "return Alchemy.removePicture('##{content.form_field_id(:picture_id)}');" %>
+<%= content_tag :div, id: content.dom_id, data: {"content-id" => content.id}, class: [
+    "essence_picture_editor",
+    options[:dragable] ? "dragable_picture" : nil,
+    options[:grouped] ? nil : "content_editor"
+  ].compact.join(" ") do %>
+  <% unless options[:grouped] %><%= content_label(content) %><% end %>
+  <div class="picture_thumbnail">
+    <span class="picture_tool delete">
+      <% if options[:grouped] %>
+        <%= link_to_confirm_dialog "", Alchemy.t(:confirm_to_delete_image),
+          alchemy.admin_essence_picture_path(
+            id: content,
+            options: options
+          ), {title: Alchemy.t(:delete_image)} %>
+      <% else %>
+        <%= link_to '', '#',
+          onclick: "return Alchemy.removePicture('##{content.form_field_id(:picture_id)}');" %>
+      <% end %>
+    </span>
+    <%- if content.ingredient -%>
+      <div class="picture_handle" title="<%= Alchemy.t(:drag_to_sort) if options[:dragable] %>"></div>
+    <%- end -%>
+    <div class="picture_image">
+      <div class="thumbnail_background<%= ' missing' if content.ingredient.nil? %>">
+        <%- if content.ingredient -%>
+        <%= essence_picture_thumbnail(content, options) %>
+        <%= hidden_field_tag content.form_field_name(:picture_id), content.ingredient.id %>
         <% end %>
-      </span>
-      <%- if content.ingredient -%>
-        <div class="picture_handle" title="<%= Alchemy.t(:drag_to_sort) if options[:dragable] %>"></div>
-      <%- end -%>
-      <div class="picture_image">
-        <div class="thumbnail_background<%= ' missing' if content.ingredient.nil? %>">
-          <%- if content.ingredient -%>
-          <%= essence_picture_thumbnail(content, options) %>
-          <%= hidden_field_tag content.form_field_name(:picture_id), content.ingredient.id %>
-          <% end %>
-        </div>
-      </div>
-      <%- if content.essence.css_class.present? -%>
-        <div class="essence_picture_css_class">
-          <%= Alchemy.t("alchemy.essence_pictures.css_classes.#{content.essence.css_class}",
-            default: content.essence.css_class.camelcase) %>
-        </div>
-      <%- end -%>
-      <div class="edit_images_bottom">
-        <%= render 'alchemy/essences/shared/essence_picture_tools', {
-          content: content,
-          options: options
-        } %>
       </div>
     </div>
-    <%= hidden_field_tag content.form_field_name(:link),
-      content.essence.link %>
-    <%= hidden_field_tag content.form_field_name(:link_title),
-      content.essence.link_title %>
-    <%= hidden_field_tag content.form_field_name(:link_class_name),
-      content.essence.link_class_name %>
-    <%= hidden_field_tag content.form_field_name(:link_target),
-      content.essence.link_target %>
-  <% end %>
+    <%- if content.essence.css_class.present? -%>
+      <div class="essence_picture_css_class">
+        <%= Alchemy.t("alchemy.essence_pictures.css_classes.#{content.essence.css_class}",
+          default: content.essence.css_class.camelcase) %>
+      </div>
+    <%- end -%>
+    <div class="edit_images_bottom">
+      <%= render 'alchemy/essences/shared/essence_picture_tools', {
+        content: content,
+        options: options
+      } %>
+    </div>
+  </div>
+  <%= hidden_field_tag content.form_field_name(:link),
+    content.essence.link %>
+  <%= hidden_field_tag content.form_field_name(:link_title),
+    content.essence.link_title %>
+  <%= hidden_field_tag content.form_field_name(:link_class_name),
+    content.essence.link_class_name %>
+  <%= hidden_field_tag content.form_field_name(:link_target),
+    content.essence.link_target %>
 <% end %>

--- a/app/views/alchemy/essences/_essence_richtext_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_richtext_editor.html.erb
@@ -1,4 +1,3 @@
-<% cache(content) do -%>
 <div class="content_editor essence_richtext" id="<%= content.dom_id %>">
   <%= content_label(content) %>
   <div class="tinymce_container">
@@ -10,4 +9,3 @@
     ) %>
   </div>
 </div>
-<% end -%>

--- a/app/views/alchemy/essences/_essence_select_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_select_editor.html.erb
@@ -1,33 +1,31 @@
-<% cache(content) do %>
-  <% select_values = content.settings_value(:select_values, local_assigns.fetch(:options, {})) %>
-  <% inline = content.settings_value(:display_inline, local_assigns.fetch(:options, {})) %>
+<% select_values = content.settings_value(:select_values, local_assigns.fetch(:options, {})) %>
+<% inline = content.settings_value(:display_inline, local_assigns.fetch(:options, {})) %>
 
-  <%= content_tag :div,
-    id: content.dom_id,
-    class: [
-      "content_editor",
-      "essence_select",
-      inline ? 'display_inline' : nil
-    ].compact, data: {content_id: content.id} do %>
-    <%= content_label(content) %>
+<%= content_tag :div,
+  id: content.dom_id,
+  class: [
+    "content_editor",
+    "essence_select",
+    inline ? 'display_inline' : nil
+  ].compact, data: {content_id: content.id} do %>
+  <%= content_label(content) %>
 
-    <% if select_values.nil? %>
-      <%== warning(':select_values is nil',
-      "<strong>No select values given.</strong>
-      <br>Please provide :<code>select_values</code> either as argument to
-      <code>render_essence_editor</code> helper or as setting on the content definition in
-      <code>elements.yml</code>.") %>
-    <% else %>
-      <%
-      if select_values.is_a?(Hash)
-        options_tags = grouped_options_for_select(select_values, content.ingredient)
-      else
-        options_tags = options_for_select(select_values, content.ingredient)
-      end %>
-      <%= select_tag content.form_field_name, options_tags, {
-        class: ["alchemy_selectbox", "essence_editor_select", html_options[:class]].compact,
-        style: html_options[:style]
-      } %>
-    <% end %>
+  <% if select_values.nil? %>
+    <%== warning(':select_values is nil',
+    "<strong>No select values given.</strong>
+    <br>Please provide :<code>select_values</code> either as argument to
+    <code>render_essence_editor</code> helper or as setting on the content definition in
+    <code>elements.yml</code>.") %>
+  <% else %>
+    <%
+    if select_values.is_a?(Hash)
+      options_tags = grouped_options_for_select(select_values, content.ingredient)
+    else
+      options_tags = options_for_select(select_values, content.ingredient)
+    end %>
+    <%= select_tag content.form_field_name, options_tags, {
+      class: ["alchemy_selectbox", "essence_editor_select", html_options[:class]].compact,
+      style: html_options[:style]
+    } %>
   <% end %>
 <% end %>

--- a/app/views/alchemy/essences/_essence_text_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_text_editor.html.erb
@@ -1,19 +1,17 @@
-<% cache(content) do %>
-  <div class="essence_text content_editor<%= options[:display_inline].to_s == 'true' ? ' display_inline' : '' %>" id="<%= content.dom_id %>">
-    <%= content_label(content) %>
-    <%= text_field_tag(
-      content.form_field_name,
-      content.ingredient,
-      class: ["thin_border #{content.settings[:linkable] ? ' text_with_icon' : ''}", html_options[:class]].join(' '),
-      style: html_options[:style],
-      type: content.settings_value(:input_type) || "text"
-    ) %>
-    <% if content.settings[:linkable] %>
-      <%= hidden_field_tag content.form_field_name(:link), content.essence.link %>
-      <%= hidden_field_tag content.form_field_name(:link_title), content.essence.link_title %>
-      <%= hidden_field_tag content.form_field_name(:link_class_name), content.essence.link_class_name %>
-      <%= hidden_field_tag content.form_field_name(:link_target), content.essence.link_target %>
-      <%= render 'alchemy/essences/shared/linkable_essence_tools', content: content %>
-    <% end %>
-  </div>
-<% end %>
+<div class="essence_text content_editor<%= options[:display_inline].to_s == 'true' ? ' display_inline' : '' %>" id="<%= content.dom_id %>">
+  <%= content_label(content) %>
+  <%= text_field_tag(
+    content.form_field_name,
+    content.ingredient,
+    class: ["thin_border #{content.settings[:linkable] ? ' text_with_icon' : ''}", html_options[:class]].join(' '),
+    style: html_options[:style],
+    type: content.settings_value(:input_type) || "text"
+  ) %>
+  <% if content.settings[:linkable] %>
+    <%= hidden_field_tag content.form_field_name(:link), content.essence.link %>
+    <%= hidden_field_tag content.form_field_name(:link_title), content.essence.link_title %>
+    <%= hidden_field_tag content.form_field_name(:link_class_name), content.essence.link_class_name %>
+    <%= hidden_field_tag content.form_field_name(:link_target), content.essence.link_target %>
+    <%= render 'alchemy/essences/shared/linkable_essence_tools', content: content %>
+  <% end %>
+</div>

--- a/lib/rails/generators/alchemy/essence/templates/editor.html.erb
+++ b/lib/rails/generators/alchemy/essence/templates/editor.html.erb
@@ -5,13 +5,11 @@
 
   Please consult Alchemy::Content.rb docs for further methods on the content object
 %>
-<%% cache(content) do %>
 <div class="content_editor <%= @essence_name.classify.demodulize.underscore %>" id="<%%= content.dom_id %>" data-content-id="<%%= content.id %>">
   <%%= content_label(content) %>
   <%%= text_field_tag(
     content.form_field_name,
     content.ingredient,
-    :id => content.form_field_id
+    id: content.form_field_id
   ) %>
 </div>
-<%% end %>


### PR DESCRIPTION
Caching essence editor partials is more harmful then useful.
With lots of options passed and using dynamic values never worked
reliably we decided to remove the cache.

If, for some reason, this will ever has performance implications for
you, please override the partial in you host app and enable caching again.