### PR TITLE
Remove the possibility to pass options as JSON string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.0.0 (unreleased)
 
+* Removes the possibility to pass options param as JSON string. [#1291](https://github.com/AlchemyCMS/alchemy_cms/pull/1291) by [tvdeyen](https://github.com/tvdeyen)
+  Pass normal params instead.
 * Removed `redirect_back_or_to_default` from `Alchemy::Admin::BaseController`
   Use Rails' `redirect_back` with a `fallback_location` instead
 * Deprecated controller requests test helpers [#1284](https://github.com/AlchemyCMS/alchemy_cms/pull/1284) by [tvdeyen](https://github.com/tvdeyen)

--- a/app/controllers/alchemy/admin/attachments_controller.rb
+++ b/app/controllers/alchemy/admin/attachments_controller.rb
@@ -23,7 +23,6 @@ module Alchemy
           .page(params[:page] || 1)
           .per(15)
 
-        @options = options_from_params
         if in_overlay?
           archive_overlay
         end
@@ -92,7 +91,6 @@ module Alchemy
 
       def archive_overlay
         @content = Content.find_by(id: params[:content_id])
-        @options = options_from_params
         respond_to do |format|
           format.html { render partial: 'archive_overlay' }
           format.js   { render action:  'archive_overlay' }

--- a/app/controllers/alchemy/admin/base_controller.rb
+++ b/app/controllers/alchemy/admin/base_controller.rb
@@ -9,7 +9,8 @@ module Alchemy
       before_action { enforce_ssl if ssl_required? && !request.ssl? }
       before_action :load_locked_pages
 
-      helper_method :clipboard_empty?, :trash_empty?, :get_clipboard, :is_admin?
+      helper_method :clipboard_empty?, :trash_empty?, :get_clipboard, :is_admin?,
+        :options_from_params
 
       check_authorization
 

--- a/app/controllers/alchemy/admin/base_controller.rb
+++ b/app/controllers/alchemy/admin/base_controller.rb
@@ -127,19 +127,15 @@ module Alchemy
         end
       end
 
-      # Extracts options from params.
+      # Extracts options from params and permits all keys
       #
-      # Helps to parse JSONified options into Hash or Array
+      # If no options are present it returns an empty parameters hash.
       #
+      # @returns [ActionController::Parameters]
       def options_from_params
-        case params[:options]
-        when '', nil
-          {}
-        when String
-          JSON.parse(params[:options])
-        else
-          params[:options].permit!.to_h
-        end.deep_symbolize_keys
+        @_options_from_params ||= begin
+          (params[:options] || ActionController::Parameters.new).permit!
+        end
       end
 
       # This method decides if we want to raise an exception or not.

--- a/app/controllers/alchemy/admin/contents_controller.rb
+++ b/app/controllers/alchemy/admin/contents_controller.rb
@@ -26,7 +26,6 @@ module Alchemy
         else
           @content_dom_id = "#add_content_for_element_#{@element.id}"
         end
-        @locals = essence_editor_locals
       end
 
       def update
@@ -58,14 +57,6 @@ module Alchemy
 
       def picture_gallery_editor?
         params[:content][:essence_type] == 'Alchemy::EssencePicture' && @options[:grouped] == 'true'
-      end
-
-      def essence_editor_locals
-        {
-          content: @content,
-          options: @options.symbolize_keys,
-          html_options: @html_options.symbolize_keys
-        }
       end
     end
   end

--- a/app/controllers/alchemy/admin/contents_controller.rb
+++ b/app/controllers/alchemy/admin/contents_controller.rb
@@ -9,19 +9,17 @@ module Alchemy
 
       def new
         @element = Element.find(params[:element_id])
-        @options = options_from_params
         @content = @element.contents.build
       end
 
       def create
         @element = Element.find(params[:content][:element_id])
         @content = Content.create_from_scratch(@element, content_params)
-        @options = options_from_params
         @html_options = params[:html_options] || {}
         if picture_gallery_editor?
           @content.update_essence(picture_id: params[:picture_id])
           @gallery_pictures = @element.contents.gallery_pictures
-          @options[:sortable] = @gallery_pictures.size > 1
+          options_from_params[:sortable] = @gallery_pictures.size > 1
           @content_dom_id = "#add_picture_#{@element.id}"
         else
           @content_dom_id = "#add_content_for_element_#{@element.id}"
@@ -56,7 +54,7 @@ module Alchemy
       end
 
       def picture_gallery_editor?
-        params[:content][:essence_type] == 'Alchemy::EssencePicture' && @options[:grouped] == 'true'
+        params[:content][:essence_type] == 'Alchemy::EssencePicture' && options_from_params[:grouped] == 'true'
       end
     end
   end

--- a/app/controllers/alchemy/admin/contents_controller.rb
+++ b/app/controllers/alchemy/admin/contents_controller.rb
@@ -20,7 +20,8 @@ module Alchemy
         @html_options = params[:html_options] || {}
         if picture_gallery_editor?
           @content.update_essence(picture_id: params[:picture_id])
-          @options = options_for_picture_gallery
+          @gallery_pictures = @element.contents.gallery_pictures
+          @options[:sortable] = @gallery_pictures.size > 1
           @content_dom_id = "#add_picture_#{@element.id}"
         else
           @content_dom_id = "#add_content_for_element_#{@element.id}"
@@ -57,11 +58,6 @@ module Alchemy
 
       def picture_gallery_editor?
         params[:content][:essence_type] == 'Alchemy::EssencePicture' && @options[:grouped] == 'true'
-      end
-
-      def options_for_picture_gallery
-        @gallery_pictures = @element.contents.gallery_pictures
-        @options.merge(sortable: @gallery_pictures.size > 1)
       end
 
       def essence_editor_locals

--- a/app/controllers/alchemy/admin/essence_files_controller.rb
+++ b/app/controllers/alchemy/admin/essence_files_controller.rb
@@ -11,7 +11,6 @@ module Alchemy
 
       def edit
         @content = @essence_file.content
-        @options = options_from_params
       end
 
       def update
@@ -26,7 +25,6 @@ module Alchemy
         @content = Content.find_by(id: params[:content_id])
         @attachment = Attachment.find_by(id: params[:attachment_id])
         @content.essence.attachment = @attachment
-        @options = options_from_params
 
         # We need to update timestamp here because we don't save yet,
         # but the cache needs to be get invalid.

--- a/app/controllers/alchemy/admin/essence_pictures_controller.rb
+++ b/app/controllers/alchemy/admin/essence_pictures_controller.rb
@@ -8,7 +8,6 @@ module Alchemy
 
       before_action :load_essence_picture, only: [:edit, :crop, :update]
       before_action :load_content, only: [:edit, :update, :assign]
-      before_action :load_options
 
       helper 'alchemy/admin/contents'
       helper 'alchemy/admin/essences'
@@ -20,7 +19,7 @@ module Alchemy
       def crop
         if @picture = @essence_picture.picture
           @content = @essence_picture.content
-          @options[:format] ||= (configuration(:image_store_format) || 'png')
+          options_from_params[:format] ||= (configuration(:image_store_format) || 'png')
 
           @min_size = sizes_from_essence_or_params
           @ratio = ratio_from_size_or_params
@@ -63,10 +62,6 @@ module Alchemy
 
       private
 
-      def load_options
-        @options = options_from_params
-      end
-
       def load_essence_picture
         @essence_picture = EssencePicture.find(params[:id])
       end
@@ -82,8 +77,8 @@ module Alchemy
       def sizes_from_essence_or_params
         if @essence_picture.render_size?
           @essence_picture.sizes_from_string(@essence_picture.render_size)
-        elsif @options[:size]
-          @essence_picture.sizes_from_string(@options[:size])
+        elsif options_from_params[:size]
+          @essence_picture.sizes_from_string(options_from_params[:size])
         else
           { width: 0, height: 0 }
         end
@@ -93,8 +88,8 @@ module Alchemy
       # aspect ratio, don't specify a size or only width or height.
       #
       def ratio_from_size_or_params
-        if @min_size.value?(0) && @options[:fixed_ratio].to_s =~ FLOAT_REGEX
-          @options[:fixed_ratio].to_f
+        if @min_size.value?(0) && options_from_params[:fixed_ratio].to_s =~ FLOAT_REGEX
+          options_from_params[:fixed_ratio].to_f
         elsif !@min_size[:width].zero? && !@min_size[:height].zero?
           @min_size[:width].to_f / @min_size[:height].to_f
         else

--- a/app/controllers/alchemy/admin/pictures_controller.rb
+++ b/app/controllers/alchemy/admin/pictures_controller.rb
@@ -129,7 +129,6 @@ module Alchemy
       def archive_overlay
         @content = Content.select('id').find_by(id: params[:content_id])
         @element = Element.select('id').find_by(id: params[:element_id])
-        @options = options_from_params
 
         respond_to do |format|
           format.html { render partial: 'archive_overlay' }

--- a/app/helpers/alchemy/admin/tags_helper.rb
+++ b/app/helpers/alchemy/admin/tags_helper.rb
@@ -102,7 +102,7 @@ module Alchemy
           :controller,
           :content_id,
           :element_id,
-          :options,
+          {options: options_from_params.keys},
           :swap,
           :use_route,
           :tagged_with,

--- a/app/views/alchemy/admin/attachments/_archive_overlay.html.erb
+++ b/app/views/alchemy/admin/attachments/_archive_overlay.html.erb
@@ -8,7 +8,7 @@
       redirect_url: admin_attachments_path(
         element_id: @element.try(:id),
         content_id: @content.try(:id),
-        options: @options ? @options.to_json : nil
+        options: options_from_params
       ) %>
   <% end %>
   <%= render 'alchemy/admin/partials/remote_search_form' %>

--- a/app/views/alchemy/admin/attachments/_file_to_assign.html.erb
+++ b/app/views/alchemy/admin/attachments/_file_to_assign.html.erb
@@ -2,7 +2,7 @@
   <%= link_to alchemy.assign_admin_essence_files_path(
       attachment_id: file_to_assign.id,
       content_id: @content.id,
-      options: @options.to_json
+      options: options_from_params
     ),
     remote: true,
     method: 'put' do %>

--- a/app/views/alchemy/admin/contents/_missing.html.erb
+++ b/app/views/alchemy/admin/contents/_missing.html.erb
@@ -9,7 +9,7 @@
           name: name
         },
         was_missing: true,
-        options: options.to_json
+        options: options
       ),
       'data-create-missing-content' => true,
       class: 'small button' %>

