### PR TITLE
Don't convert AR relations to arrays in breadcrump

### DIFF
--- a/app/helpers/alchemy/pages_helper.rb
+++ b/app/helpers/alchemy/pages_helper.rb
@@ -246,15 +246,12 @@ module Alchemy
       end
 
       if options.delete(:reverse)
-        pages.to_a.reverse!
+        pages = pages.reorder('lft DESC')
       end
 
       if options[:without].present?
-        if options[:without].class == Array
-          pages = pages.to_a - options[:without]
-        else
-          pages.to_a.delete(options[:without])
-        end
+        without = options.delete(:without)
+        pages = pages.where.not(id: without.try(:collect, &:id) || without.id)
       end
 
       render 'alchemy/breadcrumb/wrapper', pages: pages, options: options


### PR DESCRIPTION
Previously we converted the active record relation for pages
in the breadcrump helper into arrays to support options like
`:reverse` and `:without`.

Now we use the active record counterparts `#reorder` and `where.not` instead.
We could cache the breadcrumb views now if someone wanted to.

Also the implementation used in-self-replaced calls (`#reverse!` and `#delete`)
that where called on new arrays through `#to_a`, which lead to bugs in Rails 5.