### PR TITLE
Fix API response for users able to edit content

### DIFF
--- a/app/controllers/alchemy/api/contents_controller.rb
+++ b/app/controllers/alchemy/api/contents_controller.rb
@@ -7,7 +7,12 @@ module Alchemy
     # You can either load all or only these for :element_id param
     #
     def index
-      @contents = Content.accessible_by(current_ability, :index)
+      # Fix for cancancan not able to merge multiple AR scopes for logged in users
+      if can? :manage, Alchemy::Content
+        @contents = Content.all
+      else
+        @contents = Content.accessible_by(current_ability, :index)
+      end
       if params[:element_id].present?
         @contents = @contents.where(element_id: params[:element_id])
       end

--- a/app/controllers/alchemy/api/elements_controller.rb
+++ b/app/controllers/alchemy/api/elements_controller.rb
@@ -9,7 +9,12 @@ module Alchemy
     # If you want to only load a specific type of element pass ?named=an_element_name
     #
     def index
-      @elements = Element.accessible_by(current_ability, :index)
+      # Fix for cancancan not able to merge multiple AR scopes for logged in users
+      if can? :manage, Alchemy::Element
+        @elements = Element.all
+      else
+        @elements = Element.accessible_by(current_ability, :index)
+      end
       if params[:page_id].present?
         @elements = @elements.where(page_id: params[:page_id])
       end

--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -7,7 +7,12 @@ module Alchemy
     # Returns all pages as json object
     #
     def index
-      @pages = Page.accessible_by(current_ability, :index)
+      # Fix for cancancan not able to merge multiple AR scopes for logged in users
+      if can? :edit_content, Alchemy::Page
+        @pages = Page.all
+      else
+        @pages = Page.accessible_by(current_ability, :index)
+      end
       if params[:page_layout].present?
         @pages = @pages.where(page_layout: params[:page_layout])
       end

--- a/spec/controllers/alchemy/api/contents_controller_spec.rb
+++ b/spec/controllers/alchemy/api/contents_controller_spec.rb
@@ -52,6 +52,24 @@ module Alchemy
           expect(result['contents'].size).to eq(Alchemy::Content.count)
         end
       end
+
+      context 'as author' do
+        before do
+          authorize_user(build(:alchemy_dummy_user, :as_author))
+        end
+
+        it "returns all contents" do
+          get :index, params: {format: :json}
+
+          expect(response.status).to eq(200)
+          expect(response.content_type).to eq('application/json')
+
+          result = JSON.parse(response.body)
+
+          expect(result).to have_key('contents')
+          expect(result['contents'].size).to eq(Alchemy::Content.count)
+        end
+      end
     end
 
     describe '#show' do

--- a/spec/controllers/alchemy/api/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/api/elements_controller_spec.rb
@@ -85,6 +85,24 @@ module Alchemy
           expect(result['elements'].size).to eq(Alchemy::Element.count)
         end
       end
+
+      context 'as author' do
+        before do
+          authorize_user(build(:alchemy_dummy_user, :as_author))
+        end
+
+        it "returns all elements" do
+          get :index, params: {format: :json}
+
+          expect(response.status).to eq(200)
+          expect(response.content_type).to eq('application/json')
+
+          result = JSON.parse(response.body)
+
+          expect(result).to have_key('elements')
+          expect(result['elements'].size).to eq(Alchemy::Element.count)
+        end
+      end
     end
 
     describe '#show' do

--- a/spec/controllers/alchemy/api/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/api/pages_controller_spec.rb
@@ -48,6 +48,24 @@ module Alchemy
           expect(result['pages'].size).to eq(2)
         end
       end
+
+      context 'as author' do
+        before do
+          authorize_user(build(:alchemy_dummy_user, :as_author))
+        end
+
+        it "returns all pages" do
+          get :index, params: {format: :json}
+
+          expect(response.status).to eq(200)
+          expect(response.content_type).to eq('application/json')
+
+          result = JSON.parse(response.body)
+
+          expect(result).to have_key('pages')
+          expect(result['pages'].size).to eq(Alchemy::Page.count)
+        end
+      end
     end
 
     describe '#nested' do


### PR DESCRIPTION
We defined multiple CanCan abilities for the various roles we have.
Since CanCan can not merge multiple AR scopes we need to handle the
ability check in the api controllers ourselves.

Fixes #792