### PR TITLE
Permit element create params

### DIFF
--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -39,7 +39,7 @@ module Alchemy
             @element = paste_element_from_clipboard
             @cell = @element.cell
           else
-            @element = Element.new_from_scratch(params[:element])
+            @element = Element.new_from_scratch(create_element_params)
             if @page.can_have_cells?
               @cell = find_or_create_cell
               @element.cell = @cell
@@ -172,6 +172,10 @@ module Alchemy
         else
           params.fetch(:element, {})
         end
+      end
+
+      def create_element_params
+        params.require(:element).permit(:name, :page_id, :parent_element_id)
       end
     end
   end

--- a/spec/dummy/config/initializers/new_framework_defaults.rb
+++ b/spec/dummy/config/initializers/new_framework_defaults.rb
@@ -9,6 +9,7 @@ Rails.application.config.action_controller.per_form_csrf_tokens = true
 
 # Enable origin-checking CSRF mitigation. Previous versions had false.
 Rails.application.config.action_controller.forgery_protection_origin_check = true
+Rails.application.config.action_controller.raise_on_unfiltered_parameters = true
 
 # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
 # Previous versions had false.


### PR DESCRIPTION
Let unpermitted parameters raise in the dummy test app and permits the only unpermitted param we have left. A small fix that removes a Rails 5 deprecation.