### PR TITLE
Increase EssenceDate fields to 100% width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ __New Features__
 
 __Notable Changes__
 
+* The essence date input field is now 100% width (#1191)
 * The essence view partials don't get cached anymore (#1099)
 * The essence editor partials don't get cached anymore (#1171)
 * Removes update_essence_select_elements (#1103)

--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -434,17 +434,6 @@
   }
 }
 
-.content_editor.essence_date {
-  float: none;
-  display: inline-block;
-  vertical-align: middle;
-  vertical-align: top;
-
-  input.date {
-    width: 154px;
-  }
-}
-
 .essence_picture_editor {
   position: relative;
 
@@ -745,17 +734,6 @@ select.long {
     }
   }
 
-  &.essence_date {
-    float: none;
-    display: inline-block;
-    vertical-align: middle;
-    vertical-align: top;
-
-    input.date {
-      width: 154px;
-    }
-  }
-
   &.essence_picture_editor {
     float: none;
     height: auto;
@@ -849,4 +827,10 @@ textarea.has_tinymce {
 
 .add-nestable-element-button {
   margin-top: 0;
+}
+
+.essence_date--label {
+  position: absolute;
+  right: 5px;
+  top: 31px;
 }

--- a/app/views/alchemy/essences/_essence_date_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_date_editor.html.erb
@@ -7,7 +7,7 @@
       value: content.settings_value(:default_value, local_assigns.fetch(:options, {}))
     }
   ) %>
-  <label for="<%= content.form_field_id %>" style="cursor: pointer; display: inline; display: inline-block; position: relative; top: 3px; margin: 0;">
+  <label for="<%= content.form_field_id %>" class="essence_date--label">
     <span class="ui-icon ui-icon-calendar"></span>
   </label>
 </div>


### PR DESCRIPTION
Previously, the date picker would become difficult to use for
a second date field in a row: They would be displayed next
to each other and then the Sunday column of the datepicker
would jump off the screen.