### PR TITLE
Bye bye seeder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 3.6.0 (unreleased)
+
+__Notable Changes__
+
+* The seeder does not generate default site and root page anymore.
+  Alchemy handles this auto-magically now. No need to run `Alchemy::Seeder.seed!` any more |o/
+
 ## 3.5.0 (unreleased)
 
 __New Features__

--- a/app/controllers/alchemy/admin/languages_controller.rb
+++ b/app/controllers/alchemy/admin/languages_controller.rb
@@ -7,14 +7,9 @@ module Alchemy
       end
 
       def new
-        @language = Language.new
-        @language.page_layout = configured_page_layout || @language.page_layout
-      end
-
-      private
-
-      def configured_page_layout
-        Config.get(:default_language).try('[]', 'page_layout')
+        @language = Language.new(
+          page_layout: Config.get(:default_language)['page_layout']
+        )
       end
     end
   end

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -139,6 +139,15 @@ module Alchemy
     # Class methods
     #
     class << self
+      # The root page of the page tree
+      #
+      # Internal use only. You wouldn't use this page ever.
+      #
+      # Automatically created when accessed the first time.
+      #
+      def root
+        super || create!(name: 'Root')
+      end
       alias_method :rootpage, :root
 
       # Used to store the current page previewed in the edit page template.

--- a/app/models/alchemy/page/page_natures.rb
+++ b/app/models/alchemy/page/page_natures.rb
@@ -20,7 +20,7 @@ module Alchemy
     end
 
     def systempage?
-      return true if Page.root.nil?
+      return true if Page.count.zero?
       rootpage? || (parent_id == Page.root.id && !language_root?)
     end
 

--- a/app/models/alchemy/site.rb
+++ b/app/models/alchemy/site.rb
@@ -62,7 +62,7 @@ module Alchemy
       end
 
       def default
-        Site.first
+        Site.first || create_default_site!
       end
 
       def find_for_host(host)
@@ -77,6 +77,17 @@ module Alchemy
 
         all.find do |site|
           site.aliases.split.include?(host) if site.aliases.present?
+        end
+      end
+
+      private
+
+      def create_default_site!
+        default_site = Alchemy::Config.get(:default_site)
+        if default_site
+          create!(name: default_site['name'], host: default_site['host'])
+        else
+          raise DefaultSiteNotFoundError
         end
       end
     end

--- a/app/models/alchemy/site.rb
+++ b/app/models/alchemy/site.rb
@@ -24,7 +24,7 @@ module Alchemy
     scope :published, -> { where(public: true) }
 
     # Callbacks
-    before_create :create_default_language, unless: -> { languages.any? }
+    before_create :create_default_language!, unless: -> { languages.any? }
 
     # concerns
     include Alchemy::Site::Layout
@@ -96,17 +96,21 @@ module Alchemy
 
     # If no languages are present, create a default language based
     # on the host app's Alchemy configuration.
-    def create_default_language
+    def create_default_language!
       default_language = Alchemy::Config.get(:default_language)
-      languages.build(
-        name:           default_language['name'],
-        language_code:  default_language['code'],
-        locale:         default_language['code'],
-        frontpage_name: default_language['frontpage_name'],
-        page_layout:    default_language['page_layout'],
-        public:         true,
-        default:        true
-      )
+      if default_language
+        languages.build(
+          name:           default_language['name'],
+          language_code:  default_language['code'],
+          locale:         default_language['code'],
+          frontpage_name: default_language['frontpage_name'],
+          page_layout:    default_language['page_layout'],
+          public:         true,
+          default:        true
+        )
+      else
+        raise DefaultLanguageNotFoundError
+      end
     end
   end
 end

--- a/lib/alchemy/controller_actions.rb
+++ b/lib/alchemy/controller_actions.rb
@@ -65,7 +65,7 @@ module Alchemy
         # find the best language and remember it for later
         @language = load_alchemy_language_from_params ||
                     load_alchemy_language_from_session ||
-                    load_default_alchemy_language
+                    Language.default
       end
       store_current_alchemy_language(@language)
     end
@@ -87,11 +87,6 @@ module Alchemy
     def load_alchemy_language_from_id_or_code(id_or_code)
       Language.find_by(id: id_or_code) ||
         Language.find_by_code(id_or_code)
