### PR TITLE
Pass search filter params with resource filter requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 4.0.0 (unreleased)
 
+* Removed `tag_list_tag_active?` from `Alchemy::Admin::TagsHelper`
+  Use `filtered_by_tag?` instead
+* Removed `add_to_tag_filter` and `remove_from_tag_filter` from `Alchemy::Admin::TagsHelper`
+  Use `tags_for_filter` and pass the `current` tag instead
 * Removes the possibility to pass options param as JSON string. [#1291](https://github.com/AlchemyCMS/alchemy_cms/pull/1291) by [tvdeyen](https://github.com/tvdeyen)
   Pass normal params instead.
 * Removed `redirect_back_or_to_default` from `Alchemy::Admin::BaseController`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.0.0 (unreleased)
 
+* Removed `merge_params_without` from `Alchemy::Admin::BaseHelper`
+  Use `ActionController::Parameters#delete_if` instead
 * Removed `tag_list_tag_active?` from `Alchemy::Admin::TagsHelper`
   Use `filtered_by_tag?` instead
 * Removed `add_to_tag_filter` and `remove_from_tag_filter` from `Alchemy::Admin::TagsHelper`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.0.0 (unreleased)
 
+* Removed `merge_params_only` from `Alchemy::Admin::BaseHelper`
+  Use methods from `ActionController::Parameters` instead
 * Removed `merge_params_without` from `Alchemy::Admin::BaseHelper`
   Use `ActionController::Parameters#delete_if` instead
 * Removed `tag_list_tag_active?` from `Alchemy::Admin::TagsHelper`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.0.0 (unreleased)
 
+* Removed `merge_params` from `Alchemy::Admin::BaseHelper`
+  Use `ActionController::Parameters#merge` instead
 * Removed `merge_params_only` from `Alchemy::Admin::BaseHelper`
   Use methods from `ActionController::Parameters` instead
 * Removed `merge_params_without` from `Alchemy::Admin::BaseHelper`

--- a/app/controllers/alchemy/admin/attachments_controller.rb
+++ b/app/controllers/alchemy/admin/attachments_controller.rb
@@ -45,7 +45,7 @@ module Alchemy
         else
           render_errors_or_redirect(
             @attachment,
-            admin_attachments_path(search_params),
+            admin_attachments_path(search_filter_params),
             Alchemy.t("File successfully updated")
           )
         end
@@ -54,7 +54,7 @@ module Alchemy
       def destroy
         name = @attachment.name
         @attachment.destroy
-        @url = admin_attachments_url(search_params)
+        @url = admin_attachments_url(search_filter_params)
         flash[:notice] = Alchemy.t('File deleted successfully', name: name)
       end
 
@@ -68,12 +68,12 @@ module Alchemy
 
       private
 
-      def search_params
-        params.except(:attachment, :id).permit(
-          :file_type,
-          :page,
-          {q: resource_handler.search_field_name},
-          :tagged_with
+      def search_filter_params
+        params.except(*COMMON_SEARCH_FILTER_EXCLUDES + [:attachment]).permit(
+          *common_search_filter_includes + [
+            :file_type,
+            :content_id
+          ]
         )
       end
 

--- a/app/controllers/alchemy/admin/pictures_controller.rb
+++ b/app/controllers/alchemy/admin/pictures_controller.rb
@@ -137,16 +137,17 @@ module Alchemy
       end
 
       def redirect_to_index
-        do_redirect_to admin_pictures_path(search_params)
+        do_redirect_to admin_pictures_path(search_filter_params)
       end
 
-      def search_params
-        params.except(:id, :picture_ids).permit(
-          :filter,
-          :page,
-          {q: resource_handler.search_field_name},
-          :size,
-          :tagged_with
+      def search_filter_params
+        params.except(*COMMON_SEARCH_FILTER_EXCLUDES + [:picture_ids]).permit(
+          *common_search_filter_includes + [
+            :size,
+            :element_id,
+            :swap,
+            :content_id
+          ]
         )
       end
 

--- a/app/helpers/alchemy/admin/base_helper.rb
+++ b/app/helpers/alchemy/admin/base_helper.rb
@@ -385,18 +385,6 @@ module Alchemy
         params.merge(p).delete_if { |_k, v| v.blank? }
       end
 
-      # Deletes all params from the params-hash except the given ones and merges some new params in
-      def merge_params_only(includes, p = {})
-        current_params = params.clone.symbolize_keys
-        if includes.is_a?(Array)
-          symbolized_includes = includes.map(&:to_sym)
-          current_params.delete_if { |k, _v| !symbolized_includes.include?(k) }
-        else
-          current_params.delete_if { |k, _v| k != includes.to_sym }
-        end
-        current_params.merge(p).delete_if { |_k, v| v.blank? }
-      end
-
       # Render a hint icon with tooltip for given object.
       # The model class needs to include the hints module
       def render_hint_for(element)

--- a/app/helpers/alchemy/admin/base_helper.rb
+++ b/app/helpers/alchemy/admin/base_helper.rb
@@ -385,17 +385,6 @@ module Alchemy
         params.merge(p).delete_if { |_k, v| v.blank? }
       end
 
-      # Deletes one or several params from the params-hash and merges some new params in
-      def merge_params_without(excludes, p = {})
-        current_params = params.clone.symbolize_keys
-        if excludes.is_a?(Array)
-          excludes.map { |i| current_params.delete(i.to_sym) }
-        else
-          current_params.delete(excludes.to_sym)
-        end
-        current_params.merge(p).delete_if { |_k, v| v.blank? }
-      end
-
       # Deletes all params from the params-hash except the given ones and merges some new params in
       def merge_params_only(includes, p = {})
         current_params = params.clone.symbolize_keys

--- a/app/helpers/alchemy/admin/base_helper.rb
+++ b/app/helpers/alchemy/admin/base_helper.rb
@@ -380,11 +380,6 @@ module Alchemy
           method.to_sym, {type: "text", class: type, "data-datepicker-type" => type, value: value}.merge(html_options)
       end
 
-      # Merges the params-hash with the given hash
-      def merge_params(p = {})
-        params.merge(p).delete_if { |_k, v| v.blank? }
-      end
-
       # Render a hint icon with tooltip for given object.
       # The model class needs to include the hints module
       def render_hint_for(element)

--- a/app/helpers/alchemy/admin/tags_helper.rb
+++ b/app/helpers/alchemy/admin/tags_helper.rb
@@ -13,102 +13,48 @@ module Alchemy
       #
       def render_tag_list(class_name)
         raise ArgumentError, 'Please provide a String as class_name' if class_name.nil?
-        li_s = []
-        class_name.constantize.tag_counts.sort { |x, y| x.name.downcase <=> y.name.downcase }.each do |tag|
-          tags = filtered_by_tag?(tag) ? tag_filter(remove: tag) : tag_filter(add: tag)
-          li_s << content_tag('li', name: tag.name, class: tag_list_tag_active?(tag) ? 'active' : nil) do
+        sorted_tags_from(class_name: class_name).map do |tag|
+          content_tag('li', name: tag.name, class: filtered_by_tag?(tag) ? 'active' : nil) do
             link_to(
               "#{tag.name} (#{tag.count})",
               url_for(
-                tag_list_params.reject { |k, _v| k == "page" }.merge(
-                  action: 'index',
-                  tagged_with: tags
+                search_filter_params.except(:page, :tagged_with).merge(
+                  tagged_with: tags_for_filter(current: tag).presence
                 )
               ),
               remote: request.xhr?,
               class: 'please_wait'
             )
           end
-        end
-        li_s.join.html_safe
+        end.join.html_safe
       end
 
-      # Returns true if the given tag is in +params[:tag_list]+
+      # Returns true if the given tag is in +params[:tagged_with]+
       #
-      # @param tag [ActsAsTaggableOn::Tag]
-      #   the tag
-      # @param params [Hash]
-      #   url params
-      # @return [Boolean]
-      #
-      def tag_list_tag_active?(tag)
-        tag_list_params[:tagged_with].to_s.split(',').include?(tag.name)
-      end
-
-      # Checks if the tagged_with param contains the given tag
       def filtered_by_tag?(tag)
-        if tag_list_params[:tagged_with].present?
-          tags = tag_list_params[:tagged_with].split(',')
-          tags.include?(tag.name)
-        else
-          false
-        end
+        tags_from_params.include?(tag.name)
       end
 
-      # Adds the given tag to the tag filter.
-      def add_to_tag_filter(tag)
-        if tag_list_params[:tagged_with].present?
-          tags = tag_list_params[:tagged_with].split(',')
-          tags << tag.name
-        else
-          [tag.name]
-        end
-      end
-
-      # Removes the given tag from the tag filter.
-      def remove_from_tag_filter(tag)
-        if tag_list_params[:tagged_with].present?
-          tags = tag_list_params[:tagged_with].split(',')
-          tags.delete_if { |t| t == tag.name }
-        else
-          []
-        end
-      end
-
-      # Returns the tag filter from params.
+      # Returns the tags from params suitable for the tags filter.
       #
-      # A tag can be added to the filter.
-      # A tag can also be removed.
-      #
-      # Options are:
-      #   * options (Hash):
-      #   ** :add (ActsAsTaggableOn::Tag) - The tag that should be added to the tag-filter
-      #   ** :remove (ActsAsTaggableOn::Tag) - The tag that should be removed from the tag-filter
-      #
-      def tag_filter(options = {})
-        if options[:add]
-          taglist = add_to_tag_filter(options[:add])
-        elsif options[:remove]
-          taglist = remove_from_tag_filter(options[:remove])
+      # @param current [ActsAsTaggableOn::Tag] - The current tag that will be added or removed if already present
+      # @returns [String]
+      def tags_for_filter(current:)
+        if filtered_by_tag?(current)
+          tags_from_params - Array(current.name)
         else
-          return tag_list_params[:tagged_with]
-        end
-        return nil if taglist.blank?
-        taglist.uniq.join(',')
+          tags_from_params.push(current.name)
+        end.uniq.join(',')
       end
 
-      def tag_list_params
-        params.permit(
-          :controller,
-          :content_id,
-          :element_id,
-          {options: options_from_params.keys},
-          :swap,
-          :use_route,
-          :tagged_with,
-          :filter,
-          q: params.fetch(:q, {}).keys
-        )
+      # Returns tags from params
+      # @returns [Array]
+      def tags_from_params
+        search_filter_params[:tagged_with].to_s.split(',')
+      end
+
+      def sorted_tags_from(class_name:)
+        class_name.constantize.tag_counts.sort { |x, y| x.name.downcase <=> y.name.downcase }
       end
     end
   end

--- a/app/views/alchemy/admin/attachments/_filter_bar.html.erb
+++ b/app/views/alchemy/admin/attachments/_filter_bar.html.erb
@@ -1,5 +1,3 @@
-<% params_to_keep = [:tagged_with, :q, :content_id, :options] %>
-
 <div id="filter_bar">
   <h2><%= Alchemy.t('Filter') %></h2>
   <%= select_tag(
@@ -18,7 +16,7 @@
   $(function() {
     $('#file_type_filter').on('change', function(e) {
       var $this = $(this);
-      var url = '<%= alchemy.admin_attachments_path(merge_params_only(params_to_keep)).html_safe %>';
+      var url = '<%= alchemy.admin_attachments_path(search_filter_params.except(:file_type).to_h) %>';
       if ($this.data('remote') === true) {
         $.get(url, {file_type: $this.val()}, null, 'script');
       } else {

--- a/app/views/alchemy/admin/attachments/_tag_list.html.erb
+++ b/app/views/alchemy/admin/attachments/_tag_list.html.erb
@@ -7,7 +7,7 @@
   <% if params[:tagged_with].present? %>
     <%= link_to(
       render_icon('delete-small') + Alchemy.t('Remove tag filter'),
-      url_for(tag_list_params.delete_if { |k, v| k == "tagged_with" }.merge(action: 'index')),
+      url_for(search_filter_params.except(:tagged_with)),
       remote: request.xhr?,
       class: 'button small with_icon please_wait'
     ) %>

--- a/app/views/alchemy/admin/pictures/_filter_bar.html.erb
+++ b/app/views/alchemy/admin/pictures/_filter_bar.html.erb
@@ -1,5 +1,3 @@
-<% params_to_keep = [:size, :tagged_with, :query, :element_id, :options, :content_id, :_] %>
-
 <div id="filter_bar">
   <h2><%= Alchemy.t('Filter') %></h2>
   <%= select_tag(
@@ -19,7 +17,7 @@
   $(function() {
     $('#picture_filter').on('change', function(e) {
       var $this = $(this);
-      var url = '<%= alchemy.admin_pictures_path(merge_params_only(params_to_keep)).html_safe %>';
+      var url = '<%= alchemy.admin_pictures_path(search_filter_params.except(:filter).to_h) %>';
       if ($this.data('remote') === true) {
         $.get(url, {filter: $this.val()}, null, 'script');
       } else {

--- a/app/views/alchemy/admin/pictures/_tag_list.html.erb
+++ b/app/views/alchemy/admin/pictures/_tag_list.html.erb
@@ -7,7 +7,7 @@
   <% if params[:tagged_with].present? %>
     <%= link_to(
       render_icon('delete-small') + Alchemy.t('Remove tag filter'),
-      url_for(tag_list_params.delete_if { |k, v| k == "tagged_with" }.merge(action: 'index')),
+      url_for(search_filter_params.except(:tagged_with)),
       remote: request.xhr?,
       class: 'button small with_icon please_wait'
     ) %>

--- a/app/views/alchemy/admin/resources/_filter_bar.html.erb
+++ b/app/views/alchemy/admin/resources/_filter_bar.html.erb
@@ -1,5 +1,3 @@
-<% params_to_keep = [:tagged_with, :q] %>
-
 <div id="filter_bar">
   <h2><%= Alchemy.t('Filter') %></h2>
   <%= select_tag(
@@ -17,7 +15,7 @@
   $(function() {
     $('#resource_filter').on('change', function(e) {
       var $this = $(this);
-      var url = '<%= resources_path(resource_handler.namespaced_resources_name, merge_params_only(params_to_keep)).html_safe %>';
+      var url = '<%= resources_path(resource_handler.namespaced_resources_name, search_filter_params.except(:filter).to_h) %>';
       if ($this.data('remote') === true) {
         $.get(url, {filter: $this.val()}, null, 'script');
       } else {

--- a/app/views/alchemy/admin/resources/_tag_list.html.erb
+++ b/app/views/alchemy/admin/resources/_tag_list.html.erb
@@ -7,7 +7,7 @@
   <% if params[:tagged_with].present? %>
     <%= link_to(
       render_icon('delete-small') + Alchemy.t('Remove tag filter'),
-      url_for(tag_list_params.delete_if { |k, v| k == "tagged_with" }.merge(action: 'index')),
+      url_for(search_filter_params.except(:tagged_with)),
       remote: request.xhr?,
       class: 'button small with_icon please_wait'
     ) %>

--- a/spec/controllers/alchemy/admin/attachments_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/attachments_controller_spec.rb
@@ -153,7 +153,7 @@ module Alchemy
         end
 
         context 'with search params' do
-          let(:search_params) do
+          let(:search_filter_params) do
             {
               q: {name_or_file_name_cont: 'kitten'},
               tagged_with: 'cute',
@@ -165,11 +165,11 @@ module Alchemy
           subject do
             put :update, params: {
               id: attachment.id, attachment: {name: ''}
-            }.merge(search_params)
+            }.merge(search_filter_params)
           end
 
           it "passes them along" do
-            is_expected.to redirect_to admin_attachments_path(search_params)
+            is_expected.to redirect_to admin_attachments_path(search_filter_params)
           end
         end
       end
@@ -197,7 +197,7 @@ module Alchemy
       end
 
       context 'with search params' do
-        let(:search_params) do
+        let(:search_filter_params) do
           {
             q: {name_or_file_name_cont: 'kitten'},
             tagged_with: 'cute',
@@ -208,8 +208,8 @@ module Alchemy
 
         it "passes them along" do
           expect(attachment).to receive(:destroy) { true }
-          delete :destroy, params: {id: 1}.merge(search_params), xhr: true
-          expect(assigns(:url)).to eq admin_attachments_url(search_params.merge(host: 'test.host'))
+          delete :destroy, params: {id: 1}.merge(search_filter_params), xhr: true
+          expect(assigns(:url)).to eq admin_attachments_url(search_filter_params.merge(host: 'test.host'))
         end
       end
     end

--- a/spec/helpers/alchemy/admin/base_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/base_helper_spec.rb
@@ -42,29 +42,6 @@ module Alchemy
       end
     end
 
-    describe "#merge_params_without" do
-      before do
-        allow(controller).to receive(:params).and_return({first: '1', second: '2'})
-      end
-
-      it "can delete a single param" do
-        expect(helper.merge_params_without(:second)).to eq({first: '1'})
-      end
-
-      it "can delete several params" do
-        expect(helper.merge_params_without([:first, :second])).to eq({})
-      end
-
-      it "can delete a param and add new params at the same time" do
-        expect(helper.merge_params_without([:first], {third: '3'})).to eq({second: '2', third: '3'})
-      end
-
-      it "should not change params" do
-        helper.merge_params_without([:first])
-        expect(controller.params).to eq({first: '1', second: '2'})
-      end
-    end
-
     describe "#merge_params_only" do
       before do
         allow(controller).to receive(:params).and_return({first: '1', second: '2', third: '3'})

--- a/spec/helpers/alchemy/admin/base_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/base_helper_spec.rb
@@ -32,16 +32,6 @@ module Alchemy
       end
     end
 
-    describe "#merge_params" do
-      before do
-        allow(controller).to receive(:params).and_return({first: '1', second: '2'})
-      end
-
-      it "returns a hash that contains the current params and additional params given as attributes" do
-        expect(helper.merge_params(third: '3', fourth: '4')).to eq({first: '1', second: '2', third: '3', fourth: '4'})
-      end
-    end
-
     describe '#toolbar_button' do
       context "with permission" do
         before { allow(helper).to receive(:can?).and_return(true) }

--- a/spec/helpers/alchemy/admin/base_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/base_helper_spec.rb
@@ -42,29 +42,6 @@ module Alchemy
       end
     end
 
-    describe "#merge_params_only" do
-      before do
-        allow(controller).to receive(:params).and_return({first: '1', second: '2', third: '3'})
-      end
-
-      it "can keep a single param" do
-        expect(helper.merge_params_only(:second)).to eq({second: '2'})
-      end
-
-      it "can keep several params" do
-        expect(helper.merge_params_only([:first, :second])).to eq({first: '1', second: '2'})
-      end
-
-      it "can keep a param and add new params at the same time" do
-        expect(helper.merge_params_only([:first], {third: '3'})).to eq({first: '1', third: '3'})
-      end
-
-      it "should not change params" do
-        helper.merge_params_only([:first])
-        expect(controller.params).to eq({first: '1', second: '2', third: '3'})
-      end
-    end
-
     describe '#toolbar_button' do
       context "with permission" do
         before { allow(helper).to receive(:can?).and_return(true) }

--- a/spec/helpers/alchemy/admin/tags_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/tags_helper_spec.rb
@@ -6,74 +6,67 @@ module Alchemy
     let(:tag2) { mock_model(ActsAsTaggableOn::Tag, name: 'abc', count: 1) }
 
     let(:params) do
-      ActionController::Parameters.new({
-        controller: 'alchemy/admin/attachments',
-        action: 'index',
-        use_route: 'alchemy',
-        tagged_with: 'foo'
-      })
+      ActionController::Parameters.new(tagged_with: 'foo')
     end
 
     before do
-      allow(helper).to receive(:params) { params }
-      allow(helper).to receive(:options_from_params) do
-        ActionController::Parameters.new.permit!
+      allow(helper).to receive(:search_filter_params) do
+        params.permit!.merge(controller: 'admin/attachments', action: 'index', use_route: 'alchemy')
       end
     end
 
     describe '#render_tag_list' do
+      subject { helper.render_tag_list('Alchemy::Attachment') }
+
       context "with tagged objects" do
         before { allow(Attachment).to receive(:tag_counts).and_return([tag, tag2]) }
 
         it "returns a tag list as <li> tags" do
-          expect(helper.render_tag_list('Alchemy::Attachment')).to match(/li/)
+          is_expected.to match(/li/)
         end
 
         it "has the tags name in the li's name attribute" do
-          expect(helper.render_tag_list('Alchemy::Attachment')).to match(/li.+name="#{tag.name}"/)
+          is_expected.to match(/li.+name="#{tag.name}"/)
         end
 
         it "has active class if tag is present in params" do
-          expect(helper.render_tag_list('Alchemy::Attachment')).to match(/li.+class="active"/)
+          is_expected.to match(/li.+class="active"/)
         end
 
         it "tags are sorted alphabetically" do
-          expect(helper.render_tag_list('Alchemy::Attachment')).to match(/li.+name="#{tag2.name}.+li.+name="#{tag.name}/)
+          is_expected.to match(/li.+name="#{tag2.name}.+li.+name="#{tag.name}/)
         end
 
         context "with lowercase and uppercase tag names mixed" do
           let(:tag) { mock_model(ActsAsTaggableOn::Tag, name: 'Foo', count: 1) }
 
           it "tags are sorted alphabetically correctly" do
-            expect(helper.render_tag_list('Alchemy::Attachment')).to match(/li.+name="#{tag2.name}.+li.+name="#{tag.name}/)
+            is_expected.to match(/li.+name="#{tag2.name}.+li.+name="#{tag.name}/)
           end
         end
 
         it "output is html_safe" do
-          expect(helper.render_tag_list('Alchemy::Attachment').html_safe?).to be_truthy
+          expect(subject.html_safe?).to be(true)
         end
 
         context "when filter and search params are present" do
           let(:params) do
-            ActionController::Parameters.new({
-              controller: 'alchemy/admin/attachments',
-              action: 'index',
-              use_route: 'alchemy',
+            ActionController::Parameters.new(
               filter: 'foo',
               q: {name_eq: 'foo'}
-            })
+            )
           end
 
           it 'keeps them' do
-            expect(helper.render_tag_list('Alchemy::Attachment')).to match(/filter/)
-            expect(helper.render_tag_list('Alchemy::Attachment')).to match(/name_eq/)
+            is_expected.to match(/filter/)
+            is_expected.to match(/name_eq/)
           end
         end
       end
 
       context "without any tagged objects" do
         it "returns empty string" do
-          expect(helper.render_tag_list('Alchemy::Attachment')).to be_empty
+          is_expected.to be_empty
         end
       end
 
@@ -84,108 +77,64 @@ module Alchemy
       end
     end
 
-    describe '#tag_list_tag_active?' do
-      context "the tag is in params" do
-        it "returns true" do
-          expect(helper.tag_list_tag_active?(tag)).to be_truthy
+    describe "#filtered_by_tag?" do
+      subject { helper.filtered_by_tag?(tag) }
+
+      context 'if the filter list params contains the given tag' do
+        let(:params) do
+          ActionController::Parameters.new(tagged_with: 'foo,bar,baz')
         end
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'if the filter list params does not contain the given tag' do
+        let(:params) do
+          ActionController::Parameters.new(tagged_with: 'bar,baz')
+        end
+
+        it { is_expected.to eq(false) }
       end
 
       context "params[:tagged_with] is not present" do
         let(:params) do
-          ActionController::Parameters.new({
-            controller: 'alchemy/admin/attachments',
-            action: 'index',
-            use_route: 'alchemy'
-          })
+          ActionController::Parameters.new
         end
 
-        it "returns false" do
-          expect(helper.tag_list_tag_active?(tag)).to be_falsey
-        end
+        it { is_expected.to eq(false) }
       end
     end
 
-    describe "#filtered_by_tag?" do
-      it "should return true if the filterlist contains the given tag" do
-        controller.params[:tagged_with] = "foo,bar,baz"
-        expect(helper.filtered_by_tag?(tag)).to eq(true)
-      end
+    describe "#tags_for_filter" do
+      subject { helper.tags_for_filter(current: tag) }
 
-      context 'if the filterlist does not contain the given tag' do
-        let(:params) do
-          ActionController::Parameters.new({
-            controller: 'alchemy/admin/attachments',
-            action: 'index',
-            use_route: 'alchemy',
-            tagged_with: 'bar,baz'
-          })
-        end
-
-        it "should return false" do
-          expect(helper.filtered_by_tag?(tag)).to eq(false)
-        end
-      end
-    end
-
-    describe "#add_to_tag_filter" do
       context "if params[:tagged_with] is not present" do
         let(:params) do
-          ActionController::Parameters.new({
-            controller: 'alchemy/admin/attachments',
-            action: 'index',
-            use_route: 'alchemy'
-          })
+          ActionController::Parameters.new
         end
 
-        it "should return an Array with the given tag name" do
-          expect(helper.add_to_tag_filter(tag)).to eq(["foo"])
+        it "should return a String with the given tag name" do
+          is_expected.to eq("foo")
         end
       end
 
       context "if params[:tagged_with] contains some tag names" do
         let(:params) do
-          ActionController::Parameters.new({
-            controller: 'alchemy/admin/attachments',
-            action: 'index',
-            use_route: 'alchemy',
-            tagged_with: 'bar,baz'
-          })
+          ActionController::Parameters.new(tagged_with: 'bar,baz')
         end
 
-        it "should return an Array of tag names including the given one" do
-          expect(helper.add_to_tag_filter(tag)).to eq(["bar", "baz", "foo"])
-        end
-      end
-    end
-
-    describe "#remove_from_tag_filter" do
-      context "if params[:tagged_with] is not present" do
-        let(:params) do
-          ActionController::Parameters.new({
-            controller: 'alchemy/admin/attachments',
-            action: 'index',
-            use_route: 'alchemy'
-          })
-        end
-
-        it "should return an empty Array" do
-          expect(helper.remove_from_tag_filter(tag)).to be_empty
+        it "should return a String of tag names including the given one" do
+          is_expected.to eq("bar,baz,foo")
         end
       end
 
-      context "if params[:tagged_with] contains some tag names" do
+      context "if params[:tagged_with] contains current tag name" do
         let(:params) do
-          ActionController::Parameters.new({
-            controller: 'alchemy/admin/attachments',
-            action: 'index',
-            use_route: 'alchemy',
-            tagged_with: 'bar,baz,foo'
-          })
+          ActionController::Parameters.new(tagged_with: 'bar,baz,foo')
         end
 
-        it "should return an Array of tag names without the given one" do
-          expect(helper.remove_from_tag_filter(tag)).to eq(["bar", "baz"])
+        it "should return a String of tag names without the current one" do
+          is_expected.to eq("bar,baz")
         end
       end
     end


### PR DESCRIPTION
Instead of using a custom params manipulating helper
we introduce and expose a `search_filter_params` method as helper into the view.

This way we do not need to duplicate behavior of `ActionController::Parameters` and can use the
already sanitized params we use in the controller to make redirects.