### PR TITLE
Fix broken Dragonfly link

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ something like S3.
 
 Please follow the guidelines about picture caching on the Dragonfly homepage for further instructions:
 
-http://markevans.github.io/dragonfly/cache/
+http://markevans.github.io/dragonfly/cache
 
 
 ## Upgrading


### PR DESCRIPTION
Trailing slash causes 404 on GitHub Pages