--- a/app/views/alchemy/admin/contents/create.js.erb
+++ b/app/views/alchemy/admin/contents/create.js.erb
@@ -1,20 +1,16 @@
+var editor_html = '<%= j(render "alchemy/essences/#{@content.essence_partial_name}_editor", {
+  content: @content,
+  options: options_from_params.symbolize_keys,
+  html_options: @html_options.symbolize_keys
+}) %>';
+
 <% if params[:was_missing] %>
 
-$("[data-element-<%= @element.id %>-missing-content=\"<%= @content.name %>\"]").replaceWith('<%= j(
-  render(
-    partial: "alchemy/essences/#{@content.essence_partial_name}_editor",
-    locals: @locals
-  )
-) %>');
+$("[data-element-<%= @element.id %>-missing-content=\"<%= @content.name %>\"]").replaceWith(editor_html);
 
 <% else %>
 
-$("<%= @content_dom_id %>").before('<%= j(
-  render(
-    partial: "alchemy/essences/#{@content.essence_partial_name}_editor",
-    locals: @locals
-  )
-) %>');
+$("<%= @content_dom_id %>").before(editor_html);
 Alchemy.Buttons.enable();
 Alchemy.growl('<%= j Alchemy.t("Successfully added content") % {content: @content.name_for_label} %>')
 

