### PR TITLE
Use FA calendar icons for EssenceDate picker

### DIFF
--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -738,5 +738,5 @@ textarea.has_tinymce {
 .essence_date--label {
   position: absolute;
   right: 5px;
-  top: 31px;
+  top: 33px;
 }

--- a/app/assets/stylesheets/alchemy/jquery.datetimepicker.scss
+++ b/app/assets/stylesheets/alchemy/jquery.datetimepicker.scss
@@ -170,12 +170,14 @@ $datepicker_day_color: $text-color !default;
 .xdsoft_datetimepicker .xdsoft_today_button {
   float: left;
   margin: 0 5px;
+  font-family: 'Font Awesome 5 Free';
+  font-style: normal;
+  font-weight: 400;
 
   &:before {
-    font-family: 'Alchemy Icons';
+    content: fa-content($fa-var-calendar-check);
     font-size: 16px;
     line-height: 18px;
-    content: "\e00a";
   }
 }
 

--- a/app/views/alchemy/essences/_essence_date_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_date_editor.html.erb
@@ -8,6 +8,6 @@
     }
   ) %>
   <label for="<%= content.form_field_id %>" class="essence_date--label">
-    <span class="ui-icon ui-icon-calendar"></span>
+    <i class="icon far fa-calendar-alt fa-fw fa-lg"></i>
   </label>
 </div>


### PR DESCRIPTION
After removing the jquery ui icons I missed to replace the EssenceDate
datepicker icons with fontawesome icons.