### PR TITLE
Fix resources search

### DIFF
--- a/app/controllers/alchemy/admin/attachments_controller.rb
+++ b/app/controllers/alchemy/admin/attachments_controller.rb
@@ -8,15 +8,15 @@ module Alchemy
       helper 'alchemy/admin/tags'
 
       def index
-        @query = Attachment.ransack(params[:q])
+        @query = Attachment.ransack(search_filter_params[:q])
         @attachments = @query.result
 
-        if params[:tagged_with].present?
-          @attachments = @attachments.tagged_with(params[:tagged_with])
+        if search_filter_params[:tagged_with].present?
+          @attachments = @attachments.tagged_with(search_filter_params[:tagged_with])
         end
 
-        if params[:file_type].present?
-          @attachments = @attachments.with_file_type(params[:file_type])
+        if search_filter_params[:file_type].present?
+          @attachments = @attachments.with_file_type(search_filter_params[:file_type])
         end
 
         @attachments = @attachments

--- a/app/controllers/alchemy/admin/attachments_controller.rb
+++ b/app/controllers/alchemy/admin/attachments_controller.rb
@@ -69,7 +69,7 @@ module Alchemy
       private
 
       def search_filter_params
-        params.except(*COMMON_SEARCH_FILTER_EXCLUDES + [:attachment]).permit(
+        @_search_filter_params ||= params.except(*COMMON_SEARCH_FILTER_EXCLUDES + [:attachment]).permit(
           *common_search_filter_includes + [
             :file_type,
             :content_id

--- a/app/controllers/alchemy/admin/languages_controller.rb
+++ b/app/controllers/alchemy/admin/languages_controller.rb
@@ -4,7 +4,7 @@ module Alchemy
   module Admin
     class LanguagesController < ResourcesController
       def index
-        @query = Language.on_current_site.ransack(params[:q])
+        @query = Language.on_current_site.ransack(search_filter_params[:q])
         @languages = @query.result.page(params[:page] || 1).per(per_page_value_for_screen_size)
       end
 

--- a/app/controllers/alchemy/admin/pictures_controller.rb
+++ b/app/controllers/alchemy/admin/pictures_controller.rb
@@ -141,7 +141,7 @@ module Alchemy
       end
 
       def search_filter_params
-        params.except(*COMMON_SEARCH_FILTER_EXCLUDES + [:picture_ids]).permit(
+        @_search_filter_params ||= params.except(*COMMON_SEARCH_FILTER_EXCLUDES + [:picture_ids]).permit(
           *common_search_filter_includes + [
             :size,
             :element_id,

--- a/app/controllers/alchemy/admin/pictures_controller.rb
+++ b/app/controllers/alchemy/admin/pictures_controller.rb
@@ -14,8 +14,8 @@ module Alchemy
 
       def index
         @size = params[:size].present? ? params[:size] : 'medium'
-        @query = Picture.ransack(params[:q])
-        @pictures = Picture.search_by(params, @query, pictures_per_page_for_size(@size))
+        @query = Picture.ransack(search_filter_params[:q])
+        @pictures = Picture.search_by(search_filter_params, @query, pictures_per_page_for_size(@size))
 
         if in_overlay?
           archive_overlay

--- a/app/controllers/alchemy/admin/resources_controller.rb
+++ b/app/controllers/alchemy/admin/resources_controller.rb
@@ -137,7 +137,7 @@ module Alchemy
       end
 
       def search_filter_params
-        params.except(*COMMON_SEARCH_FILTER_EXCLUDES).permit(*common_search_filter_includes)
+        @_search_filter_params ||= params.except(*COMMON_SEARCH_FILTER_EXCLUDES).permit(*common_search_filter_includes)
       end
 
       def common_search_filter_includes

--- a/app/controllers/alchemy/admin/resources_controller.rb
+++ b/app/controllers/alchemy/admin/resources_controller.rb
@@ -7,7 +7,7 @@ require 'alchemy/resources_helper'
 module Alchemy
   module Admin
     class ResourcesController < Alchemy::Admin::BaseController
-      COMMON_SEARCH_FILTER_EXCLUDES = [:id, :utf8, :_method, :_].freeze
+      COMMON_SEARCH_FILTER_EXCLUDES = [:id, :utf8, :_method, :_, :format].freeze
 
       include Alchemy::ResourcesHelper
 
@@ -20,18 +20,18 @@ module Alchemy
       before_action :authorize_resource
 
       def index
-        @query = resource_handler.model.ransack(params[:q])
+        @query = resource_handler.model.ransack(search_filter_params[:q])
         items = @query.result
 
         if contains_relations?
           items = items.includes(*resource_relations_names)
         end
 
-        if params[:tagged_with].present?
-          items = items.tagged_with(params[:tagged_with])
+        if search_filter_params[:tagged_with].present?
+          items = items.tagged_with(search_filter_params[:tagged_with])
         end
 
-        if params[:filter].present?
+        if search_filter_params[:filter].present?
           items = items.public_send(sanitized_filter_params)
         end
 
@@ -132,7 +132,7 @@ module Alchemy
 
       def sanitized_filter_params
         resource_model.alchemy_resource_filters.detect do |filter|
-          filter == params[:filter]
+          filter == search_filter_params[:filter]
         end || :all
       end
 

--- a/app/controllers/alchemy/admin/resources_controller.rb
+++ b/app/controllers/alchemy/admin/resources_controller.rb
@@ -61,7 +61,7 @@ module Alchemy
         resource_instance_variable.save
         render_errors_or_redirect(
           resource_instance_variable,
-          resources_path(resource_handler.namespaced_resources_name, current_location_params),
+          resources_path(resource_handler.namespaced_resources_name, search_filter_params),
           flash_notice_for_resource_action
         )
       end
@@ -70,7 +70,7 @@ module Alchemy
         resource_instance_variable.update_attributes(resource_params)
         render_errors_or_redirect(
           resource_instance_variable,
-          resources_path(resource_handler.namespaced_resources_name, current_location_params),
+          resources_path(resource_handler.namespaced_resources_name, search_filter_params),
           flash_notice_for_resource_action
         )
       end
@@ -78,7 +78,7 @@ module Alchemy
       def destroy
         resource_instance_variable.destroy
         flash_notice_for_resource_action
-        do_redirect_to resource_url_proxy.url_for(current_location_params.merge(action: 'index'))
+        do_redirect_to resource_url_proxy.url_for(search_filter_params.merge(action: 'index'))
       end
 
       def resource_handler
@@ -137,7 +137,7 @@ module Alchemy
       end
 
       def search_filter_params
-        @_search_filter_params ||= params.except(*COMMON_SEARCH_FILTER_EXCLUDES).permit(*common_search_filter_includes)
+        @_search_filter_params ||= params.except(*COMMON_SEARCH_FILTER_EXCLUDES).permit(*common_search_filter_includes).to_h
       end
 
       def common_search_filter_includes

--- a/app/controllers/alchemy/admin/tags_controller.rb
+++ b/app/controllers/alchemy/admin/tags_controller.rb
@@ -6,7 +6,7 @@ module Alchemy
       before_action :load_tag, only: [:edit, :update, :destroy]
 
       def index
-        @query = Gutentag::Tag.ransack(params[:q])
+        @query = Gutentag::Tag.ransack(search_filter_params[:q])
         @tags = @query
                   .result
                   .page(params[:page] || 1)

--- a/app/views/alchemy/admin/attachments/_archive_overlay.html.erb
+++ b/app/views/alchemy/admin/attachments/_archive_overlay.html.erb
@@ -14,7 +14,7 @@
   <%= render 'alchemy/admin/partials/remote_search_form' %>
 </div>
 
-<div id="assign_file_list" class="with_padding<%= params[:tagged_with].present? ? ' filtered' : '' %>">
+<div id="assign_file_list" class="with_padding<%= search_filter_params[:tagged_with].present? ? ' filtered' : '' %>">
   <div id="library_sidebar">
     <%= render 'filter_bar' %>
 

--- a/app/views/alchemy/admin/attachments/_attachment.html.erb
+++ b/app/views/alchemy/admin/attachments/_attachment.html.erb
@@ -54,7 +54,7 @@
       Alchemy.t(:confirm_to_delete_file),
       alchemy.admin_attachment_path(
         id: attachment,
-        q: params[:q],
+        q: search_filter_params[:q],
         page: params[:page],
         per_page: params[:per_page]
       ),
@@ -62,7 +62,7 @@
   <% end %>
   <% if can?(:edit, attachment) %>
     <%= link_to_dialog render_icon(:edit),
-      alchemy.edit_admin_attachment_path(attachment, q: params[:q], page: params[:page]),
+      alchemy.edit_admin_attachment_path(attachment, q: search_filter_params[:q], page: params[:page]),
       {
         title: Alchemy.t(:rename_file),
         size: '500x250'

--- a/app/views/alchemy/admin/attachments/_files_list.html.erb
+++ b/app/views/alchemy/admin/attachments/_files_list.html.erb
@@ -1,6 +1,6 @@
 <% if @attachments.empty? %>
   <%= render_message do %>
-    <% if params[:q].present? %>
+    <% if search_filter_params[:q].present? %>
       <%= Alchemy.t(:no_search_results) %>
     <% else %>
       <%= Alchemy.t(:no_files_in_archive) %>

--- a/app/views/alchemy/admin/attachments/_filter_bar.html.erb
+++ b/app/views/alchemy/admin/attachments/_filter_bar.html.erb
@@ -4,7 +4,7 @@
     'file_type_filter',
     options_for_select(
       Alchemy::Attachment.file_types_for_select,
-      params[:file_type]
+      search_filter_params[:file_type]
     ),
     include_blank: Alchemy.t('Show all files'),
     data: { remote: !!request.xhr? },

--- a/app/views/alchemy/admin/attachments/_overlay_file_list.html.erb
+++ b/app/views/alchemy/admin/attachments/_overlay_file_list.html.erb
@@ -1,6 +1,6 @@
 <% if @attachments.empty? %>
   <%= render_message do %>
-    <% if params[:q].present? %>
+    <% if search_filter_params[:q].present? %>
       <%= Alchemy.t(:no_search_results) %>
     <% else %>
       <%= Alchemy.t(:no_files_in_archive) %>

--- a/app/views/alchemy/admin/attachments/_tag_list.html.erb
+++ b/app/views/alchemy/admin/attachments/_tag_list.html.erb
@@ -4,7 +4,7 @@
   <ul>
     <%= render_tag_list('Alchemy::Attachment') %>
   </ul>
-  <% if params[:tagged_with].present? %>
+  <% if search_filter_params[:tagged_with].present? %>
     <%= link_to(
       render_icon(:times, size: 'xs') + Alchemy.t('Remove tag filter'),
       url_for(search_filter_params.except(:tagged_with)),

--- a/app/views/alchemy/admin/attachments/edit.html.erb
+++ b/app/views/alchemy/admin/attachments/edit.html.erb
@@ -1,5 +1,5 @@
 <%= alchemy_form_for([:admin, @attachment],
-  url: {action: :update, q: params[:q], page: params[:page]}) do |f| -%>
+  url: {action: :update, q: search_filter_params[:q], page: params[:page]}) do |f| -%>
   <%= f.input :name, input_html: {autofocus: true} %>
   <%= f.input :file_name, input_html: {autofocus: true}, hint: Alchemy.t(:attachment_filename_notice) %>
   <div class="input string autocomplete_tag_list">

--- a/app/views/alchemy/admin/attachments/index.html.erb
+++ b/app/views/alchemy/admin/attachments/index.html.erb
@@ -7,7 +7,8 @@
         file_attribute: 'file' %>
     <% end %>
   </div>
-  <%= render 'alchemy/admin/partials/search_form' %>
+  <%= render 'alchemy/admin/partials/search_form',
+    additional_params: [:file_type, :tagged_with] %>
 <% end %>
 
 <div id="archive_all" class="with_tag_filter resources-table-wrapper">

--- a/app/views/alchemy/admin/attachments/index.html.erb
+++ b/app/views/alchemy/admin/attachments/index.html.erb
@@ -18,7 +18,7 @@
     <%= render 'filter_bar' %>
 
     <% if Alchemy::Attachment.tag_counts.any? %>
-      <div class="tag-list with_filter_bar<%= ' filtered' if params[:tagged_with].present? %>">
+      <div class="tag-list with_filter_bar<%= ' filtered' if search_filter_params[:tagged_with].present? %>">
         <%= render 'tag_list' %>
       </div>
     <% end %>

--- a/app/views/alchemy/admin/languages/_table.html.erb
+++ b/app/views/alchemy/admin/languages/_table.html.erb
@@ -36,7 +36,7 @@
     <%= render_resources %>
   </tbody>
 </table>
-<%- elsif params[:q].present? -%>
+<%- elsif search_filter_params[:q].present? -%>
 <p><%= Alchemy.t('Nothing found') %></p>
 <%- end -%>
 

--- a/app/views/alchemy/admin/partials/_remote_search_form.html.erb
+++ b/app/views/alchemy/admin/partials/_remote_search_form.html.erb
@@ -22,6 +22,6 @@
       remote: true,
       class: 'search_field_clear',
       title: Alchemy.t(:click_to_show_all),
-      style: params[:q].blank? ? 'display: none' : 'display: block' %>
+      style: search_filter_params[:q].blank? ? 'display: none' : 'display: block' %>
   </div>
 <% end %>

--- a/app/views/alchemy/admin/partials/_search_form.html.erb
+++ b/app/views/alchemy/admin/partials/_search_form.html.erb
@@ -13,9 +13,9 @@
         class: 'search_field_clear',
         id: 'search_field_clear',
         title: Alchemy.t(:click_to_show_all),
-        style: params.fetch(:q, {}).fetch(resource_handler.search_field_name, '').present? ? 'display: block' : 'display: none' %>
+        style: search_filter_params.fetch(:q, {}).fetch(resource_handler.search_field_name, '').present? ? 'display: block' : 'display: none' %>
     <% local_assigns.fetch(:additional_params, []).each do |additional_param| %>
-      <%= hidden_field_tag additional_param, params[additional_param] %>
+      <%= hidden_field_tag additional_param, search_filter_params[additional_param] %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/alchemy/admin/pictures/_archive.html.erb
+++ b/app/views/alchemy/admin/pictures/_archive.html.erb
@@ -2,7 +2,7 @@
   <%= render 'filter_bar' %>
 
   <% if Alchemy::Picture.tag_counts.any? %>
-    <div class="tag-list with_filter_bar<%= ' filtered' if params[:tagged_with].present? %>">
+    <div class="tag-list with_filter_bar<%= ' filtered' if search_filter_params[:tagged_with].present? %>">
       <%= render 'tag_list' %>
     </div>
   <% end %>
@@ -29,17 +29,17 @@
     <%= link_to(
       render_icon(:times, size: 'xs') + Alchemy.t("Clear selection"),
       admin_pictures_path(
-        q: params[:q],
-        tagged_with: params[:tagged_with],
+        q: search_filter_params[:q],
+        tagged_with: search_filter_params[:tagged_with],
         size: params[:size],
-        filter: params[:filter]
+        filter: search_filter_params[:filter]
       ),
       class: 'secondary button with_icon',
       style: 'float: none'
     ) %>
   </div>
   <div id="pictures">
-  <% if @pictures.blank? and @recent_pictures.blank? and params[:q].blank? %>
+  <% if @pictures.blank? and @recent_pictures.blank? and search_filter_params[:q].blank? %>
     <%= render_message do %>
       <%= Alchemy.t(:no_images_in_archive) %>
     <% end %>

--- a/app/views/alchemy/admin/pictures/_archive_overlay.html.erb
+++ b/app/views/alchemy/admin/pictures/_archive_overlay.html.erb
@@ -1,7 +1,7 @@
 <div id="overlay_toolbar">
   <%= render 'filter_and_size_bar' %>
 </div>
-<div id="assign_image_list" class="with_padding<%= params[:tagged_with].present? ? ' filtered' : '' %>">
+<div id="assign_image_list" class="with_padding<%= search_filter_params[:tagged_with].present? ? ' filtered' : '' %>">
   <div id="library_sidebar">
     <%= render 'filter_bar' %>
     <div class="tag-list">

--- a/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
+++ b/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
@@ -6,7 +6,7 @@
       file_attribute: 'image_file',
       in_dialog: true,
       redirect_url: alchemy.admin_pictures_path(
-        size: params[:size],
+        size: search_filter_params[:size],
         filter: 'last_upload',
         content_id: @content.try(:id),
         element_id: @element.try(:id),
@@ -22,10 +22,10 @@
           size: "small",
           content_id: @content,
           element_id: @element,
-          q: params[:q],
+          q: search_filter_params[:q],
           options: options_from_params,
-          filter: params[:filter],
-          tagged_with: params[:tagged_with]
+          filter: search_filter_params[:filter],
+          tagged_with: search_filter_params[:tagged_with]
         }),
         remote: true,
         title: Alchemy.t(:small_thumbnails),
@@ -39,10 +39,10 @@
           size: "medium",
           content_id: @content,
           element_id: @element,
-          q: params[:q],
+          q: search_filter_params[:q],
           options: options_from_params,
-          filter: params[:filter],
-          tagged_with: params[:tagged_with]
+          filter: search_filter_params[:filter],
+          tagged_with: search_filter_params[:tagged_with]
         }),
         remote: true,
         title: Alchemy.t(:medium_thumbnails),
@@ -56,10 +56,10 @@
           size: "large",
           content_id: @content,
           element_id: @element,
-          q: params[:q],
+          q: search_filter_params[:q],
           options: options_from_params,
-          filter: params[:filter],
-          tagged_with: params[:tagged_with]
+          filter: search_filter_params[:filter],
+          tagged_with: search_filter_params[:tagged_with]
         }),
         remote: true,
         title: Alchemy.t(:big_thumbnails),

--- a/app/views/alchemy/admin/pictures/_filter_bar.html.erb
+++ b/app/views/alchemy/admin/pictures/_filter_bar.html.erb
@@ -7,7 +7,7 @@
       [Alchemy.t(:last_upload_only), 'last_upload'],
       [Alchemy.t(:recently_uploaded_only), 'recent'],
       [Alchemy.t(:without_tag), 'without_tag']
-    ], params[:filter]),
+    ], search_filter_params[:filter]),
     :data => { :remote => !!request.xhr? },
     :class => 'alchemy_selectbox'
   ) %>

