### PR TITLE
Fix: `language_links` scopes languages to current site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ __Notable Changes__
 
 * Allow users to manually publish changes on global pages
 
+__Fixed Bugs__
+
+* The `language_links` helper now only renders languages from the current site
+
 ## 3.4.1 (2016-08-31)
 
 __Fixed Bugs__

--- a/app/helpers/alchemy/pages_helper.rb
+++ b/app/helpers/alchemy/pages_helper.rb
@@ -29,7 +29,7 @@ module Alchemy
         spacer: '',
         reverse: false
       }.merge(options)
-      languages = Language.published.with_root_page.order("name #{options[:reverse] ? 'DESC' : 'ASC'}")
+      languages = Language.on_current_site.published.with_root_page.order("name #{options[:reverse] ? 'DESC' : 'ASC'}")
       return nil if languages.count < 2
       render(
         partial: "alchemy/language_links/language",

--- a/spec/helpers/alchemy/pages_helper_spec.rb
+++ b/spec/helpers/alchemy/pages_helper_spec.rb
@@ -288,7 +288,20 @@ module Alchemy
     end
 
     describe "#language_links" do
-      context "with two public languages" do
+      context "with another site, root page and language present" do
+        let!(:second_site) { create(:alchemy_site, name: "Other", host: "example.com") }
+        let!(:language_root_2) { create(:alchemy_page, :language_root, name: "Intro", language: klingon_2) }
+        let!(:public_page_2) { create(:alchemy_page, :public, language: klingon_2) }
+        let!(:klingon_2) { create(:alchemy_language, :klingon, site: second_site) }
+
+        before { klingon_language_root }
+
+        it 'should still only render two links' do
+          expect(helper.language_links).to have_selector('a', count: 2)
+        end
+      end
+
+      context "with two public languages on the same site" do
         # Always create second language
         before { klingon }
 


### PR DESCRIPTION
We removed the default scope on the Language model, and now
the `language_links` helper rendered links to different sites.
This uses the `on_current_site` scope so that that does not happen.