### PR TITLE
Use hashes with indifferent access instead of converting keys

### DIFF
--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -2,6 +2,13 @@
 
 module Alchemy
   class PagesController < Alchemy::BaseController
+    SHOW_PAGE_PARAMS_KEYS = [
+      'action',
+      'controller',
+      'urlname',
+      'locale'
+    ]
+
     include OnPageLayout::CallbacksRunner
 
     # Redirecting concerns. Order is important here!
@@ -126,8 +133,8 @@ module Alchemy
     # * locale
     #
     def additional_params
-      params.symbolize_keys.delete_if do |key, _|
-        [:action, :controller, :urlname, :locale].include?(key)
+      params.to_unsafe_hash.delete_if do |key, _|
+        SHOW_PAGE_PARAMS_KEYS.include?(key)
       end
     end
 

--- a/app/models/alchemy/content.rb
+++ b/app/models/alchemy/content.rb
@@ -107,7 +107,7 @@ module Alchemy
     # Settings from the elements.yml definition
     def settings
       return {} if definition.blank?
-      @settings ||= definition.fetch('settings', {}).symbolize_keys
+      @settings ||= definition.fetch(:settings, {})
     end
 
     # Fetches value from settings

--- a/app/models/alchemy/content/factory.rb
+++ b/app/models/alchemy/content/factory.rb
@@ -33,9 +33,8 @@ module Alchemy
       # @return [Alchemy::Content]
       #
       def create_from_scratch(element, essence_hash)
-        essence_hash.stringify_keys!
         if content = build(element, essence_hash)
-          content.create_essence!(essence_hash['essence_type'])
+          content.create_essence!(essence_hash[:essence_type])
         end
         content
       end
@@ -51,7 +50,7 @@ module Alchemy
       #
       def copy(source, differences = {})
         new_content = Content.new(
-          source.attributes.except(*SKIPPED_ATTRIBUTES_ON_COPY).merge(differences.stringify_keys)
+          source.attributes.except(*SKIPPED_ATTRIBUTES_ON_COPY).merge(differences)
         )
 
         new_essence = new_content.essence.class.create!(
@@ -68,12 +67,11 @@ module Alchemy
       # 2. It builds a definition hash from essence type, if the the name key is not present
       #
       def content_definition(element, essence_hash)
-        essence_hash.stringify_keys!
         # No name given. We build the content from essence type.
-        if essence_hash['name'].blank? && essence_hash['essence_type'].present?
-          content_definition_from_essence_type(element, essence_hash['essence_type'])
+        if essence_hash[:name].blank? && essence_hash[:essence_type].present?
+          content_definition_from_essence_type(element, essence_hash[:essence_type])
         else
-          element.content_definition_for(essence_hash['name'])
+          element.content_definition_for(essence_hash[:name])
         end
       end
 

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -124,9 +124,7 @@ module Alchemy
       #   could be found
       #
       def new_from_scratch(attributes = {})
-        attributes = attributes.dup.symbolize_keys
         return new if attributes[:name].blank?
-
         new_element_from_definition_by(attributes) || raise(ElementDefinitionError, attributes)
       end
 
@@ -196,16 +194,11 @@ module Alchemy
       private
 
       def new_element_from_definition_by(attributes)
-        remove_cell_name_from_element_name!(attributes)
-
-        element_definition = Element.definition_by_name(attributes[:name])
+        element_attributes = attributes.to_h.merge(name: attributes[:name].split('#').first)
+        element_definition = Element.definition_by_name(element_attributes[:name])
         return if element_definition.nil?
 
-        new(element_definition.merge(attributes).except(*FORBIDDEN_DEFINITION_ATTRIBUTES))
-      end
-
-      def remove_cell_name_from_element_name!(attributes)
-        attributes[:name] = attributes[:name].split('#').first
+        new(element_definition.merge(element_attributes).except(*FORBIDDEN_DEFINITION_ATTRIBUTES))
       end
     end
 

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -153,10 +153,7 @@ module Alchemy
       #   @copy.public? # => false
       #
       def copy(source_element, differences = {})
-        source_element.attributes.stringify_keys!
-        differences.stringify_keys!
-
-        attributes = source_element.attributes
+        attributes = source_element.attributes.with_indifferent_access
                        .except(*SKIPPED_ATTRIBUTES_ON_COPY)
                        .merge(differences)
                        .merge({

--- a/app/models/alchemy/element/definitions.rb
+++ b/app/models/alchemy/element/definitions.rb
@@ -13,7 +13,7 @@ module Alchemy
       # your own set of elements
       #
       def definitions
-        @definitions ||= read_definitions_file
+        @definitions ||= read_definitions_file.map(&:with_indifferent_access)
       end
 
       # Returns one element definition by given name.

--- a/app/models/alchemy/element/element_contents.rb
+++ b/app/models/alchemy/element/element_contents.rb
@@ -140,7 +140,7 @@ module Alchemy
     # creates the contents for this element as described in the elements.yml
     def create_contents
       definition.fetch("contents", []).each do |content_hash|
-        Content.create_from_scratch(self, content_hash.symbolize_keys)
+        Content.create_from_scratch(self, content_hash)
       end
     end
   end

--- a/spec/controllers/alchemy/admin/base_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/base_controller_spec.rb
@@ -12,19 +12,21 @@ describe Alchemy::Admin::BaseController do
 
     context "params[:options] are Rails parameters" do
       let(:options) do
-        ActionController::Parameters.new('hallo' => {'great' => 'World'})
+        ActionController::Parameters.new('hello' => 'world')
       end
 
       it "returns the options as permitted parameters with indifferent access" do
         expect(subject).to be_permitted
-        expect(subject).to eq({hallo: {great: 'World'}})
+        expect(subject[:hello]).to eq('world')
       end
     end
 
     context "params[:options] is nil" do
       let(:options) { nil }
 
-      it { is_expected.to eq({}) }
+      it "returns an empty permitted parameters hash" do
+        is_expected.to eq(ActionController::Parameters.new.permit!)
+      end
     end
   end
 

--- a/spec/models/alchemy/content_spec.rb
+++ b/spec/models/alchemy/content_spec.rb
@@ -417,7 +417,7 @@ module Alchemy
       let(:content) { build_stubbed(:alchemy_content, name: 'headline', element: element) }
 
       it "returns the settings hash from definition" do
-        expect(content.settings).to eq({linkable: true})
+        expect(content.settings).to eq({'linkable' => true})
       end
 
       context 'if settings are not defined' do

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -118,7 +118,7 @@ module Alchemy
       end
 
       context "with a YAML file including a symbol" do
-        let(:yaml) { 'name: :symbol' }
+        let(:yaml) { '- name: :symbol' }
         before do
           expect(File).to receive(:exist?).and_return(true)
           expect(File).to receive(:read).and_return(yaml)


### PR DESCRIPTION
We used to convert lots of hash keys from Element and Content definitions
to compare them with params where we also converted the keys before.

Instead we now use HasWithIndifferentAccess from ActiveSupport and do not
need to compare hash keys anymore.

This is the last PR to get rid of Rails 5 deprecations