### PR TITLE
Update Post Install Message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ __Notable Changes__
 
 * The seeder does not generate default site and root page anymore.
   Alchemy handles this auto-magically now. No need to run `Alchemy::Seeder.seed!` any more |o/
+* Remove post install message reference to the `alchemy` standalone installer.
 
 ## 3.5.0 (unreleased)
 

--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -46,10 +46,6 @@ Gem::Specification.new do |gem|
             Thank you for installing Alchemy CMS
 -------------------------------------------------------------
 
-- Create a new standalone Alchemy project:
-
-  $ alchemy new my_project_name
-
 - Complete the installation in an existing Rails application:
 
   $ bin/rake alchemy:install


### PR DESCRIPTION
* Remove reference to the `alchemy` standalone installer inside the
  post install message. This was executable was removed in this pull
  request: https://github.com/AlchemyCMS/alchemy_cms/pull/1206.