### PR TITLE
Update jquery-ui-rails to 6.0

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'gutentag',                         ['~> 2.2', '>= 2.2.1']
   gem.add_runtime_dependency 'handlebars_assets',                ['~> 0.23']
   gem.add_runtime_dependency 'jquery-rails',                     ['~> 4.0', '>= 4.0.4']
-  gem.add_runtime_dependency 'jquery-ui-rails',                  ['~> 5.0.0']
+  gem.add_runtime_dependency 'jquery-ui-rails',                  ['~> 6.0']
   gem.add_runtime_dependency 'kaminari',                         ['~> 1.1']
   gem.add_runtime_dependency 'originator',                       ['~> 3.1']
   gem.add_runtime_dependency 'non-stupid-digest-assets',         ['~> 1.0.8']

--- a/app/assets/javascripts/alchemy/admin.js
+++ b/app/assets/javascripts/alchemy/admin.js
@@ -3,10 +3,10 @@
 //= require jquery2
 //= require jquery_ujs
 //= require turbolinks
-//= require jquery-ui/draggable
-//= require jquery-ui/effect-fade
-//= require jquery-ui/sortable
-//= require jquery-ui/tabs
+//= require jquery-ui/effects/effect-fade
+//= require jquery-ui/widgets/draggable
+//= require jquery-ui/widgets/sortable
+//= require jquery-ui/widgets/tabs
 //= require tinymce/tinymce.min
 //= require_tree ../../../../vendor/assets/javascripts/jquery_plugins/
 //= require clipboard.min

--- a/app/assets/javascripts/alchemy/alchemy.dragndrop.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.dragndrop.js.coffee
@@ -1,5 +1,5 @@
-#= require jquery-ui/draggable
-#= require jquery-ui/sortable
+#= require jquery-ui/widgets/draggable
+#= require jquery-ui/widgets/sortable
 #
 window.Alchemy = {} if typeof (window.Alchemy) is "undefined"
 


### PR DESCRIPTION
Updates `jquery-ui-rails` from 5.0 to 6.0. This is a breaking change as some assets have been moved. 

Closes #1417 