--- a/app/views/alchemy/admin/contents/new.html.erb
+++ b/app/views/alchemy/admin/contents/new.html.erb
@@ -1,6 +1,6 @@
 <%= alchemy_form_for [:admin, @content] do |f| %>
   <%= f.hidden_field :element_id %>
-  <%= hidden_field_tag('options', @options.to_json) %>
+  <%= hidden_field_tag('options', options_from_params) %>
   <%= f.input :name, collection: @contents.map { |content|
       [
         Alchemy.t(content['name'], scope: 'content_names', default: content['name'].humanize),

--- a/app/views/alchemy/admin/essence_files/assign.js.erb
+++ b/app/views/alchemy/admin/essence_files/assign.js.erb
@@ -2,7 +2,7 @@ $('#<%= @content.dom_id %>').replaceWith('<%= j(
   render "alchemy/essences/essence_file_editor",
     formats: [:html],
     content: @content,
-    options: @options
+    options: options_from_params
 ) %>');
 Alchemy.closeCurrentDialog();
 Alchemy.setElementDirty($('#element_<%= @content.element.id %>'));

--- a/app/views/alchemy/admin/essence_pictures/assign.js.erb
+++ b/app/views/alchemy/admin/essence_pictures/assign.js.erb
@@ -3,7 +3,7 @@ $('#<%= @content.dom_id -%>').replaceWith('<%= j(
   render(
     "alchemy/essences/essence_picture_editor",
     content: @content,
-    options: @options
+    options: options_from_params
   )
 ) %>');
 

--- a/app/views/alchemy/admin/essence_pictures/crop.html.erb
+++ b/app/views/alchemy/admin/essence_pictures/crop.html.erb
@@ -12,7 +12,7 @@
   </div>
   <%= form_for(
     @essence_picture,
-    url: alchemy.admin_essence_picture_path(@essence_picture, options: @options.to_json),
+    url: alchemy.admin_essence_picture_path(@essence_picture, options: options_from_params),
     id: 'image_cropper_form',
     remote: true
   ) do |f| %>

--- a/app/views/alchemy/admin/essence_pictures/destroy.js.erb
+++ b/app/views/alchemy/admin/essence_pictures/destroy.js.erb
@@ -9,7 +9,7 @@
       $picture_editor.append('<%= j(
         render "alchemy/admin/elements/add_picture",
           element: @element,
-          options: @options
+          options: options_from_params
       ) %>');
     }
 

--- a/app/views/alchemy/admin/essence_pictures/edit.html.erb
+++ b/app/views/alchemy/admin/essence_pictures/edit.html.erb
@@ -1,18 +1,20 @@
 <%= alchemy_form_for @essence_picture,
-    url: alchemy.admin_essence_picture_path(@essence_picture, options: @options.to_json) do |f| %>
+    url: alchemy.admin_essence_picture_path(@essence_picture, options: options_from_params) do |f| %>
   <%= hidden_field_tag 'content_id', @content.id %>
-  <%= f.input :caption, as: @options[:caption_as_textarea] ? 'text' : 'string' %>
+  <%= f.input :caption, as: options_from_params[:caption_as_textarea] ? 'text' : 'string' %>
   <%= f.input :title %>
   <%= f.input :alt_tag %>
-  <%- if @options[:sizes].present? -%>
+  <%- if options_from_params[:sizes].present? -%>
     <%= f.input :render_size,
-      collection: [[Alchemy.t('Layout default'), @options[:size]]] + @options[:sizes].to_a,
+      collection: [
+        [Alchemy.t('Layout default'), options_from_params[:size]]
+      ] + options_from_params[:sizes].to_a,
       include_blank: false,
       input_html: {class: 'alchemy_selectbox'} %>
   <%- end -%>
-  <%- if @options[:css_classes].present? -%>
+  <%- if options_from_params[:css_classes].present? -%>
     <%= f.input :css_class,
-      collection: @options[:css_classes],
+      collection: options_from_params[:css_classes],
       include_blank: Alchemy.t('None'),
       input_html: {class: 'alchemy_selectbox'} %>
   <%- else -%>

--- a/app/views/alchemy/admin/essence_pictures/update.js.erb
+++ b/app/views/alchemy/admin/essence_pictures/update.js.erb
@@ -3,7 +3,7 @@
   Alchemy.closeCurrentDialog();
   Alchemy.setElementDirty('#element_<%= @content.element.id %>');
 <% if @content.ingredient %>
-  $('.thumbnail_background img', '#<%= @content.dom_id %>').replaceWith('<%= essence_picture_thumbnail(@content, @options) %>');
+  $('.thumbnail_background img', '#<%= @content.dom_id %>').replaceWith('<%= essence_picture_thumbnail(@content, options_from_params) %>');
   Alchemy.ImageLoader('#<%= @content.dom_id %> .thumbnail_background');
 <% end %>
 })(jQuery);

