### PR TITLE
Do not cache sitemap in Turbolinks

### DIFF
--- a/app/views/alchemy/admin/pages/index.html.erb
+++ b/app/views/alchemy/admin/pages/index.html.erb
@@ -1,3 +1,7 @@
+<% content_for :javascript_includes do %>
+  <meta name="turbolinks-cache-control" content="no-cache">
+<% end %>
+
 <% content_for :toolbar do %>
 <div class="toolbar_buttons">
   <%= render 'alchemy/admin/partials/site_select' %>


### PR DESCRIPTION
With Turbolinks caching enabled the sitemap renders twice. With large sitemaps this is already slow, doubling the request time is not nice :)

Refs #1350