### PR TITLE
Expect full mime type string instead of abbreviation

### DIFF
--- a/spec/requests/alchemy/admin/resources_requests_spec.rb
+++ b/spec/requests/alchemy/admin/resources_requests_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Resource requests' do
   describe 'csv export' do
     it 'returns valid csv file' do
       get '/admin/events.csv'
-      expect(response.content_type).to eq(:csv)
+      expect(response.content_type).to eq('text/csv')
       expect(response.body).to include(';')
     end
 

--- a/spec/requests/alchemy/sitemap_spec.rb
+++ b/spec/requests/alchemy/sitemap_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Requests for PagesController#sitemap' do
 
   it 'renders valid xml sitemap' do
     get '/sitemap.xml'
-    expect(response.content_type).to eq(:xml)
+    expect(response.content_type).to eq('application/xml')
     xml_doc = Nokogiri::XML(response.body)
     expect(xml_doc.namespaces).to have_key('xmlns')
     expect(xml_doc.namespaces['xmlns']).to eq('http://www.sitemaps.org/schemas/sitemap/0.9')
@@ -14,7 +14,7 @@ RSpec.describe 'Requests for PagesController#sitemap' do
 
   it 'lastmod dates are ISO 8601 timestamps' do
     get '/sitemap.xml'
-    expect(response.content_type).to eq(:xml)
+    expect(response.content_type).to eq('application/xml')
     xml_doc = Nokogiri::XML(response.body)
     xml_doc.css('urlset url lastmod').each do |timestamps|
       expect(timestamps.text).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/)


### PR DESCRIPTION
Rails 5 now returns full mime type string instead of abbreviated symbol.