### PR TITLE
Remove unused Alchemy.Buttons function

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.base.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.base.js.coffee
@@ -77,10 +77,6 @@ $.extend Alchemy,
       dropdownAutoWidth: true
     return
 
-  Buttons: (options) ->
-    $("button, input:submit, a.button").button options
-    return
-
   # Selects cell tab for given name.
   # Creates it if it's not present yet.
   selectOrCreateCellTab: (cell_name, label) ->


### PR DESCRIPTION
A piece of code that never gets called and would not work anyway, because we don't have a `$.button` function defined, also `Alchemy.Buttons` is an object we define in https://github.com/AlchemyCMS/alchemy_cms/blob/master/app/assets/javascripts/alchemy/alchemy.buttons.js.coffee and would never be callable as a function...