### PR TITLE
Don't prevent submit event of element save button

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.element_editors.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.element_editors.js.coffee
@@ -186,11 +186,13 @@ Alchemy.ElementEditors =
   # - Triggers custom 'SelectPreviewElement.Alchemy' event on target element in preview frame.
   #
   onClickElement: (e) ->
-    $element = $(e.target).closest(".element-editor")
+    $target = $(e.target)
+    $element = $target.closest(".element-editor")
     element_id = $element.attr("id").replace(/\D/g, "")
     @selectElement($element)
     @selectElementInPreview(element_id)
-    e.preventDefault()
+    # Element submit button needs to keep it's default event
+    e.preventDefault() unless $target.is(':submit')
     return
 
   # Double click event handler for element head.


### PR DESCRIPTION
The onClickElement handler must not prevent the default browser event, if the event target is a submit button.