### PR TITLE
Add srcset and sizes support for EssencePicture

### DIFF
--- a/app/models/alchemy/essence_picture_view.rb
+++ b/app/models/alchemy/essence_picture_view.rb
@@ -9,7 +9,9 @@ module Alchemy
 
     DEFAULT_OPTIONS = {
       show_caption: true,
-      disable_link: false
+      disable_link: false,
+      srcset: [],
+      sizes: []
     }
 
     def initialize(content, options = {}, html_options = {})
@@ -59,7 +61,9 @@ module Alchemy
         essence.picture_url(options.except(*DEFAULT_OPTIONS.keys)), {
           alt: essence.alt_tag.presence,
           title: essence.title.presence,
-          class: caption ? nil : essence.css_class.presence
+          class: caption ? nil : essence.css_class.presence,
+          srcset: srcset.join(', ').presence,
+          sizes: options[:sizes].join(', ').presence
         }.merge(caption ? {} : html_options)
       )
     end
@@ -70,6 +74,14 @@ module Alchemy
 
     def is_linked?
       !options[:disable_link] && essence.link.present?
+    end
+
+    def srcset
+      options[:srcset].map do |size|
+        url = essence.picture_url(size: size)
+        width, height = size.split('x')
+        width.present? ? "#{url} #{width}w" : "#{url} #{height}h"
+      end
     end
   end
 end

--- a/spec/models/alchemy/essence_picture_view_spec.rb
+++ b/spec/models/alchemy/essence_picture_view_spec.rb
@@ -168,4 +168,99 @@ describe Alchemy::EssencePictureView, type: :model do
       expect(picture_view.options).to_not have_key(:my_custom_option)
     end
   end
+
+  context "with srcset content setting" do
+    before do
+      allow(content).to receive(:settings) do
+        {srcset: srcset}
+      end
+    end
+
+    subject(:view) do
+      Alchemy::EssencePictureView.new(content).render
+    end
+
+    let(:srcset) do
+      []
+    end
+
+    it 'does not pass srcset option to picture_url' do
+      expect(essence_picture).to receive(:picture_url).with({})
+      view
+    end
+
+    context "when only width or width and height are set" do
+      let(:srcset) do
+        %w(1024x768 800x)
+      end
+
+      it 'adds srcset attribute including image url and width for each size' do
+        url1 = essence_picture.picture_url(size: '1024x768')
+        url2 = essence_picture.picture_url(size: '800x')
+
+        expect(view).to have_selector("img[srcset=\"#{url1} 1024w, #{url2} 800w\"]")
+      end
+    end
+
+    context "when only height is set" do
+      let(:srcset) do
+        %w(x768 x600)
+      end
+
+      it 'adds srcset attribute including image url and height for each size' do
+        url1 = essence_picture.picture_url(size: 'x768')
+        url2 = essence_picture.picture_url(size: 'x600')
+
+        expect(view).to have_selector("img[srcset=\"#{url1} 768h, #{url2} 600h\"]")
+      end
+    end
+  end
+
+  context "with no srcset content setting" do
+    subject(:view) do
+      Alchemy::EssencePictureView.new(content).render
+    end
+
+    it 'image tag has no srcset attribute' do
+      expect(view).not_to have_selector('img[srcset]')
+    end
+  end
+
+  context "with sizes content setting" do
+    before do
+      allow(content).to receive(:settings) do
+        {sizes: sizes}
+      end
+    end
+
+    subject(:view) do
+      Alchemy::EssencePictureView.new(content).render
+    end
+
+    let(:sizes) do
+      [
+        '(max-width: 1023px) 100vh',
+        '(min-width: 1024px) 33.333vh'
+      ]
+    end
+
+    it 'does not pass sizes option to picture_url' do
+      expect(essence_picture).to receive(:picture_url).with({})
+      view
+    end
+
+    it 'adds sizes attribute for each size' do
+      expect(view).to have_selector("img[sizes=\"#{sizes[0]}, #{sizes[1]}\"]")
+    end
+  end
+
+  context "with no sizes content setting" do
+    subject(:view) do
+      Alchemy::EssencePictureView.new(content).render
+    end
+
+    it 'image tag has no sizes attribute' do
+      expect(view).not_to have_selector('img[sizes]')
+    end
+  end
 end


### PR DESCRIPTION
If `srcset` content setting is present a `srcset` attribute
including resize image url and dimensions for each size is added
to the resulting image tag.

Also `sizes` setting gets added to the image tag.

### Example:

    - name: slide
      contents:
      - name: picture
        type: EssencePicture
        settings:
          size: 800x600
          srcset:
            - 1024x768
            - 800x600
          sizes:
            - '(max-width: 1023px) 100vw'
            - '(min-width: 1024px) 33.333vw'

Read more about image src sets in this excellent blog post http://ericportis.com/posts/2014/srcset-sizes/

With > 82% browser support (http://caniuse.com/#feat=srcset) responsive images are a thing now.