### PR TITLE
Do not prevent default click handling in Element editor

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.element_editors.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.element_editors.js.coffee
@@ -191,8 +191,6 @@ Alchemy.ElementEditors =
     element_id = $element.attr("id").replace(/\D/g, "")
     @selectElement($element)
     @selectElementInPreview(element_id)
-    # Element submit button needs to keep it's default event
-    e.preventDefault() unless $target.is(':submit')
     return
 
   # Double click event handler for element head.


### PR DESCRIPTION
Check boxes, their labels, and submit buttons need to handle their own click
events.

## What is this pull request for?

Closes #1444 

### Notable changes (remove if none)

I'm not very sure about this change as I don't quite get why the `preventDefault` call is in that method at all. With this change, clicks will actually click buttons, labels and inputs. That's most of the area of an Element editor.

