### PR TITLE
Update Ransack version

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'originator',                       ['~> 3.1']
   gem.add_runtime_dependency 'non-stupid-digest-assets',         ['~> 1.0.8']
   gem.add_runtime_dependency 'rails',                            ['~> 5.0', '< 6.0']
-  gem.add_runtime_dependency 'ransack',                          ['~> 1.4']
+  gem.add_runtime_dependency 'ransack',                          ['~> 2.0']
   gem.add_runtime_dependency 'request_store',                    ['~> 1.2']
   gem.add_runtime_dependency 'responders',                       ['~> 2.0']
   gem.add_runtime_dependency 'select2-rails',                    ['>= 3.5.9.1', '< 4.0']


### PR DESCRIPTION
## What is this pull request for?

Ransack 1.x break with ActiveRecord >= 5.2.1. A new version has been
released that fixes things.

### Notable changes (remove if none)

There shouldn't be any. See https://github.com/activerecord-hackery/ransack/blob/9b00080c0b5ff9cf1ff596e505ebb9d8ebcebb5e/CHANGELOG.md, it's all pretty peaceful.
