### PR TITLE
Hardens the admin attachments download spec

### DIFF
--- a/spec/controllers/alchemy/admin/attachments_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/attachments_controller_spec.rb
@@ -196,18 +196,12 @@ module Alchemy
 
     describe "#download" do
       before do
-        expect(Attachment).to receive(:find).with(attachment.id.to_s).and_return(attachment)
-        allow(controller).to receive(:render).and_return(nil)
+        expect(Attachment).to receive(:find).and_return(attachment)
       end
 
-      it "should assign @attachment with Attachment found by id" do
+      it "sends the file as download" do
         alchemy_get :download, id: attachment.id
-        expect(assigns(:attachment)).to eq(attachment)
-      end
-
-      it "should send the data to the browser" do
-        expect(controller).to receive(:send_file)
-        alchemy_get :download, id: attachment.id
+        expect(response.headers['Content-Disposition']).to match(/attachment/)
       end
     end
   end


### PR DESCRIPTION
By stubbing too much of what happens inside the controller
this test actually tests nothing.

By using the same expectation on the response object like
we already do in the frontend attachment download spec we
make this test future proof for Rails 5 and beyond.