--- a/app/views/alchemy/admin/pictures/_form.html.erb
+++ b/app/views/alchemy/admin/pictures/_form.html.erb
@@ -6,9 +6,9 @@
     <%= render 'alchemy/admin/partials/autocomplete_tag_list', f: f %>
     <small class="hint"><%= Alchemy.t('Please seperate the tags with commata') %></small>
   </div>
-  <%= hidden_field_tag :q, params[:q] %>
+  <%= hidden_field_tag :q, search_filter_params[:q] %>
   <%= hidden_field_tag :size, params[:size] %>
-  <%= hidden_field_tag :tagged_with, params[:tagged_with] %>
-  <%= hidden_field_tag :filter, params[:filter] %>
+  <%= hidden_field_tag :tagged_with, search_filter_params[:tagged_with] %>
+  <%= hidden_field_tag :filter, search_filter_params[:filter] %>
   <%= f.submit Alchemy.t(:save) %>
 <% end %>

--- a/app/views/alchemy/admin/pictures/_picture.html.erb
+++ b/app/views/alchemy/admin/pictures/_picture.html.erb
@@ -9,11 +9,11 @@
       Alchemy.t(:confirm_to_delete_image_from_server),
       alchemy.admin_picture_path(
         id: picture,
-        q: params[:q],
+        q: search_filter_params[:q],
         page: params[:page],
-        tagged_with: params[:tagged_with],
+        tagged_with: search_filter_params[:tagged_with],
         size: params[:size],
-        filter: params[:filter]
+        filter: search_filter_params[:filter]
       ),
       {
         title: Alchemy.t('Delete image')
@@ -31,11 +31,11 @@
       image,
       alchemy.admin_picture_path(
         id: picture,
-        q: params[:q],
+        q: search_filter_params[:q],
         page: params[:page],
-        tagged_with: params[:tagged_with],
+        tagged_with: search_filter_params[:tagged_with],
         size: params[:size],
-        filter: params[:filter]
+        filter: search_filter_params[:filter]
       ),
       class: 'thumbnail_background'
     ) %>

