### PR TITLE
Fix specs for MySQL date precision

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 3.0'
   gem 'shoulda-matchers', '~> 3.1'
   gem 'rails-controller-testing', '~> 1.0'
+  gem 'timecop', '~> 0.8'
 end
 
 # We need this if we want to start the dummy app in production, ie on Teatro.io

--- a/lib/alchemy/test_support/essence_shared_examples.rb
+++ b/lib/alchemy/test_support/essence_shared_examples.rb
@@ -11,9 +11,11 @@ shared_examples_for "an essence" do
     essence.save
     content.update(essence: essence, essence_type: essence.class.name)
     date = content.updated_at
-    content.essence.update(essence.ingredient_column.to_sym => ingredient_value)
-    content.reload
-    expect(content.updated_at).not_to eq(date)
+    Timecop.travel(5.minutes.from_now) do
+      content.essence.update(essence.ingredient_column.to_sym => ingredient_value)
+      content.reload
+      expect(content.updated_at).not_to eq(date)
+    end
   end
 
   it "should have correct partial path" do

--- a/spec/controllers/alchemy/admin/essence_files_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/essence_files_controller_spec.rb
@@ -48,7 +48,11 @@ module Alchemy
     end
 
     describe '#assign' do
-      let(:content) { create(:alchemy_content) }
+      let(:content) do
+        Timecop.travel(5.minutes.ago) do
+          create(:alchemy_content)
+        end
+      end
 
       before do
         expect(Content).to receive(:find_by).and_return(content)

--- a/spec/controllers/alchemy/admin/essence_pictures_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/essence_pictures_controller_spec.rb
@@ -186,7 +186,11 @@ module Alchemy
     end
 
     describe '#assign' do
-      let(:content) { create(:alchemy_content) }
+      let(:content) do
+        Timecop.travel(5.minutes.ago) do
+          create(:alchemy_content)
+        end
+      end
 
       before do
         expect(Content).to receive(:find).and_return(content)

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -857,8 +857,17 @@ module Alchemy
     end
 
     context 'with parent element' do
-      let!(:parent_element) { create(:alchemy_element, :with_nestable_elements) }
-      let!(:element)        { create(:alchemy_element, name: 'slide', parent_element: parent_element) }
+      let!(:parent_element) do
+        Timecop.travel(10.minutes.ago) do
+          create(:alchemy_element, :with_nestable_elements)
+        end
+      end
+
+      let!(:element) do
+        Timecop.travel(5.minutes.ago) do
+          create(:alchemy_element, name: 'slide', parent_element: parent_element)
+        end
+      end
 
       it "touches parent after update" do
         expect { element.update!(public: false) }.to change(parent_element, :updated_at)

--- a/spec/models/alchemy/essence_date_spec.rb
+++ b/spec/models/alchemy/essence_date_spec.rb
@@ -6,7 +6,7 @@ module Alchemy
 
     it_behaves_like "an essence" do
       let(:essence)          { EssenceDate.new }
-      let(:ingredient_value) { DateTime.current }
+      let(:ingredient_value) { DateTime.current.iso8601 }
     end
 
     describe '#preview_text' do

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -2394,8 +2394,8 @@ module Alchemy
 
     describe '#published_at' do
       context 'with published_at date set' do
-        let(:published_at) { Time.current }
-        let(:page)         { build_stubbed(:alchemy_page, published_at: published_at) }
+        let(:page)         { build_stubbed(:alchemy_page, published_at: Time.current) }
+        let(:published_at) { page.published_at }
 
         it "returns the published_at value from database" do
           expect(page.published_at).to eq(published_at)
@@ -2403,8 +2403,8 @@ module Alchemy
       end
 
       context 'with published_at is nil' do
-        let(:updated_at) { Time.current }
-        let(:page)       { build_stubbed(:alchemy_page, published_at: nil, updated_at: updated_at) }
+        let(:page)       { build_stubbed(:alchemy_page, published_at: nil, updated_at: Time.current) }
+        let(:updated_at) { page.updated_at }
 
         it "returns the updated_at value" do
           expect(page.published_at).to eq(updated_at)

--- a/spec/requests/alchemy/admin/pages_controller_spec.rb
+++ b/spec/requests/alchemy/admin/pages_controller_spec.rb
@@ -663,7 +663,11 @@ module Alchemy
       end
 
       describe '#publish' do
-        let(:page) { create(:alchemy_page) }
+        let(:page) do
+          Timecop.travel(5.minutes.ago) do
+            create(:alchemy_page)
+          end
+        end
 
         it "should publish the page" do
           expect {


### PR DESCRIPTION
According to the MySQL docs their default precision for storing datetimes is 0
(i.e. 1-second resolution). Because of this, tests that set and
update date columns within the same second often present false negatives. We
work around this by using the Timecop library to enforce super-second
resolution on the tests where needed.