### PR TITLE
Use normal view for pages sort action

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.page_sorter.js
+++ b/app/assets/javascripts/alchemy/alchemy.page_sorter.js
@@ -1,48 +1,24 @@
-if (typeof(Alchemy) === 'undefined') {
-  var Alchemy = {};
-}
+Alchemy.PageSorter = function() {
+  var $sortables = $('ul#sitemap').find('ul.level_1_children');
 
-(function($) {
+  $sortables.nestedSortable({
+    disableNesting: 'no-nest',
+    forcePlaceholderSize: true,
+    handle: '.handle',
+    items: 'li',
+    listType: 'ul',
+    opacity: 0.5,
+    placeholder: 'placeholder',
+    tabSize: 16,
+    tolerance: 'pointer',
+    toleranceElement: '> div'
+  });
 
-  var PageSorter = {};
-  $.extend(Alchemy, PageSorter);
-
-  Alchemy.PageSorter = {
-
-    init: function() {
-      var $sortables = $('ul#sitemap').find('ul.level_1_children');
-      $sortables.nestedSortable({
-        disableNesting: 'no-nest',
-        forcePlaceholderSize: true,
-        handle: '.handle',
-        items: 'li',
-        listType: 'ul',
-        opacity: 0.5,
-        placeholder: 'placeholder',
-        tabSize: 16,
-        tolerance: 'pointer',
-        toleranceElement: '> div'
-      });
-      $('#save_page_order').click(function(e) {
-        var params = {
-          set: JSON.stringify($sortables.nestedSortable('toHierarchy'))
-        };
-        $.post(Alchemy.routes.order_admin_pages_path, params);
-        return false;
-      });
-      $('#sort_panel .button').click(Alchemy.pleaseWaitOverlay);
-      Alchemy.PageSorter.disableButton();
-    },
-
-    disableButton: function() {
-      var $buttonLink = $('#page_sorting_button a');
-      $buttonLink.removeAttr('onclick');
-      $('#page_sorting_button').addClass('active');
-      $buttonLink.css({
-        cursor: 'default'
-      });
-    }
-
-  }
-
-})(jQuery);
+  $('#save_page_order').click(function(e) {
+    e.preventDefault();
+    Alchemy.Buttons.disable(this);
+    $.post(Alchemy.routes.order_admin_pages_path, {
+      set: JSON.stringify($sortables.nestedSortable('toHierarchy'))
+    });
+  });
+};

--- a/app/assets/stylesheets/alchemy/sitemap.scss
+++ b/app/assets/stylesheets/alchemy/sitemap.scss
@@ -1,8 +1,8 @@
 #sort_panel {
-  background: $medium-gray;
-  padding: 45px 0 8px 0;
+  background: $light-gray;
+  padding: 47px 0 8px 0;
   position: fixed;
-  top: 27px;
+  top: 29px;
   left: 0;
   z-index: 1;
   width: 100%;
@@ -13,7 +13,8 @@
   }
 
   .buttons {
-    margin-left: 163px;
+    margin: 0 12px 0 163px;
+    text-align: right;
   }
 }
 

--- a/app/views/alchemy/admin/pages/_sitemap.html.erb
+++ b/app/views/alchemy/admin/pages/_sitemap.html.erb
@@ -22,7 +22,7 @@
      full: <%= full %>
      <% if @sorting  %>
      ,ready: function () {
-       Alchemy.PageSorter.init();
+       Alchemy.PageSorter();
      }
      <% elsif action_name == 'link' %>
      ,spinner: Alchemy.Spinner.small(),

--- a/app/views/alchemy/admin/pages/index.html.erb
+++ b/app/views/alchemy/admin/pages/index.html.erb
@@ -16,15 +16,13 @@
   </div>
   <% end %>
   <% if can?(:sort, Alchemy::Page) %>
-  <div class="button_with_label" id="page_sorting_button">
+  <div class="button_with_label">
     <%= link_to(
-      render_icon('sort'),
+      render_icon(:sort),
       alchemy.sort_admin_pages_path,
-      :complete => '',
-      :method => :get,
-      :remote => true,
-      :class => 'icon_button please_wait',
-      :title => Alchemy.t('Sort pages')
+      method: :get,
+      class: 'icon_button please_wait',
+      title: Alchemy.t('Sort pages')
     ) %>
     <label><%= Alchemy.t('Sort pages') %></label>
   </div>

--- a/app/views/alchemy/admin/pages/sort.html.erb
+++ b/app/views/alchemy/admin/pages/sort.html.erb
@@ -1,0 +1,19 @@
+<% content_for :toolbar do %>
+  <div class="button_with_label">
+    <%= link_to alchemy.admin_pages_path, class: 'icon_button' do %>
+      <%= render_icon :back %>
+    <% end %>
+    <label><%= Alchemy.t(:cancel) %></label>
+  </div>
+<% end %>
+
+<div id="sort_panel">
+  <%= render_message do %>
+    <%= Alchemy.t(:explain_sitemap_dragndrop_sorting) %>
+  <% end %>
+  <div class="buttons">
+    <%= button_tag Alchemy.t('save order'), id: 'save_page_order' %>
+  </div>
+</div>
+
+<%= render 'sitemap', page_partial: 'page', full: true %>

--- a/app/views/alchemy/admin/pages/sort.js.erb
+++ b/app/views/alchemy/admin/pages/sort.js.erb
@@ -1,4 +1,0 @@
-$('#sitemap-wrapper').replaceWith('<%= j render('sitemap', page_partial: 'page', full: true) %>');
-$('#sort_panel').show();
-$('#sitemap_heading').css({'padding-top': 102});
-Alchemy.pleaseWaitOverlay(false);


### PR DESCRIPTION
Instead of using a ajax get request and the need for jQuery soup we make the admin pages sort action a normal view that's returned by the already existing action.

This also changes the layout a little bit.

![monosnap 2016-11-22 23-08-40](https://cloud.githubusercontent.com/assets/42868/20544091/a6e27a78-b108-11e6-93f9-740cc0523cfa.jpg)