--- a/app/views/alchemy/admin/pictures/_tag_list.html.erb
+++ b/app/views/alchemy/admin/pictures/_tag_list.html.erb
@@ -4,7 +4,7 @@
   <ul>
     <%= render_tag_list('Alchemy::Picture') %>
   </ul>
-  <% if params[:tagged_with].present? %>
+  <% if search_filter_params[:tagged_with].present? %>
     <%= link_to(
       render_icon(:times, size: 'xs') + Alchemy.t('Remove tag filter'),
       url_for(search_filter_params.except(:tagged_with)),

--- a/app/views/alchemy/admin/pictures/edit_multiple.html.erb
+++ b/app/views/alchemy/admin/pictures/edit_multiple.html.erb
@@ -1,8 +1,8 @@
 <%= form_tag update_multiple_admin_pictures_path do %>
-  <%= hidden_field_tag :q, params[:q] %>
+  <%= hidden_field_tag :q, search_filter_params[:q] %>
   <%= hidden_field_tag :size, params[:size] %>
-  <%= hidden_field_tag :tagged_with, params[:tagged_with] %>
-  <%= hidden_field_tag :filter, params[:filter] %>
+  <%= hidden_field_tag :tagged_with, search_filter_params[:tagged_with] %>
+  <%= hidden_field_tag :filter, search_filter_params[:filter] %>
 
   <% @pictures.pluck(:id).each do |id| %>
   <%= hidden_field_tag "picture_ids[]", id %>

--- a/app/views/alchemy/admin/pictures/index.html.erb
+++ b/app/views/alchemy/admin/pictures/index.html.erb
@@ -14,7 +14,7 @@
       <div class="button_with_label">
         <%= link_to(
           render_icon('search-minus'),
-          alchemy.admin_pictures_path(size: "small", q: params[:q]),
+          alchemy.admin_pictures_path(size: "small", q: search_filter_params[:q]),
           title: Alchemy.t(:small_thumbnails),
           class: "icon_button"
         ) %>
@@ -22,7 +22,7 @@
       <div class="button_with_label">
         <%= link_to(
           render_icon('search'),
-          alchemy.admin_pictures_path(size: "medium", q: params[:q]),
+          alchemy.admin_pictures_path(size: "medium", q: search_filter_params[:q]),
           title: Alchemy.t(:medium_thumbnails),
           class: "icon_button"
         ) %>
@@ -30,7 +30,7 @@
       <div class="button_with_label">
         <%= link_to(
           render_icon('search-plus'),
-          alchemy.admin_pictures_path(size: "large", q: params[:q]),
+          alchemy.admin_pictures_path(size: "large", q: search_filter_params[:q]),
           title: Alchemy.t(:big_thumbnails),
           class: "icon_button"
         ) %>
@@ -59,7 +59,7 @@
   <h1>
     <%= @pictures.total_count %>
     <%= Alchemy::Picture.model_name.human(count: @pictures.total_count) %>
-    <%= Alchemy.t("picture_library.filter.#{params[:filter]}") if params[:filter].present? %>
+    <%= Alchemy.t("picture_library.filter.#{search_filter_params[:filter]}") if search_filter_params[:filter].present? %>
   </h1>
   <%= render 'archive' %>
 </div>

--- a/app/views/alchemy/admin/pictures/show.html.erb
+++ b/app/views/alchemy/admin/pictures/show.html.erb
@@ -6,11 +6,11 @@
   <% if @previous %>
     <%= link_to alchemy.admin_picture_path(
         id: @previous,
-        q: params[:q],
+        q: search_filter_params[:q],
         page: params[:page],
-        tagged_with: params[:tagged_with],
+        tagged_with: search_filter_params[:tagged_with],
         size: params[:size],
-        filter: params[:filter]
+        filter: search_filter_params[:filter]
       ),
       class: "previous-picture",
       remote: true do %>
@@ -20,11 +20,11 @@
   <% if @next %>
     <%= link_to alchemy.admin_picture_path(
         id: @next,
-        q: params[:q],
+        q: search_filter_params[:q],
         page: params[:page],
-        tagged_with: params[:tagged_with],
+        tagged_with: search_filter_params[:tagged_with],
         size: params[:size],
-        filter: params[:filter]
+        filter: search_filter_params[:filter]
       ),
       class: "next-picture",
       remote: true do %>

--- a/app/views/alchemy/admin/resources/_filter_bar.html.erb
+++ b/app/views/alchemy/admin/resources/_filter_bar.html.erb
@@ -3,7 +3,7 @@
   <%= select_tag(
     'resource_filter',
     options_for_select(
-      resource_filter_select, params[:filter]
+      resource_filter_select, search_filter_params[:filter]
     ),
     include_blank: Alchemy.t(:all, scope: ['resources', resource_name, 'filters']),
     data: { remote: !!request.xhr? },

--- a/app/views/alchemy/admin/resources/_form.html.erb
+++ b/app/views/alchemy/admin/resources/_form.html.erb
@@ -1,4 +1,4 @@
-<%= alchemy_form_for resource_instance_variable, url: resource_path(resource_instance_variable, current_location_params) do |f| %>
+<%= alchemy_form_for resource_instance_variable, url: resource_path(resource_instance_variable, search_filter_params) do |f| %>
   <% resource_handler.editable_attributes.each do |attribute| %>
     <% if relation = attribute[:relation] %>
       <%= f.association relation[:name].to_sym,

--- a/app/views/alchemy/admin/resources/_resource.html.erb
+++ b/app/views/alchemy/admin/resources/_resource.html.erb
@@ -10,11 +10,11 @@
 <% end %>
   <td class="tools">
   <% if can?(:destroy, resource) %>
-    <%= delete_button resource_path(resource, current_location_params) %>
+    <%= delete_button resource_path(resource, search_filter_params) %>
   <% end %>
   <% if can?(:edit, resource) %>
     <%= link_to_dialog render_icon(:edit),
-      edit_resource_path(resource, current_location_params),
+      edit_resource_path(resource, search_filter_params),
       {
         title: Alchemy.t('Edit'),
         size: resource_window_size

--- a/app/views/alchemy/admin/resources/_table.html.erb
+++ b/app/views/alchemy/admin/resources/_table.html.erb
@@ -17,7 +17,7 @@
     <%= render_resources %>
   </tbody>
 </table>
-<% elsif params[:q].present? %>
+<% elsif search_filter_params[:q].present? %>
 <p><%= Alchemy.t('Nothing found') %></p>
 <% end %>
 

--- a/app/views/alchemy/admin/resources/_tag_list.html.erb
+++ b/app/views/alchemy/admin/resources/_tag_list.html.erb
@@ -1,10 +1,10 @@
-<div class="tag-list<%= ' with_filter_bar' if resource_has_filters %><%= ' filtered' if params[:tagged_with].present? %>">
+<div class="tag-list<%= ' with_filter_bar' if resource_has_filters %><%= ' filtered' if search_filter_params[:tagged_with].present? %>">
   <h2><%= Alchemy.t("Filter by tag") %></h2>
   <%= js_filter_field '.tag-list li' %>
   <ul>
     <%= render_tag_list(resource_model.name) %>
   </ul>
-  <% if params[:tagged_with].present? %>
+  <% if search_filter_params[:tagged_with].present? %>
     <%= link_to(
       render_icon(:times, size: 'xs') + Alchemy.t('Remove tag filter'),
       url_for(search_filter_params.except(:tagged_with)),

--- a/app/views/alchemy/admin/resources/index.html.erb
+++ b/app/views/alchemy/admin/resources/index.html.erb
@@ -16,7 +16,7 @@
     },
     {
       icon: 'download',
-      url: resource_url_proxy.url_for(action: 'index', format: 'csv', q: params[:q], sort: params[:sort]),
+      url: resource_url_proxy.url_for(action: 'index', format: 'csv', q: search_filter_params[:q], sort: params[:sort]),
       label: Alchemy.t(:download_csv),
       title: Alchemy.t(:download_csv),
       dialog: false,

--- a/app/views/alchemy/admin/tags/index.html.erb
+++ b/app/views/alchemy/admin/tags/index.html.erb
@@ -43,7 +43,7 @@
 
   <%= render_message do %>
     <h2><%= Alchemy.t('No Tags found') %></h2>
-    <% if params[:q].blank? %>
+    <% if search_filter_params[:q].blank? %>
       <p><%= Alchemy.t(:tags_get_created_if_used_the_first_time) %></p>
     <% end %>
   <% end %>

--- a/lib/alchemy/resources_helper.rb
+++ b/lib/alchemy/resources_helper.rb
@@ -168,10 +168,10 @@ module Alchemy
     #
     def current_location_params
       {
-        q: params[:q],
+        q: search_filter_params[:q],
         page: params[:page],
         tagged_with: params[:tagged_with],
-        filter: params[:filter]
+        filter: search_filter_params[:filter]
       }
     end
 

--- a/lib/alchemy/resources_helper.rb
+++ b/lib/alchemy/resources_helper.rb
@@ -163,18 +163,6 @@ module Alchemy
       render partial: 'resource', collection: resources_instance_variable
     end
 
-    # Returns all the params necessary to get you back from where you where
-    # before: the Ransack query and the current page.
-    #
-    def current_location_params
-      {
-        q: search_filter_params[:q],
-        page: params[:page],
-        tagged_with: params[:tagged_with],
-        filter: search_filter_params[:filter]
-      }
-    end
-
     def resource_has_tags
       resource_model.respond_to?(:tag_counts) && resource_model.tag_counts.any?
     end

--- a/spec/controllers/alchemy/admin/resources_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/resources_controller_spec.rb
@@ -1,8 +1,5 @@
 require "spec_helper"
 
-class Admin::EventsController < Alchemy::Admin::ResourcesController
-end
-
 describe Admin::EventsController do
   it "should include ResourcesHelper" do
     expect(controller.respond_to?(:resource_window_size)).to be_truthy
@@ -24,7 +21,7 @@ describe Admin::EventsController do
     end
 
     context 'with search query given' do
-      let(:params) { {q: {name_or_hidden_name_or_location_name_cont: "PeTer"}} }
+      let(:params) { {q: {name_or_hidden_name_or_description_or_location_name_cont: "PeTer"}} }
 
       it "returns only matching records" do
         get :index, params: params
@@ -34,7 +31,7 @@ describe Admin::EventsController do
 
       context "but searching for record with certain association" do
         let(:bauwagen) { create(:location, name: 'Bauwagen') }
-        let(:params)   { {q: {name_or_hidden_name_or_location_name_cont: "Bauwagen"}} }
+        let(:params)   { {q: {name_or_hidden_name_or_description_or_location_name_cont: "Bauwagen"}} }
 
         before do
           peter.location = bauwagen
@@ -51,32 +48,32 @@ describe Admin::EventsController do
   end
 
   describe '#update' do
-    let(:params) { {q: 'some_query', page: 6} }
+    let(:params) { {q: {name_or_hidden_name_or_description_or_location_name_cont: 'some_query'}, page: 6} }
     let!(:peter)  { create(:event, name: 'Peter') }
 
     it 'redirects to index, keeping the current location parameters' do
       post :update, params: {id: peter.id, event: {name: "Hans"}}.merge(params)
-      expect(response.redirect_url).to eq("http://test.host/admin/events?page=6&q=some_query")
+      expect(response.redirect_url).to eq("http://test.host/admin/events?page=6&q%5Bname_or_hidden_name_or_description_or_location_name_cont%5D=some_query")
     end
   end
 
   describe '#create' do
-    let(:params) { {q: 'some_query', page: 6} }
+    let(:params) { {q: {name_or_hidden_name_or_description_or_location_name_cont: 'some_query'}, page: 6} }
     let!(:location) { create(:location) }
 
     it 'redirects to index, keeping the current location parameters' do
       post :create, params: {event: {name: "Hans", location_id: location.id}}.merge(params)
-      expect(response.redirect_url).to eq("http://test.host/admin/events?page=6&q=some_query")
+      expect(response.redirect_url).to eq("http://test.host/admin/events?page=6&q%5Bname_or_hidden_name_or_description_or_location_name_cont%5D=some_query")
     end
   end
 
   describe '#destroy' do
-    let(:params) { {q: 'some_query', page: 6} }
+    let(:params) { {q: {name_or_hidden_name_or_description_or_location_name_cont: 'some_query'}, page: 6} }
     let!(:peter)  { create(:event, name: 'Peter') }
 
     it 'redirects to index, keeping the current location parameters' do
       delete :destroy, params: {id: peter.id}.merge(params)
-      expect(response.redirect_url).to eq("http://test.host/admin/events?page=6&q=some_query")
+      expect(response.redirect_url).to eq("http://test.host/admin/events?page=6&q%5Bname_or_hidden_name_or_description_or_location_name_cont%5D=some_query")
     end
   end
 end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -29,9 +29,6 @@ Rails.application.configure do
   config.action_controller.allow_forgery_protection = false
   config.action_mailer.perform_caching = false
 
-  # Raise if unpermitted attributes get accessed
-  config.action_controller.action_on_unpermitted_parameters = :raise
-
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.

--- a/spec/libraries/resources_helper_spec.rb
+++ b/spec/libraries/resources_helper_spec.rb
@@ -186,31 +186,4 @@ describe Alchemy::ResourcesHelper do
       expect(controller.resource_name).to eq("my_resource")
     end
   end
-
-  describe '#current_location_params' do
-    let(:params) do
-      {
-        q: "some_query",
-        page: 6,
-        action: "some_action",
-        filter: "some_filter",
-        tagged_with: "some_tag"
-      }
-    end
-
-    before do
-      allow(controller).to receive(:params) { params }
-      allow(controller).to receive(:search_filter_params) { params }
-    end
-
-    it 'returns the current location params' do
-      expect(controller.current_location_params).to eq(
-        {q: "some_query", page: 6, filter: "some_filter", tagged_with: "some_tag"}
-      )
-    end
-
-    it 'only includes the q and page parameters' do
-      expect(controller.current_location_params).not_to have_key(:action)
-    end
-  end
 end

--- a/spec/libraries/resources_helper_spec.rb
+++ b/spec/libraries/resources_helper_spec.rb
@@ -200,6 +200,7 @@ describe Alchemy::ResourcesHelper do
 
     before do
       allow(controller).to receive(:params) { params }
+      allow(controller).to receive(:search_filter_params) { params }
     end
 
     it 'returns the current location params' do

--- a/spec/views/admin/pictures/show_spec.rb
+++ b/spec/views/admin/pictures/show_spec.rb
@@ -19,6 +19,7 @@ describe "alchemy/admin/pictures/show.html.erb" do
   before do
     allow(view).to receive(:admin_picture_path).and_return("/path")
     allow(view).to receive(:render_message) {}
+    allow(view).to receive(:search_filter_params) { {} }
     view.extend Alchemy::Admin::FormHelper
   end
 


### PR DESCRIPTION
Use sanitized search filter params in all resource views.

In Rails 5.1 unpermitted params cause errors while generating urls. Use the sanitized `search_filter_params` in all our resources views instead of the raw `params` Fixes this.

Fixes #1337