### PR TITLE
Refactor uploader specs for attachment and picture

### DIFF
--- a/lib/alchemy/test_support/shared_contexts.rb
+++ b/lib/alchemy/test_support/shared_contexts.rb
@@ -1,0 +1,14 @@
+RSpec.shared_context 'with invalid file' do
+  let(:invalid_file) do
+    fixture_file_upload(
+      File.expand_path('../../../../spec/fixtures/users.yml', __FILE__),
+      'text/x-yaml'
+    )
+  end
+
+  before do
+    allow(Alchemy::Attachment).to receive(:allowed_filetypes) do
+      ['png']
+    end
+  end
+end

--- a/lib/alchemy/test_support/shared_uploader_examples.rb
+++ b/lib/alchemy/test_support/shared_uploader_examples.rb
@@ -1,0 +1,10 @@
+RSpec.shared_examples_for "having a json uploader error message" do
+  it "renders json response with error message" do
+    subject
+    expect(response.content_type).to eq('application/json')
+    expect(response.status).to eq(422)
+    json = JSON.parse(response.body)
+    expect(json).to have_key('growl_message')
+    expect(json).to have_key('files')
+  end
+end

--- a/spec/controllers/alchemy/admin/attachments_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/attachments_controller_spec.rb
@@ -93,17 +93,12 @@ module Alchemy
         end
       end
 
-      context 'without passing validations' do
-        let(:params) { {attachment: {file: nil}} }
+      context 'with failing validations' do
+        include_context 'with invalid file'
 
-        it "renders json response with error message" do
-          subject
-          expect(response.content_type).to eq('application/json')
-          expect(response.status).to eq(422)
-          json = JSON.parse(response.body)
-          expect(json).to have_key('growl_message')
-          expect(json).to have_key('files')
-        end
+        let(:params) { {attachment: {file: invalid_file}} }
+
+        it_behaves_like 'having a json uploader error message'
       end
     end
 
@@ -118,7 +113,7 @@ module Alchemy
         alchemy_put :update, params
       end
 
-      let(:attachment) { create(:alchemy_attachment) }
+      let!(:attachment) { create(:alchemy_attachment) }
 
       context "when file is passed" do
         let(:file) do
@@ -177,11 +172,7 @@ module Alchemy
       end
 
       context 'with failing validations' do
-        let(:params) do
-          {
-            id: attachment.id, attachment: {file: nil}
-          }
-        end
+        include_context 'with invalid file'
 
         it "renders edit form" do
           is_expected.to render_template(:edit)

--- a/spec/controllers/alchemy/admin/pictures_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/pictures_controller_spec.rb
@@ -119,15 +119,8 @@ module Alchemy
         end
       end
 
-      context 'without passing validations' do
-        it "renders json response with error message" do
-          subject
-          expect(response.content_type).to eq('application/json')
-          expect(response.status).to eq(422)
-          json = JSON.parse(response.body)
-          expect(json).to have_key('growl_message')
-          expect(json).to have_key('files')
-        end
+      context 'with failing validations' do
+        it_behaves_like 'having a json uploader error message'
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,8 @@ require 'alchemy/test_support/controller_requests'
 require 'alchemy/test_support/essence_shared_examples'
 require 'alchemy/test_support/integration_helpers'
 require 'alchemy/test_support/factories'
+require 'alchemy/test_support/shared_contexts'
+require 'alchemy/test_support/shared_uploader_examples'
 
 require_relative 'factories'
 require_relative "support/hint_examples.rb"


### PR DESCRIPTION
Previously we made the silly assumption that nil values
passed as files lead to invalid uploads.

This works in Rails 4 as the params from test controllers
won't be converted into strings, as they would in real controllers.

In Rails 5 this is fixed, so that nil values passed as params
will correctly be converted into strings even in controller tests.

Now we make a correct invalid file by uploading in unsupported file type.