### PR TITLE
Permit search params while redirecting in library

### DIFF
--- a/app/controllers/alchemy/admin/attachments_controller.rb
+++ b/app/controllers/alchemy/admin/attachments_controller.rb
@@ -44,11 +44,7 @@ module Alchemy
         else
           render_errors_or_redirect(
             @attachment,
-            admin_attachments_path(
-              per_page: params[:per_page],
-              page: params[:page],
-              q: params[:q]
-            ),
+            admin_attachments_path(search_params),
             Alchemy.t("File successfully updated")
           )
         end
@@ -57,11 +53,7 @@ module Alchemy
       def destroy
         name = @attachment.name
         @attachment.destroy
-        @url = admin_attachments_url(
-          per_page: params[:per_page],
-          page: params[:page],
-          q: params[:q]
-        )
+        @url = admin_attachments_url(search_params)
         flash[:notice] = Alchemy.t('File deleted successfully', name: name)
       end
 
@@ -74,6 +66,15 @@ module Alchemy
       end
 
       private
+
+      def search_params
+        params.except(:attachment, :id).permit(
+          :file_type,
+          :page,
+          {q: resource_handler.search_field_name},
+          :tagged_with
+        )
+      end
 
       def handle_uploader_response(status:)
         if @attachment.valid?

--- a/app/controllers/alchemy/admin/pictures_controller.rb
+++ b/app/controllers/alchemy/admin/pictures_controller.rb
@@ -136,12 +136,16 @@ module Alchemy
       end
 
       def redirect_to_index
-        do_redirect_to admin_pictures_path(
-          filter: params[:filter].presence,
-          page: params[:page].presence,
-          q: params[:q].presence,
-          size: params[:size].presence,
-          tagged_with: params[:tagged_with].presence
+        do_redirect_to admin_pictures_path(search_params)
+      end
+
+      def search_params
+        params.except(:id, :picture_ids).permit(
+          :filter,
+          :page,
+          {q: resource_handler.search_field_name},
+          :size,
+          :tagged_with
         )
       end
 

--- a/app/models/alchemy/attachment.rb
+++ b/app/models/alchemy/attachment.rb
@@ -36,6 +36,10 @@ module Alchemy
 
     # We need to define this method here to have it available in the validations below.
     class << self
+      def searchable_alchemy_resource_attributes
+        %w(name file_name)
+      end
+
       def allowed_filetypes
         Config.get(:uploader).fetch('allowed_filetypes', {}).fetch('alchemy/attachments', [])
       end

--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -92,6 +92,10 @@ module Alchemy
     # Class methods
 
     class << self
+      def searchable_alchemy_resource_attributes
+        %w(name image_file_name)
+      end
+
       def last_upload
         last_picture = Picture.last
         return Picture.all unless last_picture

--- a/spec/controllers/alchemy/admin/attachments_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/attachments_controller_spec.rb
@@ -153,8 +153,9 @@ module Alchemy
         context 'with search params' do
           let(:search_params) do
             {
-              q: {name_cont: 'kitten'},
-              per_page: 20,
+              q: {name_or_file_name_cont: 'kitten'},
+              tagged_with: 'cute',
+              file_type: 'pdf',
               page: 2
             }
           end
@@ -185,12 +186,29 @@ module Alchemy
         expect(Attachment).to receive(:find).and_return(attachment)
       end
 
-      it "destroys the attachment and sets and success message" do
+      it "destroys the attachment and sets a success message" do
         expect(attachment).to receive(:destroy)
         alchemy_xhr :delete, :destroy, id: 1
         expect(assigns(:attachment)).to eq(attachment)
         expect(assigns(:url)).not_to be_blank
         expect(flash[:notice]).not_to be_blank
+      end
+
+      context 'with search params' do
+        let(:search_params) do
+          {
+            q: {name_or_file_name_cont: 'kitten'},
+            tagged_with: 'cute',
+            file_type: 'pdf',
+            page: 2
+          }
+        end
+
+        it "passes them along" do
+          expect(attachment).to receive(:destroy) { true }
+          alchemy_xhr :delete, :destroy, {id: 1}.merge(search_params)
+          expect(assigns(:url)).to eq admin_attachments_url(search_params.merge(host: 'test.host'))
+        end
       end
     end
 

--- a/spec/controllers/alchemy/admin/pictures_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/pictures_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.shared_examples :redirecting_to_picture_library do
     {
       filter: 'latest',
       page: 2,
-      q: {name_cont: 'kitten'},
+      q: {name_or_image_file_name_cont: 'kitten'},
       size: 'small',
       tagged_with: 'cat'
     }
@@ -28,7 +28,7 @@ module Alchemy
         let!(:picture_2) { create(:alchemy_picture, name: 'nice beach') }
 
         it 'assigns @pictures with filtered pictures' do
-          alchemy_get :index, q: {name_cont: 'kitten'}
+          alchemy_get :index, q: {name_or_image_file_name_cont: 'kitten'}
           expect(assigns(:pictures)).to include(picture_1)
           expect(assigns(:pictures)).to_not include(picture_2)
         end


### PR DESCRIPTION
Former we build a hash of parameters to pass along while redirecting
in attachment and picture library. In Rails 5 this leads to errors.

By explicitely permitting the parameters we want to pass along, we
avoid these errors and even enhance security.