### PR TITLE
Re-color the Turbolinks progressbar

### DIFF
--- a/app/assets/stylesheets/alchemy/base.scss
+++ b/app/assets/stylesheets/alchemy/base.scss
@@ -3,8 +3,7 @@ html {
 
   &.turbolinks-progress-bar::before,
   .turbolinks-progress-bar {
-    background-color: $blue !important;
-    height: 3px !important;
+    background-color: #fff !important;
     z-index: 400001;
   }
 }


### PR DESCRIPTION
A white progress bar fits better to the light UI and has a nice contrast to the topbar