### PR TITLE
Render "text" as type for datepicker input fields

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.datepicker.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.datepicker.js.coffee
@@ -3,33 +3,24 @@ window.Alchemy = {} if typeof(window.Alchemy) is 'undefined'
 $.extend Alchemy,
 
   Datepicker: (scope) ->
-    options =
-      format: Alchemy.t('formats.datetime')
-      formatDate: Alchemy.t('formats.date')
-      formatTime: Alchemy.t('formats.time')
-      dayOfWeekStart: Alchemy.t('formats.start_of_week')
-      onSelectDate: ->
-        Alchemy.setElementDirty $(this).closest(".element-editor")
-
-    datepicker_options = $.extend {}, options,
-      format: options.formatDate
-      timepicker: false
-
-    timepicker_options = $.extend {}, options,
-      format: options.formatTime
-      datepicker: false
-
     $.datetimepicker.setLocale(Alchemy.locale);
+    $datepicker_inputs = $('input[data-datepicker-type]', scope)
 
-    # Initializes the datepickers and disables the browsers default Datepicker
-    # unless the browser is iOS.
-    $('input[type="date"], input.date', scope)
-      .datetimepicker(datepicker_options).prop "type", "text" unless Alchemy.isiOS
-
-    $('input[type="time"], input.time', scope)
-      .datetimepicker(timepicker_options).prop "type", "text" unless Alchemy.isiOS
-
-    $('input[type="datetime"], input.datetime', scope)
-      .datetimepicker(options).prop "type", "text" unless Alchemy.isiOS
+    # Initializes the datepickers on the text inputs and sets the proper type
+    # to enable browsers default datepicker if the current OS is iOS.
+    if Alchemy.isiOS
+      $datepicker_inputs.prop "type", ->
+        return $(this).data('datepicker-type')
+    else
+      $datepicker_inputs.each ->
+        type = $(this).data('datepicker-type')
+        options =
+          format: Alchemy.t("formats.#{type}")
+          timepicker: /time/.test(type)
+          datepicker: /date/.test(type)
+          dayOfWeekStart: Alchemy.t('formats.start_of_week')
+          onSelectDate: ->
+            Alchemy.setElementDirty $(this).closest(".element-editor")
+        $(this).datetimepicker(options)
 
     return

--- a/app/helpers/alchemy/admin/base_helper.rb
+++ b/app/helpers/alchemy/admin/base_helper.rb
@@ -332,12 +332,17 @@ module Alchemy
 
       # Renders a textfield ready to display a datepicker
       #
-      # Uses a HTML5 +<input type="date">+ field.
       # A Javascript observer converts this into a fancy Datepicker.
       # If you pass +'datetime'+ as +:type+ the datepicker will also have a Time select.
+      # If you pass +'time'+ as +:type+ the datepicker will only have a Time select.
       #
-      # The date value gets localized via +I18n.l+. The format on Time and Date is +datepicker+
+      # The date value gets localized via +I18n.l+. The format on Time and Date is +datepicker+, +timepicker+
       # or +datetimepicker+, if you pass another +type+.
+      #
+      # This helper always renders "text" as input type because:
+      # HTML5 supports input types like 'date' but Browsers are using the users OS settings
+      # to validate the input format. Since Alchemy is localized in the backend the date formats
+      # should be aligned with the users locale setting in the backend but not the OS settings.
       #
       # === Date Example
       #
@@ -347,13 +352,17 @@ module Alchemy
       #
       #   <%= alchemy_datepicker(@page, :public_on, type: 'datetime') %>
       #
+      # === Time Example
+      #
+      #   <%= alchemy_datepicker(@meeting, :starts_at, type: 'time') %>
+      #
       # @param [ActiveModel::Base] object
       #   An instance of a model
       # @param [String or Symbol] method
       #   The attribute method to be called for the date value
       #
-      # @option html_options [String] :type (date)
-      #   The type of text field
+      # @option html_options [String] :data-datepicker-type (type)
+      #   The value of the data attribute for the type
       # @option html_options [String] :class (type)
       #   CSS classes of the input field
       # @option html_options [String] :value (value of method on object)
@@ -366,7 +375,7 @@ module Alchemy
         value = date ? l(date, format: "#{type}picker".to_sym) : nil
 
         text_field object.class.name.demodulize.underscore.to_sym,
-          method.to_sym, {type: type, class: type, value: value}.merge(html_options)
+          method.to_sym, {type: "text", class: type, "data-datepicker-type" => type, value: value}.merge(html_options)
       end
 
       # Merges the params-hash with the given hash

--- a/spec/helpers/alchemy/admin/base_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/base_helper_spec.rb
@@ -221,23 +221,23 @@ module Alchemy
       let(:value) { nil }
       let(:type) { nil }
 
-      it "renders a date field" do
-        is_expected.to have_selector("input[type='date']")
+      it "renders a text field with data attribute for 'date'" do
+        is_expected.to have_selector("input[type='text'][data-datepicker-type='date']")
       end
 
       context "when datetime given as type" do
         let(:type) { :datetime }
 
-        it "renders a datetime field" do
-          is_expected.to have_selector("input[type='datetime']")
+        it "renders a text field with data attribute for 'datetime'" do
+          is_expected.to have_selector("input[type='text'][data-datepicker-type='datetime']")
         end
       end
 
       context "when time given as type" do
         let(:type) { :time }
 
-        it "renders a time field" do
-          is_expected.to have_selector("input[type='time']")
+        it "renders a text field with data attribute for 'time'" do
+          is_expected.to have_selector("input[type='text'][data-datepicker-type='time']")
         end
       end
 


### PR DESCRIPTION
- [x] Refactor the way the datepicker is initialized

This change fixes an issue that appears when you are using a type `date` field. What happens is that google chrome renders its HTML5 input field for dates but complains if the date format is not the same as defined in the users OS settings. You can still save new values, but since the values are localized by Rails they are not being presented in the input field (happens when you enter the page or reload). https://github.com/AlchemyCMS/alchemy_cms/issues/1245