### PR TITLE
Load Jcrop selection gif via asset pipeline

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -9,5 +9,6 @@ Rails.application.config.assets.precompile += [
   'alchemy/menubar.js',
   'alchemy/print.css',
   'alchemy/welcome.css',
+  'Jcrop.gif',
   'tinymce/*'
 ]

--- a/vendor/assets/stylesheets/jquery.Jcrop.min.scss
+++ b/vendor/assets/stylesheets/jquery.Jcrop.min.scss
@@ -1,6 +1,6 @@
 /* jquery.Jcrop.min.css v0.9.10 (build:20120429) */
 .jcrop-holder{direction:ltr;text-align:left;}
-.jcrop-vline,.jcrop-hline{background:#FFF url(/assets/Jcrop.gif) top left repeat;font-size:0;position:absolute;}
+.jcrop-vline,.jcrop-hline{background:#FFF image-url('Jcrop.gif') top left repeat;font-size:0;position:absolute;}
 .jcrop-vline{height:100%;width:1px!important;}
 .jcrop-hline{height:1px!important;width:100%;}
 .jcrop-vline.right{right:0;}


### PR DESCRIPTION
The image cropper on production is missing the "ant-track" animation
for the crop selection.