### PR TITLE
Hide the upload container if cancelled last item

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.file_progress.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.file_progress.js.coffee
@@ -58,6 +58,9 @@ Alchemy.FileProgress::setCancelled = ->
   @$fileProgressCancel.hide()
   @$fileProgressWrapper.delay(1500).fadeOut ->
     $(this).remove()
+    if $('.upload-progress-container').is(':empty')
+      $('.overall-upload').removeClass('visible')
+    return
 
 Alchemy.FileProgress::setStatus = (status) ->
   @$fileProgressStatus.text Alchemy.t(status)


### PR DESCRIPTION
If the uploader shows an error (ie. the file size is too large) the uploader displays a error message and the user can close this message. The uploader container stays open. This changes this behavior in that it closes the upload container when the last remaining item was closed.