### PR TITLE
New thumbnail style

### DIFF
--- a/app/assets/stylesheets/alchemy/_extends.scss
+++ b/app/assets/stylesheets/alchemy/_extends.scss
@@ -7,16 +7,6 @@
   -moz-text-overflow: ellipsis;
 }
 
-%thumbnail-background {
-  position: relative;
-  display: table-cell;
-  background-color: $dark-gray;
-  text-align: center;
-  vertical-align: middle;
-  padding: 0;
-  line-height: 0;
-}
-
 %field-with-error {
   border-color: $error_border_color;
   color: $error_text_color;

--- a/app/assets/stylesheets/alchemy/_variables.scss
+++ b/app/assets/stylesheets/alchemy/_variables.scss
@@ -148,3 +148,5 @@ $datepicker_header_color: $text-color !default;
 $datepicker_day_bg: $light-gray !default;
 $datepicker_day_border: 1px solid $medium-gray !default;
 $datepicker_day_color: $text-color !default;
+
+$thumbnail-background-color: opacify($default-border-color, 1) !default;

--- a/app/assets/stylesheets/alchemy/archive.scss
+++ b/app/assets/stylesheets/alchemy/archive.scss
@@ -14,28 +14,29 @@ div#image_assign_filter_and_image_sizing {
   }
 }
 
