### PR TITLE
Remove jasmine gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,6 @@ gem 'pg',     '~> 0.21'   if ENV['DB'] == 'postgresql'
 gem 'sassc-rails'
 
 group :development, :test do
-  gem 'jasmine-rails',        github: 'searls/jasmine-rails'
-  gem 'jasmine-jquery-rails', github: 'travisjeffery/jasmine-jquery-rails'
   gem 'simplecov', require: false
   if ENV['TRAVIS']
     gem 'codeclimate-test-reporter', '~> 1.0', require: false


### PR DESCRIPTION
Although we have very litte javascript specs, we don't maintain them and do not run jasmine specs on CI. Since jasmine integration does not work for Rails engines, we should remove this dependency (which is also currently failing).