### PR TITLE
Fix removing picture essences

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.base.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.base.js.coffee
@@ -64,8 +64,7 @@ $.extend Alchemy,
     $element = $form_field.closest(".element-editor")
     if $form_field[0]
       $form_field.val ""
-      $form_field.prev().remove()
-      $form_field.parent().html '<i class="icon far fa-image fa-fw"/>'
+      $element.find(".thumbnail_background").html('<i class="icon far fa-image fa-fw"/>')
       Alchemy.setElementDirty $element
     false
 

--- a/app/views/alchemy/essences/_essence_picture_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_picture_editor.html.erb
@@ -24,7 +24,6 @@
       <div class="thumbnail_background">
         <%- if content.ingredient -%>
           <%= essence_picture_thumbnail(content, options) %>
-          <%= hidden_field_tag content.form_field_name(:picture_id), content.ingredient.id %>
         <% else %>
           <%= render_icon(:image, style: 'regular') %>
         <% end %>
@@ -43,6 +42,8 @@
       } %>
     </div>
   </div>
+  <%= hidden_field_tag content.form_field_name(:picture_id),
+    content.ingredient.try!(:id) %>
   <%= hidden_field_tag content.form_field_name(:link),
     content.essence.link %>
   <%= hidden_field_tag content.form_field_name(:link_title),


### PR DESCRIPTION
## What is this pull request for?

This fixes removing picture essences in the element editor.

### Notable changes (remove if none)

Prior to this commit, removing a picture would not
work because the click handler for the delete button
would delete the input field, removing Rails' ability
to actually update the content.

