### PR TITLE
A few admin layout refinements

### DIFF
--- a/app/assets/javascripts/alchemy/admin.js
+++ b/app/assets/javascripts/alchemy/admin.js
@@ -4,7 +4,6 @@
 //= require jquery_ujs
 //= require turbolinks
 //= require jquery-ui/draggable
-//= require jquery-ui/effect-drop
 //= require jquery-ui/effect-fade
 //= require jquery-ui/sortable
 //= require jquery-ui/tabs

--- a/app/assets/javascripts/alchemy/alchemy.datepicker.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.datepicker.js.coffee
@@ -15,6 +15,7 @@ $.extend Alchemy,
       $datepicker_inputs.each ->
         type = $(this).data('datepicker-type')
         options =
+          scrollInput: false
           format: Alchemy.t("formats.#{type}")
           timepicker: /time/.test(type)
           datepicker: /date/.test(type)

--- a/app/assets/javascripts/alchemy/alchemy.elements_window.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.elements_window.js.coffee
@@ -21,6 +21,7 @@ Alchemy.ElementsWindow =
 
   init: (url, options, callback) ->
     @hidden = false
+    @$body = $('body')
     @element_window = $('<div id="alchemy_elements_window"/>')
     @element_area = $('<div id="element_area"/>')
     @url = url
@@ -32,11 +33,11 @@ Alchemy.ElementsWindow =
     @button.click =>
       @hide()
       false
-    height = @resize()
     window.requestAnimationFrame =>
       spinner = new Alchemy.Spinner('medium')
       spinner.spin @element_area[0]
     $('#main_content').append(@element_window)
+    @show()
     @reload()
 
   createToolbar: (buttons) ->
@@ -44,14 +45,6 @@ Alchemy.ElementsWindow =
     for btn in buttons
       @toolbar.append Alchemy.ToolbarButton(btn)
     @toolbar
-
-  resize: ->
-    height = $(window).height() - 73
-    @element_window.css
-      height: height
-    @element_area.css
-      height: height - 46
-    height
 
   reload: ->
     $.get @url, (data) =>
@@ -63,16 +56,14 @@ Alchemy.ElementsWindow =
       Alchemy.AjaxErrorHandler @element_area, xhr.status, status, error
 
   hide: ->
-    @element_window.css(right: -400)
+    @$body.removeClass('elements-window-visible');
     @hidden = true
     @toggleButton()
-    Alchemy.PreviewWindow.resize()
 
   show: ->
-    @element_window.css(right: 0)
+    @$body.addClass('elements-window-visible');
     @hidden = false
     @toggleButton()
-    Alchemy.PreviewWindow.resize()
 
   toggleButton: ->
     if @hidden

--- a/app/assets/javascripts/alchemy/alchemy.growler.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.growler.js.coffee
@@ -11,16 +11,14 @@ Alchemy.Growler =
     Alchemy.Growler.fade()
 
   fade: ->
-    $(".flash.notice, .flash.warning, .flash.warn, .flash.alert", "#flash_notices").delay(5000).hide "drop",
-      direction: "up"
-    , 400, ->
-      $(this).remove()
+    $(".flash:not(.error)", "#flash_notices").delay(5000).queue(-> Alchemy.Growler.dismiss(this))
+    $(".flash", "#flash_notices").click((e) => @dismiss(e.currentTarget))
+    return
 
-    $(".flash.error", "#flash_notices").click ->
-      $(this).hide "drop",
-        direction: "up"
-      , 400, ->
-        $(this).remove()
+  dismiss: (element) ->
+    $(element).on 'transitionend', => $(element).remove()
+    $(element).addClass('dismissed')
+    return
 
 Alchemy.growl = (message, style = "notice") ->
   Alchemy.Growler.build message, style

