### PR TITLE
Handle zero plural resource names

### DIFF
--- a/app/controllers/alchemy/admin/resources_controller.rb
+++ b/app/controllers/alchemy/admin/resources_controller.rb
@@ -61,7 +61,7 @@ module Alchemy
         resource_instance_variable.save
         render_errors_or_redirect(
           resource_instance_variable,
-          resources_path(resource_handler.namespaced_resources_name, search_filter_params),
+          resources_path(resource_instance_variable.class, search_filter_params),
           flash_notice_for_resource_action
         )
       end
@@ -70,7 +70,7 @@ module Alchemy
         resource_instance_variable.update_attributes(resource_params)
         render_errors_or_redirect(
           resource_instance_variable,
-          resources_path(resource_handler.namespaced_resources_name, search_filter_params),
+          resources_path(resource_instance_variable.class, search_filter_params),
           flash_notice_for_resource_action
         )
       end

--- a/spec/controllers/alchemy/admin/resources_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/resources_controller_spec.rb
@@ -49,11 +49,25 @@ describe Admin::EventsController do
 
   describe '#update' do
     let(:params) { {q: {name_or_hidden_name_or_description_or_location_name_cont: 'some_query'}, page: 6} }
-    let!(:peter)  { create(:event, name: 'Peter') }
 
-    it 'redirects to index, keeping the current location parameters' do
-      post :update, params: {id: peter.id, event: {name: "Hans"}}.merge(params)
-      expect(response.redirect_url).to eq("http://test.host/admin/events?page=6&q%5Bname_or_hidden_name_or_description_or_location_name_cont%5D=some_query")
+    context 'with regular noun model name' do
+      let(:peter) { create(:event, name: 'Peter') }
+
+      it 'redirects to index, keeping the current location parameters' do
+        post :update, params: {id: peter.id, event: {name: "Hans"}}.merge(params)
+        expect(response.redirect_url).to eq("http://test.host/admin/events?page=6&q%5Bname_or_hidden_name_or_description_or_location_name_cont%5D=some_query")
+      end
+    end
+
+    context 'with zero plural noun model name' do
+      let!(:peter) { create(:series, name: 'Peter') }
+      let(:params) { {q: { name_cont: 'some_query'}, page: 6} }
+
+      it 'redirects to index, keeping the current location parameters' do
+        expect(controller).to receive(:controller_path) { 'admin/series' }
+        post :update, params: {id: peter.id, series: {name: "Hans"}}.merge(params)
+        expect(response.redirect_url).to eq("http://test.host/admin/series?page=6&q%5Bname_cont%5D=some_query")
+      end
     end
   end
 
@@ -61,9 +75,21 @@ describe Admin::EventsController do
     let(:params) { {q: {name_or_hidden_name_or_description_or_location_name_cont: 'some_query'}, page: 6} }
     let!(:location) { create(:location) }
 
-    it 'redirects to index, keeping the current location parameters' do
-      post :create, params: {event: {name: "Hans", location_id: location.id}}.merge(params)
-      expect(response.redirect_url).to eq("http://test.host/admin/events?page=6&q%5Bname_or_hidden_name_or_description_or_location_name_cont%5D=some_query")
+    context 'with regular noun model name' do
+      it 'redirects to index, keeping the current location parameters' do
+        post :create, params: {event: {name: "Hans", location_id: location.id}}.merge(params)
+        expect(response.redirect_url).to eq("http://test.host/admin/events?page=6&q%5Bname_or_hidden_name_or_description_or_location_name_cont%5D=some_query")
+      end
+    end
+
+    context 'with zero plural noun model name' do
+      let(:params) { {q: {name_cont: 'some_query'}, page: 6} }
+
+      it 'redirects to index, keeping the current location parameters' do
+        expect(controller).to receive(:controller_path) { 'admin/series' }
+        post :create, params: {series: {name: "Hans"}}.merge(params)
+        expect(response.redirect_url).to eq("http://test.host/admin/series?page=6&q%5Bname_cont%5D=some_query")
+      end
     end
   end
 

--- a/spec/dummy/app/controllers/admin/series_controller.rb
+++ b/spec/dummy/app/controllers/admin/series_controller.rb
@@ -1,0 +1,2 @@
+class Admin::SeriesController < Alchemy::Admin::ResourcesController
+end

--- a/spec/dummy/app/models/ability.rb
+++ b/spec/dummy/app/models/ability.rb
@@ -6,5 +6,7 @@ class Ability
     can :index, :admin_events
     can :manage, Location
     can :index, :admin_locations
+    can :manage, Series
+    can :index, :admin_series
   end
 end

--- a/spec/dummy/app/models/series.rb
+++ b/spec/dummy/app/models/series.rb
@@ -1,0 +1,2 @@
+class Series < ActiveRecord::Base
+end

--- a/spec/dummy/config/initializers/alchemy.rb
+++ b/spec/dummy/config/initializers/alchemy.rb
@@ -16,6 +16,10 @@ Alchemy::Modules.register_module(
       name: 'Locations',
       controller: '/admin/locations',
       action: 'index'
+    }, {
+      name: 'Series',
+      controller: '/admin/series',
+      action: 'index'  
     }]
   }
 )

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :events
     resources :locations
+    resources :series
   end
 
   mount Alchemy::Engine => "/"

--- a/spec/dummy/db/migrate/20180409171801_create_series.rb
+++ b/spec/dummy/db/migrate/20180409171801_create_series.rb
@@ -1,0 +1,7 @@
+class CreateSeries < ActiveRecord::Migration[5.1]
+  def change
+    create_table :series do |t|
+      t.string :name
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180227224537) do
+ActiveRecord::Schema.define(version: 20180409171801) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string "name"
@@ -316,6 +316,10 @@ ActiveRecord::Schema.define(version: 20180227224537) do
     t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
+  end
+
+  create_table "series", force: :cascade do |t|
+    t.string "name"
   end
 
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -15,4 +15,8 @@ FactoryBot.define do
   factory :location do
     name 'Awesome Lodge'
   end
+
+  factory :series do
+    name 'My Series'
+  end
 end


### PR DESCRIPTION
Fixes issue where 'zero plural' (same word for singular and plural) resource model names can't be routed correctly by `ActionDispatch::Routing::PolymorphicRoutes.polymorphic_url` using just `Resource#namespaced_resources_name` name, because the plural and singular are the same.  In this case, sending `Resource#namespaced_resources_name` to `polymorphic_url` routes to the singular `#show` path instead of the expected `#index`.  This changes it to use the resource model's class instead, which will reliably route to the `#index` path in all cases.