### PR TITLE
Permit parameters in render_tag_list helper

### DIFF
--- a/app/views/alchemy/admin/attachments/_tag_list.html.erb
+++ b/app/views/alchemy/admin/attachments/_tag_list.html.erb
@@ -1,14 +1,15 @@
-<% p = params.dup %>
-<h2><%= Alchemy.t("Filter by tag") %></h2>
-<%= js_filter_field '.tag-list li' %>
-<ul>
-  <%= render_tag_list('Alchemy::Attachment', p) %>
-</ul>
-<% if p[:tagged_with].present? %>
-  <%= link_to(
-    render_icon('delete-small') + Alchemy.t('Remove tag filter'),
-    url_for(p.delete_if { |k, v| k == "tagged_with" }.merge(action: 'index')),
-    remote: request.xhr?,
-    class: 'button small with_icon please_wait'
-  ) %>
+<% if Alchemy::Attachment.tag_counts.any? %>
+  <h2><%= Alchemy.t("Filter by tag") %></h2>
+  <%= js_filter_field '.tag-list li' %>
+  <ul>
+    <%= render_tag_list('Alchemy::Attachment') %>
+  </ul>
+  <% if params[:tagged_with].present? %>
+    <%= link_to(
+      render_icon('delete-small') + Alchemy.t('Remove tag filter'),
+      url_for(tag_list_params.delete_if { |k, v| k == "tagged_with" }.merge(action: 'index')),
+      remote: request.xhr?,
+      class: 'button small with_icon please_wait'
+    ) %>
+  <% end %>
 <% end %>

--- a/app/views/alchemy/admin/pictures/_tag_list.html.erb
+++ b/app/views/alchemy/admin/pictures/_tag_list.html.erb
@@ -1,14 +1,13 @@
-<% p = params.dup %>
 <% if Alchemy::Picture.tag_counts.any? %>
   <h2><%= Alchemy.t("Filter by tag") %></h2>
   <%= js_filter_field '.tag-list li' %>
   <ul>
-    <%= render_tag_list('Alchemy::Picture', p) %>
+    <%= render_tag_list('Alchemy::Picture') %>
   </ul>
-  <% if p[:tagged_with].present? %>
+  <% if params[:tagged_with].present? %>
     <%= link_to(
       render_icon('delete-small') + Alchemy.t('Remove tag filter'),
-      url_for(p.delete_if { |k, v| k == "tagged_with" }.merge(action: 'index')),
+      url_for(tag_list_params.delete_if { |k, v| k == "tagged_with" }.merge(action: 'index')),
       remote: request.xhr?,
       class: 'button small with_icon please_wait'
     ) %>

--- a/app/views/alchemy/admin/resources/_tag_list.html.erb
+++ b/app/views/alchemy/admin/resources/_tag_list.html.erb
@@ -1,14 +1,13 @@
 <div class="<%= params[:tagged_with].present? ? 'tag-list filtered' : 'tag-list' %>">
-  <% p = params.dup %>
   <h2><%= Alchemy.t("Filter by tag") %></h2>
   <%= js_filter_field '.tag-list li' %>
   <ul>
-    <%= render_tag_list(resource_model.name, p) %>
+    <%= render_tag_list(resource_model.name) %>
   </ul>
-  <% if p[:tagged_with].present? %>
+  <% if params[:tagged_with].present? %>
     <%= link_to(
       render_icon('delete-small') + Alchemy.t('Remove tag filter'),
-      url_for(p.delete_if { |k, v| k == "tagged_with" }.merge(action: 'index')),
+      url_for(tag_list_params.delete_if { |k, v| k == "tagged_with" }.merge(action: 'index')),
       remote: request.xhr?,
       class: 'button small with_icon please_wait'
     ) %>

--- a/spec/helpers/alchemy/admin/tags_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/tags_helper_spec.rb
@@ -2,52 +2,81 @@ require 'spec_helper'
 
 module Alchemy
   describe Admin::TagsHelper do
