### PR TITLE
Cleanup ActiveRecord Queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ __Notable Changes__
 
 * The seeder does not generate default site and root page anymore.
   Alchemy handles this auto-magically now. No need to run `Alchemy::Seeder.seed!` any more |o/
+* Security: Sanitize ActiveRecord queries in `Alchemy::Element`, `Alchemy::Page` and
+  `Alchemy::PagesHelper`.
 
 ## 3.5.0 (unreleased)
 

--- a/app/helpers/alchemy/pages_helper.rb
+++ b/app/helpers/alchemy/pages_helper.rb
@@ -166,7 +166,7 @@ module Alchemy
       pages = page.children.accessible_by(current_ability, :see)
       pages = pages.restricted if options.delete(:restricted_only)
       if depth = options[:deepness]
-        pages = pages.where("#{Page.table_name}.depth <= #{depth}")
+        pages = pages.where("#{Page.table_name}.depth <= ?", depth)
       end
       if options[:reverse]
         pages.reverse!

--- a/app/helpers/alchemy/pages_helper.rb
+++ b/app/helpers/alchemy/pages_helper.rb
@@ -166,7 +166,7 @@ module Alchemy
       pages = page.children.accessible_by(current_ability, :see)
       pages = pages.restricted if options.delete(:restricted_only)
       if depth = options[:deepness]
-        pages = pages.where("#{Page.table_name}.depth <= ?", depth)
+        pages = pages.where('depth <= ?', depth)
       end
       if options[:reverse]
         pages.reverse!

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -321,9 +321,11 @@ module Alchemy
     #   Pass an element name to get previous of this kind.
     #
     def previous_or_next(dir, name = nil)
-      elements = page.elements.published.where("#{self.class.table_name}.position #{dir} #{position}")
+      dir = dir == '>' ? '>' : '<'
+      order = dir == '>' ? :asc : :desc
+      elements = page.elements.published.where("#{self.class.table_name}.position #{dir} ?", position)
       elements = elements.named(name) if name.present?
-      elements.reorder("position #{dir == '>' ? 'ASC' : 'DESC'}").limit(1).first
+      elements.reorder(position: order).limit(1).first
     end
 
     # Returns all cells from given page this element could be placed in.

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -211,7 +211,8 @@ module Alchemy
     # Pass an element name to get next of this kind.
     #
     def next(name = nil)
-      previous_or_next('>', name)
+      elements = page.elements.published.where('position > ?', position)
+      select_element(elements, name, :asc)
     end
 
     # Returns previous public element from same page.
@@ -219,7 +220,8 @@ module Alchemy
     # Pass an element name to get previous of this kind.
     #
     def prev(name = nil)
-      previous_or_next('<', name)
+      elements = page.elements.published.where('position < ?', position)
+      select_element(elements, name, :desc)
     end
 
     # Stores the page into +touchable_pages+ (Pages that have to be touched after updating the element).
@@ -313,17 +315,7 @@ module Alchemy
 
     private
 
-    # Returns previous or next public element from same page.
-    #
-    # @param [String]
-    #   Pass '>' or '<' to find next or previous public element.
-    # @param [String]
-    #   Pass an element name to get previous of this kind.
-    #
-    def previous_or_next(dir, name = nil)
-      dir = dir == '>' ? '>' : '<'
-      order = dir == '>' ? :asc : :desc
-      elements = page.elements.published.where("#{self.class.table_name}.position #{dir} ?", position)
+    def select_element(elements, name, order)
       elements = elements.named(name) if name.present?
       elements.reorder(position: order).limit(1).first
     end

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -474,10 +474,12 @@ module Alchemy
         public: true
       }.update(options)
 
-      pages = self_and_siblings.where(["#{Page.table_name}.lft #{dir} ?", lft])
+      dir = dir == '>' ? '>' : '<'
+      order = dir == '>' ? 'lft' : 'lft DESC'
+      pages = self_and_siblings.where("#{Page.table_name}.lft #{dir} ?", lft)
       pages = options[:public] ? pages.published : pages.not_public
       pages.where(restricted: options[:restricted])
-        .reorder(dir == '>' ? 'lft' : 'lft DESC')
+        .reorder(order)
         .limit(1).first
     end
 

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -311,19 +311,27 @@ module Alchemy
 
     # Returns the previous page on the same level or nil.
     #
-    # For options @see #next_or_previous
+    # @option options [Boolean] :restricted (false)
+    #   only restricted pages (true), skip restricted pages (false)
+    # @option options [Boolean] :public (true)
+    #   only public pages (true), skip public pages (false)
     #
     def previous(options = {})
-      next_or_previous('<', options)
+      pages = self_and_siblings.where('lft < ?', lft)
+      select_page(pages, options.merge(order: :desc))
     end
     alias_method :previous_page, :previous
 
     # Returns the next page on the same level or nil.
     #
-    # For options @see #next_or_previous
+    # @option options [Boolean] :restricted (false)
+    #   only restricted pages (true), skip restricted pages (false)
+    # @option options [Boolean] :public (true)
+    #   only public pages (true), skip public pages (false)
     #
     def next(options = {})
-      next_or_previous('>', options)
+      pages = self_and_siblings.where('lft > ?', lft)
+      select_page(pages, options.merge(order: :asc))
     end
     alias_method :next_page, :next
 
@@ -458,28 +466,10 @@ module Alchemy
       end
     end
 
-    # Returns the next or previous page on the same level or nil.
-    #
-    # @param [String]
-    #   Pass '>' for next and '<' for previous page.
-    #
-    # @option options [Boolean] :restricted (nil)
-    #   only restricted pages (true), skip restricted pages (false)
-    # @option options [Boolean] :public (true)
-    #   only public pages (true), skip public pages (false)
-    #
-    def next_or_previous(dir = '>', options = {})
-      options = {
-        restricted: false,
-        public: true
-      }.update(options)
-
-      dir = dir == '>' ? '>' : '<'
-      order = dir == '>' ? 'lft' : 'lft DESC'
-      pages = self_and_siblings.where("#{Page.table_name}.lft #{dir} ?", lft)
-      pages = options[:public] ? pages.published : pages.not_public
-      pages.where(restricted: options[:restricted])
-        .reorder(order)
+    def select_page(pages, options = {})
+      pages = options.fetch(:public, true) ? pages.published : pages.not_public
+      pages.where(restricted: options.fetch(:restricted, false))
+        .reorder(lft: options.fetch(:order))
         .limit(1).first
     end
 


### PR DESCRIPTION
Brakeman indicated 3 potential SQL injection issues.

The following list outlines the issues from highest to
lowest severity:

1) `Alchemy::PagesHelper#render_navigation` - If the developer passed
   user-controlled parameters to the `deepness` argument, SQL injection
   would be possible via interpolation inside a where clause.
2) `Alchemy::Page#next_or_previous` - A raw interpolation of the
   `dir` variable in a where clause that could only result from
   malicious use of the `next_or_previous` method (which is private).
3) `Alchemy::Element#previous_or_next` - A raw interpolation of the
   `dir` variable in a where clause. Again, this could only
   result from improper use of the `previous_or_next` private
   method.

#### Notes
* I tried to match existing style where possible. Please let me know if something seems off!
* I thought about adding tests, but I'm not sure if that was necessary - please let me know if you think it's needed.