### PR TITLE
Page status tooltips

### DIFF
--- a/app/assets/stylesheets/alchemy/sitemap.scss
+++ b/app/assets/stylesheets/alchemy/sitemap.scss
@@ -212,54 +212,52 @@ ul.list .sitemap_sitename {
   border-left: 1px solid $light-gray;
   float: right;
   height: $sitemap-line-height;
-  line-height: $sitemap-line-height - 2px;
+  line-height: $sitemap-line-height;
   padding: 0 $default-padding;
 
   .page_status {
-    margin: 0 $default-margin;
+    padding: 0 $default-padding;
   }
 }
 
 #header .page_status_and_name .page_status {
-  float: none;
-  display: inline-block;
-  vertical-align: -3px;
   margin-left: 2px;
+  line-height: 1;
+  vertical-align: text-bottom;
 }
 
 .page_status {
   display: inline-block;
-  width: 16px;
-  height: 16px;
-  background-image: image-url('alchemy/icons.png');
-  background-repeat: no-repeat;
-  vertical-align: middle;
 
-  &.restricted {
-    background-position: -256px -39px;
-  }
+  .icon {
+    vertical-align: text-bottom;
 
-  &.not_restricted {
-    background-position: -288px -39px;
-    opacity: 0.3;
-  }
+    &.restricted {
+      background-position: -256px -39px;
+    }
 
-  &.visible {
-    background-position: -128px -39px;
-  }
+    &.not_restricted {
+      background-position: -288px -39px;
+      opacity: 0.3;
+    }
 
-  &.not_visible {
-    background-position: -160px -39px;
-    opacity: 0.3;
-  }
+    &.visible {
+      background-position: -128px -39px;
+    }
 
-  &.public {
-    background-position: -192px -39px;
-  }
+    &.not_visible {
+      background-position: -160px -39px;
+      opacity: 0.3;
+    }
 
-  &.not_public {
-    background-position: -224px -39px;
-    opacity: 0.3;
+    &.public {
+      background-position: -192px -39px;
+    }
+
+    &.not_public {
+      background-position: -224px -39px;
+      opacity: 0.3;
+    }
   }
 }
 
@@ -286,11 +284,10 @@ ul.list .sitemap_sitename {
       background: image-url('alchemy/icons.png') -5px -77px;
     }
   }
-}
 
-.sitemap_sitestatus {
-  float: right;
-  margin-top: $default-margin;
+  .page_status .icon {
+    vertical-align: middle;
+  }
 }
 
 a.folder_link {

--- a/app/helpers/alchemy/admin/pages_helper.rb
+++ b/app/helpers/alchemy/admin/pages_helper.rb
@@ -17,17 +17,6 @@ module Alchemy
         ])
       end
 
-      # Returns the translated explanation of the page status.
-      #
-      def combined_page_status(page)
-        page.status.map do |state, _value|
-          next if state == :locked
-          css_class = page.send("#{state}?") ? "page_status #{state}" : "page_status not_#{state}"
-          val = content_tag(:span, '', class: css_class)
-          val + page.status_title(state)
-        end.delete_if(&:blank?).join("<br>").html_safe
-      end
-
       # Renders a label for page's page layout
       #
       # If the page layout definition of the page is missing, it displays a warning.

--- a/app/views/alchemy/admin/pages/_page.html.erb
+++ b/app/views/alchemy/admin/pages/_page.html.erb
@@ -138,9 +138,18 @@
       <%- end -%>
     </div>
     <div class="page_infos" id="page_<%= page.id %>_infos">