-    end
-
-    # Load the default language from current site.
-    def load_default_alchemy_language
-      Language.default || raise(DefaultLanguageNotFoundError)
     end
 
     # Stores language's id in the session.

--- a/lib/alchemy/errors.rb
+++ b/lib/alchemy/errors.rb
@@ -16,6 +16,14 @@ module Alchemy
     end
   end
 
+  class DefaultSiteNotFoundError < StandardError
+    # Raised if no default site configuration can be found.
+    def message
+      "No default site configuration found!" \
+        " Please ensure that you have a 'default_site' defined in Alchemy configuration file."
+    end
+  end
+
   class DefaultLanguageNotDeletable < StandardError
     # Raised if one tries to delete the default language.
     def message

--- a/lib/alchemy/errors.rb
+++ b/lib/alchemy/errors.rb
@@ -10,9 +10,10 @@ module Alchemy
   end
 
   class DefaultLanguageNotFoundError < StandardError
-    # Raised if no default language can be found.
+    # Raised if no default language configuration can be found.
     def message
-      "No default language found! Please run the `bin/rake db:seed` task."
+      "No default language configuration found!" \
+        " Please ensure that you have a 'default_language' defined in Alchemy configuration file."
     end
   end
 

--- a/lib/alchemy/seeder.rb
+++ b/lib/alchemy/seeder.rb
@@ -1,61 +1,33 @@
 require "alchemy/shell"
 
 module Alchemy
+  # This seeder builds Alchemy pages in your database.
+  #
+  # Create a +db/seeds/alchemy/pages.yml+ and +db/seeds/alchemy/users.yml+ files
+  # and put +Alchemy::Seeder.seed!+ into your +db/seeds.rb+ file.
+  #
+  # Then run +rake db:seed+
+  #
   class Seeder
     extend Alchemy::Shell
 
     class << self
-      # This seed builds the necessary page structure for Alchemy in your database.
-      #
-      # Call this from your +db/seeds.rb+ file with the `rake db:seed task'.
+      # Put +Alchemy::Seeder.seed!+ into your +db/seeds.rb+ file and run +rake db:seed+.
       #
       def seed!
-        create_default_site
-        if create_root_page
-          try_seed_pages
-        elsif page_seeds_file.file?
-          desc "Seeding Alchemy pages"
-          log "There are already pages present in your database. " \
-              "Please use `rake db:reset' if you want to rebuild your database.", :skip
-        end
+        try_seed_pages
         seed_users if user_seeds_file.file?
       end
 
       protected
 
-      def create_default_site
-        desc "Creating default Alchemy site"
-        if Alchemy::Site.count == 0
-          site = Alchemy::Site.new(
-            name: site_config['name'],
-            host: site_config['host']
-          )
-          if Alchemy::Language.any?
-            site.languages = Alchemy::Language.all
-          end
-          site.save!
-          log "Created default Alchemy site with default language."
-        else
-          log "Default Alchemy site was already present.", :skip
-        end
-      end
-
-      def create_root_page
-        desc "Creating Alchemy root page"
-        root = Alchemy::Page.find_or_initialize_by(name: 'Root')
-        if root.new_record?
-          if root.save!
-            log "Created Alchemy root page."
-            return true
-          end
-        else
-          log "Alchemy root page was already present.", :skip
-          return false
-        end
-      end
-
       def try_seed_pages
-        if page_seeds_file.file?
+        return unless page_seeds_file.file?
+        if Alchemy::Page.exists?
+          desc "Seeding Alchemy pages"
+          log "There are already pages present in your database. " \
+              "Please use `rake db:reset' if you want to rebuild your database.", :skip
+        else
           seed_pages if contentpages.present?
           seed_layoutpages if layoutpages.present?
         end
@@ -105,10 +77,6 @@ module Alchemy
       end
 
       private
-
-      def site_config
-        @_site_config ||= Alchemy::Config.get(:default_site)
-      end
 
       def page_seeds_file
         @_page_seeds_file ||= Rails.root.join('db', 'seeds', 'alchemy', 'pages.yml')