--- a/app/views/alchemy/admin/partials/_remote_search_form.html.erb
+++ b/app/views/alchemy/admin/partials/_remote_search_form.html.erb
@@ -1,6 +1,6 @@
 <%= search_form_for @query, url: url_for(
     action: 'index',
-    options: @options.to_json,
+    options: options_from_params,
     size: @size
   ), remote: true, html: {class: 'search_form', id: nil} do |f| %>
   <%= hidden_field_tag("element_id", @element.blank? ? "" : @element.id) %>
@@ -15,7 +15,7 @@
         action: 'index',
         element_id: @element.blank? ? '' : @element.id,
         content_id: @content.blank? ? '' : @content.id,
-        options: @options.to_json,
+        options: options_from_params,
         size: @size,
         overlay: true
       ),

--- a/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
+++ b/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
@@ -10,7 +10,7 @@
         filter: 'last_upload',
         content_id: @content.try(:id),
         element_id: @element.try(:id),
-        options: @options
+        options: options_from_params
       ) %>
     <div class="toolbar_spacer"></div>
   <% end %>
@@ -23,7 +23,7 @@
           content_id: @content,
           element_id: @element,
           q: params[:q],
-          options: @options.to_json,
+          options: options_from_params,
           filter: params[:filter],
           tagged_with: params[:tagged_with]
         }),
