### PR TITLE
Use headless chrome for feature tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,21 @@
 language: ruby
 dist: trusty
 sudo: false
+addons:
+  apt:
+    packages:
+      - chromium-chromedriver
 cache:
   bundler: true
-  directories:
-    - "travis_phantomjs"
 rvm:
 - 2.3.5
 - 2.4.2
 - 2.5.0
 before_install:
-  - "phantomjs --version"
-  - "export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH"
-  - "phantomjs --version"
-  - "if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
-  - "if [ $(phantomjs --version) != '2.1.1' ]; then wget https://assets.membergetmember.co/software/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2; fi"
-  - "if [ $(phantomjs --version) != '2.1.1' ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
-  - "phantomjs --version"
   - gem install bundler
-before_script: bundle exec rake alchemy:spec:prepare
+before_script:
+  - bundle exec rake alchemy:spec:prepare
+  - export PATH=$PATH:/usr/lib/chromium-browser/
 script: bundle exec rspec
 after_success: bundle exec codeclimate-test-reporter
 env:

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ group :development, :test do
   gem 'capybara-screenshot', '>= 1.0.18'
   gem 'database_cleaner', '~> 1.3'
   gem 'factory_bot_rails', '~> 4.5'
-  gem 'poltergeist', '~> 1.10'
+  gem 'selenium-webdriver', '~> 3.8'
   gem 'rspec-activemodel-mocks', '~> 1.0'
   gem 'rspec-rails', '~> 3.0'
   gem 'shoulda-matchers', '~> 3.1'

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ group :development, :test do
     gem 'listen'
   end
   gem 'capybara', '~> 2.4'
+  gem 'capybara-screenshot', '>= 1.0.18'
   gem 'database_cleaner', '~> 1.3'
   gem 'factory_bot_rails', '~> 4.5'
   gem 'poltergeist', '~> 1.10'

--- a/spec/features/admin/language_tree_feature_spec.rb
+++ b/spec/features/admin/language_tree_feature_spec.rb
@@ -15,7 +15,7 @@ describe 'Language tree feature', type: :feature, js: true do
 
     it "one should be able to switch the language tree" do
       visit('/admin/pages')
-      page.select 'Klingon', from: 'language_id'
+      select2 'Klingon', from: 'Language tree'
       expect(page).to have_selector('#sitemap', text: 'Klingon')
     end
   end
@@ -25,7 +25,7 @@ describe 'Language tree feature', type: :feature, js: true do
 
     it "displays a form for creating language root with preselected page layout and front page name" do
       visit('/admin/pages')
-      page.select 'Klingon', from: 'language_id'
+      select2 'Klingon', from: 'Language tree'
       expect(page).to have_content('This language tree does not exist')
 
       within('form#create_language_tree') do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,7 @@ require 'alchemy/test_support/shared_uploader_examples'
 require_relative 'factories'
 require_relative "support/hint_examples.rb"
 require_relative "support/transformation_examples.rb"
+require_relative "support/capybara_select2.rb"
 
 ActionMailer::Base.delivery_method = :test
 ActionMailer::Base.perform_deliveries = true
@@ -76,6 +77,7 @@ RSpec.configure do |config|
     config.include Alchemy::TestSupport::IntegrationHelpers, type: type
   end
   config.include FactoryBot::Syntax::Methods
+  config.include CapybaraSelect2, type: :feature
 
   config.use_transactional_fixtures = false
   # Make sure the database is clean and ready for test

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ ENV["RAILS_ENV"] = "test"
 
 require File.expand_path("../dummy/config/environment.rb", __FILE__)
 require 'rspec/rails'
-require 'capybara/poltergeist'
+require 'selenium/webdriver'
 require 'capybara/rails'
 require 'capybara-screenshot/rspec'
 require 'database_cleaner'
@@ -50,12 +50,18 @@ if ENV['DB'] == 'mysql'
 end
 
 # Configure capybara for integration testing
+Capybara.register_driver :selenium_chrome_headless do |app|
+  browser_options = ::Selenium::WebDriver::Chrome::Options.new
+  browser_options.args << '--headless'
+  browser_options.args << '--no-sandbox'
+  browser_options.args << '--disable-gpu'
+  browser_options.args << '--window-size=1440,1080'
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
+end
+
+Capybara.javascript_driver = :selenium_chrome_headless
 Capybara.default_driver = :rack_test
 Capybara.default_selector = :css
-Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app)
-end
-Capybara.javascript_driver = :poltergeist
 Capybara.ignore_hidden_elements = false
 
 Shoulda::Matchers.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ require File.expand_path("../dummy/config/environment.rb", __FILE__)
 require 'rspec/rails'
 require 'capybara/poltergeist'
 require 'capybara/rails'
+require 'capybara-screenshot/rspec'
 require 'database_cleaner'
 require 'rspec-activemodel-mocks'
 

--- a/spec/support/capybara_select2.rb
+++ b/spec/support/capybara_select2.rb
@@ -1,0 +1,19 @@
+module CapybaraSelect2
+  # Select2 capybara helper
+  def select2(value, options)
+    label = find('label:not(.select2-offscreen)',
+      text: /#{Regexp.escape(options[:from])}/i,
+      match: :one)
+
+    within label.first(:xpath, ".//..") do
+      options[:from] = "##{find('.select2-container')['id']}"
+    end
+
+    find(options[:from]).find('a').click
+
+    within(:xpath, '//body') do
+      page.find("div.select2-result-label",
+        text: /#{Regexp.escape(value)}/i, match: :prefer_exact).click
+    end
+  end
+end


### PR DESCRIPTION
PhantomJS was abondoned by the author and does not support modern javascript and css.
By switching to headless Chrome we test the features in real browser instead.