--- a/lib/alchemy/test_support/factories/language_factory.rb
+++ b/lib/alchemy/test_support/factories/language_factory.rb
@@ -9,7 +9,7 @@ FactoryGirl.define do
     frontpage_name 'Intro'
     page_layout { Alchemy::Config.get(:default_language)['page_layout'] }
     public true
-    site { Alchemy::Site.first || FactoryGirl.create(:alchemy_site) }
+    site { Alchemy::Site.default }
 
     trait :klingon do
       name 'Klingon'

--- a/lib/alchemy/test_support/factories/page_factory.rb
+++ b/lib/alchemy/test_support/factories/page_factory.rb
@@ -16,6 +16,13 @@ FactoryGirl.define do
     # Pass do_not_autogenerate: false to generate elements
     do_not_autogenerate true
 
+    trait :root do
+      name 'Root'
+      language nil
+      parent_id nil
+      page_layout nil
+    end
+
     trait :language_root do
       name 'Startseite'
       page_layout { language.page_layout }

--- a/lib/alchemy/test_support/factories/site_factory.rb
+++ b/lib/alchemy/test_support/factories/site_factory.rb
@@ -5,6 +5,12 @@ FactoryGirl.define do
     name 'A Site'
     host 'domain.com'
 
+    trait :default do
+      public true
+      name Alchemy::Config.get(:default_site)['name']
+      host Alchemy::Config.get(:default_site)['host']
+    end
+
     trait :public do
       public true
     end

--- a/spec/controllers/alchemy/admin/languages_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/languages_controller_spec.rb
@@ -7,22 +7,22 @@ describe Alchemy::Admin::LanguagesController do
 
   describe "#index" do
     context "with multiple sites" do
+      let!(:default_site_language) do
+        create(:alchemy_language)
+      end
+
       let!(:site_2) do
         create(:alchemy_site, host: 'another-site.com')
       end
 
-      let(:language_2) do
+      let!(:site_2_language) do
         site_2.default_language
-      end
-
-      let(:language) do
-        create(:alchemy_language)
       end
 
       it 'only shows languages from current site' do
         alchemy_get :index
-        expect(assigns(:languages)).to include(language)
-        expect(assigns(:languages)).to_not include(language_2)
+        expect(assigns(:languages)).to include(default_site_language)
+        expect(assigns(:languages)).to_not include(site_2_language)
       end
     end
 

--- a/spec/controllers/alchemy/admin/languages_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/languages_controller_spec.rb
@@ -39,37 +39,10 @@ describe Alchemy::Admin::LanguagesController do
   end
 
   describe "#new" do
-    context "when default_language.page_layout is set" do
-      before do
-        stub_alchemy_config(:default_language, {'page_layout' => "new_standard"})
-      end
-
-      it "uses it as page_layout-default for the new language" do
-        alchemy_get :new
-        expect(assigns(:language).page_layout).to eq("new_standard")
-      end
-    end
-
-    context "when default_language is not configured" do
-      before do
-        stub_alchemy_config(:default_language, nil)
-      end
-
-      it "falls back to default database value." do
-        alchemy_get :new
-        expect(assigns(:language).page_layout).to eq("intro")
-      end
-    end
-
-    context "when default language page_layout is not configured" do
-      before do
-        stub_alchemy_config(:default_language, {})
-      end
-
-      it "falls back to default database value." do
-        alchemy_get :new
-        expect(assigns(:language).page_layout).to eq("intro")
-      end
+    it "has default language's page_layout set" do
+      alchemy_get :new
+      expect(assigns(:language).page_layout).
+        to eq(Alchemy::Config.get(:default_language)['page_layout'])
     end
   end
 end

--- a/spec/controllers/alchemy/admin/layoutpages_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/layoutpages_controller_spec.rb
@@ -18,16 +18,16 @@ module Alchemy
       end
 
       context "with multiple sites" do
+        let!(:language) do
+          create(:alchemy_language)
+        end
+
         let!(:site_2) do
           create(:alchemy_site, host: 'another-site.com')
         end
 
         let(:language_2) do
           site_2.default_language
-        end
-
-        let(:language) do
-          create(:alchemy_language)
         end
 
         it 'only shows languages from current site' do

