### PR TITLE
Give capybara more time to render pictures

### DIFF
--- a/spec/features/admin/picture_assignment_overlay_spec.rb
+++ b/spec/features/admin/picture_assignment_overlay_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Picture assignment overlay" do
 
       within ".alchemy-dialog.modal" do
         # We expect to see both pictures
-        expect(page).to have_selector("#overlay_picture_list a img", count: 2)
+        expect(page).to have_selector("#overlay_picture_list a img", count: 2, wait: 10)
 
         # Click on a tag to filter the pictures
         within ".tag-list" do


### PR DESCRIPTION
Rendering pictures can sometomes take a little longer. The spec should
not fail in this case. Raising the wait time to 10 seconds should be
enough time for chrome to render the pics.