### PR TITLE
Add `nested_elements` to serialized element json

### DIFF
--- a/app/controllers/alchemy/api/elements_controller.rb
+++ b/app/controllers/alchemy/api/elements_controller.rb
@@ -9,11 +9,10 @@ module Alchemy
     # If you want to only load a specific type of element pass ?named=an_element_name
     #
     def index
+      @elements = Element.not_nested
       # Fix for cancancan not able to merge multiple AR scopes for logged in users
-      if can? :manage, Alchemy::Element
-        @elements = Element.all
-      else
-        @elements = Element.accessible_by(current_ability, :index)
+      if cannot? :manage, Alchemy::Element
+        @elements = @elements.accessible_by(current_ability, :index)
       end
       if params[:page_id].present?
         @elements = @elements.where(page_id: params[:page_id])

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -102,6 +102,7 @@ module Alchemy
     scope :from_current_site, -> { where(Language.table_name => {site_id: Site.current || Site.default}).joins(page: 'language') }
     scope :folded,            -> { where(folded: true) }
     scope :expanded,          -> { where(folded: false) }
+    scope :not_nested,        -> { where(parent_element_id: nil) }
 
     delegate :restricted?, to: :page, allow_nil: true
 

--- a/app/serializers/alchemy/element_serializer.rb
+++ b/app/serializers/alchemy/element_serializer.rb
@@ -15,6 +15,8 @@ module Alchemy
       :ingredients,
       :content_ids
 
+    has_many :nested_elements
+
     def ingredients
       object.contents.collect(&:serialize)
     end

--- a/lib/alchemy/test_support/factories/element_factory.rb
+++ b/lib/alchemy/test_support/factories/element_factory.rb
@@ -15,6 +15,11 @@ FactoryBot.define do
       name 'slider'
     end
 
+    trait :nested do
+      association :parent_element, factory: :alchemy_element, name: 'slider'
+      name 'slide'
+    end
+
     trait :with_contents do
       create_contents_after_create true
     end

--- a/spec/controllers/alchemy/api/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/api/elements_controller_spec.rb
@@ -9,9 +9,10 @@ module Alchemy
 
       before do
         2.times { create(:alchemy_element, page: page) }
+        create(:alchemy_element, :nested, page: page)
       end
 
-      it "returns all public elements as json objects" do
+      it "returns all public not nested elements as json objects" do
         get :index, params: {format: :json}
 
         expect(response.status).to eq(200)
@@ -20,7 +21,8 @@ module Alchemy
         result = JSON.parse(response.body)
 
         expect(result).to have_key('elements')
-        expect(result['elements'].size).to eq(Alchemy::Element.count)
+        expect(result['elements'].last['nested_elements']).to_not be_empty
+        expect(result['elements'].size).to eq(Alchemy::Element.not_nested.count)
       end
 
       context 'with page_id param' do
@@ -42,7 +44,7 @@ module Alchemy
       end
 
       context 'with empty page_id param' do
-        it "returns all elements" do
+        it "returns all not nested elements" do
           get :index, params: {page_id: '', format: :json}
 
           expect(response.status).to eq(200)
@@ -51,7 +53,7 @@ module Alchemy
           result = JSON.parse(response.body)
 
           expect(result).to have_key('elements')
-          expect(result['elements'].size).to eq(Alchemy::Element.count)
+          expect(result['elements'].size).to eq(Alchemy::Element.not_nested.count)
         end
       end
 
@@ -73,7 +75,7 @@ module Alchemy
       end
 
       context 'with empty named param' do
-        it "returns all elements" do
+        it "returns all not nested elements" do
           get :index, params: {named: '', format: :json}
 
           expect(response.status).to eq(200)
@@ -82,7 +84,7 @@ module Alchemy
           result = JSON.parse(response.body)
 
           expect(result).to have_key('elements')
-          expect(result['elements'].size).to eq(Alchemy::Element.count)
+          expect(result['elements'].size).to eq(Alchemy::Element.not_nested.count)
         end
       end
 
@@ -91,7 +93,7 @@ module Alchemy
           authorize_user(build(:alchemy_dummy_user, :as_author))
         end
 
-        it "returns all elements" do
+        it "returns all not nested elements" do
           get :index, params: {format: :json}
 
           expect(response.status).to eq(200)
@@ -100,7 +102,7 @@ module Alchemy
           result = JSON.parse(response.body)
 
           expect(result).to have_key('elements')
-          expect(result['elements'].size).to eq(Alchemy::Element.count)
+          expect(result['elements'].size).to eq(Alchemy::Element.not_nested.count)
         end
       end
     end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -19,8 +19,8 @@ ActiveRecord::Schema.define(version: 20180227224537) do
     t.integer "file_size"
     t.integer "creator_id"
     t.integer "updater_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "file_uid"
     t.index ["file_uid"], name: "index_alchemy_attachments_on_file_uid"
   end
@@ -28,8 +28,8 @@ ActiveRecord::Schema.define(version: 20180227224537) do
   create_table "alchemy_cells", force: :cascade do |t|
     t.integer "page_id", null: false
     t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["page_id"], name: "index_alchemy_cells_on_page_id"
   end
 
@@ -39,8 +39,8 @@ ActiveRecord::Schema.define(version: 20180227224537) do
     t.integer "essence_id", null: false
     t.integer "element_id", null: false
     t.integer "position"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.integer "creator_id"
     t.integer "updater_id"
     t.index ["element_id", "position"], name: "index_contents_on_element_id_and_position"
