### PR TITLE
Remove display cancan alias (3.6-stable)

### DIFF
--- a/lib/alchemy/permissions.rb
+++ b/lib/alchemy/permissions.rb
@@ -35,7 +35,6 @@ module Alchemy
       def alchemy_guest_user_rules
         can([:show, :download], Alchemy::Attachment) { |a| !a.restricted? }
         can :see,               Alchemy::Page,       restricted: false, visible: true
-        can([:show, :thumbnail, :zoom], Alchemy::Picture) { |p| !p.restricted? }
 
         can :read, Alchemy::Content, Alchemy::Content.available.not_restricted do |c|
           c.public? && !c.restricted? && !c.trashed?
@@ -65,7 +64,6 @@ module Alchemy
         can [:show, :download], Alchemy::Attachment
         can :read,              Alchemy::Page,      Alchemy::Page.published, &:public?
         can :see,               Alchemy::Page,      restricted: true, visible: true
-        can [:show, :thumbnail, :zoom], Alchemy::Picture
 
         can :read, Alchemy::Content, Alchemy::Content.available do |c|
           c.public? && !c.trashed?

--- a/lib/alchemy/permissions.rb
+++ b/lib/alchemy/permissions.rb
@@ -35,7 +35,7 @@ module Alchemy
       def alchemy_guest_user_rules
         can([:show, :download], Alchemy::Attachment) { |a| !a.restricted? }
         can :see,               Alchemy::Page,       restricted: false, visible: true
-        can(:display,           Alchemy::Picture)    { |p| !p.restricted? }
+        can([:show, :thumbnail, :zoom], Alchemy::Picture) { |p| !p.restricted? }
 
         can :read, Alchemy::Content, Alchemy::Content.available.not_restricted do |c|
           c.public? && !c.restricted? && !c.trashed?
@@ -65,7 +65,7 @@ module Alchemy
         can [:show, :download], Alchemy::Attachment
         can :read,              Alchemy::Page,      Alchemy::Page.published, &:public?
         can :see,               Alchemy::Page,      restricted: true, visible: true
-        can :display,           Alchemy::Picture
+        can [:show, :thumbnail, :zoom], Alchemy::Picture
 
         can :read, Alchemy::Content, Alchemy::Content.available do |c|
           c.public? && !c.trashed?
@@ -215,11 +215,6 @@ module Alchemy
         :unlock,
         :visit,
         to: :edit_content
-
-      alias_action :show,
-        :thumbnail,
-        :zoom,
-        to: :display
     end
 
     # Include the role specific permissions.

--- a/spec/libraries/permissions_spec.rb
+++ b/spec/libraries/permissions_spec.rb
@@ -33,15 +33,6 @@ describe Alchemy::Permissions do
       is_expected.not_to be_able_to(:show, restricted_attachment)
     end
 
-    it "can only see not restricted pictures" do
-      is_expected.to be_able_to(:show, picture)
-      is_expected.to be_able_to(:thumbnail, picture)
-      is_expected.to be_able_to(:zoom, picture)
-      is_expected.not_to be_able_to(:show, restricted_picture)
-      is_expected.not_to be_able_to(:thumbnail, restricted_picture)
-      is_expected.not_to be_able_to(:zoom, restricted_picture)
-    end
-
     it "can only visit not restricted pages" do
       is_expected.to be_able_to(:show, public_page)
       is_expected.not_to be_able_to(:show, restricted_page)
@@ -80,15 +71,6 @@ describe Alchemy::Permissions do
     it "can see all attachments" do
       is_expected.to be_able_to(:show, attachment)
       is_expected.to be_able_to(:show, restricted_attachment)
-    end
-
-    it "can see all pictures" do
-      is_expected.to be_able_to(:show, picture)
-      is_expected.to be_able_to(:thumbnail, picture)
-      is_expected.to be_able_to(:zoom, picture)
-      is_expected.to be_able_to(:show, restricted_picture)
-      is_expected.to be_able_to(:thumbnail, restricted_picture)
-      is_expected.to be_able_to(:zoom, restricted_picture)
     end
 
     it "can visit restricted pages" do
@@ -132,10 +114,6 @@ describe Alchemy::Permissions do
     it "can visit the dashboard" do
       is_expected.to be_able_to(:index, :alchemy_admin_dashboard)
       is_expected.to be_able_to(:info, :alchemy_admin_dashboard)
-    end
-
-    it "can see picture thumbnails" do
-      is_expected.to be_able_to(:thumbnail, Alchemy::Picture)
     end
 
     it "can edit page content" do


### PR DESCRIPTION
The `display` cancan alias is also defined by Spree/Solidus. And because
Spree/Solidus clear all pre defined aliases in their Ability class it can
happen that our alias is not working anymore. Their alias is then used
instead.