### PR TITLE
Fixes essence picture rendering for contents with settings

### DIFF
--- a/app/models/alchemy/essence_picture.rb
+++ b/app/models/alchemy/essence_picture.rb
@@ -56,6 +56,7 @@ module Alchemy
     # @option options crop [Boolean]
     #   If set to true the picture will be cropped to fit the size value.
     #
+    # @return [String]
     def picture_url(options = {})
       return if picture.nil?
 
@@ -68,11 +69,12 @@ module Alchemy
       picture.url(options)
     end
 
-    # Renders a thumbnail representation of the assigned image
+    # Returns an url for the thumbnail representation of the assigned picture
     #
     # It takes cropping values into account, so it always represents the current
     # image displayed in the frontend.
     #
+    # @return [String]
     def thumbnail_url(options = {})
       return if picture.nil?
 
@@ -96,6 +98,7 @@ module Alchemy
     # @param max [Integer]
     #   The maximum length of the text returned.
     #
+    # @return [String]
     def preview_text(max = 30)
       return "" if picture.nil?
       picture.name.to_s[0..max - 1]
@@ -103,6 +106,7 @@ module Alchemy
 
     # A Hash of coordinates suitable for the graphical image cropper.
     #
+    # @return [Hash]
     def cropping_mask
       return if crop_from.blank? || crop_size.blank?
       crop_from = point_from_string(read_attribute(:crop_from))
@@ -112,6 +116,8 @@ module Alchemy
     end
 
     # Returns a serialized ingredient value for json api
+    #
+    # @return [String]
     def serialized_ingredient
       picture_url(content.settings)
     end

--- a/app/models/alchemy/essence_picture.rb
+++ b/app/models/alchemy/essence_picture.rb
@@ -60,13 +60,23 @@ module Alchemy
     def picture_url(options = {})
       return if picture.nil?
 
-      options = {
+      picture.url picture_url_options.merge(options)
+    end
+
+    # Picture rendering options
+    #
+    # Returns the +default_render_format+ of the associated +Alchemy::Picture+
+    # together with the +crop_from+ and +crop_size+ values
+    #
+    # @return [HashWithIndifferentAccess]
+    def picture_url_options
+      return {} if picture.nil?
+
+      {
         format: picture.default_render_format,
         crop_from: crop_from,
         crop_size: crop_size
-      }.merge(options)
-
-      picture.url(options)
+      }.with_indifferent_access
     end
 
     # Returns an url for the thumbnail representation of the assigned picture

--- a/app/models/alchemy/essence_picture_view.rb
+++ b/app/models/alchemy/essence_picture_view.rb
@@ -14,7 +14,7 @@ module Alchemy
       disable_link: false,
       srcset: [],
       sizes: []
-    }
+    }.with_indifferent_access
 
     def initialize(content, options = {}, html_options = {})
       @content = content

--- a/spec/models/alchemy/essence_picture_spec.rb
+++ b/spec/models/alchemy/essence_picture_spec.rb
@@ -94,6 +94,38 @@ module Alchemy
       end
     end
 
+    describe '#picture_url_options' do
+      subject(:picture_url_options) { essence.picture_url_options }
+
+      let(:picture) { build_stubbed(:alchemy_picture) }
+      let(:essence) { build_stubbed(:alchemy_essence_picture, picture: picture) }
+
+      it { is_expected.to be_a(HashWithIndifferentAccess) }
+
+      it "includes the pictures default render format." do
+        expect(picture).to receive(:default_render_format) { 'img' }
+        expect(picture_url_options[:format]).to eq('img')
+      end
+
+      context 'with crop sizes present' do
+        before do
+          expect(essence).to receive(:crop_size) { '200x200' }
+          expect(essence).to receive(:crop_from) { '10x10' }
+        end
+
+        it "includes these crop sizes.", :aggregate_failures do
+          expect(picture_url_options[:crop_from]).to eq '10x10'
+          expect(picture_url_options[:crop_size]).to eq '200x200'
+        end
+      end
+
+      context 'without picture assigned' do
+        let(:picture) { nil }
+
+        it { is_expected.to be_a(Hash) }
+      end
+    end
+
     describe '#thumbnail_url' do
       subject(:thumbnail_url) { essence.thumbnail_url(options) }
 

--- a/spec/models/alchemy/essence_picture_view_spec.rb
+++ b/spec/models/alchemy/essence_picture_view_spec.rb
@@ -32,6 +32,13 @@ describe Alchemy::EssencePictureView, type: :model do
     allow(picture).to receive(:url) { picture_url }
   end
 
+  describe 'DEFAULT_OPTIONS' do
+    it do
+      expect(Alchemy::EssencePictureView::DEFAULT_OPTIONS).
+        to be_a(HashWithIndifferentAccess)
+    end
+  end
+
   context "with caption" do
     let(:options) do
       {}


### PR DESCRIPTION
Fixes rendering of essence pictures which contents have settings defined in `elements.yml`.

1. Make EssencePicture url options a HashWithIndifferentAccess
Content's settings - which we use to merge with the default EssencePicture `picture_url` options - are a `HashWithIndifferentAccess`. But the default url options were a simple `Hash` instead. Merging these two leads to url options having the `format` and `size` keys duplicated once as `String` once as `Symbol`. By using a `HashWithIndifferentAccess` for the `picture_url_options` we fix that.

2. Make EssencePictureView DEFAULT_OPTIONS a HashWithIndifferentAccess 
Content's settings - which we use to merge with the EssencePictureView default options - are a `HashWithIndifferentAccess`. But the default options were a simple `Hash` instead. Merging these two leads to url options having the `format` and `size` keys duplicated once as `String` once as `Symbol`. By using a `HashWithIndifferentAccess` for the `DEFAULT_OPTIONS` we fix that.