### PR TITLE
Picture zoom UX enhancements

### DIFF
--- a/app/assets/stylesheets/alchemy/image_library.scss
+++ b/app/assets/stylesheets/alchemy/image_library.scss
@@ -1,4 +1,4 @@
-$picture-overlay-handle-width: 18px;
+$picture-overlay-handle-width: 24px;
 $image-overlay-form-width: 350px - $picture-overlay-handle-width;
 $image-overlay-transition-duration: $transition-duration;
 $image-overlay-transition-easing: ease-in;
@@ -96,12 +96,7 @@ $image-overlay-transition-easing: ease-in;
 
   form .control-label,
   .resource_info .value label {
-    width: 100%;
     text-align: left;
-    float: none;
-    display: block;
-    padding: 0;
-    margin: $default-margin 0 0;
   }
 
   form .input .hint {

--- a/app/assets/stylesheets/alchemy/image_library.scss
+++ b/app/assets/stylesheets/alchemy/image_library.scss
@@ -178,27 +178,38 @@ $image-overlay-transition-easing: ease-in;
 }
 
 #pictures_page_list {
-
   h3 {
-    padding: $default-padding 0 0;
+    display: flex;
+    padding: 4px 8px 0;
     margin: 0;
   }
 
-  ol {
+  ul {
     padding-left: 0;
-    list-style-position: inside;
+    list-style-type: none;
   }
 
   .list {
     margin: 2*$default-margin 0;
 
     li {
+      display: flex;
       padding: 2*$default-padding;
       border-radius: $default-border-radius;
       white-space: normal;
-
-      &.even { background: #F7F7F7 }
+      margin-bottom: 1em;
     }
+  }
+
+  .icon {
+    padding-top: 3px;
+    text-align: left;
+    width: 7%;
+  }
+
+  p {
+    width: 93%;
+    margin: 0;
   }
 }
 

--- a/app/controllers/alchemy/admin/pictures_controller.rb
+++ b/app/controllers/alchemy/admin/pictures_controller.rb
@@ -25,7 +25,7 @@ module Alchemy
       def show
         @previous = @picture.previous(params)
         @next = @picture.next(params)
-        @pages = @picture.essence_pictures.group_by(&:page)
+        @assignments = @picture.essence_pictures.joins(content: {element: :page})
         render action: 'show'
       end
 

--- a/app/views/alchemy/admin/pictures/_infos.html.erb
+++ b/app/views/alchemy/admin/pictures/_infos.html.erb
@@ -20,11 +20,14 @@
   <h2><%= Alchemy.t(:this_picture_is_used_on_these_pages) %></h2>
   <div id="pictures_page_list">
     <% if @assignments.any? %>
-      <ol>
+      <ul>
         <% @assignments.group_by(&:page).each do |page, essence_pictures| %>
           <% if page %>
             <li>
-              <h3><%= link_to page.name, edit_admin_page_path(page) %></h3>
+              <h3>
+                <%= render_icon 'file-alt' %>
+                <p><%= link_to page.name, edit_admin_page_path(page) %></p>
+              </h3>
               <ul class="list">
                 <% essence_pictures.group_by(&:element).each do |element, essence_pictures| %>
                   <li class="<%= cycle('even', 'odd') %>">
@@ -33,14 +36,22 @@
                     <% pictures = essence_pictures.collect do |e|
                                     e.content.name_for_label
                                   end.to_sentence %>
-                    <%== Alchemy.t(:pictures_in_page, page: page_link, pictures: pictures) %>
+                    <% if element.public? %>
+                      <%= render_icon('window-maximize', style: 'regular') %>
+                    <% else %>
+                      <%= render_icon('window-close') %>
+                    <% end %>
+                    <p>
+                      <%== Alchemy.t(:pictures_in_page, page: page_link, pictures: pictures) %>
+                      <em><%= Alchemy::Element.human_attribute_name(:trashed) if element.trashed? %></em>
+                    </p>
                   </li>
                 <% end %>
               </ul>
             </li>
           <% end %>
         <% end %>
-      </ol>
+      </ul>
     <% else %>
       <%= render_message do %>
         <%= Alchemy.t(:picture_not_in_use_yet) %>

--- a/app/views/alchemy/admin/pictures/_infos.html.erb
+++ b/app/views/alchemy/admin/pictures/_infos.html.erb
@@ -19,9 +19,9 @@
 <div class="picture-usage-info resource_info">
   <h2><%= Alchemy.t(:this_picture_is_used_on_these_pages) %></h2>
   <div id="pictures_page_list">
-    <% if @pages.any? %>
+    <% if @assignments.any? %>
       <ol>
-        <% @pages.each do |page, essence_pictures| %>
+        <% @assignments.group_by(&:page).each do |page, essence_pictures| %>
           <% if page %>
             <li>
               <h3><%= link_to page.name, edit_admin_page_path(page) %></h3>

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -734,6 +734,7 @@ en:
         name: "Name"
         public: "visible"
         tag_list: Tags
+        trashed: Trashed
       alchemy/essence_file:
         css_class: Style
       alchemy/essence_picture:

--- a/spec/controllers/alchemy/admin/pictures_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/pictures_controller_spec.rb
@@ -155,9 +155,9 @@ module Alchemy
         let!(:content) { create(:alchemy_content, element: element) }
         let!(:essence) { create(:alchemy_essence_picture, content: content, picture: picture) }
 
-        it 'assigns @pages to assignments grouped by page' do
+        it 'assigns all essence pictures having an assignment to @assignments' do
           get :show, params: {id: picture.id}
-          expect(assigns(:pages)).to eq({page => [essence]})
+          expect(assigns(:assignments)).to eq([essence])
         end
       end
 

--- a/spec/views/admin/pictures/show_spec.rb
+++ b/spec/views/admin/pictures/show_spec.rb
@@ -27,7 +27,7 @@ describe "alchemy/admin/pictures/show.html.erb" do
 
   it "displays picture in original format" do
     assign(:picture, picture)
-    assign(:pages, [])
+    assign(:assignments, [])
 
     render
 
@@ -37,7 +37,7 @@ describe "alchemy/admin/pictures/show.html.erb" do
   it "separates the tags with a comma" do
     allow(picture).to receive(:tag_list).and_return(["one", "two", "three"])
     assign(:picture, picture)
-    assign(:pages, [])
+    assign(:assignments, [])
 
     render
 


### PR DESCRIPTION
Some enhancements to picture detail/zoom overlay

In the assignments info

- Better distinction between pages and elements
- Show the status of the element (public, visible, trashed)

Closes #1026 

#### Before

![alchemy cms - images 2018-05-08 11-08-17](https://user-images.githubusercontent.com/42868/39748346-27ae4250-52b0-11e8-883d-1723b5a59607.png)

#### After

![alchemy cms - images 2018-05-08 11-06-39](https://user-images.githubusercontent.com/42868/39748257-e563f8b8-52af-11e8-92d3-dcf5abce32c9.png)

