### PR TITLE
Remove translations provided by ActiveModel

### DIFF
--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -713,26 +713,11 @@ en:
       body: "Please review the form and check the errors."
 
     messages:
-      inclusion: "is not included in the list"
-      exclusion: "is reserved"
-      invalid: "is invalid"
       record_invalid: 'Validation of %{errors} failed'
-      confirmation: "doesn't match confirmation"
-      accepted: "must be accepted"
-      empty: "can't be empty"
-      blank: "can't be blank"
       too_long: "is too long (maximum is %{count} characters)"
       too_short: "is too short (minimum is %{count} characters)"
       wrong_length: "is the wrong length (should be %{count} characters)"
       taken: "has already been taken"
-      not_a_number: "is not a number"
-      greater_than: "must be greater than %{count}"
-      greater_than_or_equal_to: "must be greater than or equal to %{count}"
-      equal_to: "must be equal to %{count}"
-      less_than: "must be less than %{count}"
-      less_than_or_equal_to: "must be less than or equal to %{count}"
-      odd: "must be odd"
-      even: "must be even"
     models:
       alchemy/content:
         attributes:


### PR DESCRIPTION
Alchemy defines several translations that are already defined by ActiveModel. One of these, the "confirmation" translation, is actually incorrect.

As of Rails 5, ActiveModel includes an "%{attribute}" variable reference in the translation, whereas Alchemy's copy simply has the word "confirmation." This results in poorly worded confirmation validation error messages.

For example, with a model defined this way:

```
class User < ActiveRecord::Base
  validates :password, confirmation: true
end
```

If the user doesn't provide a matching password confirmation, the validation error is:

"Password Confirmation doesn't match confirmation"

Whereas using the Rails 5 translation with the embedded "%{attribute}" variable gives:

"Password Confirmation doesn't match Password"

Which makes a whole lot more sense.

I've opted to simply remove the Alchemy translations entirely since these are already defined/provided by ActiveModel and there is really no need to redefine them again in Alchemy's translation file.