### PR TITLE
Show languages for current site only in layout pages

### DIFF
--- a/app/controllers/alchemy/admin/layoutpages_controller.rb
+++ b/app/controllers/alchemy/admin/layoutpages_controller.rb
@@ -6,7 +6,7 @@ module Alchemy
 
       def index
         @layout_root = Page.find_or_create_layout_root_for(Language.current.id)
-        @languages = Language.all
+        @languages = Language.on_current_site
       end
 
       def edit

--- a/spec/controllers/alchemy/admin/layoutpages_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/layoutpages_controller_spec.rb
@@ -16,6 +16,26 @@ module Alchemy
         alchemy_get :index
         expect(assigns(:languages).first).to be_a(Language)
       end
+
+      context "with multiple sites" do
+        let!(:site_2) do
+          create(:alchemy_site, host: 'another-site.com')
+        end
+
+        let(:language_2) do
+          site_2.default_language
+        end
+
+        let(:language) do
+          create(:alchemy_language)
+        end
+
+        it 'only shows languages from current site' do
+          alchemy_get :index
+          expect(assigns(:languages)).to include(language)
+          expect(assigns(:languages)).to_not include(language_2)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Default scope on `Language` has been removed [here](https://github.com/AlchemyCMS/alchemy_cms/commit/2a2a3408b9162fd66bfed76bcec93491d3861fd2#diff-23d21467ab865799a19dd49ee8d172c0) and I think we never want to see *all* languages even in layout pages.