### PR TITLE
Remove Rails Test Helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,6 @@ ENV["RAILS_ENV"] = "test"
 
 require File.expand_path("../dummy/config/environment.rb", __FILE__)
 require 'rspec/rails'
-require 'rails/test_help'
 require 'capybara/poltergeist'
 require 'capybara/rails'
 require 'database_cleaner'


### PR DESCRIPTION
I was running into issues with `bundle exec rake` returning a non-zero exit code.

After looking into the issue, it looks like the `spec_helper.rb` file was loading `rails/test_help`. This helper was loading components of minitest that were conflicting with rspec.

After removing the `require` all tests appear to pass without issue. And now `bundle exec rake` exits successfully!

Here's the error I was encountering:

<img width="1250" alt="rake_error" src="https://cloud.githubusercontent.com/assets/6474230/25107599/a48bd0d8-238d-11e7-864d-76ebe99e1ad8.png">


SEE: https://github.com/rspec/rspec-rails/issues/1171