### PR TITLE
Exclud off limits templates from the available templates listings

### DIFF
--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -28,7 +28,7 @@ module Alchemy
         if !@page_root
           @language = Language.current
           @languages_with_page_tree = Language.on_current_site.with_root_page
-          @page_layouts = PageLayout.layouts_for_select(@language.id)
+          @page_layouts = PageLayout.layouts_for_select(@language.id, current_alchemy_user)
         end
       end
 
@@ -56,7 +56,7 @@ module Alchemy
 
       def new
         @page = Page.new(layoutpage: params[:layoutpage] == 'true', parent_id: params[:parent_id])
-        @page_layouts = PageLayout.layouts_for_select(Language.current.id, @page.layoutpage?)
+        @page_layouts = PageLayout.layouts_for_select(Language.current.id, current_alchemy_user, @page.layoutpage?)
         @clipboard = get_clipboard('pages')
         @clipboard_items = Page.all_from_clipboard_for_select(@clipboard, Language.current.id, @page.layoutpage?)
       end
@@ -67,7 +67,7 @@ module Alchemy
           flash[:notice] = Alchemy.t("Page created", name: @page.name)
           do_redirect_to(redirect_path_after_create_page)
         else
-          @page_layouts = PageLayout.layouts_for_select(Language.current.id, @page.layoutpage?)
+          @page_layouts = PageLayout.layouts_for_select(Language.current.id, current_alchemy_user, @page.layoutpage?)
           @clipboard = get_clipboard('pages')
           @clipboard_items = Page.all_from_clipboard_for_select(@clipboard, Language.current.id, @page.layoutpage?)
           render :new

--- a/lib/alchemy/page_layout.rb
+++ b/lib/alchemy/page_layout.rb
@@ -55,9 +55,9 @@ module Alchemy
 
       # Returns page layouts ready for Rails' select form helper.
       #
-      def layouts_for_select(language_id, only_layoutpages = false)
+      def layouts_for_select(language_id, user, only_layoutpages = false)
         @map_array = [[Alchemy.t('Please choose'), '']]
-        mapped_layouts_for_select(selectable_layouts(language_id, only_layoutpages))
+        mapped_layouts_for_select(selectable_layouts(language_id, only_layoutpages), user)
       end
 
       # Returns page layouts including given layout ready for Rails' select form helper.
@@ -171,8 +171,9 @@ module Alchemy
 
       # Maps given layouts for Rails select form helper.
       #
-      def mapped_layouts_for_select(layouts)
+      def mapped_layouts_for_select(layouts, user = false)
         layouts.each do |layout|
+          next if user && layout["editable_by"] && (layout["editable_by"] & user.alchemy_roles).empty?
           @map_array << [human_layout_name(layout['name']), layout["name"]]
         end
         @map_array

--- a/spec/libraries/page_layout_spec.rb
+++ b/spec/libraries/page_layout_spec.rb
@@ -146,5 +146,38 @@ module Alchemy
         end
       end
     end
+
+    describe ".layouts_for_select" do
+      let(:user) { build(:alchemy_dummy_user, :as_editor) }
+
+      context "without scoped templates" do
+        it "returns all templates" do
+          expect(PageLayout.layouts_for_select(1, user).size).to eq(PageLayout.all.size)
+        end
+      end
+
+      context "with scoped templates" do
+        let(:scoped_layout){ PageLayout.get("news") }
+        let(:available_layouts){ PageLayout.layouts_for_select(1, user) }
+
+        context "excluding current user role" do
+          before { scoped_layout["editable_by"] = ["freelancer"] }
+
+          it "templates are excluded" do
+            expect(available_layouts.size).to eq(PageLayout.all.size - 1)
+            expect(available_layouts.select { |l| l[1] == "news" }.length).to eq(0)
+          end
+        end
+
+        context "including current user role" do
+          before { scoped_layout["editable_by"] = ["editor"] }
+
+          it "templates are included" do
+            expect(available_layouts.size).to eq(PageLayout.all.size)
+            expect(available_layouts.select { |l| l[1] == "news" }.length).to eq(1)
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently a template which defines user types with edit abilities still show up to off limit users in the new page dropdown. This removes those templates from the list.