### PR TITLE
Only allow floats and ints as fixed ratio for crop

### DIFF
--- a/app/controllers/alchemy/admin/essence_pictures_controller.rb
+++ b/app/controllers/alchemy/admin/essence_pictures_controller.rb
@@ -1,6 +1,7 @@
 module Alchemy
   module Admin
     class EssencePicturesController < Alchemy::Admin::BaseController
+      FLOAT_REGEX = /\A\d+(\.\d+)?\z/
       authorize_resource class: Alchemy::EssencePicture
 
       before_action :load_essence_picture, only: [:edit, :crop, :update]
@@ -92,7 +93,7 @@ module Alchemy
       # aspect ratio, don't specify a size or only width or height.
       #
       def ratio_from_size_or_params
-        if @min_size.value?(0) && @options[:fixed_ratio]
+        if @min_size.value?(0) && @options[:fixed_ratio].to_s =~ FLOAT_REGEX
           @options[:fixed_ratio].to_f
         elsif !@min_size[:width].zero? && !@min_size[:height].zero?
           @min_size[:width].to_f / @min_size[:height].to_f

--- a/spec/controllers/alchemy/admin/essence_pictures_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/essence_pictures_controller_spec.rb
@@ -150,6 +150,13 @@ module Alchemy
           end
         end
 
+        context 'with fixed_ratio set to a non float string' do
+          it "doesn't set a fixed ratio" do
+            alchemy_get :crop, id: 1, options: {fixed_ratio: '123,45'}
+            expect(assigns(:ratio)).to eq(false)
+          end
+        end
+
         context 'with no fixed_ratio set in params' do
           it "sets a fixed ratio from sizes" do
             alchemy_get :crop, id: 1, options: {size: '80x60'}


### PR DESCRIPTION
Former we only checked if a fixed ratio was passed or not by checking its existence.
In Rails 5 all param values are strings, even booleans. This leads to NaN errors.
By checking the value to match an integer or float string we make sure this does
not happen any more.