### PR TITLE
(4.0) Allow later versions of Kaminari

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'handlebars_assets',                ['~> 0.23']
   gem.add_runtime_dependency 'jquery-rails',                     ['~> 4.0']
   gem.add_runtime_dependency 'jquery-ui-rails',                  ['~> 5.0.0']
-  gem.add_runtime_dependency 'kaminari',                         ['~> 0.15']
+  gem.add_runtime_dependency 'kaminari',                         ['>= 0.15', '< 2.0']
   gem.add_runtime_dependency 'originator',                       ['~> 3.1']
   gem.add_runtime_dependency 'non-stupid-digest-assets',         ['~> 1.0.8']
   gem.add_runtime_dependency 'rails',                            ['~> 5.0', '< 6.0']


### PR DESCRIPTION
Some gems that are used together with Alchemy, like Solidus 2.5, already depend
on Kaminari 1.0, while we only allow 0.x

There is no breaking change in Kaminari 1.0

Manual tests show Alchemy 4.0 works with Kaminari 1.0, tests should pass as well