### PR TITLE
feat: render essence link with title

### DIFF
--- a/app/views/alchemy/essences/_essence_link_view.html.erb
+++ b/app/views/alchemy/essences/_essence_link_view.html.erb
@@ -4,6 +4,6 @@
 }.merge(local_assigns.fetch(:html_options, {})) -%>
 <%= link_to(content.ingredient, html_options) do -%>
 <%= content.settings_value(:text, local_assigns.fetch(:options, {})) ||
-  content.ingredient -%>
+  content.essence.link_title || content.ingredient -%>
 <%- end -%>
 <%- end -%>


### PR DESCRIPTION
normally EssenceLink will render a link with the ingredient, so the link attribute, as link title and href. 
This change uses the link_title attribute when set, and falls back to the link attribute otherwise. 