### PR TITLE
Fix Admin pages controller spec

### DIFF
--- a/spec/controllers/alchemy/admin/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/pages_controller_spec.rb
@@ -718,6 +718,7 @@ module Alchemy
 
           before do
             allow(request).to receive(:port).and_return(3000)
+            allow(@controller).to receive(:request).and_return(request)
           end
 
           it "should redirect to the page path on the right site" do


### PR DESCRIPTION
Under Rails 5, the request object used in specs seems to be a different one
than the one used in the controller. This commit adds an explicit stub for that
object to be used; otherwise the port number is not passed through.