### PR TITLE
Use at least dragonfly 1.0.7

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'bourbon',                          ['~> 4.2']
   gem.add_runtime_dependency 'cancancan',                        ['~> 1.9']
   gem.add_runtime_dependency 'coffee-rails',                     ['~> 4.0']
-  gem.add_runtime_dependency 'dragonfly',                        ['~> 1.0.1']
+  gem.add_runtime_dependency 'dragonfly',                        ['~> 1.0.7']
   gem.add_runtime_dependency 'dragonfly_svg',                    ['~> 0.0.4']
   gem.add_runtime_dependency 'handlebars_assets',                ['~> 0.23']
   gem.add_runtime_dependency 'jquery-rails',                     ['~> 4.0']


### PR DESCRIPTION
Dragonfly < 1.0.7 has security issues fixed with 1.0.7

See: https://hakiri.io/technologies/dragonfly/issues/b1dab2e1699d03