### PR TITLE
HOTFIX: Fix page publish

### DIFF
--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -419,11 +419,6 @@ module Alchemy
       fixed_attributes.fixed?(name)
     end
 
-    # True if given attribute name is not defined as fixed
-    def attribute_editable?(name)
-      !attribute_fixed?(name)
-    end
-
     # Checks the current page's list of editors, if defined.
     #
     # This allows us to pass in a user and see if any of their roles are enable

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -429,6 +429,22 @@ module Alchemy
       (editor_roles & user.alchemy_roles).any?
     end
 
+    # Returns the value of +public_on+ attribute
+    #
+    # If it's a fixed attribute then the fixed value is returned instead
+    #
+    def public_on
+      attribute_fixed?(:public_on) ? fixed_attributes[:public_on] : self[:public_on]
+    end
+
+    # Returns the value of +public_until+ attribute
+    #
+    # If it's a fixed attribute then the fixed value is returned instead
+    #
+    def public_until
+      attribute_fixed?(:public_until) ? fixed_attributes[:public_until] : self[:public_until]
+    end
+
     private
 
     def set_fixed_attributes

--- a/app/models/alchemy/page/fixed_attributes.rb
+++ b/app/models/alchemy/page/fixed_attributes.rb
@@ -52,5 +52,12 @@ module Alchemy
       return false if name.nil?
       attributes.key?(name.to_sym)
     end
+
+    # Returns the attribute by key
+    #
+    def [](name)
+      return nil if name.nil?
+      attributes[name.to_sym]
+    end
   end
 end

--- a/lib/alchemy/permissions.rb
+++ b/lib/alchemy/permissions.rb
@@ -158,13 +158,9 @@ module Alchemy
         #
         can([
           :create,
-          :destroy
+          :destroy,
+          :publish
         ], Alchemy::Page) { |p| p.editable_by?(@user) }
-
-        can(:publish, Alchemy::Page) do |page|
-          page.editable_by?(@user) &&
-            (page.attribute_editable?(:public_on) || page.attribute_editable?(:public_until))
-        end
 
         can :manage, Alchemy::Picture
         can :manage, Alchemy::Attachment

--- a/spec/dummy/config/alchemy/page_layouts.yml
+++ b/spec/dummy/config/alchemy/page_layouts.yml
@@ -4,8 +4,8 @@
 - name: readonly
   fixed_attributes:
     page_layout: readonly
-    public_on: nil
-    public_until: nil
+    public_on: ~
+    public_until: ~
     visible: false
     restricted: false
     name: false
@@ -13,8 +13,8 @@
     title: false
     robot_index: false
     robot_follow: false
-    meta_keywords: nil
-    meta_description: nil
+    meta_keywords: ~
+    meta_description: ~
 
 - name: standard
   elements: [article, header, slider]

--- a/spec/features/admin/page_editing_feature_spec.rb
+++ b/spec/features/admin/page_editing_feature_spec.rb
@@ -36,15 +36,6 @@ describe 'Page editing feature' do
         expect(page).to have_selector('#publish_page_form')
       end
     end
-
-    context 'when publication columns are fixed attributes' do
-      let(:a_page) { create(:alchemy_page, page_layout: 'readonly') }
-
-      it 'cannot publish page' do
-        visit alchemy.edit_admin_page_path(a_page)
-        expect(page).to_not have_selector('#publish_page_form')
-      end
-    end
   end
 
   context 'as admin' do

--- a/spec/models/alchemy/page/fixed_attributes_spec.rb
+++ b/spec/models/alchemy/page/fixed_attributes_spec.rb
@@ -105,4 +105,36 @@ RSpec.describe Alchemy::Page::FixedAttributes do
       it { is_expected.to eq(true) }
     end
   end
+
+  describe '#[]' do
+    subject(:fetch) do
+      described_class.new(page)[name]
+    end
+
+    context 'with nil given as name' do
+      let(:name) { nil }
+
+      it { is_expected.to be(nil) }
+    end
+
+    context 'with name not defined as fixed attribute' do
+      let(:name) { 'lol' }
+
+      it { is_expected.to be(nil) }
+    end
+
+    context 'with name defined as fixed attribute' do
+      let(:name) { :name }
+
+      before do
+        allow(page).to receive(:definition) do
+          definition_with_fixed_attributes
+        end
+      end
+
+      it 'returns the value' do
+        is_expected.to eq('Home')
+      end
+    end
+  end
 end

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -2370,15 +2370,6 @@ module Alchemy
       end
     end
 
-    describe '#attribute_editable?' do
-      let(:page) { Alchemy::Page.new }
-
-      it 'is the opposite of Page#attribute_fixed?' do
-        expect_any_instance_of(Alchemy::Page).to receive(:attribute_fixed?).with('yolo') { true }
-        expect(page.attribute_editable?('yolo')).to be(false)
-      end
-    end
-
     describe '#set_fixed_attributes' do
       context 'when fixed attributes are defined' do
         let(:page) { create(:alchemy_page, page_layout: 'readonly') }

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1548,6 +1548,54 @@ module Alchemy
       end
     end
 
+    describe '#public_on' do
+      subject(:public_on) { page.public_on }
+
+      context 'when is fixed attribute' do
+        let(:page) do
+          create(:alchemy_page, page_layout: 'readonly')
+        end
+
+        it 'returns the fixed value' do
+          is_expected.to eq(nil)
+        end
+      end
+
+      context 'when is not fixed attribute' do
+        let(:page) do
+          create(:alchemy_page, page_layout: 'standard', public_on: '2016-11-01')
+        end
+
+        it 'returns value' do
+          is_expected.to eq('2016-11-01'.to_time(:utc))
+        end
+      end
+    end
+
+    describe '#public_until' do
+      subject(:public_until) { page.public_until }
+
+      context 'when is fixed attribute' do
+        let(:page) do
+          create(:alchemy_page, page_layout: 'readonly')
+        end
+
+        it 'returns the fixed value' do
+          is_expected.to eq(nil)
+        end
+      end
+
+      context 'when is not fixed attribute' do
+        let(:page) do
+          create(:alchemy_page, page_layout: 'standard', public_until: '2016-11-01')
+        end
+
+        it 'returns value' do
+          is_expected.to eq('2016-11-01'.to_time(:utc))
+        end
+      end
+    end
+
     describe '#public?' do
       subject { page.public? }
 


### PR DESCRIPTION
As #1178 was a naive fix for the problem this hotfix reverts 5090607d6f64cbb96197f532c69ba9783e59c511 and overwrites the getter of `Page#public_on` and `Page#public_until` instead.

### Some Background

The page publish button does two things:

1. It resets the cache key (`published_at`) to current time
2. It publishes the page if it was not public before

In #1178 we wanted to prohibit the second one, but as we still need the first one, we can't just hide the button.

By overwriting the getters for `public_on` and `public_until` we ensure that the values always get set to the fixed value instead.

TIL: `~` is `nil` in YAML http://yaml4r.sourceforge.net/doc/page/basic_types_in_yaml.htm