### PR TITLE
Check if file exists on disk before calling identify

### DIFF
--- a/lib/alchemy/upgrader/three_point_four.rb
+++ b/lib/alchemy/upgrader/three_point_four.rb
@@ -18,7 +18,7 @@ module Alchemy
         pictures.find_each(batch_size: 100).with_index do |pic, i|
           begin
             puts "   -> Reading file format of #{pic.image_file_name} (#{i + 1}/#{count})"
-            format = pic.image_file.identify('-ping -format "%m"')
+            format = pic.image_file.identify('-ping -format "%m"') if pic.image_file.file
             pic.update_column('image_file_format', format.to_s.chomp.downcase)
             converted_pics += 1
           rescue Dragonfly::Job::Fetch::NotFound => e


### PR DESCRIPTION
If the file is not on disk, identify can't be called so we need to check
for a file first.

Calling `image_file.file` will throw an exception if the file doesn't
exist so it will be catched by the rescue.

This fixes issue the issue describe here https://github.com/AlchemyCMS/alchemy_cms/issues/1326#issuecomment-345450662