### PR TITLE
Set parent element id when pasting from clipboard

### DIFF
--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -147,7 +147,10 @@ module Alchemy
 
       def paste_element_from_clipboard
         @source_element = Element.find(element_from_clipboard['id'])
-        new_attributes = {page_id: @page.id}
+        new_attributes = {
+          parent_element_id: create_element_params[:parent_element_id],
+          page_id: @page.id
+        }
         if @page.can_have_cells?
           new_attributes = new_attributes.merge({cell_id: find_or_create_cell.try(:id)})
         end

--- a/app/views/alchemy/admin/elements/new.html.erb
+++ b/app/views/alchemy/admin/elements/new.html.erb
@@ -11,7 +11,8 @@
   </div>
   <div id="paste_element_tab">
     <%= alchemy_form_for([:admin, @element]) do |f| %>
-      <%= f.hidden_field(:page_id) %>
+      <%= f.hidden_field :page_id %>
+      <%= f.hidden_field :parent_element_id, value: @parent_element.try(:id) %>
       <div class="input select">
         <label for="paste_from_clipboard" class="control-label"><%= Alchemy.t("Element") %></label>
         <%= select_tag 'paste_from_clipboard',

--- a/spec/controllers/alchemy/admin/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/elements_controller_spec.rb
@@ -343,6 +343,16 @@ module Alchemy
             expect(session[:alchemy_clipboard]['elements'].detect { |item| item['id'] == element_in_clipboard.id.to_s }).to be_nil
           end
         end
+
+        context "with parent_element_id given" do
+          let(:element_in_clipboard) { create(:alchemy_element, :nested, page: alchemy_page) }
+          let(:parent_element) { create(:alchemy_element, :with_nestable_elements, page: alchemy_page) }
+
+          it "moves the element to new parent" do
+            post :create, params: {paste_from_clipboard: element_in_clipboard.id, element: {page_id: alchemy_page.id, parent_element_id: parent_element.id}}, xhr: true
+            expect(Alchemy::Element.last.parent_element_id).to eq(parent_element.id)
+          end
+        end
       end
 
       context 'if element could not be saved' do


### PR DESCRIPTION
Set the parent element id for elements created from clipboard.

Fixes #817