### PR TITLE
Allow all html_options to be passed to render_navigation

### DIFF
--- a/app/views/alchemy/navigation/_renderer.html.erb
+++ b/app/views/alchemy/navigation/_renderer.html.erb
@@ -1,8 +1,7 @@
 <% if pages.present? %>
 <%= content_tag(
   'ul',
-  :class => html_options[:class] || "navigation level_#{pages.first.level - 1}",
-  :id => html_options[:id]
+  html_options.reverse_merge(class: "navigation level_#{pages.first.level - 1}")
 ) do %>
   <% pages.each do |page| %>
     <% position = 'first' if page == pages.first %>

--- a/spec/helpers/alchemy/pages_helper_spec.rb
+++ b/spec/helpers/alchemy/pages_helper_spec.rb
@@ -104,13 +104,15 @@ module Alchemy
         end
       end
 
-      context "with id and class in the html options" do
-        it "should append id to the generated ul tag" do
-          expect(helper.render_navigation({}, {id: 'foobar_id'})).to have_selector("ul[id='foobar_id']")
+      context "when passing html options" do
+        it "should append all given attributes to the generated ul tag" do
+          expect(helper.render_navigation({}, {id: 'foo', data: {navigation: 'main'} })).to have_selector("ul[id='foo'][data-navigation='main']")
         end
 
-        it "should replace the default css class from the generated ul tag" do
-          expect(helper.render_navigation({}, {class: 'foobar_class'})).to have_selector("ul[class='foobar_class']")
+        context "when overriding the `class` attribute" do
+          it "should replace the default css classes from the generated ul tag" do
+            expect(helper.render_navigation({}, {class: 'foo'})).to have_selector("ul[class='foo']")
+          end
         end
       end
 


### PR DESCRIPTION
Before, when you tried to pass html_options like `data` or `rel` etc. these were silently dropped.
This just forwards all given options while keeping all default classes.