@@ -54,8 +54,8 @@ ActiveRecord::Schema.define(version: 20180227224537) do
     t.boolean "public", default: true
     t.boolean "folded", default: false
     t.boolean "unique", default: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.integer "creator_id"
     t.integer "updater_id"
     t.integer "cell_id"
@@ -72,8 +72,8 @@ ActiveRecord::Schema.define(version: 20180227224537) do
 
   create_table "alchemy_essence_booleans", force: :cascade do |t|
     t.boolean "value"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.integer "creator_id"
     t.integer "updater_id"
     t.index ["value"], name: "index_alchemy_essence_booleans_on_value"
@@ -83,8 +83,8 @@ ActiveRecord::Schema.define(version: 20180227224537) do
     t.datetime "date"
     t.integer "creator_id"
     t.integer "updater_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "alchemy_essence_files", force: :cascade do |t|
@@ -93,8 +93,8 @@ ActiveRecord::Schema.define(version: 20180227224537) do
     t.string "css_class"
     t.integer "creator_id"
     t.integer "updater_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "link_text"
     t.index ["attachment_id"], name: "index_alchemy_essence_files_on_attachment_id"
   end
@@ -103,8 +103,8 @@ ActiveRecord::Schema.define(version: 20180227224537) do
     t.text "source"
     t.integer "creator_id"
     t.integer "updater_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "alchemy_essence_links", force: :cascade do |t|
@@ -112,8 +112,8 @@ ActiveRecord::Schema.define(version: 20180227224537) do
     t.string "link_title"
     t.string "link_target"
     t.string "link_class_name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.integer "creator_id"
     t.integer "updater_id"
   end
@@ -130,8 +130,8 @@ ActiveRecord::Schema.define(version: 20180227224537) do
     t.string "link_target"
     t.integer "creator_id"
     t.integer "updater_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "crop_from"
     t.string "crop_size"
     t.string "render_size"
@@ -144,14 +144,14 @@ ActiveRecord::Schema.define(version: 20180227224537) do
     t.boolean "public"
     t.integer "creator_id"
     t.integer "updater_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "alchemy_essence_selects", force: :cascade do |t|
     t.string "value"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.integer "creator_id"
     t.integer "updater_id"
     t.index ["value"], name: "index_alchemy_essence_selects_on_value"
@@ -166,8 +166,8 @@ ActiveRecord::Schema.define(version: 20180227224537) do
     t.string "link_target"
     t.integer "creator_id"
     t.integer "updater_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "alchemy_folded_pages", force: :cascade do |t|
@@ -183,8 +183,8 @@ ActiveRecord::Schema.define(version: 20180227224537) do
     t.string "frontpage_name"
     t.string "page_layout", default: "intro"
     t.boolean "public", default: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.integer "creator_id"
     t.integer "updater_id"
     t.boolean "default", default: false
@@ -199,8 +199,8 @@ ActiveRecord::Schema.define(version: 20180227224537) do
   create_table "alchemy_legacy_page_urls", force: :cascade do |t|
     t.string "urlname", null: false
     t.integer "page_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["page_id"], name: "index_alchemy_legacy_page_urls_on_page_id"
     t.index ["urlname"], name: "index_alchemy_legacy_page_urls_on_urlname"
   end
@@ -225,8 +225,8 @@ ActiveRecord::Schema.define(version: 20180227224537) do
     t.boolean "robot_follow", default: true
     t.boolean "sitemap", default: true
     t.boolean "layoutpage", default: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.integer "creator_id"
     t.integer "updater_id"
     t.integer "language_id"
@@ -247,8 +247,8 @@ ActiveRecord::Schema.define(version: 20180227224537) do
     t.string "image_file_name"
     t.integer "image_file_width"
     t.integer "image_file_height"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.integer "creator_id"
     t.integer "updater_id"
     t.string "upload_hash"
@@ -260,8 +260,8 @@ ActiveRecord::Schema.define(version: 20180227224537) do
   create_table "alchemy_sites", force: :cascade do |t|
     t.string "host"
     t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.boolean "public", default: false
     t.text "aliases"
     t.boolean "redirect_to_primary_host"
@@ -298,8 +298,8 @@ ActiveRecord::Schema.define(version: 20180227224537) do
     t.integer "tag_id", null: false
     t.string "taggable_type", null: false
     t.integer "taggable_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["tag_id", "taggable_id", "taggable_type"], name: "unique_taggings", unique: true
     t.index ["tag_id"], name: "index_gutentag_taggings_on_tag_id"
     t.index ["taggable_id", "taggable_type"], name: "index_gutentag_taggings_on_taggable_id_and_taggable_type"

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -217,6 +217,17 @@ module Alchemy
       end
     end
 
+    describe '.not_nested' do
+      subject { Element.not_nested }
+
+      let!(:element_1) { create(:alchemy_element) }
+      let!(:element_2) { create(:alchemy_element, :nested) }
+
+      it "returns all not nested elements" do
+        is_expected.to match_array([element_1, element_2.parent_element])
+      end
+    end
+
     context 'trash' do
       let(:element) { create(:alchemy_element) }
 


### PR DESCRIPTION
Instead of returning all elements regardless of their nesting we return 
not nested elements with their children nested in the `nested_elements` key.