### PR TITLE
Resource Controller: Allow overriding authorize_resource

### DIFF
--- a/app/controllers/alchemy/admin/resources_controller.rb
+++ b/app/controllers/alchemy/admin/resources_controller.rb
@@ -13,9 +13,7 @@ module Alchemy
       before_action :load_resource,
         only: [:show, :edit, :update, :destroy]
 
-      before_action do
-        authorize!(action_name.to_sym, resource_instance_variable || resource_handler.model)
-      end
+      before_action :authorize_resource
 
       def index
         @query = resource_handler.model.ransack(params[:q])
@@ -110,6 +108,10 @@ module Alchemy
 
       def load_resource
         instance_variable_set("@#{resource_handler.resource_name}", resource_handler.model.find(params[:id]))
+      end
+
+      def authorize_resource
+        authorize!(action_name.to_sym, resource_instance_variable || resource_handler.model)
       end
 
       # Permits all parameters as default!


### PR DESCRIPTION
In a host app, I want to use scopes as resource models for index actions.
Scopes can not be authorized through CanCanCan like actual models can.

This is a pretty remote use case, so I won't try baking that into the
already pretty complex resource handling system. However, it would be
convenient to be able to override the authorization logic from my host app.
This commit achieves that.