### PR TITLE
Create instead attachment in essence file spec

### DIFF
--- a/spec/models/alchemy/essence_file_spec.rb
+++ b/spec/models/alchemy/essence_file_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Alchemy
   describe EssenceFile do
-    let(:attachment) { build_stubbed(:alchemy_attachment) }
+    let(:attachment) { create(:alchemy_attachment) }
     let(:essence)    { EssenceFile.new(attachment: attachment) }
 
     it_behaves_like "an essence" do


### PR DESCRIPTION
Only stubbing it does not work because in the shared example we access the database.

Factory Girl 4.8.0 complained about and was totally right.
