### PR TITLE
Do not ask for systempage everytime we load the page definition

### DIFF
--- a/app/models/alchemy/page/page_natures.rb
+++ b/app/models/alchemy/page/page_natures.rb
@@ -96,7 +96,6 @@ module Alchemy
 
     # Returns the self#page_layout definition from config/alchemy/page_layouts.yml file.
     def definition
-      return {} if systempage?
       definition = PageLayout.get(page_layout)
       if definition.nil?
         log_warning "Page definition for `#{page_layout}` not found. Please check `page_layouts.yml` file."


### PR DESCRIPTION
While rendering the sitemap we ask for the page definition.

Previously we immediately returned an empty hash if the page is a `systempage?`.
That causes two extra queries for each page we render.

Instead we do not ask for `systempage?` anymore, because if the page definition
can't be found we already return an emtpy hash.

This speeds up rendering large sitemaps by about 6 times.