### PR TITLE
Remove unused Page attr_accessors

### DIFF
--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -43,7 +43,6 @@ module Alchemy
 
     DEFAULT_ATTRIBUTES_FOR_COPY = {
       do_not_autogenerate: true,
-      do_not_sweep: true,
       visible: false,
       public_on: nil,
       public_until: nil,
@@ -98,9 +97,6 @@ module Alchemy
     validates_presence_of :page_layout, unless: :systempage?
     validates_format_of :page_layout, with: /\A[a-z0-9_-]+\z/, unless: -> { systempage? || page_layout.blank? }
     validates_presence_of :parent_id, if: proc { Page.count > 1 }
-
-    attr_accessor :do_not_sweep
-    attr_accessor :do_not_validate_language
 
     before_save :set_language_code,
       if: -> { language.present? },

--- a/lib/alchemy/seeder.rb
+++ b/lib/alchemy/seeder.rb
@@ -43,7 +43,6 @@ module Alchemy
       def create_root_page
         desc "Creating Alchemy root page"
         root = Alchemy::Page.find_or_initialize_by(name: 'Root')
-        root.do_not_sweep = true
         if root.new_record?
           if root.save!
             log "Created Alchemy root page."


### PR DESCRIPTION
Page `:do_not_sweep` and `:do_not_validate_language` are left overs from acient times.