### PR TITLE
Fixate Gutentag to 2.1.0 for now

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'coffee-rails',                     ['~> 4.0']
   gem.add_runtime_dependency 'dragonfly',                        ['~> 1.0', '>= 1.0.7']
   gem.add_runtime_dependency 'dragonfly_svg',                    ['~> 0.0.4']
-  gem.add_runtime_dependency 'gutentag',                         ['~> 2.1']
+  gem.add_runtime_dependency 'gutentag',                         ['~> 2.1.0']
   gem.add_runtime_dependency 'handlebars_assets',                ['~> 0.23']
   gem.add_runtime_dependency 'jquery-rails',                     ['~> 4.0', '>= 4.0.4']
   gem.add_runtime_dependency 'jquery-ui-rails',                  ['~> 5.0.0']


### PR DESCRIPTION
The latest release of Gutentag (2.2.0) [is broken](https://github.com/pat/gutentag/issues/50). Reading tags via
`tag_names` is always empty and setting new tags via `tag_names=` is
not replacing any tags.