### PR TITLE
Future proof option params parsing

### DIFF
--- a/app/controllers/alchemy/admin/base_controller.rb
+++ b/app/controllers/alchemy/admin/base_controller.rb
@@ -138,17 +138,13 @@ module Alchemy
       #
       def options_from_params
         case params[:options]
-        when ''
+        when '', nil
           {}
         when String
           JSON.parse(params[:options])
-        when Hash
-          params[:options]
-        when Array
-          params[:options]
         else
-          {}
-        end.symbolize_keys
+          params[:options].permit!.to_h
+        end.deep_symbolize_keys
       end
 
       # This method decides if we want to raise an exception or not.

--- a/spec/controllers/alchemy/admin/base_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/base_controller_spec.rb
@@ -4,30 +4,41 @@ describe Alchemy::Admin::BaseController do
   describe '#options_from_params' do
     subject { controller.send(:options_from_params) }
 
+    before do
+      expect(controller).to receive(:params).at_least(:once) do
+        ActionController::Parameters.new(options: options)
+      end
+    end
+
     context "params[:options] is a JSON string" do
-      before { expect(controller).to receive(:params).at_least(:once).and_return(options: '{"hallo":"World"}') }
+      let(:options) { '{"hallo":"World"}' }
 
       it "parses the string into an object" do
-        expect(subject).to be_an_instance_of(Hash)
         expect(subject).to eq({hallo: 'World'})
       end
     end
 
-    context "params[:options] is already an object" do
-      before { expect(controller).to receive(:params).at_least(:once).and_return(options: {hallo: "World"}) }
+    context "params[:options] are Rails parameters" do
+      let(:options) do
+        ActionController::Parameters.new('hallo' => {'great' => 'World'})
+      end
 
-      it "parses the string into an object" do
+      it "returns the options as hash with permitted and deeply symbolized keys" do
         expect(subject).to be_an_instance_of(Hash)
+        expect(subject).to eq({hallo: {great: 'World'}})
       end
     end
 
-    context "params[:options] is not present" do
-      before { expect(controller).to receive(:params).at_least(:once).and_return({}) }
+    context "params[:options] is an empty string" do
+      let(:options) { '' }
 
-      it "returns ampty object" do
-        expect(subject).to be_an_instance_of(Hash)
-        expect(subject).to eq({})
-      end
+      it { is_expected.to eq({}) }
+    end
+
+    context "params[:options] is nil" do
+      let(:options) { nil }
+
+      it { is_expected.to eq({}) }
     end
   end
 


### PR DESCRIPTION
Previously we dealed with Strings, Hashes and Arrays (which are obviously never used, because we symbolised keys in all cases).

Now only distinguish between JSON strings and ActionController::Parameters, everything else is never used and have a Hash fallback for emtpy strings and nil.

By not asking explicitly for Hash anymore we are future proof as Rails 5 doesn't inherit from Hash for ActionContoller::Params anymmore.