### PR TITLE
Correct notes about ruby compatibilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ Read more about Alchemy on the [website](https://alchemy-cms.com) and in the [gu
 
 ## Ruby Version
 
-Alchemy runs with Ruby >= 2.0.0.
+Alchemy runs with Ruby >= 2.1.0.
+
+For a Ruby 2.0.0 compatible version use the [`3.2-stable` branch](https://github.com/AlchemyCMS/alchemy_cms/tree/3.2-stable).
 
 For a Ruby 1.9.3 compatible version use the [`3.1-stable` branch](https://github.com/AlchemyCMS/alchemy_cms/tree/3.1-stable).
 


### PR DESCRIPTION
With ruby 2.1 the keyword arguments implementation changed so that default values can be omitted. Resource: https://github.com/ruby/ruby/blob/v2_1_0/NEWS

Alchemy 3.2-stable is the latest stable branch that is not using keyword arguments without a default value.