--- a/spec/controllers/alchemy/base_controller_spec.rb
+++ b/spec/controllers/alchemy/base_controller_spec.rb
@@ -47,6 +47,8 @@ module Alchemy
       end
 
       context "for multiple sites" do
+        let!(:default_site) { create(:alchemy_site, :default) }
+
         let!(:site_2) do
           create(:alchemy_site, host: 'another-host.com')
         end

--- a/spec/controllers/alchemy/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/pages_controller_spec.rb
@@ -26,9 +26,7 @@ module Alchemy
     describe "#index" do
       before do
         default_language_root
-        allow(Config).to receive(:get) do |arg|
-          arg == :redirect_index ? false : Config.parameter(arg)
-        end
+        stub_alchemy_config(:redirect_index, false)
       end
 
       it 'renders :show template' do
@@ -53,9 +51,7 @@ module Alchemy
 
           context 'and redirect_to_public_child is set to false' do
             before do
-              allow(Config).to receive(:get) do |arg|
-                arg == :redirect_to_public_child ? false : Config.parameter(arg)
-              end
+              stub_alchemy_config(:redirect_to_public_child, false)
             end
 
             it 'raises routing error (404)' do
@@ -82,9 +78,7 @@ module Alchemy
 
           context 'and redirect_to_public_child is set to true' do
             before do
-              allow(Config).to receive(:get) do |arg|
-                arg == :redirect_to_public_child ? true : Config.parameter(arg)
-              end
+              stub_alchemy_config(:redirect_to_public_child, true)
             end
 
             context 'that has a public child' do
@@ -255,7 +249,7 @@ module Alchemy
 
       before do
         allow(Alchemy.user_class).to receive(:admins).and_return(OpenStruct.new(count: 1))
-        allow(Config).to receive(:get) { |arg| arg == :url_nesting ? true : false }
+        stub_alchemy_config(:url_nesting, true)
         product.elements.find_by_name('article').contents.essence_texts.first.essence.update_column(:body, 'screwdriver')
       end
 

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -45,9 +45,8 @@ describe 'Dashboard feature' do
 
   describe 'Sites widget' do
     context 'with multiple sites' do
-      before do
-        Alchemy::Site.create!(name: 'Site', host: 'site.com')
-      end
+      let!(:default_site) { create(:alchemy_site, :default) }
+      let!(:another_site) { create(:alchemy_site, name: 'Site', host: 'site.com') }
 
       it "lists all sites" do
         visit admin_dashboard_path

--- a/spec/features/admin/languages_features_spec.rb
+++ b/spec/features/admin/languages_features_spec.rb
@@ -23,6 +23,8 @@ RSpec.feature "Admin::LanguagesFeatures", type: :feature do
     end
 
     context "with multiple sites" do
+      let!(:default_site) { create(:alchemy_site, :default) }
+
       let!(:site_2) do
         create(:alchemy_site, host: 'another-site.com')
       end

--- a/spec/features/admin/site_select_feature_spec.rb
+++ b/spec/features/admin/site_select_feature_spec.rb
@@ -13,6 +13,7 @@ describe 'Site select' do
   end
 
   context "with multiple sites" do
+    let!(:default_site) { create(:alchemy_site, :default) }
     let!(:a_site) { create(:alchemy_site) }
 
     context "not on pages or languages module" do

--- a/spec/features/page_seeder_spec.rb
+++ b/spec/features/page_seeder_spec.rb
@@ -12,7 +12,10 @@ RSpec.describe 'Page seeding' do
       Alchemy::Seeder.instance_variable_set(:@_page_yml, nil)
     end
 
-    subject(:seed) { Alchemy::Seeder.seed! }
+    subject(:seed) do
+      Alchemy::Shell.silence!
+      Alchemy::Seeder.seed!
+    end
 
     context 'when no pages are present yet' do
       before do
@@ -42,6 +45,8 @@ RSpec.describe 'Page seeding' do
     end
 
     context "when pages are already present" do
+      let!(:page) { create(:alchemy_page) }
+
       it 'does not seed' do
         seed
         expect(Alchemy::Page.find_by(name: 'Home')).to_not be_present

