### PR TITLE
Add pg-search compatibility notice

### DIFF
--- a/lib/alchemy/upgrader/three_point_four.rb
+++ b/lib/alchemy/upgrader/three_point_four.rb
@@ -2,9 +2,26 @@ require_relative 'tasks/install_asset_manifests'
 
 module Alchemy
   class Upgrader::ThreePointFour < Upgrader
-    def self.install_asset_manifests
-      desc 'Install asset manifests into `vendor/assets`'
-      Alchemy::Upgrader::Tasks::InstallAssetManifests.new.install
+    class << self
+      def install_asset_manifests
+        desc 'Install asset manifests into `vendor/assets`'
+        Alchemy::Upgrader::Tasks::InstallAssetManifests.new.install
+      end
+
+      def alchemy_3_4_todos
+        notice = <<-NOTE
+
+        Time-based publishing
+        ---------------------
+
+        Alchemy now uses time-based publishing on the page models. Gems that
+        rely on the #public method will break. If you are using an older version
+        of `alchemy-pg_search`, you should now upgrade to a more recent version.
+
+        Ref: https://github.com/AlchemyCMS/alchemy-pg_search/pull/8
+        NOTE
+        todo notice, 'Alchemy v3.4 changes'
+      end
     end
   end
 end

--- a/lib/tasks/alchemy/upgrade.rake
+++ b/lib/tasks/alchemy/upgrade.rake
@@ -9,7 +9,7 @@ namespace :alchemy do
     'alchemy:upgrade:3.1:todo',
     'alchemy:upgrade:3.2:run', 'alchemy:upgrade:3.2:todo',
     'alchemy:upgrade:3.3:run', 'alchemy:upgrade:3.3:todo',
-    'alchemy:upgrade:3.4:run',
+    'alchemy:upgrade:3.4:run', 'alchemy:upgrade:3.4:todo',
     'alchemy:upgrade:3.5:run', 'alchemy:upgrade:3.5:todo'
   ] do
     Alchemy::Upgrader.display_todos
@@ -153,6 +153,10 @@ namespace :alchemy do
       desc 'Install asset manifests into `vendor/assets`'
       task install_asset_manifests: [:environment] do
         Alchemy::Upgrader::ThreePointFour.install_asset_manifests
+      end
+
+      task :todo do
+        Alchemy::Upgrader::ThreePointFour.alchemy_3_4_todos
       end
     end
 


### PR DESCRIPTION
Figured it was worth updating the notice on this to help other devs that may be updating older versions of AlchemyCMS.

Relevant change on `alchemy-pg_search`: https://github.com/AlchemyCMS/alchemy-pg_search/pull/8