### PR TITLE
Add a configuration stubbing helper

### DIFF
--- a/lib/alchemy/test_support/config_stubbing.rb
+++ b/lib/alchemy/test_support/config_stubbing.rb
@@ -1,0 +1,28 @@
+module Alchemy
+  module TestSupport
+    # Allows you to stub the Alchemy configuration in your specs
+    #
+    # Require and include this file in your RSpec config.
+    #
+    #     RSpec.configure do |config|
+    #       config.include Alchemy::TestSupport::ConfigStubbing
+    #     end
+    #
+    module ConfigStubbing
+      # Stub a key from the Alchemy config
+      #
+      # @param key [Symbol] The configuration key you want to stub
+      # @param value [Object] The value you want to return instead of the original one
+      #
+      def stub_alchemy_config(key, value)
+        allow(Alchemy::Config).to receive(:get) do |arg|
+          if arg == key
+            value
+          else
+            Alchemy::Config.show[arg.to_s]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/alchemy/admin/languages_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/languages_controller_spec.rb
@@ -41,13 +41,7 @@ describe Alchemy::Admin::LanguagesController do
   describe "#new" do
     context "when default_language.page_layout is set" do
       before do
-        allow(Alchemy::Config).to receive(:get) do |arg|
-          if arg == :default_language
-            {'page_layout' => "new_standard"}
-          else
-            Alchemy::Config.show[arg.to_s]
-          end
-        end
+        stub_alchemy_config(:default_language, {'page_layout' => "new_standard"})
       end
 
       it "uses it as page_layout-default for the new language" do
@@ -58,13 +52,7 @@ describe Alchemy::Admin::LanguagesController do
 
     context "when default_language is not configured" do
       before do
-        allow(Alchemy::Config).to receive(:get) do |arg|
-          if arg == :default_language
-            nil
-          else
-            Alchemy::Config.show[arg.to_s]
-          end
-        end
+        stub_alchemy_config(:default_language, nil)
       end
 
       it "falls back to default database value." do
@@ -75,13 +63,7 @@ describe Alchemy::Admin::LanguagesController do
 
     context "when default language page_layout is not configured" do
       before do
-        allow(Alchemy::Config).to receive(:get) do |arg|
-          if arg == :default_language
-            {}
-          else
-            Alchemy::Config.show[arg.to_s]
-          end
-        end
+        stub_alchemy_config(:default_language, {})
       end
 
       it "falls back to default database value." do

--- a/spec/controllers/alchemy/admin/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/pages_controller_spec.rb
@@ -304,7 +304,7 @@ module Alchemy
 
         context 'with url nesting enabled' do
           before do
-            expect(Alchemy::Config).to receive(:get).with(:url_nesting).at_least(:once).and_return(true)
+            stub_alchemy_config(:url_nesting, true)
           end
 
           it "updates the pages urlnames" do

--- a/spec/features/admin/page_editing_feature_spec.rb
+++ b/spec/features/admin/page_editing_feature_spec.rb
@@ -55,9 +55,7 @@ describe 'Page editing feature' do
 
         context "with sitemaps show_flag config option set to true" do
           before do
-            allow(Alchemy::Config).to receive(:get) do |arg|
-              arg == :sitemap ? {'show_flag' => true} : Alchemy::Config.show[arg.to_s]
-            end
+            stub_alchemy_config(:sitemap, {'show_flag' => true})
           end
 
           it "should show sitemap checkbox" do
@@ -68,9 +66,7 @@ describe 'Page editing feature' do
 
         context "with sitemaps show_flag config option set to false" do
           before do
-            allow(Alchemy::Config).to receive(:get) do |arg|
-              arg == :sitemap ? {'show_flag' => false} : Alchemy::Config.show[arg.to_s]
-            end
+            stub_alchemy_config(:sitemap, {'show_flag' => false})
           end
 
           it "should not show sitemap checkbox" do

--- a/spec/helpers/alchemy/admin/base_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/base_helper_spec.rb
@@ -289,7 +289,7 @@ module Alchemy
 
       context 'if the expression from config is nil' do
         before do
-          expect(Alchemy::Config).to receive(:get).and_return({link_url: nil})
+          stub_alchemy_config(:format_matchers, {link_url: nil})
         end
 
         it "returns the default expression" do

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1956,7 +1956,9 @@ module Alchemy
       let(:node) { TreeNode.new(10, 11, 12, 13, "another-url", true) }
 
       context "when nesting is enabled" do
-        before { allow(Alchemy::Config).to receive(:get).with(:url_nesting) { true } }
+        before do
+          stub_alchemy_config(:url_nesting, true)
+        end
 
         context "when page is not external" do
           before do
@@ -2021,7 +2023,7 @@ module Alchemy
 
       context "when nesting is disabled" do
         before do
-          allow(Alchemy::Config).to receive(:get).with(:url_nesting) { false }
+          stub_alchemy_config(:url_nesting, false)
         end
 
         context "when page is not external" do
@@ -2049,7 +2051,6 @@ module Alchemy
 
         context "when page is external" do
           before do
-            expect(Alchemy::Config).to receive(:get).and_return(true)
             allow(page).to receive(:redirects_to_external?).and_return(true)
           end
 
@@ -2090,7 +2091,7 @@ module Alchemy
       end
 
       it 'returns false when caching is deactivated in the Alchemy config' do
-        allow(Alchemy::Config).to receive(:get).with(:cache_pages).and_return(false)
+        stub_alchemy_config(:cache_pages, false)
         expect(subject).to be false
       end
 

--- a/spec/models/alchemy/picture_spec.rb
+++ b/spec/models/alchemy/picture_spec.rb
@@ -424,13 +424,7 @@ module Alchemy
 
       context "when `image_output_format` is configured to `original`" do
         before do
-          allow(Alchemy::Config).to receive(:get) do |args|
-            if args == :image_output_format
-              'original'
-            else
-              Alchemy::Config.show[args]
-            end
-          end
+          stub_alchemy_config(:image_output_format, 'original')
         end
 
         it "returns the image file format" do
@@ -440,13 +434,7 @@ module Alchemy
 
       context "when `image_output_format` is configured to an image format" do
         before do
-          allow(Alchemy::Config).to receive(:get) do |args|
-            if args == :image_output_format
-              'jpg'
-            else
-              Alchemy::Config.show[args]
-            end
-          end
+          stub_alchemy_config(:image_output_format, 'jpg')
         end
 
         context "and the format is a convertible format" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,7 @@ require 'rspec-activemodel-mocks'
 
 require 'alchemy/seeder'
 require 'alchemy/test_support/controller_requests'
+require 'alchemy/test_support/config_stubbing'
 require 'alchemy/test_support/essence_shared_examples'
 require 'alchemy/test_support/integration_helpers'
 require 'alchemy/test_support/factories'
@@ -64,6 +65,7 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
   config.include Alchemy::Engine.routes.url_helpers
   config.include Alchemy::TestSupport::ControllerRequests, type: :controller
+  config.include Alchemy::TestSupport::ConfigStubbing
   [:controller, :feature, :request].each do |type|
     config.include Alchemy::TestSupport::IntegrationHelpers, type: type
   end


### PR DESCRIPTION
In order to be able to stub Alchemy configuration you can use this helper in you specs.

Require and include `alchemy/test_support/config_stubbing` in your RSpec config.

    RSpec.configure do |config|
      config.include Alchemy::TestSupport::ConfigStubbing
    end