-    let(:tag)    { mock_model(ActsAsTaggableOn::Tag, name: 'foo', count: 1) }
-    let(:tag2)   { mock_model(ActsAsTaggableOn::Tag, name: 'abc', count: 1) }
-    let(:params) { {controller: 'admin/attachments', action: 'index', use_route: 'alchemy', tagged_with: 'foo'} }
+    let(:tag)  { mock_model(ActsAsTaggableOn::Tag, name: 'foo', count: 1) }
+    let(:tag2) { mock_model(ActsAsTaggableOn::Tag, name: 'abc', count: 1) }
+
+    let(:params) do
+      ActionController::Parameters.new({
+        controller: 'alchemy/admin/attachments',
+        action: 'index',
+        use_route: 'alchemy',
+        tagged_with: 'foo'
+      })
+    end
+
+    before do
+      allow(helper).to receive(:params) { params }
+    end
 
     describe '#render_tag_list' do
       context "with tagged objects" do
         before { allow(Attachment).to receive(:tag_counts).and_return([tag, tag2]) }
 
         it "returns a tag list as <li> tags" do
-          expect(helper.render_tag_list('Alchemy::Attachment', params)).to match(/li/)
+          expect(helper.render_tag_list('Alchemy::Attachment')).to match(/li/)
         end
 
         it "has the tags name in the li's name attribute" do
-          expect(helper.render_tag_list('Alchemy::Attachment', params)).to match(/li.+name="#{tag.name}"/)
+          expect(helper.render_tag_list('Alchemy::Attachment')).to match(/li.+name="#{tag.name}"/)
         end
 
         it "has active class if tag is present in params" do
-          expect(helper.render_tag_list('Alchemy::Attachment', params)).to match(/li.+class="active"/)
+          expect(helper.render_tag_list('Alchemy::Attachment')).to match(/li.+class="active"/)
         end
 
         it "tags are sorted alphabetically" do
