### PR TITLE
Make essence delegation tests independent of hard-coded fixtures

### DIFF
--- a/lib/alchemy/test_support/essence_shared_examples.rb
+++ b/lib/alchemy/test_support/essence_shared_examples.rb
@@ -250,27 +250,9 @@ shared_examples_for "an essence" do
   end
 
   context 'delegations' do
-    let(:page)    { create(:alchemy_page, :restricted) }
-    let(:element) { create(:alchemy_element, name: 'headline', create_contents_after_create: true, page: page) }
-    let(:content) { element.contents.find_by(essence_type: 'Alchemy::EssenceText') }
-    let(:essence) { content.essence }
-
-    it "delegates restricted? to page" do
-      expect(page.restricted?).to be(true)
-      expect(essence.restricted?).to be(true)
-    end
-
-    it "delegates trashed? to element" do
-      element.update!(position: nil)
-      expect(element.trashed?).to be true
-      expect(essence.trashed?).to be true
-    end
-
-    it "delegates public? to element" do
-      element.update!(public: false)
-      expect(element.public?).to be false
-      expect(essence.public?).to be false
-    end
+    it { should delegate_method(:restricted?).to(:page) }
+    it { should delegate_method(:trashed?).to(:element) }
+    it { should delegate_method(:public?).to(:element)  }
   end
 
   describe 'essence relations' do


### PR DESCRIPTION
Before this change the delegation tests in the shared essence examples relied on an element with a certain name and a content with a text essence.

When testing an essence in an external engine for Alchemy I don't want to be forced to look into the Alchemy specs to understand I have to set up very certain fixtures that have nothing to do with my add-on I am building.

This change allows external engines to better test essences with the shared examples provided by Alchemy.