--- a/spec/models/alchemy/language_spec.rb
+++ b/spec/models/alchemy/language_spec.rb
@@ -144,6 +144,8 @@ module Alchemy
       end
 
       context "with multiple sites having languages with same code" do
+        let!(:default_site) { create(:alchemy_site, :default) }
+
         let!(:current_site) do
           create(:alchemy_site, host: 'other.com')
         end

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -784,9 +784,25 @@ module Alchemy
       end
     end
 
-    describe '.rootpage' do
-      it "should contain one rootpage" do
-        expect(Page.rootpage).to be_instance_of(Page)
+    describe '.root' do
+      context 'when root page is present' do
+        let!(:root_page) { Page.root }
+
+        it 'returns root page' do
+          expect(Page.root).to eq(root_page)
+        end
+      end
+
+      context 'when no root page is present yet' do
+        before do
+          Page.delete_all
+        end
+
+        it "creates and returns root page" do
+          expect {
+            Page.root
+          }.to change { Page.count }.by(1)
+        end
       end
     end
 

--- a/spec/models/alchemy/site_spec.rb
+++ b/spec/models/alchemy/site_spec.rb
@@ -19,6 +19,18 @@ module Alchemy
             expect(subject.languages.count).to eq(1)
             expect(subject.languages.first).to be_default
           end
+
+          context 'when default language configuration is missing' do
+            before do
+              stub_alchemy_config(:default_language, nil)
+            end
+
+            it 'raises error' do
+              expect {
+                subject.save!
+              }.to raise_error(DefaultLanguageNotFoundError)
+            end
+          end
         end
 
         context 'when it already has a language' do

--- a/spec/models/alchemy/site_spec.rb
+++ b/spec/models/alchemy/site_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 module Alchemy
   describe Site do
     let(:site) { create(:alchemy_site) }
-    let(:another_site) { create(:alchemy_site, name: 'Another Site', host: 'another.com') }
 
     describe 'new instances' do
       subject { build(:alchemy_site, host: 'bla.com') }
@@ -153,23 +152,27 @@ module Alchemy
     end
 
     describe '#current?' do
-      let!(:site) { create(:alchemy_site) }
+      let!(:default_site) { create(:alchemy_site, :default) }
 
-      subject { site.current? }
+      let!(:another_site) do
+        create(:alchemy_site, name: 'Another Site', host: 'another.com')
+      end
+
+      subject { default_site.current? }
 
       context 'when Site.current is set to the same site' do
-        before { Site.current = site }
-        it { is_expected.to be_truthy }
+        before { Site.current = default_site }
+        it { is_expected.to be(true) }
       end
 
       context 'when Site.current is set to nil' do
         before { Site.current = nil }
-        it { is_expected.to be_falsey }
+        it { is_expected.to be(true) }
       end
 
       context 'when Site.current is set to a different site' do
         before { Site.current = another_site }
-        it { is_expected.to be_falsey }
+        it { is_expected.to be(false) }
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -75,8 +75,6 @@ RSpec.configure do |config|
   # Make sure the database is clean and ready for test
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
-    Alchemy::Shell.silence!
-    Alchemy::Seeder.seed!
   end
 
   # All specs are running in transactions, but feature specs not.
@@ -95,9 +93,5 @@ RSpec.configure do |config|
   # After every feature spec the database gets seeded so the next spec can rely on that data.
   config.append_after(:each) do
     DatabaseCleaner.clean
-    if RSpec.current_example.metadata[:type] == :feature
-      allow(Alchemy::Seeder).to receive(:puts)
-      Alchemy::Seeder.seed!
-    end
   end
 end


### PR DESCRIPTION
Instead of the need for running `Alchemy::Seeder.seed!` Alchemy creates all objects it needs to run when they are accessed the first time. Mainly these are:

* The default site. Now gets created when `Alchemy::Site.default` gets accessed the first time
* The root page. Now gets created when `Alchemy::Page.root` gets accessed the first time
* The sites default language. Gets created when a site gets created. Was like this before. So, no change in this behaviour

The seeder is still present, but it now only has the very one purpose to seed pages and users that are defined in `db/seeds/alchemy` folder.

This should also speed up lots of test suites as there is:

**no need to run the seeder before each spec anymore |o/**