-.picture_thumbnail {
-  padding: $default-padding;
-  margin: 2px 1px 2px 2px;
-  background-color: #fff;
-  float: none;
-  display: inline-block;
-  border: 1px solid #c0c0c0;
+.thumbnail_background {
   position: relative;
-  border-radius: $default-border-radius;
-  width: 170px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: $thumbnail-background-color;
+  width: 100%;
+  height: 120px;
+}
+
+.picture_thumbnail {
+  margin: 2*$default-margin;
+  background-color: #fff;
+  display: inline-block;
+  position: relative;
+  box-shadow: 0 0 0 1px $default-border-color;
+  width: 160px;
 
   img {
     width: auto;
     height: auto;
     max-width: 100%;
     max-height: 100%;
-  }
-
-  .thumbnail_background {
-    @extend %thumbnail-background;
-    width: 160px;
-    height: 120px;
   }
 
   .picture_name {
@@ -46,33 +47,32 @@ div#image_assign_filter_and_image_sizing {
     overflow: hidden;
     bottom: 0;
     left: 0;
-    font-family: "Courier New", Courier, mono;
-    line-height: 16px;
-    padding: $default-padding 0 0;
+    line-height: 2;
+    padding: 0 $default-padding;
+    text-overflow: ellipsis;
   }
 
   &.small {
-    width: 90px;
+    width: 80px;
 
     .thumbnail_background {
-      width: 80px;
       height: 60px;
     }
   }
 
   &.large {
-    width: 250px;
+    width: 240px;
 
     .thumbnail_background {
-      width: 240px;
       height: 180px;
     }
   }
 
   &:hover {
 
-    .picture_tool {
-      display: block;
+    .picture_tool, .picture_tags {
+      visibility: visible;
+      opacity: 1;
     }
   }
 }
@@ -82,13 +82,8 @@ div#image_assign_filter_and_image_sizing {
   padding-bottom: 60px;
   overflow: hidden;
 
-  .picture_thumbnail {
-    margin: 0 2*$default-margin 2*$default-margin 0;
-    float: left;
-
-    .thumbnail_background {
-      @include zoom-in;
-    }
+  .thumbnail_background {
+    @include zoom-in;
   }
 }
 
@@ -108,16 +103,20 @@ div.assign_image_list_image {
   position: absolute;
   background-color: white;
   top: $default-padding;
-  padding: 2px 3px;
+  padding: $default-padding / 2;
   z-index: 10;
-  display: none;
+  text-align: center;
+  border-radius: $default-border-radius;
+  box-shadow: 0 0 1px $dark-gray;
 
   &.visible {
-    display: block;
+    visibility: visible;
+    opacity: 1;
   }
 
   &.hidden {
-    display: none;
+    // Overwrite the `.hidden { display: none }` style
+    display: block;
   }
 
   &.select {
@@ -139,6 +138,23 @@ div.assign_image_list_image {
     height: 16px;
     cursor: pointer;
   }
+}
+
+.picture_tags {
+  overflow: hidden;
+  position: absolute;
+  bottom: 22px;
+  left: 0;
+  width: 100%;
+  max-height: 80%;
+  padding: $default-padding;
+  pointer-events: none;
+}
+
+.picture_tags, .picture_tool {
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity $transition-duration;
 }
 
 div#library_sidebar {
@@ -178,7 +194,7 @@ div#filter_bar {
 
 #assign_image_list, #assign_file_list {
   position: relative;
-  height: 535px;
+  height: 548px;
 }
 
 #assign_image_list {

--- a/app/assets/stylesheets/alchemy/dialogs.scss
+++ b/app/assets/stylesheets/alchemy/dialogs.scss
@@ -77,7 +77,6 @@ $dialog-transition-duration: 150ms;
     padding: 2 * $default-padding;
 
     .thumbnail_background {
-      @extend %thumbnail-background;
       width: 800px;
       height: 600px;
       position: relative;

--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -310,7 +310,6 @@
 }
 
 .picture_thumbnail .picture_image {
-  height: 93px;
   overflow: hidden;
 
   img.img_paddingtop {
@@ -391,6 +390,7 @@
   left: 0;
   bottom: 0;
   z-index: 0;
+  width: 100%;
   padding: $default-padding $default-padding/2;
 
   a {
@@ -426,14 +426,9 @@
   }
 
   .picture_thumbnail {
-    width: 121px;
-    height: 125px;
+    width: 160px;
     margin: $default-margin 0;
-
-    .thumbnail_background {
-      width: 111px;
-      height: 93px;
-    }
+    padding-bottom: 28px;
   }
 
   &.validation_failed .picture_thumbnail {

--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -292,6 +292,11 @@
   }
 }
 
+.element-content-editors {
+  display: flex;
+  flex-wrap: wrap;
+}
+
 .picture_gallery_images {
   overflow: hidden;
   margin: $default-margin 0;
@@ -544,6 +549,7 @@ select.long {
 }
 
 .content_editor {
+  width: 100%;
   padding: $default-padding 0;
   position: relative;
 
@@ -651,10 +657,14 @@ select.long {
   }
 
   &.essence_picture {
-    float: none;
-    height: auto;
-    display: inline-block;
-    vertical-align: middle;
+    width: 50%;
+    padding-left: 1px; // Compensate the box shadow
+    padding-right: $default-padding;
+
+    + .essence_picture {
+      padding-left: $default-padding;
+      padding-right: 1px; // Compensate the box shadow
+    }
   }
 }
 

--- a/app/assets/stylesheets/alchemy/tags.scss
+++ b/app/assets/stylesheets/alchemy/tags.scss
@@ -71,22 +71,6 @@
   }
 }
 
-.picture_tags {
-  overflow: hidden;
-  position: absolute;
-  top: 22px;
-  left: $default-padding;
-  width: 50%;
-  max-height: 80%;
-  padding: $default-padding;
-  pointer-events: none;
-  display: none;
-}
-
-.picture_thumbnail:hover .picture_tags {
-  display: block;
-}
-
 .tag {
   @include tag-base(
     $margin: $default-margin/2 0,

--- a/app/models/alchemy/picture/transformations.rb
+++ b/app/models/alchemy/picture/transformations.rb
@@ -7,6 +7,9 @@ module Alchemy
   module Picture::Transformations
     extend ActiveSupport::Concern
 
+    THUMBNAIL_WIDTH = 160
+    THUMBNAIL_HEIGHT = 120
+
     # Returns the default centered image mask for a given size.
     # If the mask is bigger than the image, the mask is scaled down
     # so the largest possible part of the image is visible.
@@ -37,7 +40,7 @@ module Alchemy
         size = get_base_dimensions
       end
 
-      size = size_when_fitting({width: 111, height: 93}, size)
+      size = size_when_fitting({width: THUMBNAIL_WIDTH, height: THUMBNAIL_HEIGHT}, size)
       "#{size[:width]}x#{size[:height]}"
     end
 

--- a/app/views/alchemy/essences/shared/_essence_picture_tools.html.erb
+++ b/app/views/alchemy/essences/shared/_essence_picture_tools.html.erb
@@ -24,7 +24,7 @@
   ),
   {
     title: (content.ingredient ? Alchemy.t(:swap_image) : Alchemy.t(:insert_image)),
-    size: '780x580',
+    size: '790x590',
     padding: false
   },
   title: (content.ingredient ? Alchemy.t(:swap_image) : Alchemy.t(:insert_image)) %>

--- a/spec/support/transformation_examples.rb
+++ b/spec/support/transformation_examples.rb
@@ -10,7 +10,7 @@ module Alchemy
           allow(picture).to receive(:image_file_width) { 400 }
           allow(picture).to receive(:image_file_height) { 300 }
 
-          expect(picture.thumbnail_size).to eq('111x83')
+          expect(picture.thumbnail_size).to eq('160x120')
         end
       end
 
@@ -19,21 +19,21 @@ module Alchemy
           allow(picture).to receive(:image_file_width) { 300 }
           allow(picture).to receive(:image_file_height) { 400 }
 
-          expect(picture.thumbnail_size).to eq('70x93')
+          expect(picture.thumbnail_size).to eq('90x120')
         end
       end
 
       context "picture has crop_size of 400x300" do
         it "scales to 400x300 if that is the size of the cropped image" do
           allow(picture).to receive(:crop_size) { "400x300" }
-          expect(picture.thumbnail_size).to eq('111x83')
+          expect(picture.thumbnail_size).to eq('160x120')
         end
       end
 
       context "picture has crop_size of 0x0" do
         it "returns default thumbnail size" do
           allow(picture).to receive(:crop_size) { "0x0" }
-          expect(picture.thumbnail_size).to eq('111x93')
+          expect(picture.thumbnail_size).to eq('160x120')
         end
       end
     end


### PR DESCRIPTION
## What is this pull request for?

Introduces a new picture thumbnail style.

This new thumbnail style gives more room for the picture itself and uses the same medium thumbnail picture size in the library and the essence picture editor.

This reduces styles (and therefore space and/or requests to external services) that needs to be created per picture.

Also this aligns content editors with flex-box. This gives us the ability to truly align the content editors vertically and horizontally in a very flexible way.

### Screenshots

![new-thumbnail-style](https://user-images.githubusercontent.com/42868/40225278-e49aae46-5a88-11e8-9112-f631c2e25d17.jpg)

![new-thumbnail-element](https://user-images.githubusercontent.com/42868/40225277-e47d55ee-5a88-11e8-9d96-66ba717d6821.png)