### PR TITLE
Use optional: true for optional belongs_to associations

### DIFF
--- a/app/models/alchemy/cell.rb
+++ b/app/models/alchemy/cell.rb
@@ -27,7 +27,7 @@ module Alchemy
   class Cell < BaseRecord
     include Alchemy::Logger
 
-    belongs_to :page
+    belongs_to :page, inverse_of: :cells
     validates_uniqueness_of :name, scope: 'page_id'
     validates_format_of :name, with: /\A[a-z0-9_-]+\z/
     has_many :elements, -> { where(parent_element_id: nil).order(:position) }, dependent: :destroy

--- a/app/models/alchemy/cell.rb
+++ b/app/models/alchemy/cell.rb
@@ -27,7 +27,7 @@ module Alchemy
   class Cell < BaseRecord
     include Alchemy::Logger
 
-    belongs_to :page, required: true
+    belongs_to :page
     validates_uniqueness_of :name, scope: 'page_id'
     validates_format_of :name, with: /\A[a-z0-9_-]+\z/
     has_many :elements, -> { where(parent_element_id: nil).order(:position) }, dependent: :destroy

--- a/app/models/alchemy/content.rb
+++ b/app/models/alchemy/content.rb
@@ -25,7 +25,7 @@ module Alchemy
     include Alchemy::Content::Factory
 
     belongs_to :essence, polymorphic: true, dependent: :destroy
-    belongs_to :element, touch: true
+    belongs_to :element, touch: true, inverse_of: :contents
     has_one :page, through: :element
 
     stampable stamper_class_name: Alchemy.user_class_name

--- a/app/models/alchemy/content.rb
+++ b/app/models/alchemy/content.rb
@@ -24,8 +24,8 @@ module Alchemy
     # Concerns
     include Alchemy::Content::Factory
 
-    belongs_to :essence, required: true, polymorphic: true, dependent: :destroy
-    belongs_to :element, required: true, touch: true
+    belongs_to :essence, polymorphic: true, dependent: :destroy
+    belongs_to :element, touch: true
     has_one :page, through: :element
 
     stampable stamper_class_name: Alchemy.user_class_name

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -70,7 +70,7 @@ module Alchemy
       dependent: :destroy
 
     belongs_to :cell, optional: true, touch: true
-    belongs_to :page, touch: true
+    belongs_to :page, touch: true, inverse_of: :descendent_elements
 
     # A nested element belongs to a parent element.
     belongs_to :parent_element,

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -69,13 +69,13 @@ module Alchemy
       foreign_key: :parent_element_id,
       dependent: :destroy
 
-    belongs_to :cell, required: false, touch: true
+    belongs_to :cell, optional: true, touch: true
     belongs_to :page, touch: true
 
     # A nested element belongs to a parent element.
     belongs_to :parent_element,
       class_name: 'Alchemy::Element',
-      required: false,
+      optional: true,
       touch: true
 
     has_and_belongs_to_many :touchable_pages, -> { distinct },

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -70,7 +70,7 @@ module Alchemy
       dependent: :destroy
 
     belongs_to :cell, required: false, touch: true
-    belongs_to :page, required: true, touch: true
+    belongs_to :page, touch: true
 
     # A nested element belongs to a parent element.
     belongs_to :parent_element,

--- a/app/models/alchemy/essence_file.rb
+++ b/app/models/alchemy/essence_file.rb
@@ -17,7 +17,7 @@
 
 module Alchemy
   class EssenceFile < BaseRecord
-    belongs_to :attachment, required: false
+    belongs_to :attachment, optional: true
     acts_as_essence ingredient_column: 'attachment'
 
     def attachment_url

--- a/app/models/alchemy/essence_picture.rb
+++ b/app/models/alchemy/essence_picture.rb
@@ -27,7 +27,7 @@ module Alchemy
   class EssencePicture < BaseRecord
     acts_as_essence ingredient_column: 'picture'
 
-    belongs_to :picture, required: false
+    belongs_to :picture, optional: true
     delegate :image_file_width, :image_file_height, :image_file, to: :picture
     before_save :fix_crop_values
     before_save :replace_newlines

--- a/app/models/alchemy/folded_page.rb
+++ b/app/models/alchemy/folded_page.rb
@@ -12,8 +12,8 @@
 
 module Alchemy
   class FoldedPage < BaseRecord
-    belongs_to :page
-    belongs_to :user, class_name: Alchemy.user_class_name
+    belongs_to :page, inverse_of: :folded_pages
+    belongs_to :user, inverse_of: :folded_pages, class_name: Alchemy.user_class_name
 
     def self.folded_for_user(user)
       return none unless Alchemy.user_class < ActiveRecord::Base

--- a/app/models/alchemy/folded_page.rb
+++ b/app/models/alchemy/folded_page.rb
@@ -12,9 +12,8 @@
 
 module Alchemy
   class FoldedPage < BaseRecord
-    belongs_to :page, required: true
-    belongs_to :user, required: true,
-      class_name: Alchemy.user_class_name
+    belongs_to :page
+    belongs_to :user, class_name: Alchemy.user_class_name
 
     def self.folded_for_user(user)
       return none unless Alchemy.user_class < ActiveRecord::Base

--- a/app/models/alchemy/language.rb
+++ b/app/models/alchemy/language.rb
@@ -22,7 +22,7 @@
 
 module Alchemy
   class Language < BaseRecord
-    belongs_to :site, required: true
+    belongs_to :site
     has_many :pages
 
     before_validation :set_locale, if: -> { locale.blank? }

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -86,7 +86,7 @@ module Alchemy
 
     stampable stamper_class_name: Alchemy.user_class_name
 
-    belongs_to :language, required: false
+    belongs_to :language, optional: true
 
     has_one :site, through: :language
     has_many :site_languages, through: :site, source: :languages

--- a/spec/controllers/alchemy/admin/clipboard_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/clipboard_controller_spec.rb
@@ -19,7 +19,7 @@ module Alchemy
       context 'with `remarkable_type` being an allowed type' do
         it 'is successful' do
           get :index, params: {remarkable_type: 'elements'}
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
 

--- a/spec/controllers/alchemy/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/pages_controller_spec.rb
@@ -193,7 +193,7 @@ module Alchemy
 
       it "renders page" do
         get :show, params: {urlname: still_public_page.urlname}
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
 
@@ -207,7 +207,7 @@ module Alchemy
 
       it "renders page" do
         get :show, params: {urlname: still_public_page.urlname}
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
 

--- a/spec/dummy/app/models/dummy_user.rb
+++ b/spec/dummy/app/models/dummy_user.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class DummyUser < ActiveRecord::Base
+  has_many :folded_pages, class_name: 'Alchemy::FoldedPage'
   attr_writer :alchemy_roles, :name
 
   def self.logged_in


### PR DESCRIPTION
- Using `required: false` for optional `belongs_to` associations is deprecated in Rails 5 and will be removed in Rails 6.
- Also `required: true` is the new default in Rails 5.
- Setting `inverse_of` to required `belongs_to` associations is recommended to avoid extra DB queries.
- Using `be_success` in controller tests is deprectated in favor of `be_successful`.