### PR TITLE
Fix Psych error

### DIFF
--- a/app/models/alchemy/element/definitions.rb
+++ b/app/models/alchemy/element/definitions.rb
@@ -26,7 +26,7 @@ module Alchemy
       #
       def read_definitions_file
         if ::File.exist?(definitions_file_path)
-          ::YAML.safe_load(ERB.new(File.read(definitions_file_path)).result, [Regexp, Date], [], true) || []
+          ::YAML.safe_load(ERB.new(File.read(definitions_file_path)).result, [Date, Regexp, Symbol], [], true) || []
         else
           raise LoadError, "Could not find elements.yml file! Please run `rails generate alchemy:scaffold`"
         end

--- a/lib/alchemy/page_layout.rb
+++ b/lib/alchemy/page_layout.rb
@@ -157,7 +157,7 @@ module Alchemy
       #
       def read_definitions_file
         if File.exist?(layouts_file_path)
-          YAML.safe_load(ERB.new(File.read(layouts_file_path)).result, [Date], [], true) || []
+          YAML.safe_load(ERB.new(File.read(layouts_file_path)).result, [Date, Symbol], [], true) || []
         else
           raise LoadError, "Could not find page_layouts.yml file! Please run `rails generate alchemy:scaffold`"
         end

--- a/spec/libraries/page_layout_spec.rb
+++ b/spec/libraries/page_layout_spec.rb
@@ -17,6 +17,18 @@ module Alchemy
         expect(subject.collect { |l| l['name'] }).to include('erb_layout')
       end
 
+      context "with a YAML file including a symbol" do
+        let(:yaml) { 'name: :symbol' }
+        before do
+          expect(File).to receive(:exist?).and_return(true)
+          expect(File).to receive(:read).and_return(yaml)
+        end
+
+        it "returns the definition without error" do
+          expect { subject }.to_not raise_error
+        end
+      end
+
       context "with empty layouts file" do
         before { expect(YAML).to receive(:safe_load).and_return(false) }
 

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -117,6 +117,19 @@ module Alchemy
         expect(Element.definitions.collect { |el| el['name'] }).to include('erb_element')
       end
 
+      context "with the generated, default template" do
+        let(:template_path) { 'lib/rails/generators/alchemy/install/templates/elements.yml.tt' }
+        let(:template) { File.read(template_path).gsub(/<%.+%>/, '') }
+        before do
+          expect(File).to receive(:exist?).and_return(true)
+          expect(File).to receive(:read).and_return(template)
+        end
+
+        it "returns without error" do
+          expect { Element.definitions }.to_not raise_error
+        end
+      end
+
       context "without existing yml files" do
         before { allow(File).to receive(:exist?).and_return(false) }
 

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -117,15 +117,14 @@ module Alchemy
         expect(Element.definitions.collect { |el| el['name'] }).to include('erb_element')
       end
 
-      context "with the generated, default template" do
-        let(:template_path) { 'lib/rails/generators/alchemy/install/templates/elements.yml.tt' }
-        let(:template) { File.read(template_path).gsub(/<%.+%>/, '') }
+      context "with a YAML file including a symbol" do
+        let(:yaml) { 'name: :symbol' }
         before do
           expect(File).to receive(:exist?).and_return(true)
-          expect(File).to receive(:read).and_return(template)
+          expect(File).to receive(:read).and_return(yaml)
         end
 
-        it "returns without error" do
+        it "returns the definition without error" do
           expect { Element.definitions }.to_not raise_error
         end
       end


### PR DESCRIPTION
The default generator for `elements.yml` contains Symbol classes (https://github.com/AlchemyCMS/alchemy_cms/blob/caf798aabfd7a2f551bcbb08f4f9e6c420d5c6dc/lib/rails/generators/alchemy/install/templates/elements.yml.tt#L12), which cause an error `Psych::DisallowedClass Tried to load unspecified class: Symbol`. I didn't see a spec for `models/alchemy/definitions_spec.rb`, but happy to add one in if needed. Or, perhaps, adjust the default generator with a compatible one.