-          expect(helper.render_tag_list('Alchemy::Attachment', params)).to match(/li.+name="#{tag2.name}.+li.+name="#{tag.name}/)
+          expect(helper.render_tag_list('Alchemy::Attachment')).to match(/li.+name="#{tag2.name}.+li.+name="#{tag.name}/)
         end
 
         context "with lowercase and uppercase tag names mixed" do
           let(:tag) { mock_model(ActsAsTaggableOn::Tag, name: 'Foo', count: 1) }
 
           it "tags are sorted alphabetically correctly" do
-            expect(helper.render_tag_list('Alchemy::Attachment', params)).to match(/li.+name="#{tag2.name}.+li.+name="#{tag.name}/)
+            expect(helper.render_tag_list('Alchemy::Attachment')).to match(/li.+name="#{tag2.name}.+li.+name="#{tag.name}/)
           end
         end
 
         it "output is html_safe" do
-          expect(helper.render_tag_list('Alchemy::Attachment', params).html_safe?).to be_truthy
+          expect(helper.render_tag_list('Alchemy::Attachment').html_safe?).to be_truthy
+        end
+
+        context "when filter and search params are present" do
+          let(:params) do
+            ActionController::Parameters.new({
+              controller: 'alchemy/admin/attachments',
+              action: 'index',
+              use_route: 'alchemy',
+              filter: 'foo',
+              q: {name_eq: 'foo'}
+            })
+          end
+
+          it 'keeps them' do
+            expect(helper.render_tag_list('Alchemy::Attachment')).to match(/filter/)
+            expect(helper.render_tag_list('Alchemy::Attachment')).to match(/name_eq/)
+          end
         end
       end
 
       context "without any tagged objects" do
         it "returns empty string" do
-          expect(render_tag_list('Alchemy::Attachment', params)).to be_empty
+          expect(render_tag_list('Alchemy::Attachment')).to be_empty
         end
       end
 
       context "with nil given as class_name parameter" do
         it "raises argument error" do
-          expect { render_tag_list(nil, params) }.to raise_error(ArgumentError)
+          expect { render_tag_list(nil) }.to raise_error(ArgumentError)
         end
       end
     end
@@ -55,13 +84,21 @@ module Alchemy
     describe '#tag_list_tag_active?' do
       context "the tag is in params" do
         it "returns true" do
-          expect(tag_list_tag_active?(tag, params)).to be_truthy
+          expect(tag_list_tag_active?(tag)).to be_truthy
         end
       end
 
       context "params[:tagged_with] is not present" do
+        let(:params) do
+          ActionController::Parameters.new({
+            controller: 'alchemy/admin/attachments',
+            action: 'index',
+            use_route: 'alchemy'
+          })
+        end
+
         it "returns false" do
-          expect(tag_list_tag_active?(tag, {})).to be_falsey
+          expect(tag_list_tag_active?(tag)).to be_falsey
         end
       end
     end
@@ -72,22 +109,48 @@ module Alchemy
         expect(helper.filtered_by_tag?(tag)).to eq(true)
       end
 
-      it "should return false if the filterlist does not contain the given tag" do
-        controller.params[:tagged_with] = "bar,baz"
-        expect(helper.filtered_by_tag?(tag)).to eq(false)
+      context 'if the filterlist does not contain the given tag' do
+        let(:params) do
+          ActionController::Parameters.new({
+            controller: 'alchemy/admin/attachments',
+            action: 'index',
+            use_route: 'alchemy',
+            tagged_with: 'bar,baz'
+          })
+        end
+
+        it "should return false" do
+          expect(helper.filtered_by_tag?(tag)).to eq(false)
+        end
       end
     end
 
     describe "#add_to_tag_filter" do
       context "if params[:tagged_with] is not present" do
+        let(:params) do
+          ActionController::Parameters.new({
+            controller: 'alchemy/admin/attachments',
+            action: 'index',
+            use_route: 'alchemy'
+          })
+        end
+
         it "should return an Array with the given tag name" do
           expect(helper.add_to_tag_filter(tag)).to eq(["foo"])
         end
       end
 
       context "if params[:tagged_with] contains some tag names" do
+        let(:params) do
+          ActionController::Parameters.new({
+            controller: 'alchemy/admin/attachments',
+            action: 'index',
+            use_route: 'alchemy',
+            tagged_with: 'bar,baz'
+          })
+        end
+
         it "should return an Array of tag names including the given one" do
-          controller.params[:tagged_with] = "bar,baz"
           expect(helper.add_to_tag_filter(tag)).to eq(["bar", "baz", "foo"])
         end
       end
@@ -95,14 +158,30 @@ module Alchemy
 
     describe "#remove_from_tag_filter" do
       context "if params[:tagged_with] is not present" do
+        let(:params) do
+          ActionController::Parameters.new({
+            controller: 'alchemy/admin/attachments',
+            action: 'index',
+            use_route: 'alchemy'
+          })
+        end
+
         it "should return an empty Array" do
           expect(helper.remove_from_tag_filter(tag)).to be_empty
         end
       end
 
       context "if params[:tagged_with] contains some tag names" do
+        let(:params) do
+          ActionController::Parameters.new({
+            controller: 'alchemy/admin/attachments',
+            action: 'index',
+            use_route: 'alchemy',
+            tagged_with: 'bar,baz,foo'
+          })
+        end
+
         it "should return an Array of tag names without the given one" do
-          controller.params[:tagged_with] = "bar,baz,foo"
           expect(helper.remove_from_tag_filter(tag)).to eq(["bar", "baz"])
         end
       end


### PR DESCRIPTION
The parameters passed to the url helper in `render_tag_list` helper are unsanitzed.

Although considered harmless (we are in the protected admin namespace), Rails 5 raises errors if these aren't sanitized.

**DISCLAIMER:**

The whole helper should be refactored into a view object, but since Rails is not pretty good at supporting view objects, I went further down the dirty road this path already lead.

I am absolutely **not** proud of this!