### PR TITLE
Always use border-box box model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 4.0.0 (unreleased)
+
+* Always use `border-box` box model for all CSS components in the admin
+
 ## 4.0.0.rc2 (2017-08-18)
 
 * Removed deprecated `:image_size` option from `EssencePicture`

--- a/app/assets/stylesheets/alchemy/_extends.scss
+++ b/app/assets/stylesheets/alchemy/_extends.scss
@@ -33,7 +33,6 @@
 }
 
 %default-input-style {
-  box-sizing: border-box;
   @extend %rounded-border;
   box-shadow: inset 0px 1px 1px $medium-gray;
   font: $default-font-style;
@@ -66,5 +65,5 @@
 %gradiated-toolbar {
   background: $toolbar-bg-color;
   padding: 8px 4px;
-  height: $default-form-field-height;
+  height: $toolbar-height;
 }

--- a/app/assets/stylesheets/alchemy/_mixins.scss
+++ b/app/assets/stylesheets/alchemy/_mixins.scss
@@ -74,7 +74,6 @@
 }
 
 @mixin form-label {
-  @extend .border-box-sizing;
   width: $form-left-width;
   padding-right: 2*$default-padding;
   padding-top: $default-padding + 1;
@@ -105,7 +104,6 @@
   min-height: $default-form-field-height;
   background: white;
   @extend %rounded-border;
-  @extend .border-box-sizing;
 }
 
 @mixin form-hint($background-color: $light_yellow, $border-color: $medium-gray) {
@@ -144,12 +142,6 @@
   -ms-box-shadow: $shadow;
   -o-box-shadow: $shadow;
   box-shadow: $shadow;
-}
-
-@mixin box-sizing($box-sizing-type: content-box) {
-  -webkit-box-sizing: $box-sizing-type;
-  -moz-box-sizing: $box-sizing-type;
-  box-sizing: $box-sizing-type;
 }
 
 @mixin tag-base($margin: 2*$default-margin 0, $padding: $default-padding 4*$default-padding $default-padding 6*$default-padding) {

--- a/app/assets/stylesheets/alchemy/_variables.scss
+++ b/app/assets/stylesheets/alchemy/_variables.scss
@@ -70,6 +70,8 @@ $main-menu-active-bg-color: $light-blue !default;
 $main-menu-text-color: #222 !default;
 $main-menu-entry-max-width: 100px !default;
 $toolbar-bg-color: $medium-gray !default;
+$toolbar-height: 46px !default;
+$element-toolbar-height: 37px !default;
 $header-height: 29px !default;
 $text-shadow-light: rgba($white, 0.5) 0 0 4px !default;
 $transition-duration: 200ms !default;

--- a/app/assets/stylesheets/alchemy/archive.scss
+++ b/app/assets/stylesheets/alchemy/archive.scss
@@ -23,6 +23,7 @@ div#image_assign_filter_and_image_sizing {
   border: 1px solid #c0c0c0;
   position: relative;
   @extend %rounded-border;
+  width: 170px;
 
   img {
     width: auto;
@@ -38,28 +39,20 @@ div#image_assign_filter_and_image_sizing {
   }
 
   .picture_name {
-    height: 14px;
     display: block;
+    width: 100%;
     text-align: center;
     white-space: nowrap;
     overflow: hidden;
-    position: absolute;
-    bottom: 1px;
+    bottom: 0;
     left: 0;
     font-family: "Courier New", Courier, mono;
-    line-height: 11px;
-    padding: 2px 0;
-    margin-right: 4px;
-    margin-left: 4px;
+    line-height: 16px;
+    padding: $default-padding 0 0;
   }
 
   &.small {
-    width: 80px;
-    height: 80px;
-
-    .picture_name {
-      width: 80px;
-    }
+    width: 90px;
 
     .thumbnail_background {
       width: 80px;
@@ -67,27 +60,8 @@ div#image_assign_filter_and_image_sizing {
     }
   }
 
-  &.medium {
-    width: 160px;
-    height: 140px;
-
-    .picture_name {
-      width: 160px;
-    }
-
-    .thumbnail_background {
-      width: 160px;
-      height: 120px;
-    }
-  }
-
   &.large {
-    width: 240px;
-    height: 200px;
-
-    .picture_name {
-      width: 240px;
-    }
+    width: 250px;
 
     .thumbnail_background {
       width: 240px;
@@ -106,11 +80,11 @@ div#image_assign_filter_and_image_sizing {
 #pictures {
   margin-right: 232px;
   padding-bottom: 60px;
+  overflow: hidden;
 
   .picture_thumbnail {
-    margin: 0 8px 8px 0;
-    display: inline-block;
-    float: none;
+    margin: 0 2*$default-margin 2*$default-margin 0;
+    float: left;
 
     .thumbnail_background {
       @include zoom-in;
@@ -129,12 +103,12 @@ div.assign_image_list_image {
 }
 
 .picture_tool {
-  width: 16px;
-  height: 16px;
+  width: 20px;
+  height: 20px;
   position: absolute;
   background-color: white;
-  top: 3px;
-  padding: 1px;
+  top: $default-padding;
+  padding: $default-padding/2;
   z-index: 10;
   display: none;
 
@@ -147,7 +121,7 @@ div.assign_image_list_image {
   }
 
   &.select {
-    left: 4px;
+    left: $default-padding;
 
     input {
       margin: 0;
@@ -156,7 +130,7 @@ div.assign_image_list_image {
   }
 
   &.delete {
-    right: 4px;
+    right: $default-padding;
 
     a {
       background: image-url('alchemy/icons.png') no-repeat -63px -72px;
@@ -172,7 +146,6 @@ div.assign_image_list_image {
 }
 
 div#library_sidebar {
-  box-sizing: border-box;
   position: fixed;
   border-left: 1px solid $default-border-color;
   top: 0;
@@ -201,7 +174,6 @@ div#filter_bar {
 }
 
 .tag-list {
-  box-sizing: border-box;
   height: 100%;
   padding-bottom: 138px;
 
@@ -237,7 +209,6 @@ div#filter_bar {
   }
 
   ul {
-    box-sizing: border-box;
     list-style-type: none;
     padding: 0;
     margin: 40px 0 4px 0;
@@ -277,7 +248,7 @@ div#filter_bar {
 
 #assign_image_list, #assign_file_list {
   position: relative;
-  height: 519px;
+  height: 535px;
 }
 
 #assign_image_list {
@@ -328,7 +299,7 @@ div#filter_bar {
       display: block;
       line-height: 25px;
       text-decoration: none;
-      padding: 0px 4px 2px 4px;
+      padding: 2px $default-padding;
     }
 
     .icon {
@@ -339,12 +310,12 @@ div#filter_bar {
 }
 
 .picture_tags {
-  box-sizing: border-box;
-  width: 50%;
-  max-height: 100%;
+  overflow: hidden;
   position: absolute;
-  top: 16px;
-  left: 0;
+  top: 22px;
+  left: $default-padding;
+  width: 50%;
+  max-height: 80%;
   padding: $default-padding;
   pointer-events: none;
   display: none;

--- a/app/assets/stylesheets/alchemy/base.scss
+++ b/app/assets/stylesheets/alchemy/base.scss
@@ -1,4 +1,5 @@
 html {
+  box-sizing: border-box;
   height: 100%;
 
   &.turbolinks-progress-bar::before,
@@ -6,6 +7,12 @@ html {
     background-color: #fff !important;
     z-index: 400001;
   }
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
 }
 
 noscript {
@@ -44,7 +51,7 @@ body {
 
 h1 {
   padding: 0;
-  margin: 8px;
+  margin: 2*$default-margin;
   font-weight: bold;
   font-size: $default-font-size;
 
@@ -62,7 +69,7 @@ h1 {
 
 h2 {
   margin: $default-margin 0;
-  padding-bottom: 5px;
+  padding-bottom: $default-padding;
   clear: both;
   font-weight: bold;
   font-size: $default-font-size;
@@ -70,7 +77,7 @@ h2 {
 
 h3 {
   margin: $default-margin 0;
-  padding-bottom: 5px;
+  padding-bottom: $default-padding;
   font-size: $default-font-size;
   font-weight: bold;
 }
@@ -158,10 +165,6 @@ kbd {
 
 .disable-user-select {
   user-select: none;
-}
-
-.border-box-sizing {
-  box-sizing: border-box;
 }
 
 span.updated_at {
@@ -507,7 +510,6 @@ div.browse {
 }
 
 #alchemy_preview_window {
-  box-sizing: border-box;
   position: absolute;
   left: $main-menu-width;
   top: 75px;

--- a/app/assets/stylesheets/alchemy/buttons.scss
+++ b/app/assets/stylesheets/alchemy/buttons.scss
@@ -17,9 +17,9 @@ button, input[type="submit"], a.button, input.button {
     padding: 6px 18px 6px 6px;
 
     span.icon {
-      margin-top: -5px;
-      padding-right: 0.25em;
-      height: 15px;
+      margin-top: -$default-margin;
+      margin-right: $default-margin;
+      height: 14px;
     }
   }
 
@@ -43,7 +43,6 @@ button, input[type="submit"], a.button, input.button {
 }
 
 .icon_button {
-  box-sizing: border-box;
   width: 27px;
   height: 27px;
   line-height: 21px;

--- a/app/assets/stylesheets/alchemy/dashboard.scss
+++ b/app/assets/stylesheets/alchemy/dashboard.scss
@@ -3,8 +3,6 @@
   padding: 4*$default-padding 2*$default-padding;
   width: 100%;
   position: relative;
-  box-sizing: border-box;
-  * { box-sizing: border-box }
 
   h1 {
     font-size: 2em;

--- a/app/assets/stylesheets/alchemy/dialogs.scss
+++ b/app/assets/stylesheets/alchemy/dialogs.scss
@@ -119,7 +119,6 @@
 }
 
 .alchemy-dialog-header {
-  box-sizing: border-box;
   position: relative;
   height: $dialog-header-height;
   padding: 0 2*$default-padding;
@@ -168,7 +167,6 @@
 }
 
 .alchemy-dialog-body {
-  box-sizing: border-box;
   position: relative;
   color: $text-color;
 
@@ -207,7 +205,6 @@
 }
 
 .alchemy-dialog-buttons {
-  box-sizing: border-box;
   float: left;
   clear: both;
   width: 100%;

--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -1,5 +1,4 @@
 #alchemy_elements_window {
-  box-sizing: border-box;
   position: absolute;
   right: 0;
   top: 73px;
@@ -10,7 +9,6 @@
 }
 
 #element_area {
-  box-sizing: border-box;
   overflow-x: hidden;
   overflow-y: auto;
 
@@ -251,7 +249,6 @@
 
 .element-header {
   position: relative;
-  height: 20px;
   padding: 2*$default-padding;
   background-color: $medium-gray;
   @extend .disable-user-select;
@@ -277,14 +274,13 @@
 }
 
 .element-toolbar {
-  padding: 6px 0;
-  height: 6*$default-padding;
+  padding: $default-padding 0;
+  height: $element-toolbar-height;
   background-color: #f0f0f0;
 
   .element_tools {
     float: left;
-    margin-top: -3px;
-    margin-left: -4px;
+    margin-left: -$default-margin;
   }
 }
 
@@ -393,17 +389,16 @@
 }
 
 .edit_images_bottom {
-  height: 19px;
   position: absolute;
+  left: 0;
+  bottom: 0;
   z-index: 0;
-  left: 5px;
-  bottom: 2px;
-  width: 111px;
+  width: inherit;
+  padding: $default-padding;
 
   > a, > span.icon {
     float: left;
-    margin-left: 2px;
-    margin-right: 2px;
+    margin: 0 $default-margin/2;
     width: 18px;
     height: 18px;
   }
@@ -447,8 +442,8 @@
   }
 
   .picture_thumbnail {
-    width: 111px;
-    height: 115px;
+    width: 121px;
+    height: 125px;
     margin: $default-margin 0;
 
     .thumbnail_background {
@@ -495,72 +490,67 @@
 .picture_thumbnail .picture_handle {
   position: absolute;
   z-index: 1;
-  width: 110px;
-  height: 93px;
-  top: 4px;
-  left: 4px;
+  width: 100%;
+  height: 97px;
+  top: 0;
+  left: 0;
   background-color: transparent;
   @extend .disable-user-select;
 }
 
-div.file {
-  padding: 0;
-  margin-top: 8px;
-  margin-bottom: 4px;
-  border: 1px solid #c0c0c0;
-  background-color: #f3f3f3;
-  @extend %rounded-border;
-  height: 24px;
-
-  .validation_failed & {
-    color: $error_text_color;
-    border-color: $error_border_color;
-  }
-}
-
-div.file_icon {
-  text-align: center;
-  float: left;
-  height: 24px;
-  width: 24px;
-
-  span.icon {
-    margin: $default-margin;
-  }
-
-  a.assign_file {
-    display: block;
-    height: 16px;
-    background: image-url('alchemy/icons.png') no-repeat -480px -40px;
-    width: 16px;
-    margin: $default-margin;
-  }
-}
-
 .content_editor.essence_file {
+
+  .file {
+    margin: 6px 0 $default-margin;
+    border: $default-border;
+    background-color: $white;
+    @extend %rounded-border;
+    height: $default-form-field-height;
+
+    .validation_failed & {
+      color: $error_text_color;
+      border-color: $error_border_color;
+    }
+  }
+
+  .file_icon {
+    text-align: center;
+    float: left;
+    line-height: 25px;
+    width: 24px;
+
+    .icon {
+      margin: $default-margin;
+    }
+
+    .assign_file {
+      background-position: -480px -40px;
+    }
+  }
 
   .file_name {
     white-space: nowrap;
     overflow: hidden;
     float: left;
     max-width: 80%;
-    line-height: 25px;
+    line-height: $default-form-field-height;
     font-size: 10px;
     text-overflow: ellipsis;
   }
 }
 
 .essence_file_tools {
-  height: 24px;
+  height: 27px;
   float: right;
   background-color: white;
   width: 48px;
+  border-radius: 0 $default-border-radius $default-border-radius 0;
 
   a {
     text-decoration: none;
     width: 16px;
     height: 16px;
-    margin: $default-margin;
+    margin: 5px $default-margin;
     float: left;
 
     &.assign_file {

--- a/app/assets/stylesheets/alchemy/forms.scss
+++ b/app/assets/stylesheets/alchemy/forms.scss
@@ -136,11 +136,9 @@ form {
   .inline-input {
     @include clearfix;
     margin: 0 -1*$default-margin;
-    box-sizing: border-box;
 
     .left-column, .right-column {
       padding: 0 $default-padding;
-      box-sizing: border-box;
     }
 
     .left-column {
@@ -180,7 +178,6 @@ form {
   }
 
   .input-column {
-    box-sizing: border-box;
     float: left;
     padding: 0 $default-padding;
     width: 50%;

--- a/app/assets/stylesheets/alchemy/frame.scss
+++ b/app/assets/stylesheets/alchemy/frame.scss
@@ -29,7 +29,6 @@ div#overlay_text_box {
 }
 
 #logout {
-  box-sizing: border-box;
   position: absolute;
   z-index: 1;
   bottom: 0;
@@ -99,7 +98,6 @@ div#overlay_text_box {
 }
 
 #main_content {
-  box-sizing: border-box;
   background-color: $light-gray;
   padding: 84px 8px 8px $main-menu-width + 10px;
   z-index: 0;
@@ -108,7 +106,6 @@ div#overlay_text_box {
 }
 
 #archive_all {
-  box-sizing: border-box;
   height: 100%;
   padding-bottom: 60px;
 

--- a/app/assets/stylesheets/alchemy/image_library.scss
+++ b/app/assets/stylesheets/alchemy/image_library.scss
@@ -88,7 +88,6 @@ $image-overlay-transition-easing: ease-in;
 }
 
 .picture-details-overlay {
-  box-sizing: border-box;
   right: 0;
   width: $image-overlay-form-width;
   height: 100%;
@@ -138,7 +137,6 @@ $image-overlay-transition-easing: ease-in;
 }
 
 .zoomed-picture-background {
-  box-sizing: border-box;
   width: 100%;
   height: 100%;
   padding-top: 2*$default-padding;
@@ -175,7 +173,6 @@ $image-overlay-transition-easing: ease-in;
   padding: 2*$default-padding 0;
 
   .message {
-    box-sizing: border-box;
     margin: 2*$default-padding 0;
   }
 }

--- a/app/assets/stylesheets/alchemy/jquery.datetimepicker.scss
+++ b/app/assets/stylesheets/alchemy/jquery.datetimepicker.scss
@@ -24,7 +24,6 @@ $datepicker_day_color: $text-color !default;
   padding-top: 2px;
   position: absolute;
   z-index: 9999;
-  box-sizing: border-box;
   display: none;
 }
 
@@ -61,7 +60,6 @@ $datepicker_day_color: $text-color !default;
 }
 
 .xdsoft_datetimepicker * {
-  box-sizing: border-box;
   padding: 0;
   margin: 0;
 }

--- a/app/assets/stylesheets/alchemy/lists.scss
+++ b/app/assets/stylesheets/alchemy/lists.scss
@@ -25,6 +25,7 @@ ul.list {
       background-color: transparent;
       font-weight: bold;
       padding: $default-padding;
+      margin-bottom: $default-margin;
 
       .list-secondary {
         color: $text-color;

--- a/app/assets/stylesheets/alchemy/navigation.scss
+++ b/app/assets/stylesheets/alchemy/navigation.scss
@@ -1,5 +1,4 @@
 #top_menu {
-  box-sizing: border-box;
   position: fixed;
   top: 0;
   margin-left: $main-menu-width;
@@ -15,7 +14,6 @@
 }
 
 #left_menu {
-  box-sizing: border-box;
   z-index: 30;
   height: 100%;
   position: fixed;
@@ -49,7 +47,6 @@
       }
 
       label {
-        box-sizing: border-box;
         position: absolute;
         top: 0;
         left: $collapsed-main-menu-width - 1;

--- a/app/assets/stylesheets/alchemy/pagination.scss
+++ b/app/assets/stylesheets/alchemy/pagination.scss
@@ -1,5 +1,4 @@
 .pagination {
-  box-sizing: border-box;
   background: $light_gray;
   color: $text-color;
   position: fixed;
@@ -7,7 +6,7 @@
   right: 0;
   width: 100%;
   left: 0px;
-  height: 50px;
+  height: 52px;
   padding: 2*$default-padding;
   padding-left: $main-menu-width + 10px;
   text-align: left;
@@ -16,7 +15,6 @@
 
   a, span, em {
     font-size: $default-font-size;
-    height: 25px;
     line-height: 25px;
     padding: $default-padding;
   }

--- a/app/assets/stylesheets/alchemy/selects.scss
+++ b/app/assets/stylesheets/alchemy/selects.scss
@@ -13,8 +13,8 @@ select {
     text-shadow: #FFF 0px 1px 0px;
 
     .select2-choice {
-      height: 27px;
-      line-height: 27px;
+      height: $default-form-field-height;
+      line-height: $default-form-field-height - 2;
       @include button-defaults($padding: 0 2*$default-padding, $margin: 0);
       display: block;
       font-weight: normal;

--- a/app/assets/stylesheets/alchemy/sitemap.scss
+++ b/app/assets/stylesheets/alchemy/sitemap.scss
@@ -98,7 +98,7 @@
 .sitemap_left_images {
   @extend .left-rounded-border;
   position: relative;
-  width: 16px;
+  width: 32px;
   height: $sitemap-line-height;
   line-height: $sitemap-line-height - 2px;
   float: left;

--- a/app/assets/stylesheets/alchemy/upload.scss
+++ b/app/assets/stylesheets/alchemy/upload.scss
@@ -42,7 +42,6 @@
 }
 
 .overall-upload {
-  box-sizing: border-box;
   position: fixed;
   bottom: -100%;
   left: 0;

--- a/app/assets/stylesheets/tinymce/skins/alchemy/skin.min.css.scss
+++ b/app/assets/stylesheets/tinymce/skins/alchemy/skin.min.css.scss
@@ -29,7 +29,6 @@
 }
 
 .mce-widget button {
-  box-sizing: border-box;
 }
 
 .mce-container *[unselectable] {
@@ -255,7 +254,6 @@ div.mce-tinymce-inline {
 .mce-panel {
   border: 0 solid $default-border-color;
   background-color: $medium-gray;
-  box-sizing: border-box;
 }
 
 .mce-toolbar-grp {

--- a/app/views/alchemy/essences/_essence_file_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_file_editor.html.erb
@@ -11,7 +11,7 @@
     padding: false
   },
   {
-    class: 'assign_file',
+    class: 'icon assign_file',
     title: Alchemy.t(:assign_file)
   }
 ) %>


### PR DESCRIPTION
Instead of a mix of `border-box` and `content-box` we always use the defacto standard `border-box` for the `box-model` of all our DOM elements.

For this to work I needed to update lots of sizes of several components.