### PR TITLE
Increase robustness of time sensitive tests

### DIFF
--- a/lib/alchemy/test_support/essence_shared_examples.rb
+++ b/lib/alchemy/test_support/essence_shared_examples.rb
@@ -7,13 +7,13 @@ shared_examples_for "an essence" do
 
   it "touches the content after update" do
     element = create(:alchemy_element)
-    content = create(:alchemy_content, element: element)
-    essence.save
-    content.update(essence: essence, essence_type: essence.class.name)
-    date = content.updated_at
-    content.essence.update(essence.ingredient_column.to_sym => ingredient_value)
+    content = create(:alchemy_content, element: element, essence: essence, essence_type: essence.class.name)
+
+    content.update_column(:updated_at, 3.days.ago)
+    content.essence.update_attributes(essence.ingredient_column.to_sym => ingredient_value)
+
     content.reload
-    expect(content.updated_at).not_to eq(date)
+    expect(content.updated_at).to be_within(3.seconds).of(Time.current)
   end
 
   it "should have correct partial path" do

--- a/spec/controllers/alchemy/admin/essence_files_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/essence_files_controller_spec.rb
@@ -67,6 +67,7 @@ module Alchemy
       end
 
       it "updates the @content.updated_at column" do
+        content.update_column(:updated_at, 3.days.ago)
         expect {
           alchemy_xhr :put, :assign, content_id: content.id, attachment_id: attachment.id
         }.to change(content, :updated_at)

--- a/spec/controllers/alchemy/admin/essence_pictures_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/essence_pictures_controller_spec.rb
@@ -200,6 +200,7 @@ module Alchemy
       end
 
       it "updates the content timestamp" do
+        content.update_column(:updated_at, 3.days.ago)
         expect {
           alchemy_xhr :put, :assign, content_id: '1', picture_id: '1'
         }.to change(content, :updated_at)

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -861,6 +861,7 @@ module Alchemy
       let!(:element)        { create(:alchemy_element, name: 'slide', parent_element: parent_element) }
 
       it "touches parent after update" do
+        parent_element.update_column(:updated_at, 3.days.ago)
         expect { element.update!(public: false) }.to change(parent_element, :updated_at)
       end
     end

--- a/spec/models/alchemy/essence_date_spec.rb
+++ b/spec/models/alchemy/essence_date_spec.rb
@@ -6,7 +6,7 @@ module Alchemy
 
     it_behaves_like "an essence" do
       let(:essence)          { EssenceDate.new }
-      let(:ingredient_value) { DateTime.current }
+      let(:ingredient_value) { DateTime.current.iso8601 }
     end
 
     describe '#preview_text' do

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -2394,20 +2394,20 @@ module Alchemy
 
     describe '#published_at' do
       context 'with published_at date set' do
-        let(:published_at) { Time.current }
+        let(:published_at) { 3.days.ago }
         let(:page)         { build_stubbed(:alchemy_page, published_at: published_at) }
 
         it "returns the published_at value from database" do
-          expect(page.published_at).to eq(published_at)
+          expect(page.published_at).to be_within(1.second).of(published_at)
         end
       end
 
       context 'with published_at is nil' do
-        let(:updated_at) { Time.current }
+        let(:updated_at) { 3.days.ago }
         let(:page)       { build_stubbed(:alchemy_page, published_at: nil, updated_at: updated_at) }
 
         it "returns the updated_at value" do
-          expect(page.published_at).to eq(updated_at)
+          expect(page.published_at).to be_within(1.second).of(updated_at)
         end
       end
     end


### PR DESCRIPTION
  - change to their more robust form using `be_withing(3.seconds)` or

    update the `updated_at` column manually to an older date

Those are mostly relevant for MySQL db, which has a default time precision of a second, which in turn is frequently not enough in the tests.