### PR TITLE
Do not reload essence classes in dev mode

### DIFF
--- a/lib/alchemy/engine.rb
+++ b/lib/alchemy/engine.rb
@@ -21,17 +21,6 @@ module Alchemy
       Gutentag.normaliser = ->(value) { value.to_s }
     end
 
-    # We need to reload each essence class in development mode on every request,
-    # so it can register itself as essence relation on Page and Element models
-    #
-    # @see lib/alchemy/essence.rb:71
-    config.to_prepare do
-      unless Rails.configuration.cache_classes
-        essences = File.join(File.dirname(__FILE__), '../../app/models/alchemy/essence_*.rb')
-        Dir.glob(essences).each { |essence| load(essence) }
-      end
-    end
-
     config.after_initialize do
       require_relative './userstamp'
     end


### PR DESCRIPTION
Reloading the essence classes on each request in dev mode causes trouble
like mismatching parent classes. This also works without reloading.