@@ -40,7 +40,7 @@
           content_id: @content,
           element_id: @element,
           q: params[:q],
-          options: @options.to_json,
+          options: options_from_params,
           filter: params[:filter],
           tagged_with: params[:tagged_with]
         }),
@@ -57,7 +57,7 @@
           content_id: @content,
           element_id: @element,
           q: params[:q],
-          options: @options.to_json,
+          options: options_from_params,
           filter: params[:filter],
           tagged_with: params[:tagged_with]
         }),

--- a/app/views/alchemy/admin/pictures/_overlay_picture_list.html.erb
+++ b/app/views/alchemy/admin/pictures/_overlay_picture_list.html.erb
@@ -6,6 +6,6 @@
 <% else %>
   <%= render partial: 'picture_to_assign',
     collection: @pictures,
-    locals: {options: @options, size: @size} %>
+    locals: {options: options_from_params, size: @size} %>
   <%= paginate @pictures, theme: 'alchemy', remote: true %>
 <% end %>

--- a/app/views/alchemy/admin/pictures/_picture_to_assign.html.erb
+++ b/app/views/alchemy/admin/pictures/_picture_to_assign.html.erb
@@ -1,5 +1,5 @@
 <div class="picture_thumbnail assign_image_list_detail <%= size.blank? ? 'medium' : size %>" name="<%= picture_to_assign.name %>" id="picture_to_assign_<%= picture_to_assign.id %>">
