### PR TITLE
Add a store image file format rake task

### DIFF
--- a/db/migrate/20160422195310_add_image_file_format_to_alchemy_pictures.rb
+++ b/db/migrate/20160422195310_add_image_file_format_to_alchemy_pictures.rb
@@ -1,18 +1,6 @@
 class AddImageFileFormatToAlchemyPictures < ActiveRecord::Migration
   def up
     add_column :alchemy_pictures, :image_file_format, :string
-
-    say_with_time "Storing file format of existing pictures" do
-      Alchemy::Picture.all.each do |pic|
-        begin
-          format = pic.image_file.identify('-ping -format "%m"')
-          pic.update_column('image_file_format', format.to_s.chomp.downcase)
-        rescue Dragonfly::Job::Fetch::NotFound => e
-          say(e.message, true)
-        end
-      end
-      Alchemy::Picture.count
-    end
   end
 
   def down

--- a/lib/alchemy/upgrader/three_point_four.rb
+++ b/lib/alchemy/upgrader/three_point_four.rb
@@ -6,5 +6,30 @@ module Alchemy
       desc 'Install asset manifests into `vendor/assets`'
       Alchemy::Upgrader::Tasks::InstallAssetManifests.new.install
     end
+
+    def self.store_image_file_format
+      desc 'Store image file format'
+      pictures = Alchemy::Picture.where(image_file_format: nil)
+      count = pictures.size
+      converted_pics = 0
+      errored_pics = 0
+      puts "-- Storing file format of #{count} pictures"
+      pictures.find_each(batch_size: 100).with_index do |pic, i|
+        begin
+          puts "   -> Reading file format of #{pic.image_file_name} (#{i + 1}/#{count})"
+          format = pic.image_file.identify('-ping -format "%m"')
+          pic.update_column('image_file_format', format.to_s.chomp.downcase)
+          converted_pics += 1
+        rescue Dragonfly::Job::Fetch::NotFound => e
+          puts "   -> #{e.message}"
+          errored_pics += 1
+        end
+      end
+      puts "-- Done! Converted #{converted_pics} images."
+      unless errored_pics.zero?
+        puts "   !! But #{errored_pics} images caused errors."
+        puts "      Please check errors above and re-run `rake alchemy:upgrade:3.4:store_image_file_format`"
+      end
+    end
   end
 end

--- a/lib/tasks/alchemy/upgrade.rake
+++ b/lib/tasks/alchemy/upgrade.rake
@@ -148,11 +148,19 @@ namespace :alchemy do
     task '3.4' => ['alchemy:upgrade:prepare', 'alchemy:upgrade:3.4:run']
 
     namespace '3.4' do
-      task run: ['alchemy:upgrade:3.4:install_asset_manifests']
+      task run: [
+        'alchemy:upgrade:3.4:install_asset_manifests',
+        'alchemy:upgrade:3.4:store_image_file_format'
+      ]
 
       desc 'Install asset manifests into `vendor/assets`'
       task install_asset_manifests: [:environment] do
         Alchemy::Upgrader::ThreePointFour.install_asset_manifests
+      end
+
+      desc 'Store image file format on Alchemy pictures.'
+      task store_image_file_format: [:environment] do
+        Alchemy::Upgrader::ThreePointFour.store_image_file_format
       end
     end
 


### PR DESCRIPTION
In order to be able to run this task indepedent from a migration and be able to re-run the task anytime we introduce a new rake task

    rake alchemy:upgrade:3.4:store_image_file_format