### PR TITLE
Try .any? to prevent error in dashboard on online users

### DIFF
--- a/app/views/alchemy/admin/dashboard/_users.html.erb
+++ b/app/views/alchemy/admin/dashboard/_users.html.erb
@@ -1,4 +1,4 @@
-<div class="widget">
+<div class="widget users">
   <table class="list">
     <tr>
       <th colspan="2"><%= Alchemy.t('Who else is online') %></th>

--- a/app/views/alchemy/admin/dashboard/index.html.erb
+++ b/app/views/alchemy/admin/dashboard/index.html.erb
@@ -34,9 +34,10 @@
     <%= render 'recent_pages' %>
   </div>
   <div class="column right">
-    <% if @online_users.any? %>
+    <% if @online_users.try(:any?) %>
       <%= render 'users' %>
     <% end %>
+
     <% if multi_site? %>
       <%= render 'sites' %>
     <% end %>

--- a/spec/dummy/app/models/dummy_user.rb
+++ b/spec/dummy/app/models/dummy_user.rb
@@ -19,4 +19,8 @@ class DummyUser < ActiveRecord::Base
   def name
     @name || email
   end
+
+  def human_roles_string
+    alchemy_roles.map(&:humanize)
+  end
 end

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -79,4 +79,39 @@ describe 'Dashboard feature' do
       end
     end
   end
+
+  describe 'Online users' do
+    context 'with alchemy users' do
+      let(:other_user) { build_stubbed(:alchemy_dummy_user) }
+
+      before do
+        expect(Alchemy.user_class).to receive(:logged_in) { [other_user] }
+      end
+
+      it "lists all online users besides current user" do
+        visit admin_dashboard_path
+        users_widget = all('div[@class="widget users"]').first
+        expect(users_widget).to have_content other_user.name
+        expect(users_widget).to have_content "Member"
+        expect(users_widget).not_to have_content user.name
+      end
+    end
+
+    context 'with non alchemy user class' do
+      class SomeUser; end
+      before do
+        Alchemy.user_class_name = 'SomeUser'
+      end
+
+      it "does not list online users" do
+        visit admin_dashboard_path
+        users_widget = all('div[@class="widget users"]').first
+        expect(users_widget).to be_nil
+      end
+
+      after do
+        Alchemy.user_class_name = 'DummyUser'
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What is this pull request for?

On the dashboard the following error occurs (see screenshot):


```
An error happened
ActionView::Template::Error undefined method `any?' for nil:NilClass
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/alchemy_cms-4.1.0.rc1/app/views/alchemy/admin/dashboard/index.html.erb:37:in `_3fee54ccb462058a73fd553ef118d088'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionview-5.1.1/lib/action_view/template.rb:157:in `block in render'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/activesupport-5.1.1/lib/active_support/notifications.rb:168:in `instrument'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionview-5.1.1/lib/action_view/template.rb:352:in `instrument_render_template'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionview-5.1.1/lib/action_view/template.rb:155:in `render'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/deface-1.3.1/lib/deface/action_view_extensions.rb:41:in `render'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/rack-mini-profiler-1.0.0/lib/mini_profiler/profiling_methods.rb:104:in `block in profile_method'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionview-5.1.1/lib/action_view/renderer/template_renderer.rb:52:in `block (2 levels) in render_template'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionview-5.1.1/lib/action_view/renderer/abstract_renderer.rb:42:in `block in instrument'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/activesupport-5.1.1/lib/active_support/notifications.rb:166:in `block in instrument'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/activesupport-5.1.1/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/activesupport-5.1.1/lib/active_support/notifications.rb:166:in `instrument'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionview-5.1.1/lib/action_view/renderer/abstract_renderer.rb:41:in `instrument'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionview-5.1.1/lib/action_view/renderer/template_renderer.rb:51:in `block in render_template'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionview-5.1.1/lib/action_view/renderer/template_renderer.rb:59:in `render_with_layout'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionview-5.1.1/lib/action_view/renderer/template_renderer.rb:50:in `render_template'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/ddtrace-0.12.0/lib/ddtrace/contrib/rails/core_extensions.rb:70:in `render_template_with_datadog'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionview-5.1.1/lib/action_view/renderer/template_renderer.rb:14:in `render'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/ddtrace-0.12.0/lib/ddtrace/contrib/rails/core_extensions.rb:38:in `render_with_datadog'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionview-5.1.1/lib/action_view/renderer/renderer.rb:42:in `render_template'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionview-5.1.1/lib/action_view/renderer/renderer.rb:23:in `render'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionview-5.1.1/lib/action_view/rendering.rb:103:in `_render_template'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionpack-5.1.1/lib/action_controller/metal/streaming.rb:217:in `_render_template'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionview-5.1.1/lib/action_view/rendering.rb:83:in `render_to_body'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionpack-5.1.1/lib/action_controller/metal/rendering.rb:52:in `render_to_body'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionpack-5.1.1/lib/action_controller/metal/renderers.rb:141:in `render_to_body'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionpack-5.1.1/lib/abstract_controller/rendering.rb:24:in `render'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionpack-5.1.1/lib/action_controller/metal/rendering.rb:36:in `render'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionpack-5.1.1/lib/action_controller/metal/instrumentation.rb:44:in `block (2 levels) in render'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/activesupport-5.1.1/lib/active_support/core_ext/benchmark.rb:12:in `block in ms'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/2.5.0/benchmark.rb:308:in `realtime'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/activesupport-5.1.1/lib/active_support/core_ext/benchmark.rb:12:in `ms'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionpack-5.1.1/lib/action_controller/metal/instrumentation.rb:44:in `block in render'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionpack-5.1.1/lib/action_controller/metal/instrumentation.rb:87:in `cleanup_view_runtime'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/activerecord-5.1.1/lib/active_record/railties/controller_runtime.rb:29:in `cleanup_view_runtime'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionpack-5.1.1/lib/action_controller/metal/instrumentation.rb:43:in `render'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionpack-5.1.1/lib/action_controller/metal/implicit_render.rb:33:in `default_render'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionpack-5.1.1/lib/action_controller/metal/basic_implicit_render.rb:4:in `block in send_action'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionpack-5.1.1/lib/action_controller/metal/basic_implicit_render.rb:4:in `tap'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionpack-5.1.1/lib/action_controller/metal/basic_implicit_render.rb:4:in `send_action'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionpack-5.1.1/lib/abstract_controller/base.rb:186:in `process_action'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/ddtrace-0.12.0/lib/ddtrace/contrib/rails/core_extensions.rb:223:in `process_action'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionpack-5.1.1/lib/action_controller/metal/rendering.rb:30:in `process_action'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionpack-5.1.1/lib/abstract_controller/callbacks.rb:20:in `block in process_action'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/activesupport-5.1.1/lib/active_support/callbacks.rb:131:in `run_callbacks'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionpack-5.1.1/lib/abstract_controller/callbacks.rb:19:in `process_action'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionpack-5.1.1/lib/action_controller/metal/rescue.rb:20:in `process_action'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/actionpack-5.1.1/lib/action_controller/metal/instrumentation.rb:32:in `block in process_action'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/activesupport-5.1.1/lib/active_support/notifications.rb:166:in `block in instrument'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/activesupport-5.1.1/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/Users/ams/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/activesupport-5.1.1/lib/active_support/notifications.rb:166:in `instrument'
```

### Notable changes (remove if none)

This removes an error if `@online_users` is nil.

### Screenshots (remove if none)

https://www.dropbox.com/s/2rvr90l47hmhga3/Screenshot%202018-09-10%2011.47.16.png?dl=0