### PR TITLE
Add must_revalidate to cache-control header

### DIFF
--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -156,7 +156,7 @@ module Alchemy
 
     def set_expiration_headers
       if @page.cache_page?
-        expires_in @page.expiration_time, public: !@page.restricted
+        expires_in @page.expiration_time, public: !@page.restricted, must_revalidate: true
       else
         expires_now
       end

--- a/spec/requests/alchemy/page_request_caching_spec.rb
+++ b/spec/requests/alchemy/page_request_caching_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Page request caching' do
           it "sets public cache control header" do
             get "/#{page.urlname}"
             expect(response.headers).to have_key('Cache-Control')
-            expect(response.headers['Cache-Control']).to eq('public')
+            expect(response.headers['Cache-Control']).to eq('public, must-revalidate')
           end
         end
 
@@ -56,7 +56,7 @@ RSpec.describe 'Page request caching' do
             get "/#{page.urlname}"
             expect(response.headers).to have_key('Cache-Control')
             expect(response.headers['Cache-Control']).to \
-              eq("max-age=#{expiration_time.to_i}, public")
+              eq("max-age=#{expiration_time.to_i}, public, must-revalidate")
           end
         end
       end
@@ -69,7 +69,7 @@ RSpec.describe 'Page request caching' do
         it "sets private cache control header" do
           get "/#{page.urlname}"
           expect(response.headers).to have_key('Cache-Control')
-          expect(response.headers['Cache-Control']).to eq('private')
+          expect(response.headers['Cache-Control']).to eq('private, must-revalidate')
         end
       end
 


### PR DESCRIPTION
This PR is to add a `must_revalidate` option to the Cache-Control HTTP Header in the response, to check always the `etag` from the server before use the cached version of the page.

If I don't add this, in at least Chrome (Version 63.0.3239.132 (Official Build) (64-bit)) I would get the old page (as a guest user) also after the user logs in my website.
I'm not sure if it should be also set the `public` option and not to stay at the default of Rails (that is `private`), but at least setting the `must_revalidate` solved the issue.