### PR TITLE
Skip migrate-to-gutentag migration for fresh installs

### DIFF
--- a/db/migrate/20180227224537_migrate_tags_to_gutentag.rb
+++ b/db/migrate/20180227224537_migrate_tags_to_gutentag.rb
@@ -1,5 +1,7 @@
 class MigrateTagsToGutentag < ActiveRecord::Migration[5.0]
-  def change
+  def up
+    return if table_exists?(:gutentag_tags)
+
     remove_index :taggings, :taggable_id
     remove_column :taggings, :tagger_id, :integer
     remove_index :taggings, :taggable_type


### PR DESCRIPTION
On fresh installs the alchemy installer installs all engines migrations, including the Gutentag tables. We then already have all the tables and indexes we need, so we can skip the migration that is meant for existing Alchemy installations.


Fixes #1379