### PR TITLE
Do not add leading slash to default admin path

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ For example, these settings:
 ```ruby
 # config/initializers/alchemy.rb
 
-Alchemy.admin_path = '/backend'
+Alchemy.admin_path = 'backend'
 Alchemy.admin_constraints = {subdomain: 'hidden'}
 ```
 

--- a/lib/alchemy/paths.rb
+++ b/lib/alchemy/paths.rb
@@ -4,7 +4,7 @@
 #
 # Alchemy has some defaults for admin path and admin constraints:
 #
-# +Alchemy.admin_path defaults to +'/admin'+
+# +Alchemy.admin_path defaults to +'admin'+
 # +Alchemy.admin_constraints defaults to +{}+
 #
 # Anyway, you can tell Alchemy about your routing configuration:
@@ -17,11 +17,11 @@
 #
 # == Example
 #
-# If you do not wish to use the default admin interface routing ('example.com/admin/')
-# and prefer e.g. 'hidden.example.com/backend/', those are the settings you need:
+# If you do not wish to use the default admin interface routing ('example.com/admin')
+# and prefer e.g. 'hidden.example.com/backend', those are the settings you need:
 #
 #     # config/initializers/alchemy.rb
-#     Alchemy.admin_path = '/backend'
+#     Alchemy.admin_path = 'backend'
 #     Alchemy.admin_constraints = {subdomain: 'hidden'}
 #
 module Alchemy
@@ -29,6 +29,6 @@ module Alchemy
 
   # Defaults
   #
-  @@admin_path = '/admin'
+  @@admin_path = 'admin'
   @@admin_constraints = {}
 end

--- a/spec/libraries/paths_spec.rb
+++ b/spec/libraries/paths_spec.rb
@@ -4,7 +4,7 @@ module Alchemy
   describe 'Paths' do
     describe 'defaults' do
       it 'has default value for Alchemy.admin_path' do
-        expect(Alchemy.admin_path).to eq('/admin')
+        expect(Alchemy.admin_path).to eq('admin')
       end
 
       it 'has default value for Alchemy.admin_constraints' do

--- a/spec/routing/routing_spec.rb
+++ b/spec/routing/routing_spec.rb
@@ -205,7 +205,7 @@ describe "The Routing" do
 
     context "customized" do
       before(:all) do
-        Alchemy.admin_path = "/backend"
+        Alchemy.admin_path = "backend"
         Alchemy.admin_constraints = {subdomain: "hidden"}
         Rails.application.reload_routes!
       end
@@ -232,7 +232,7 @@ describe "The Routing" do
       end
 
       after(:all) do
-        Alchemy.admin_path = "/admin"
+        Alchemy.admin_path = "admin"
         Alchemy.admin_constraints = {}
         Rails.application.reload_routes!
       end


### PR DESCRIPTION
Since 871e77eca5bdb014339be153f4adffd21ec36344 we allow to set a custom
admin path (ie. `/backend` instead of `/admin`). The default is set to
`/admin` and since the admin dashboard redirect rule from `/admin` to
`/admin/dashboard` uses this value the redirect destination is a root
path.

This causes no problems, unless you mount Alchemy at some other path
(`/cms` instead of just `/`). Because the redirect rule has a leading
slash the Rails router does not take the mount path into account and
redirects to `/admin/dashboard` instead of `/cms/admin/dashboard`.

Closes #1244