-      <span class="page_status {{#unless public}}not_{{/unless}}public" title="{{status_titles.public}}"></span>
-      <span class="page_status {{#unless visible}}not_{{/unless}}visible" title="{{status_titles.visible}}"></span>
-      <span class="page_status {{#unless restricted}}not_{{/unless}}restricted" title="{{status_titles.restricted}}"></span>
+      <span class="page_status with-hint">
+        <span class="icon {{#unless public}}not_{{/unless}}public"></span>
+        <span class="hint-bubble">{{status_titles.public}}</span>
+      </span>
+      <span class="page_status with-hint">
+        <span class="icon {{#unless visible}}not_{{/unless}}visible"></span>
+        <span class="hint-bubble">{{status_titles.visible}}</span>
+      </span>
+      <span class="page_status with-hint">
+        <span class="icon {{#unless restricted}}not_{{/unless}}restricted"></span>
+        <span class="hint-bubble">{{status_titles.restricted}}</span>
+      </span>
     </div>
     {{#if redirects_to_external}}
       <div class="redirect_url" title="{{urlname}}">

--- a/app/views/alchemy/admin/pages/_page_infos.html.erb
+++ b/app/views/alchemy/admin/pages/_page_infos.html.erb
@@ -1,12 +1,12 @@
-<%= content_tag 'span', '', class: [
-  'page_status',
-  page.public? ? 'public' : 'not_public'
-], title: page.status_title(:public) %>
-<%= content_tag 'span', '', class: [
-  'page_status',
-  page.visible? ? 'visible' : 'not_visible'
-], title: page.status_title(:visible) %>
-<%= content_tag 'span', '', class: [
-  'page_status',
-  page.restricted? ? 'restricted' : 'not_restricted'
-], title: page.status_title(:restricted) %>
+<span class="page_status with-hint">
+  <%= render_icon page.public? ? :public : :not_public %>
+  <span class="hint-bubble"><%= page.status_title(:public) %></span>
+</span>
+<span class="page_status with-hint">
+  <%= render_icon page.visible? ? :visible : :not_visible %>
+  <span class="hint-bubble"><%= page.status_title(:visible) %></span>
+</span>
+<span class="page_status with-hint">
+  <%= render_icon page.restricted? ? :restricted : :not_restricted %>
+  <span class="hint-bubble"><%= page.status_title(:restricted) %></span>
+</span>

--- a/app/views/alchemy/admin/pages/info.html.erb
+++ b/app/views/alchemy/admin/pages/info.html.erb
@@ -24,7 +24,20 @@
   </div>
   <div class="value">
     <label><%= Alchemy.t(:page_status) %></label>
-    <p><%= combined_page_status(@page) %></p>
+    <p>
+      <span class="page_status">
+        <%= render_icon @page.public? ? :public : :not_public %>
+        <%= @page.status_title(:public) %>
+      </span>
+      <span class="page_status">
+        <%= render_icon @page.visible? ? :visible : :not_visible %>
+        <%= @page.status_title(:visible) %>
+      </span>
+      <span class="page_status">
+        <%= render_icon @page.restricted? ? :restricted : :not_restricted %>
+        <%= @page.status_title(:restricted) %>
+      </span>
+    </p>
   </div>
   <div class="value">
     <label><%= Alchemy.t(:page_was_created) %></label>

--- a/app/views/alchemy/admin/pages/update.js.erb
+++ b/app/views/alchemy/admin/pages/update.js.erb
@@ -9,7 +9,7 @@
 <% if @while_page_edit -%>
 
   Alchemy.reloadPreview();
-  $('#page_<%= @page.id %>_status').replaceWith('<%= j render("page_status", page: @page) %>');
+  $('#page_<%= @page.id %>_status').replaceWith('<%= j render("current_page", current_page: @page) %>');
 
 <% else -%>
 
@@ -18,19 +18,6 @@
   var tree = JSON.parse('<%== @tree.to_json %>');
   var html = compiler(tree.pages[0]);
   $('#page_<%= @page.id %>').replaceWith(html);
-  $page = $('#page_<%= @page.id %>');
-
-  <% if @page.locked? && @page.locker == current_alchemy_user -%>
-    $('#locked_page_<%= @page.id %> > a').html('<%= @page.name %>');
-  <% end -%>
-
-  <% if @page.restricted? -%>
-    $('.page_status:nth-child(3)', $page).addClass('restricted', 'not_restricted').removeClass('not_restricted');
-  <% elsif @page.redirects_to_external? -%>
-    $('span.redirect_url', $page).html('&raquo; <%= Alchemy.t("Redirects to") %>: <%= h @page.external_urlname %>');
-  <% else -%>
-    $('.page_status:nth-child(3)', $page).addClass('not_restricted').removeClass('restricted');
-  <% end -%>
 
 <% end -%>
 

--- a/spec/helpers/alchemy/admin/pages_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/pages_helper_spec.rb
@@ -8,27 +8,6 @@ describe Alchemy::Admin::PagesHelper do
     end
   end
 
-  describe '#combined_page_status' do
-    let(:page) { build_stubbed(:alchemy_page, :public, :restricted, :locked, visible: true) }
-    subject { helper.combined_page_status(page) }
-
-    context 'when page is locked' do
-      it { is_expected.not_to match(/locked/) } # We don't want the locked status in the return string
-    end
-
-    context 'when page is restricted' do
-      it { is_expected.to match(/is restricted/) }
-    end
-
-    context 'when page is visible in navigation' do
-      it { is_expected.to match(/is visible/) }
-    end
-
-    context 'when page is published' do
-      it { is_expected.to match(/is published/) }
-    end
-  end
-
   describe '#page_layout_label' do
     let(:page) { build(:alchemy_page) }
 


### PR DESCRIPTION
## Display hint on page status icons

Instead of title tags we use nicely formatted hints like we recently do all over the place.

### In the sitemap

![alchemy - sitemap status tooltip](https://cloud.githubusercontent.com/assets/42868/19885507/41b5c118-a01f-11e6-97a5-247c4ce04e08.jpg)

### On the active page tab

![alchemy - tab page status](https://cloud.githubusercontent.com/assets/42868/19885508/41d8c3ca-a01f-11e6-88d5-5cdd0d49be5c.jpg)

### In the page info dialog

Without hint tooltip, though. Just for reference that we don't need the superfluous helper here.

![alchemy cms - page status in info dialog](https://cloud.githubusercontent.com/assets/42868/19885548/7d315ce8-a01f-11e6-958a-632067426ff8.jpg)