### PR TITLE
Switching from therubyracer to mini_racer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 sudo: false
+dist: trusty
 cache:
   bundler: true
   directories:

--- a/Gemfile
+++ b/Gemfile
@@ -45,5 +45,5 @@ end
 # We need this if we want to start the dummy app in production, ie on Teatro.io
 group :production do
   gem 'uglifier', '>= 1.0.3'
-  gem 'therubyracer'
+  gem 'mini_racer'
 end


### PR DESCRIPTION
In local development if you want to boot the dummy app in production env, you'll need a javascript runtime. Previously we used theminiracer gem. As a faster alternative we now use mini_racer.