### PR TITLE
Explicitly set the Rails version in dummy app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'rails', '~> 5.1.6'
+
 # Profiling
 gem 'rack-mini-profiler', group: :development, require: false
 


### PR DESCRIPTION
The gemspec allows Rails 5.0 and Rails 5.1, but the dummy app is
a Rails 5.1 app.