### PR TITLE
Fix sorting in Resources controller

### DIFF
--- a/app/controllers/alchemy/admin/resources_controller.rb
+++ b/app/controllers/alchemy/admin/resources_controller.rb
@@ -144,7 +144,10 @@ module Alchemy
         [
           # contrary to Rails' documentation passing an empty hash to permit all keys does not work
           {options: options_from_params.keys},
-          {q: resource_handler.search_field_name},
+          {q: [
+            resource_handler.search_field_name,
+            :s
+          ]},
           :tagged_with,
           :filter,
           :page

--- a/spec/controllers/alchemy/admin/resources_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/resources_controller_spec.rb
@@ -46,6 +46,15 @@ describe Admin::EventsController do
           expect(assigns(:events)).not_to include(lustig)
         end
       end
+
+      context 'with sort parameter given' do
+        let(:params) { {q: {s: "name asc"}} }
+
+        it "returns records in the right order" do
+          get :index, params: params
+          expect(assigns(:events)).to eq([lustig, peter])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## What is this pull request for?

Fix sorting in resources controller. 

### Notable changes (remove if none)

Prior to this commit, Ransack sorting would not work
with the standard resources controller, as the parameter
`q[s]` that is generated by Ransack's `sort_link` helper
will be thrown away as insecure.

