### PR TITLE
Refactor sortable picture gallery

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.dragndrop.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.dragndrop.js.coffee
@@ -79,14 +79,14 @@ $.extend Alchemy,
 
   SortableContents: (selector, token) ->
     $(selector).sortable
-      items: "div.dragable_picture"
+      items: "div.draggable_picture"
       handle: "div.picture_handle"
       opacity: 0.5
       cursor: "move"
       tolerance: "pointer"
       containment: "parent"
       update: (event, ui) ->
-        ids = $.map $(this).children("div.dragable_picture"), (child) ->
+        ids = $.map $(this).children("div.draggable_picture"), (child) ->
           child.id.replace /essence_picture_/, ""
         $(event.originalTarget).css "cursor", "progress"
         $.ajax

--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -484,7 +484,7 @@
   }
 }
 
-.dragable_picture {
+.draggable_picture {
   float: left;
 
   .picture_handle {

--- a/app/controllers/alchemy/admin/contents_controller.rb
+++ b/app/controllers/alchemy/admin/contents_controller.rb
@@ -59,8 +59,8 @@ module Alchemy
 
       def options_for_picture_gallery
         @gallery_pictures = @element.contents.gallery_pictures
-        @dragable = @gallery_pictures.size > 1
-        @options.merge(dragable: @dragable)
+        @draggable = @gallery_pictures.size > 1
+        @options.merge(draggable: @draggable)
       end
 
       def essence_editor_locals

--- a/app/controllers/alchemy/admin/contents_controller.rb
+++ b/app/controllers/alchemy/admin/contents_controller.rb
@@ -59,7 +59,7 @@ module Alchemy
 
       def options_for_picture_gallery
         @gallery_pictures = @element.contents.gallery_pictures
-        @options.merge(draggable: @gallery_pictures.size > 1)
+        @options.merge(sortable: @gallery_pictures.size > 1)
       end
 
       def essence_editor_locals

--- a/app/controllers/alchemy/admin/contents_controller.rb
+++ b/app/controllers/alchemy/admin/contents_controller.rb
@@ -59,8 +59,7 @@ module Alchemy
 
       def options_for_picture_gallery
         @gallery_pictures = @element.contents.gallery_pictures
-        @draggable = @gallery_pictures.size > 1
-        @options.merge(draggable: @draggable)
+        @options.merge(draggable: @gallery_pictures.size > 1)
       end
 
       def essence_editor_locals

--- a/app/controllers/alchemy/admin/essence_pictures_controller.rb
+++ b/app/controllers/alchemy/admin/essence_pictures_controller.rb
@@ -43,8 +43,8 @@ module Alchemy
         @picture = Picture.find_by(id: params[:picture_id])
         @content.essence.picture = @picture
         @element = @content.element
-        @dragable = @options[:grouped]
-        @options = @options.merge(dragable: @dragable)
+        @draggable = @options[:grouped]
+        @options = @options.merge(draggable: @draggable)
 
         # We need to update timestamp here because we don't save yet,
         # but the cache needs to be get invalid.

--- a/app/controllers/alchemy/admin/essence_pictures_controller.rb
+++ b/app/controllers/alchemy/admin/essence_pictures_controller.rb
@@ -35,7 +35,7 @@ module Alchemy
         @essence_picture.update(essence_picture_params)
       end
 
-      # Assigns picture, but does not saves it.
+      # Assigns picture, but does not save it.
       #
       # When the user saves the element the content gets updated as well.
       #
@@ -43,7 +43,6 @@ module Alchemy
         @picture = Picture.find_by(id: params[:picture_id])
         @content.essence.picture = @picture
         @element = @content.element
-        @options = @options.merge(sortable: @options[:grouped])
 
         # We need to update timestamp here because we don't save yet,
         # but the cache needs to be get invalid.

--- a/app/controllers/alchemy/admin/essence_pictures_controller.rb
+++ b/app/controllers/alchemy/admin/essence_pictures_controller.rb
@@ -43,8 +43,7 @@ module Alchemy
         @picture = Picture.find_by(id: params[:picture_id])
         @content.essence.picture = @picture
         @element = @content.element
-        @draggable = @options[:grouped]
-        @options = @options.merge(draggable: @draggable)
+        @options = @options.merge(draggable: @options[:grouped])
 
         # We need to update timestamp here because we don't save yet,
         # but the cache needs to be get invalid.

--- a/app/controllers/alchemy/admin/essence_pictures_controller.rb
+++ b/app/controllers/alchemy/admin/essence_pictures_controller.rb
@@ -43,7 +43,7 @@ module Alchemy
         @picture = Picture.find_by(id: params[:picture_id])
         @content.essence.picture = @picture
         @element = @content.element
-        @options = @options.merge(draggable: @options[:grouped])
+        @options = @options.merge(sortable: @options[:grouped])
 
         # We need to update timestamp here because we don't save yet,
         # but the cache needs to be get invalid.

--- a/app/views/alchemy/admin/contents/create.js.erb
+++ b/app/views/alchemy/admin/contents/create.js.erb
@@ -29,7 +29,7 @@ $('#picture_to_assign_<%= @content.ingredient.id %> a').attr('href', '#').off('c
 <% if @gallery_pictures %>
 
 <% if @gallery_pictures.size > 1 %>
-$('#element_<%= @element.id %>_contents .essence_picture_editor').addClass('dragable_picture');
+$('#element_<%= @element.id %>_contents .essence_picture_editor').addClass('draggable_picture');
 <% end %>
 
 <% if !max_image_count.blank? && @gallery_pictures.size >= max_image_count %>

--- a/app/views/alchemy/admin/elements/_picture_gallery_editor.html.erb
+++ b/app/views/alchemy/admin/elements/_picture_gallery_editor.html.erb
@@ -1,23 +1,23 @@
+<% sortable = pictures.size > 1 %>
 <%- max_image_count = options[:maximum_amount_of_images] || options[:max_images] -%>
 <div class="content_editor picture_gallery_editor">
   <label><%= Alchemy.t("picture_gallery_editor.#{element.name}", default: Alchemy.t(:picture_gallery_editor)) %></label>
   <div class="picture_gallery_images" id="element_<%= element.id %>_contents">
     <%- pictures.each do |picture| -%>
-      <%= render_essence_editor(picture, {draggable: (pictures.size > 1)}.merge(options)) %>
+      <%= render_essence_editor(picture, {draggable: sortable}.merge(options)) %>
     <%- end -%>
     <%- if max_image_count.blank? || pictures.length < max_image_count.to_i -%>
       <%= render(
         partial: 'alchemy/admin/elements/add_picture',
         locals: {
           element: element,
-          options: options,
-          draggable: (pictures.size > 1)
+          options: options
         }
       ) %>
     <%- end -%>
   </div>
 </div>
-<%- if pictures.size > 1 -%>
+<%- if sortable -%>
 <script type="text/javascript" charset="utf-8">
   Alchemy.SortableContents('#element_<%= element.id %>_contents', '<%= form_authenticity_token %>');
 </script>

--- a/app/views/alchemy/admin/elements/_picture_gallery_editor.html.erb
+++ b/app/views/alchemy/admin/elements/_picture_gallery_editor.html.erb
@@ -3,7 +3,7 @@
   <label><%= Alchemy.t("picture_gallery_editor.#{element.name}", default: Alchemy.t(:picture_gallery_editor)) %></label>
   <div class="picture_gallery_images" id="element_<%= element.id %>_contents">
     <%- pictures.each do |picture| -%>
-      <%= render_essence_editor(picture, {dragable: (pictures.size > 1)}.merge(options)) %>
+      <%= render_essence_editor(picture, {draggable: (pictures.size > 1)}.merge(options)) %>
     <%- end -%>
     <%- if max_image_count.blank? || pictures.length < max_image_count.to_i -%>
       <%= render(
@@ -11,7 +11,7 @@
         locals: {
           element: element,
           options: options,
-          dragable: (pictures.size > 1)
+          draggable: (pictures.size > 1)
         }
       ) %>
     <%- end -%>

--- a/app/views/alchemy/admin/elements/_picture_gallery_editor.html.erb
+++ b/app/views/alchemy/admin/elements/_picture_gallery_editor.html.erb
@@ -4,7 +4,7 @@
   <label><%= Alchemy.t("picture_gallery_editor.#{element.name}", default: Alchemy.t(:picture_gallery_editor)) %></label>
   <div class="picture_gallery_images" id="element_<%= element.id %>_contents">
     <%- pictures.each do |picture| -%>
-      <%= render_essence_editor(picture, {draggable: sortable}.merge(options)) %>
+      <%= render_essence_editor(picture, {sortable: sortable}.merge(options)) %>
     <%- end -%>
     <%- if max_image_count.blank? || pictures.length < max_image_count.to_i -%>
       <%= render(

--- a/app/views/alchemy/admin/essence_pictures/destroy.js.erb
+++ b/app/views/alchemy/admin/essence_pictures/destroy.js.erb
@@ -1,14 +1,12 @@
 (function() {
-  var $picture_editor;
+  var $picture_editor = $('#element_<%= @element.id %>_contents');
 
   $('#essence_picture_<%= @content_id %>').remove();
 
-  <% if max_image_count.present? && @essence_pictures.count < max_image_count.to_i -%>
-
-    $picture_editor = $('#element_<%= @element.id %>_contents');
+  <% if max_image_count.present? && @essence_pictures.size < max_image_count.to_i -%>
 
     if ($('div.add_picture', $picture_editor).length === 0) {
-      $('#element_<%= @element.id %>_contents').append('<%= j(
+      $picture_editor.append('<%= j(
         render "alchemy/admin/elements/add_picture",
           element: @element,
           options: @options
@@ -17,7 +15,12 @@
 
   <% end -%>
 
-  Alchemy.SortableContents('#element_<%= @element.id %>_contents', '<%= form_authenticity_token %>');
+  <% if @essence_pictures.size > 1 %>
+    Alchemy.SortableContents($picture_editor.selector, '<%= form_authenticity_token %>');
+  <% else %>
+    $picture_editor.find('.draggable_picture').removeClass('draggable_picture');
+    $picture_editor.sortable('destroy');
+  <% end %>
   Alchemy.reloadPreview();
   Alchemy.pleaseWaitOverlay(false);
 

--- a/app/views/alchemy/essences/_essence_picture_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_picture_editor.html.erb
@@ -1,6 +1,6 @@
 <%= content_tag :div, id: content.dom_id, data: {"content-id" => content.id}, class: [
     "essence_picture_editor",
-    options[:dragable] ? "dragable_picture" : nil,
+    options[:draggable] ? "draggable_picture" : nil,
     options[:grouped] ? nil : "content_editor"
   ].compact.join(" ") do %>
   <% unless options[:grouped] %><%= content_label(content) %><% end %>
@@ -18,7 +18,7 @@
       <% end %>
     </span>
     <%- if content.ingredient -%>
-      <div class="picture_handle" title="<%= Alchemy.t(:drag_to_sort) if options[:dragable] %>"></div>
+      <div class="picture_handle" title="<%= Alchemy.t(:drag_to_sort) if options[:draggable] %>"></div>
     <%- end -%>
     <div class="picture_image">
       <div class="thumbnail_background<%= ' missing' if content.ingredient.nil? %>">

--- a/app/views/alchemy/essences/_essence_picture_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_picture_editor.html.erb
@@ -1,6 +1,6 @@
 <%= content_tag :div, id: content.dom_id, data: {"content-id" => content.id}, class: [
     "essence_picture_editor",
-    options[:draggable] ? "draggable_picture" : nil,
+    options[:sortable] ? "draggable_picture" : nil,
     options[:grouped] ? nil : "content_editor"
   ].compact.join(" ") do %>
   <% unless options[:grouped] %><%= content_label(content) %><% end %>
@@ -18,7 +18,7 @@
       <% end %>
     </span>
     <%- if content.ingredient -%>
-      <div class="picture_handle" title="<%= Alchemy.t(:drag_to_sort) if options[:draggable] %>"></div>
+      <div class="picture_handle" title="<%= Alchemy.t(:drag_to_sort) if options[:sortable] %>"></div>
     <%- end -%>
     <div class="picture_image">
       <div class="thumbnail_background<%= ' missing' if content.ingredient.nil? %>">

--- a/spec/dummy/app/views/alchemy/elements/_gallery_editor.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_gallery_editor.html.erb
@@ -1,0 +1,3 @@
+<%= element_editor_for(element) do |el| -%>
+  <%= render_picture_gallery_editor(element, max_images: nil, crop: true) %>
+<%- end -%>

--- a/spec/dummy/app/views/alchemy/elements/_gallery_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_gallery_view.html.erb
@@ -1,0 +1,11 @@
+<%- cache(element) do -%>
+  <%= element_view_for(element) do |el| -%>
+    <div class="gallery_images">
+      <%- element.contents.gallery_pictures.each do |image| -%>
+      <div class="gallery_image <%= image.essence.css_class %>">
+        <%= render_essence_view(image, size: '160x120') %>
+      </div>
+      <%- end -%>
+    </div>
+  <%- end -%>
+<%- end -%>

--- a/spec/dummy/config/alchemy/elements.yml
+++ b/spec/dummy/config/alchemy/elements.yml
@@ -123,3 +123,6 @@
 - name: slider
   nestable_elements:
     - slide
+
+- name: gallery
+  picture_gallery: true

--- a/spec/dummy/config/alchemy/page_layouts.yml
+++ b/spec/dummy/config/alchemy/page_layouts.yml
@@ -22,7 +22,7 @@
 
 - name: everything
   cells: [right_column]
-  elements: [text, all_you_can_eat]
+  elements: [text, all_you_can_eat, gallery]
   autogenerate: [all_you_can_eat]
 
 - name: news


### PR DESCRIPTION
Reduced duplications, removed ivars and renamings that cleans up code around the essence pictures gallery.
Came out of work around the necessary refactorings for Rails 5.1 deprecations.