-  <% action_url = create_or_assign_url(picture_to_assign, @options.to_json) %>
+  <% action_url = create_or_assign_url(picture_to_assign, options) %>
   <%= link_to(
     image_tag(
       picture_to_assign.url(size: preview_size(size), flatten: true),

--- a/app/views/alchemy/essences/_essence_file_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_file_editor.html.erb
@@ -3,7 +3,7 @@
     content_id: content.id,
     only: content.settings_value(:only, local_assigns.fetch(:options, {})),
     except: content.settings_value(:except, local_assigns.fetch(:options, {})),
-    options: local_assigns.fetch(:options, {}).to_json
+    options: local_assigns.fetch(:options, {})
   ),
   {
     title: Alchemy.t(:assign_file),
@@ -35,7 +35,7 @@
       <%= link_to_dialog '',
         alchemy.edit_admin_essence_file_path(
           id: content.essence.id,
-          options: local_assigns.fetch(:options, {}).to_json
+          options: local_assigns.fetch(:options, {})
         ),
         {
           title: Alchemy.t(:edit_file_properties),

--- a/app/views/alchemy/essences/shared/_essence_picture_tools.html.erb
+++ b/app/views/alchemy/essences/shared/_essence_picture_tools.html.erb
@@ -4,7 +4,7 @@
   <%= link_to_dialog render_icon('crop'),
     alchemy.crop_admin_essence_picture_path(
       content.essence,
-      options: content.settings.update(options).to_json
+      options: content.settings.update(options)
     ), {
       size: "1000x615",
       title: Alchemy.t('Edit Picturemask'),
@@ -20,7 +20,7 @@
     element_id: content.element,
     content_id: content.id,
     swap: true,
-    options: options.to_json
+    options: options
   ),
   {
     title: (content.ingredient ? Alchemy.t(:swap_image) : Alchemy.t(:insert_image)),
@@ -47,7 +47,7 @@
   alchemy.edit_admin_essence_picture_path(
     id: content.essence.id,
     content_id: content.id,
-    options: options.to_json
+    options: options
   ), {
     title: Alchemy.t(:edit_image_properties),
     size: edit_picture_dialog_size(content, options)

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -7,7 +7,7 @@
       "check_name": "MassAssignment",
       "message": "Parameters should be whitelisted for mass assignment",
       "file": "app/controllers/alchemy/admin/resources_controller.rb",
-      "line": 124,
+      "line": 128,
       "link": "http://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.require(resource_handler.namespaced_resource_name).permit!",
       "render_path": null,
@@ -21,13 +21,32 @@
       "note": "Because we actually can't know all attributes each inheriting controller supports, we permit all resource model params. It is adviced that all inheriting controllers implement this method and provide its own set of permitted attributes. As this all happens inside the password protected /admin namespace this can be considered a false positive."
     },
     {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "26461414e9f6be7b68dd8c7dda1c69b09c92a8e9997c0ac204e1756cae7f3d68",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/alchemy/admin/contents/create.js.erb",
+      "line": 1,
+      "link": "http://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => \"alchemy/essences/#{Content.create_from_scratch(Element.find(params[:content][:element_id]), content_params).essence_partial_name}_editor\", { :content => Content.create_from_scratch(Element.find(params[:content][:element_id]), content_params), :options => options_from_params.symbolize_keys, :html_options => (params[:html_options] or {}).symbolize_keys })",
+      "render_path": [{"type":"controller","class":"Alchemy::Admin::ContentsController","method":"create","line":21,"file":"app/controllers/alchemy/admin/contents_controller.rb"}],
+      "location": {
+        "type": "template",
+        "template": "alchemy/admin/contents/create"
+      },
+      "user_input": "params[:content][:element_id]",
+      "confidence": "Weak",
+      "note": "This dynamic render path comes from the Contents essence not from any params or user mutated string. This can safely be ignored."
+    },
+    {
       "warning_type": "Mass Assignment",
       "warning_code": 70,
       "fingerprint": "4b4dc24a6f5251bc1a6851597dfcee39608a2932eb7f81a4a241c00fca8a3043",
       "check_name": "MassAssignment",
       "message": "Parameters should be whitelisted for mass assignment",
       "file": "app/controllers/alchemy/admin/elements_controller.rb",
-      "line": 166,
+      "line": 168,
       "link": "http://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.fetch(:contents, {}).permit!",
       "render_path": null,
@@ -41,6 +60,6 @@
       "note": "`Alchemy::Content` is a polymorphic association of any kind of model extending `Alchemy::Essence`. Since we can't know the attributes of all potential essences we need to permit all attributes. As this all happens inside the password protected /admin namespace this can be considered a false positive."
     }
   ],
-  "updated": "2017-07-17 11:09:19 +0200",
+  "updated": "2017-08-16 15:07:26 +0200",
   "brakeman_version": "3.7.0"
 }

--- a/spec/controllers/alchemy/admin/base_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/base_controller_spec.rb
@@ -10,29 +10,15 @@ describe Alchemy::Admin::BaseController do
       end
     end
 
-    context "params[:options] is a JSON string" do
-      let(:options) { '{"hallo":"World"}' }
-
-      it "parses the string into an object" do
-        expect(subject).to eq({hallo: 'World'})
-      end
-    end
-
     context "params[:options] are Rails parameters" do
       let(:options) do
         ActionController::Parameters.new('hallo' => {'great' => 'World'})
       end
 
-      it "returns the options as hash with permitted and deeply symbolized keys" do
-        expect(subject).to be_an_instance_of(Hash)
+      it "returns the options as permitted parameters with indifferent access" do
+        expect(subject).to be_permitted
         expect(subject).to eq({hallo: {great: 'World'}})
       end
-    end
-
-    context "params[:options] is an empty string" do
-      let(:options) { '' }
-
-      it { is_expected.to eq({}) }
     end
 
     context "params[:options] is nil" do

--- a/spec/helpers/alchemy/admin/tags_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/tags_helper_spec.rb
@@ -16,6 +16,9 @@ module Alchemy
 
     before do
       allow(helper).to receive(:params) { params }
+      allow(helper).to receive(:options_from_params) do
+        ActionController::Parameters.new.permit!
+      end
     end
 
     describe '#render_tag_list' do
@@ -70,13 +73,13 @@ module Alchemy
 
       context "without any tagged objects" do
         it "returns empty string" do
-          expect(render_tag_list('Alchemy::Attachment')).to be_empty
+          expect(helper.render_tag_list('Alchemy::Attachment')).to be_empty
         end
       end
 
       context "with nil given as class_name parameter" do
         it "raises argument error" do
-          expect { render_tag_list(nil) }.to raise_error(ArgumentError)
+          expect { helper.render_tag_list(nil) }.to raise_error(ArgumentError)
         end
       end
     end
@@ -84,7 +87,7 @@ module Alchemy
     describe '#tag_list_tag_active?' do
       context "the tag is in params" do
         it "returns true" do
-          expect(tag_list_tag_active?(tag)).to be_truthy
+          expect(helper.tag_list_tag_active?(tag)).to be_truthy
         end
       end
 
@@ -98,7 +101,7 @@ module Alchemy
         end
 
         it "returns false" do
-          expect(tag_list_tag_active?(tag)).to be_falsey
+          expect(helper.tag_list_tag_active?(tag)).to be_falsey
         end
       end
     end

--- a/spec/views/essences/essence_file_editor_spec.rb
+++ b/spec/views/essences/essence_file_editor_spec.rb
@@ -25,24 +25,24 @@ describe 'alchemy/essences/_essence_editor_view' do
     end
 
     it "renders a link to open the attachment library overlay" do
-      is_expected.to have_selector("a.assign_file[href='/admin/attachments?content_id=#{content.id}&options=%7B%7D']")
+      is_expected.to have_selector("a.assign_file[href='/admin/attachments?content_id=#{content.id}']")
     end
 
     it "renders a link to edit the essence" do
-      is_expected.to have_selector("a.edit_file[href='/admin/essence_files/#{essence.id}/edit?options=%7B%7D']")
+      is_expected.to have_selector("a.edit_file[href='/admin/essence_files/#{essence.id}/edit']")
     end
 
     context 'with content settings `only`' do
       it "renders a link to open the attachment library overlay with only pdfs" do
         expect(content).to receive(:settings).at_least(:once).and_return({only: 'pdf'})
-        is_expected.to have_selector("a.assign_file[href='/admin/attachments?content_id=#{content.id}&only=pdf&options=%7B%7D']")
+        is_expected.to have_selector("a.assign_file[href='/admin/attachments?content_id=#{content.id}&only=pdf']")
       end
     end
 
     context 'with content settings `except`' do
       it "renders a link to open the attachment library overlay without pdfs" do
         expect(content).to receive(:settings).at_least(:once).and_return({except: 'pdf'})
-        is_expected.to have_selector("a.assign_file[href='/admin/attachments?content_id=#{content.id}&except=pdf&options=%7B%7D']")
+        is_expected.to have_selector("a.assign_file[href='/admin/attachments?content_id=#{content.id}&except=pdf']")
       end
     end
   end


### PR DESCRIPTION
Currently it is possible to pass options as JSON string additionally to normal
form parameters. This is unnecessary and error prone. In order to make the Rails 5.1
update smooth as possible we remove this functionality.