### PR TITLE
Change the mount point detection to read the routes object

### DIFF
--- a/lib/alchemy/mount_point.rb
+++ b/lib/alchemy/mount_point.rb
@@ -4,8 +4,6 @@ module Alchemy
   # Utilities for Alchemy's mount point in the host rails app.
   #
   class MountPoint
-    MOUNT_POINT_REGEXP = /mount\sAlchemy::Engine\s=>\s['|"](\/\w*)['|"]/
-
     class << self
       # Returns the path of Alchemy's mount point in current rails app.
       #
@@ -23,22 +21,10 @@ module Alchemy
       # Returns the mount point path from the Rails app routes.
       #
       def path
-        match = File.read(routes_file_path).match(MOUNT_POINT_REGEXP)
-        if match.nil?
-          raise NotMountedError
-        else
-          match[1]
-        end
-      end
-
-      private
-
-      def routes_file_path
-        if Rails.root
-          Rails.root.join('config/routes.rb')
-        else
-          'config/routes.rb'
-        end
+        all_routes = Rails.application.routes.routes
+        alchemy_route = all_routes.find { |r| r.name == Alchemy::Engine.engine_name }
+        raise NotMountedError if alchemy_route.nil?
+        alchemy_route.path.spec.to_s
       end
     end
   end

--- a/spec/libraries/mount_point_spec.rb
+++ b/spec/libraries/mount_point_spec.rb
@@ -38,39 +38,19 @@ describe Alchemy::MountPoint do
   end
 
   describe '.path' do
-    before do
-      allow(File)
-        .to receive(:read)
-        .and_return("mount Alchemy::Engine => '/cms'")
+    subject(:mount_path) { Alchemy::MountPoint.path }
+
+    it 'returns the mount point for the dummy app' do
+      expect(mount_path).to eq('/')
     end
 
-    it 'returns the mount point path from routes.' do
-      expect(Alchemy::MountPoint.path).to eq('/cms')
-    end
-
-    context "Alchemy mount point could not be found" do
+    context 'not mounted' do
       before do
-        allow(File)
-        .to receive(:read)
-        .and_return("")
+        allow(Rails.application.routes.routes).to receive(:find) { nil }
       end
 
-      it "raises an exception" do
-        expect {
-          Alchemy::MountPoint.path
-        }.to raise_error(Alchemy::NotMountedError)
-      end
-    end
-
-    context 'Mount point using double quotes string' do
-      before do
-        allow(File)
-          .to receive(:read)
-          .and_return('mount Alchemy::Engine => "/cms"')
-      end
-
-      it 'returns the mount point path from routes.' do
-        expect(Alchemy::MountPoint.path).to eq('/cms')
+      it 'raises an error' do
+        expect { mount_path }.to raise_error(Alchemy::NotMountedError)
       end
     end
   end


### PR DESCRIPTION
Backport from #1183 

Before, the mount point has been derived from the routes.rb file. When
you used Alchemy as a part of another engine, the mount point could not
be found. This changes the detection, so that it inspects the routes
object itself.