--- a/app/assets/javascripts/alchemy/alchemy.preview_window.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.preview_window.js.coffee
@@ -13,16 +13,12 @@ Alchemy.PreviewWindow =
     $('body').append($iframe)
     @currentWindow = $iframe
     @_bindReloadButton()
-    @resize()
 
-  resize: ->
-    width = @_calculateWidth()
-    height = $(window).height() - @HEIGHT
+  resize: (width) ->
     width = @MIN_WIDTH if width < @MIN_WIDTH
     @currentWidth = width
     @currentWindow.css
       width: width
-      height: height
 
   refresh: (callback) ->
     $iframe = $('#alchemy_preview_window')
@@ -52,12 +48,6 @@ Alchemy.PreviewWindow =
     $reload.click (e) =>
       e.preventDefault()
       @refresh()
-
-  _calculateWidth: ->
-    width = $(window).width() - $('#left_menu').width()
-    unless Alchemy.ElementsWindow.hidden
-      width -= $('#alchemy_elements_window').width()
-    return width
 
 Alchemy.reloadPreview = ->
   Alchemy.PreviewWindow.refresh()

--- a/app/assets/stylesheets/alchemy/_variables.scss
+++ b/app/assets/stylesheets/alchemy/_variables.scss
@@ -87,3 +87,5 @@ $addon-icon-opacity: 0.85;
 
 $table-row-background-color: rgba(#fff, 0.25);
 $table-row-hover-color: rgba($light_yellow, 0.5);
+$elements-window-width: 400px !default;
+$top-menu-height: 75px !default;

--- a/app/assets/stylesheets/alchemy/_variables.scss
+++ b/app/assets/stylesheets/alchemy/_variables.scss
@@ -89,3 +89,5 @@ $table-row-background-color: rgba(#fff, 0.25);
 $table-row-hover-color: rgba($light_yellow, 0.5);
 $elements-window-width: 400px !default;
 $top-menu-height: 75px !default;
+
+$tabs-height: 31px !default;

--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -5,6 +5,7 @@
   width: $elements-window-width;
   height: calc(100vh - #{$top-menu-height});
   border-left: $default-border;
+  background-color: $light-gray;
   transition: 200ms ease-in-out;
   transform: translate3d($elements-window-width - $default-border-width, 0, 0);
 

--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -2,6 +2,7 @@
   position: absolute;
   right: 0;
   top: $top-menu-height;
+  z-index: 20;
   width: $elements-window-width;
   height: calc(100vh - #{$top-menu-height});
   border-left: $default-border;

--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -296,7 +296,7 @@
   background-color: $medium-gray;
   padding: 1px;
 
-  .essence_picture_editor {
+  .essence_picture {
     margin: 1px;
     float: left;
     height: 126px;
@@ -400,7 +400,7 @@
   }
 }
 
-.essence_picture_editor {
+.essence_picture {
   position: relative;
 
   .picture_tool_delete {
@@ -646,7 +646,7 @@ select.long {
     }
   }
 
-  &.essence_picture_editor {
+  &.essence_picture {
     float: none;
     height: auto;
     display: inline-block;

--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -1,14 +1,20 @@
 #alchemy_elements_window {
   position: absolute;
   right: 0;
-  top: 73px;
-  width: 400px;
-  height: auto;
+  top: $top-menu-height;
+  width: $elements-window-width;
+  height: calc(100vh - #{$top-menu-height});
   border-left: $default-border;
   transition: 200ms ease-in-out;
+  transform: translate3d($elements-window-width - $default-border-width, 0, 0);
+
+  .elements-window-visible & {
+    transform: translate3d(0, 0, 0);
+  }
 }
 
 #element_area {
+  height: calc(100vh - #{$top-menu-height + $toolbar-height});
   overflow-x: hidden;
   overflow-y: auto;
 

--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -364,39 +364,27 @@
 
 .edit_images_bottom {
   position: absolute;
+  display: flex;
+  justify-content: space-between;
   left: 0;
   bottom: 0;
   z-index: 0;
-  width: inherit;
-  padding: $default-padding;
-
-  > a, > span.icon {
-    float: left;
-    margin: -1px $default-margin/2;
-    width: 18px;
-    height: 18px;
-  }
+  padding: $default-padding $default-padding/2;
 
   a {
+    margin: 0 $default-padding/2;
+    padding: $default-padding/2;
+    cursor: pointer;
 
     &.linked {
-      position: relative;
       border-radius: $default-border-radius;
       background-color: $linked-color;
-      border: 1px solid $button-border-color;
-      bottom: 1px;
-      margin-right: 2px;
-      width: 20px;
-      height: 18px;
-      margin-left: 0;
-
-      .icon { margin-left: 1px }
     }
-  }
 
-  a.disabled, > span.icon {
-    opacity: 0.3;
-    cursor: default;
+    &.disabled {
+      opacity: 0.3;
+      cursor: default;
+    }
   }
 }
 

--- a/app/assets/stylesheets/alchemy/flash.scss
+++ b/app/assets/stylesheets/alchemy/flash.scss
@@ -2,7 +2,7 @@ div#flash_notices {
   position: fixed;
   right: 0;
   z-index: 400000;
-  width: 348px;
+  width: 400px;
   top: 0;
 
   .flash.error {
@@ -30,13 +30,21 @@ div.flash {
   z-index: 1000;
   margin: $default-margin $default-margin 2*$default-margin;
   position: relative;
-  min-height: 1.3em;
+  min-height: 2.6em;
   word-break: break-all;
+  transition-property: opacity, transform;
+  transition-duration: 0.4s;
 
   .icon {
     position: absolute;
     top: 10px;
     left: 8px;
+  }
+
+  &.dismissed {
+    display: block;
+    opacity: 0;
+    transform: translate3d(0, -100%, 0);
   }
 
   &.notice {

--- a/app/assets/stylesheets/alchemy/flash.scss
+++ b/app/assets/stylesheets/alchemy/flash.scss
@@ -39,6 +39,7 @@ div.flash {
     position: absolute;
     top: 10px;
     left: 8px;
+    color: inherit;
   }
 
   &.dismissed {

--- a/app/assets/stylesheets/alchemy/frame.scss
+++ b/app/assets/stylesheets/alchemy/frame.scss
@@ -88,6 +88,15 @@ div#overlay_text_box {
     @extend .locked_page;
     cursor: default;
     border-bottom-color: $toolbar-bg-color;
+
+    .hint-bubble {
+      left: -40px;
+      transform: none;
+
+      &:before {
+        left: 47px;
+      }
+    }
   }
 
   .page_name {

--- a/app/assets/stylesheets/alchemy/jquery-ui.scss
+++ b/app/assets/stylesheets/alchemy/jquery-ui.scss
@@ -149,7 +149,6 @@
   background-color: #ededed;
   font-weight: normal;
   color: $text-color;
-  text-shadow: $button-text-shadow;
 }
 
 .ui-state-default a, .ui-state-default a:link, .ui-state-default a:visited {
@@ -335,41 +334,41 @@
 
 .ui-tabs .ui-tabs-nav {
   padding: 4px 8px 0;
-  background: transparent;
+  background: $toolbar-bg-color;
   border-radius: 0;
   border-bottom: $default-border;
   margin: 0;
+  padding: 0;
+  height: $tabs-height;
 }
 
 .ui-tabs .ui-tabs-nav li {
   list-style: none;
   float: left;
   position: relative;
-  height: 28px;
-  top: 1px;
-  margin: 0 .2em 1px 0;
+  height: $tabs-height - $default-border-width;
+  margin: 0;
   border-color: $default-border-color;
-  border-bottom: 0 !important;
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
+  border-width: 0;
+  border-right-width: $default-border-width;
+  border-radius: 0;
   padding: 0;
   white-space: nowrap;
-  background-color: $medium-gray;
+  background-color: transparent;
   font-weight: normal;
 
   &.ui-tabs-active {
     background-color: $light-gray;
-    margin-bottom: 0px;
-    height: $default-form-field-height;
+    height: $tabs-height;
 
     a { cursor: default }
   }
 }
 
 .ui-tabs .ui-tabs-nav li a {
-  float: left;
+  display: block;
   text-decoration: none;
-  padding: 6px 12px 5px;
+  padding: 8px 12px 7px;
 }
 
 .ui-tabs .ui-tabs-nav li.ui-tabs-selected {
@@ -400,41 +399,29 @@
 
 /* UI Tabs Paging */
 
+.ui-tabs li.ui-tabs-paging-prev {
+  border-right-width: 1px;
+}
+
 .ui-tabs li.ui-tabs-paging-next {
   float: right !important;
   padding: 0 !important;
-}
-
-.ui-tabs .ui-tabs-nav .ui-tabs-paging-prev,
-.ui-tabs .ui-tabs-nav .ui-tabs-paging-next {
-  height: 26px;
+  border-right-width: 0;
 }
 
 .ui-tabs .ui-tabs-nav .ui-tabs-paging-prev a,
 .ui-tabs .ui-tabs-nav .ui-tabs-paging-next a {
   display: block;
-  position: relative;
-  top: 1px;
   border: 0;
   z-index: 2;
-  padding: 5px;
-  color: #444;
+  padding: 8px;
+  color: $icon-color;
   text-decoration: none;
-  background: #eee;
   cursor: pointer;
 }
 
-.ui-tabs .ui-tabs-paging-next a:hover,
-.ui-tabs .ui-tabs-paging-next a:focus,
-.ui-tabs .ui-tabs-paging-next a:active,
-.ui-tabs .ui-tabs-paging-prev a:hover,
-.ui-tabs .ui-tabs-paging-prev a:focus,
-.ui-tabs .ui-tabs-paging-prev a:active {
-  background: #eee;
-}
-
 .ui-tabs .ui-tabs-nav .ui-tabs-paging-disabled {
-  visibility: hidden;
+  display: none;
 }
 
 /*

--- a/app/assets/stylesheets/alchemy/notices.scss
+++ b/app/assets/stylesheets/alchemy/notices.scss
@@ -20,6 +20,7 @@
     position: absolute;
     left: 8px;
     top: 10px;
+    color: inherit;
   }
 
   &.footnote {

--- a/app/assets/stylesheets/alchemy/preview_window.scss
+++ b/app/assets/stylesheets/alchemy/preview_window.scss
@@ -2,8 +2,8 @@
   position: absolute;
   left: $main-menu-width;
   top: 75px;
-  width: auto;
-  height: auto;
+  width: calc(100vw - #{$main-menu-width - $default-border-width});
+  height: calc(100vh - #{$top-menu-height});
   border: 0 none;
   background: #fff;
   border-right: $default-border;
@@ -11,5 +11,10 @@
 
   .collapsed-menu & {
     left: $collapsed-main-menu-width;
+    width: calc(100vw - #{$collapsed-main-menu-width - $default-border-width});
+  }
+
+  .collapsed-menu.elements-window-visible & {
+    width: calc(100vw - #{$collapsed-main-menu-width - $default-border-width} - #{$elements-window-width});
   }
 }

--- a/app/views/alchemy/admin/contents/create.js.erb
+++ b/app/views/alchemy/admin/contents/create.js.erb
@@ -23,7 +23,7 @@ $('#picture_to_assign_<%= @content.ingredient.id %> a').attr('href', '#').off('c
 <% if @gallery_pictures %>
 
 <% if @gallery_pictures.size > 1 %>
-$('#element_<%= @element.id %>_contents .essence_picture_editor').addClass('draggable_picture');
+$('#element_<%= @element.id %>_contents .essence_picture').addClass('draggable_picture');
 <% end %>
 
 <% if !max_image_count.blank? && @gallery_pictures.size >= max_image_count %>

--- a/app/views/alchemy/admin/pages/edit.html.erb
+++ b/app/views/alchemy/admin/pages/edit.html.erb
@@ -178,7 +178,12 @@
       Alchemy.ElementEditors.init();
       Alchemy.SelectBox('.element-editor');
       Alchemy.Tinymce.init(<%= @page.richtext_contents_ids.to_json %>);
-      $('#cells').tabs().tabs('paging', { follow: true, followOnSelect: true } );
+      $('#cells').tabs().tabs('paging', {
+        follow: true,
+        followOnSelect: true,
+        prevButton: '<i class="fas fa-angle-double-left"></i>',
+        nextButton: '<i class="fas fa-angle-double-right"></i>'
+      });
       Alchemy.ElementDirtyObserver('#element_area');
       if (window.location.hash) {
         $(window.location.hash).trigger('FocusElementEditor.Alchemy');

--- a/app/views/alchemy/admin/pages/edit.html.erb
+++ b/app/views/alchemy/admin/pages/edit.html.erb
@@ -195,17 +195,13 @@
       $('#top_menu').css('z-index', 30);
     });
 
-    $('select#preview_size').on('change', function(e) {
+    $('select#preview_size').on('change', function() {
       var width = this.value;
-      if (this.value === 'auto') {
-        width = Alchemy.PreviewWindow.currentWidth;
+      if (width === 'auto') {
+        Alchemy.PreviewWindow.currentWindow.css('width', '');
+      } else {
+        Alchemy.PreviewWindow.resize(width);
       }
-      Alchemy.PreviewWindow.currentWindow.css('width', width);
-    });
-
-    $(window).resize(function() {
-      Alchemy.PreviewWindow.resize();
-      Alchemy.ElementsWindow.resize();
     });
   });
 

--- a/app/views/alchemy/essences/_essence_picture_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_picture_editor.html.erb
@@ -1,5 +1,5 @@
 <%= content_tag :div, id: content.dom_id, data: {"content-id" => content.id}, class: [
-    "essence_picture_editor",
+    "essence_picture",
     options[:sortable] ? "draggable_picture" : nil,
     options[:grouped] ? nil : "content_editor"
   ].compact.join(" ") do %>

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -199,7 +199,7 @@ en:
     "Flush picture cache": "Flush picture cache"
     "Global shortcuts": "Global shortcuts"
     "Hide childpages": "Hide childpages"
-    hide_elements: hide_elements
+    hide_elements: Hide Elements
     hide_element: "Hide element"
     "Image missing": "Image missing"
     "Image size": "Image size"

--- a/spec/features/admin/page_editing_feature_spec.rb
+++ b/spec/features/admin/page_editing_feature_spec.rb
@@ -128,7 +128,7 @@ describe 'Page editing feature' do
         expect(page).to have_selector('div.content_editor.essence_file')
         expect(page).to have_selector('div.content_editor.essence_html_editor')
         expect(page).to have_selector('div.content_editor.essence_link')
-        expect(page).to have_selector('div.content_editor.essence_picture_editor')
+        expect(page).to have_selector('div.content_editor.essence_picture')
         expect(page).to have_selector('div.content_editor.essence_richtext')
         expect(page).to have_selector('div.content_editor.essence_select')
         expect(page).to have_selector('div.content_editor.essence_text')


### PR DESCRIPTION
A couple of small admin layout fixes:

- Fix the position of the current page hint bubbles
- Fix the z-index of elements window
- Adjust tab style in admin
- Prevent scrolling of datepicker input
- Fix icon color in flash notices and message panels
- Fix english hide_elements translation
- Fix the background color of elements window
- Simplify essence picture links CSS
- Rename essence_picture_editor class
- Use CSS to calculate width and height of elements and preview windows
- Use CSS to dismiss Flash notices