### PR TITLE
Allow any number of arguments on touch method

### DIFF
--- a/lib/alchemy/touching.rb
+++ b/lib/alchemy/touching.rb
@@ -2,7 +2,7 @@ module Alchemy
   module Touching
     # Touches the timestamps and userstamps
     #
-    def touch
+    def touch(*)
       # Using update here, because we want the touch call to bubble up to the page.
       update(touchable_attributes)
     end


### PR DESCRIPTION
We override active records `touch` method. 

We don't need any of the arguments passed into that method. Rails 5 introduces some additional attributes. In order to be save while upgrading we should change the signature to something more reliable here.