### PR TITLE
Allow Symbol, Date and Regexp in YAML.safe_load

### DIFF
--- a/app/models/alchemy/cell.rb
+++ b/app/models/alchemy/cell.rb
@@ -58,7 +58,7 @@ module Alchemy
       private
 
       def read_yml_file
-        ::YAML.safe_load(ERB.new(File.read(yml_file_path)).result, [], [], true) || []
+        ::YAML.safe_load(ERB.new(File.read(yml_file_path)).result, YAML_WHITELIST_CLASSES, [], true) || []
       end
 
       def yml_file_path

--- a/app/models/alchemy/element/definitions.rb
+++ b/app/models/alchemy/element/definitions.rb
@@ -28,7 +28,7 @@ module Alchemy
       #
       def read_definitions_file
         if ::File.exist?(definitions_file_path)
-          ::YAML.safe_load(ERB.new(File.read(definitions_file_path)).result, [Date, Regexp, Symbol], [], true) || []
+          ::YAML.safe_load(ERB.new(File.read(definitions_file_path)).result, YAML_WHITELIST_CLASSES, [], true) || []
         else
           raise LoadError, "Could not find elements.yml file! Please run `rails generate alchemy:scaffold`"
         end

--- a/lib/alchemy/config.rb
+++ b/lib/alchemy/config.rb
@@ -48,7 +48,8 @@ module Alchemy
       # If it does not exist, or its empty, it returns an empty Hash.
       #
       def read_file(file)
-        return YAML.load_file(file) || {} if File.exist?(file) # YAML.load_file returns false if file is empty.
+        YAML.safe_load(ERB.new(File.read(file)).result, YAML_WHITELIST_CLASSES, [], true) || {}
+      rescue Errno::ENOENT
         {}
       end
 

--- a/lib/alchemy/engine.rb
+++ b/lib/alchemy/engine.rb
@@ -14,6 +14,10 @@ module Alchemy
       NonStupidDigestAssets.whitelist += [/^tinymce\//]
     end
 
+    initializer 'alchemy.yaml_whitelist_classes' do
+      Alchemy::YAML_WHITELIST_CLASSES = %w(Symbol Date Regexp)
+    end
+
     # We need to reload each essence class in development mode on every request,
     # so it can register itself as essence relation on Page and Element models
     #

--- a/lib/alchemy/page_layout.rb
+++ b/lib/alchemy/page_layout.rb
@@ -159,7 +159,7 @@ module Alchemy
       #
       def read_definitions_file
         if File.exist?(layouts_file_path)
-          YAML.safe_load(ERB.new(File.read(layouts_file_path)).result, [Date, Symbol], [], true) || []
+          YAML.safe_load(ERB.new(File.read(layouts_file_path)).result, YAML_WHITELIST_CLASSES, [], true) || []
         else
           raise LoadError, "Could not find page_layouts.yml file! Please run `rails generate alchemy:scaffold`"
         end

--- a/lib/rails/generators/alchemy/base.rb
+++ b/lib/rails/generators/alchemy/base.rb
@@ -32,7 +32,7 @@ module Alchemy
       end
 
       def load_alchemy_yaml(name)
-        YAML.safe_load(ERB.new(File.read("#{Rails.root}/config/alchemy/#{name}")).result, [Regexp], [], true)
+        YAML.safe_load(ERB.new(File.read("#{Rails.root}/config/alchemy/#{name}")).result, [Date, Regexp, Symbol], [], true)
       rescue Errno::ENOENT
         puts "\nERROR: Could not read config/alchemy/#{name} file. Please run: rails generate alchemy:scaffold"
       end

--- a/lib/rails/generators/alchemy/base.rb
+++ b/lib/rails/generators/alchemy/base.rb
@@ -32,7 +32,7 @@ module Alchemy
       end
 
       def load_alchemy_yaml(name)
-        YAML.safe_load(ERB.new(File.read("#{Rails.root}/config/alchemy/#{name}")).result, [Date, Regexp, Symbol], [], true)
+        YAML.safe_load(ERB.new(File.read("#{Rails.root}/config/alchemy/#{name}")).result, YAML_WHITELIST_CLASSES, [], true)
       rescue Errno::ENOENT
         puts "\nERROR: Could not read config/alchemy/#{name} file. Please run: rails generate alchemy:scaffold"
       end

--- a/spec/libraries/config_spec.rb
+++ b/spec/libraries/config_spec.rb
@@ -54,17 +54,10 @@ module Alchemy
 
     describe '.read_file' do
       context 'when given path to yml file exists' do
-        before { allow(File).to receive(:exist?).and_return(true) }
-
-        it 'should call YAML.load_file with the given config path' do
-          expect(YAML).to receive(:load_file).once.with('path/to/config.yml').and_return({})
-          Config.send(:read_file, 'path/to/config.yml')
-        end
-
-        context 'but its empty' do
+        context 'and file is empty' do
           before do
             allow(File).to receive(:exist?).with('empty_file.yml').and_return(true)
-            allow(YAML).to receive(:load_file).and_return(false) # YAML.load_file returns false if file is empty.
+            allow(YAML).to receive(:safe_load).and_return(false) # YAML.safe_load returns false if file is empty.
           end
 
           it "should return an empty Hash" do

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -119,6 +119,33 @@ module Alchemy
 
       context "with a YAML file including a symbol" do
         let(:yaml) { '- name: :symbol' }
+
+        before do
+          expect(File).to receive(:exist?).and_return(true)
+          expect(File).to receive(:read).and_return(yaml)
+        end
+
+        it "returns the definition without error" do
+          expect { Element.definitions }.to_not raise_error
+        end
+      end
+
+      context "with a YAML file including a Date" do
+        let(:yaml) { '- default: 2017-12-24' }
+
+        before do
+          expect(File).to receive(:exist?).and_return(true)
+          expect(File).to receive(:read).and_return(yaml)
+        end
+
+        it "returns the definition without error" do
+          expect { Element.definitions }.to_not raise_error
+        end
+      end
+
+      context "with a YAML file including a Regex" do
+        let(:yaml) { "- format: !ruby/regexp '/\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/'" }
+
         before do
           expect(File).to receive(:exist?).and_return(true)
           expect(File).to receive(:read).and_return(yaml)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,6 +67,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.raise_errors_for_deprecations!
   config.run_all_when_everything_filtered = true
+  config.example_status_persistence_file_path = "tmp/rspec_examples.txt"
   config.filter_run :focus
   config.include ActiveSupport::Testing::TimeHelpers
   config.include Alchemy::Engine.routes.url_helpers


### PR DESCRIPTION
Date and Symbol values are quite common as default values for contents in the element definitions, so these types need to be allowed when the element generator parses them.

Fixes https://github.com/AlchemyCMS/alchemy_cms/issues/1332