### PR TITLE
Fixes admin content creation js response

### DIFF
--- a/app/views/alchemy/admin/contents/create.js.erb
+++ b/app/views/alchemy/admin/contents/create.js.erb
@@ -1,7 +1,5 @@
 var editor_html = '<%= j(render "alchemy/essences/#{@content.essence_partial_name}_editor", {
-  content: @content,
-  options: options_from_params.symbolize_keys,
-  html_options: @html_options.symbolize_keys
+  content: @content, options: options_from_params, html_options: @html_options
 }) %>';
 
 <% if params[:was_missing] %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -7,7 +7,7 @@
       "check_name": "MassAssignment",
       "message": "Parameters should be whitelisted for mass assignment",
       "file": "app/controllers/alchemy/admin/resources_controller.rb",
-      "line": 128,
+      "line": 130,
       "link": "http://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.require(resource_handler.namespaced_resource_name).permit!",
       "render_path": null,
@@ -23,13 +23,13 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "26461414e9f6be7b68dd8c7dda1c69b09c92a8e9997c0ac204e1756cae7f3d68",
+      "fingerprint": "79e194e21561d40888d86ebc7fd2ab474fdb0ce32d605dbe9ac6e8984ecc5e92",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/alchemy/admin/contents/create.js.erb",
       "line": 1,
       "link": "http://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => \"alchemy/essences/#{Content.create_from_scratch(Element.find(params[:content][:element_id]), content_params).essence_partial_name}_editor\", { :content => Content.create_from_scratch(Element.find(params[:content][:element_id]), content_params), :options => options_from_params.symbolize_keys, :html_options => (params[:html_options] or {}).symbolize_keys })",
+      "code": "render(action => \"alchemy/essences/#{Content.create_from_scratch(Element.find(params[:content][:element_id]), content_params).essence_partial_name}_editor\", { :content => Content.create_from_scratch(Element.find(params[:content][:element_id]), content_params), :options => options_from_params, :html_options => ((params[:html_options] or {})) })",
       "render_path": [{"type":"controller","class":"Alchemy::Admin::ContentsController","method":"create","line":21,"file":"app/controllers/alchemy/admin/contents_controller.rb"}],
       "location": {
         "type": "template",
@@ -60,6 +60,6 @@
       "note": "`Alchemy::Content` is a polymorphic association of any kind of model extending `Alchemy::Essence`. Since we can't know the attributes of all potential essences we need to permit all attributes. As this all happens inside the password protected /admin namespace this can be considered a false positive."
     }
   ],
-  "updated": "2017-08-16 15:07:26 +0200",
-  "brakeman_version": "3.7.0"
+  "updated": "2017-10-23 11:49:41 +0200",
+  "brakeman_version": "4.0.1"
 }

--- a/spec/requests/alchemy/admin/contents_controller_spec.rb
+++ b/spec/requests/alchemy/admin/contents_controller_spec.rb
@@ -11,14 +11,12 @@ module Alchemy
         let(:element) { create(:alchemy_element, name: 'headline') }
 
         it "creates a content from name" do
-          pending 'Rails 5.1 does not support to symbolize_keys of params anymore.'
           expect {
             post admin_contents_path(content: {element_id: element.id, name: 'headline'}, format: :js)
           }.to change { Alchemy::Content.count }.by(1)
         end
 
         it "creates a content from essence_type" do
-          pending 'Rails 5.1 does not support to symbolize_keys of params anymore.'
           expect {
             post admin_contents_path(
               content: {
@@ -47,14 +45,12 @@ module Alchemy
         end
 
         it "adds it into the gallery editor" do
-          pending 'Rails 5.1 does not support to symbolize_keys of params anymore.'
           post admin_contents_path(attributes)
           expect(assigns(:content_dom_id)).to eq("#add_picture_#{element.id}")
         end
 
         context 'with picture_id given' do
           it "assigns the picture to the essence" do
-            pending 'Rails 5.1 does not support to symbolize_keys of params anymore.'
             post admin_contents_path(attributes.merge(picture_id: '1'))
             expect(Alchemy::Content.last.essence.picture_id).to eq(1)
           end

--- a/spec/requests/alchemy/admin/contents_controller_spec.rb
+++ b/spec/requests/alchemy/admin/contents_controller_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 
 module Alchemy
   describe Admin::ContentsController do
-    routes { Alchemy::Engine.routes }
-
     before do
       authorize_user(:as_admin)
     end
@@ -13,18 +11,21 @@ module Alchemy
         let(:element) { create(:alchemy_element, name: 'headline') }
 
         it "creates a content from name" do
+          pending 'Rails 5.1 does not support to symbolize_keys of params anymore.'
           expect {
-            post :create, params: {content: {element_id: element.id, name: 'headline'}}, xhr: true
+            post admin_contents_path(content: {element_id: element.id, name: 'headline'}, format: :js)
           }.to change { Alchemy::Content.count }.by(1)
         end
 
         it "creates a content from essence_type" do
+          pending 'Rails 5.1 does not support to symbolize_keys of params anymore.'
           expect {
-            post :create, params: {
+            post admin_contents_path(
               content: {
                 element_id: element.id, essence_type: 'EssencePicture'
-              }
-            }, xhr: true
+              },
+              format: :js
+            )
           }.to change { Alchemy::Content.count }.by(1)
         end
       end
@@ -40,18 +41,21 @@ module Alchemy
             },
             options: {
               grouped: 'true'
-            }
+            },
+            format: :js
           }
         end
 
         it "adds it into the gallery editor" do
-          post :create, params: attributes, xhr: true
+          pending 'Rails 5.1 does not support to symbolize_keys of params anymore.'
+          post admin_contents_path(attributes)
           expect(assigns(:content_dom_id)).to eq("#add_picture_#{element.id}")
         end
 
         context 'with picture_id given' do
           it "assigns the picture to the essence" do
-            post :create, params: attributes.merge(picture_id: '1'), xhr: true
+            pending 'Rails 5.1 does not support to symbolize_keys of params anymore.'
+            post admin_contents_path(attributes.merge(picture_id: '1'))
             expect(Alchemy::Content.last.essence.picture_id).to eq(1)
           end
         end
@@ -67,7 +71,7 @@ module Alchemy
 
       it "should update a content via ajax" do
         expect {
-          post :update, params: {id: content.id, content: {ingredient: 'Peters Petshop'}}, xhr: true
+          patch admin_content_path(id: content.id, content: {ingredient: 'Peters Petshop'}, format: :js)
         }.to change { content.ingredient }.to 'Peters Petshop'
       end
     end
@@ -81,7 +85,7 @@ module Alchemy
         let(:content_ids) { element.contents.pluck(:id).shuffle }
 
         it "should reorder the contents" do
-          post :order, params: {content_ids: content_ids}, xhr: true
+          post order_admin_contents_path(content_ids: content_ids, format: :js)
 
           expect(response.status).to eq(200)
           expect(element.contents.reload.pluck(:id)).to eq(content_ids)


### PR DESCRIPTION
Rails 5.1 does not support `symbolize_keys` of params anymore. With the
changes we made to `options_from_params` we do not need to convert the keys
anymore as the params hash already has indifferent access.