### PR TITLE
Fixes picture per page in overlay

### DIFF
--- a/app/controllers/alchemy/admin/pictures_controller.rb
+++ b/app/controllers/alchemy/admin/pictures_controller.rb
@@ -113,7 +113,18 @@ module Alchemy
       end
 
       def items_per_page
-        cookies[:alchemy_pictures_per_page] = params[:per_page] || cookies[:alchemy_pictures_per_page] || pictures_per_page_for_size(@size)
+        if in_overlay?
+          case params[:size]
+          when 'small' then 25
+          when 'large' then 4
+          else
+            9
+          end
+        else
+          cookies[:alchemy_pictures_per_page] = params[:per_page] ||
+                                                cookies[:alchemy_pictures_per_page] ||
+                                                pictures_per_page_for_size(params[:size])
+        end
       end
 
       def items_per_page_options
@@ -125,12 +136,10 @@ module Alchemy
 
       def pictures_per_page_for_size(size)
         case size
-        when 'small'
-          in_overlay? ? 25 : 60
-        when 'large'
-          in_overlay? ? 4 : 12
+        when 'small' then 60
+        when 'large' then 12
         else
-          in_overlay? ? 9 : 20
+          20
         end
       end
 

--- a/spec/controllers/alchemy/admin/pictures_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/pictures_controller_spec.rb
@@ -362,26 +362,69 @@ module Alchemy
       end
     end
 
-    describe '#pictures_per_page_for_size' do
-      subject { controller.send(:pictures_per_page_for_size, size) }
+    describe '#items_per_page' do
+      subject { controller.send(:items_per_page) }
 
       before do
-        expect(controller).to receive(:in_overlay?).and_return(true)
+        expect(controller).to receive(:params).at_least(:once) { params }
       end
 
-      context 'with params[:size] set to medium' do
-        let(:size) { 'medium' }
-        it { is_expected.to eq(9) }
+      context 'in overlay' do
+        let(:params) { {element_id: :id, size: size} }
+
+        context 'with params[:size] set to medium' do
+          let(:size) { 'medium' }
+
+          it { is_expected.to eq(9) }
+        end
+
+        context 'with params[:size] set to small' do
+          let(:size) { 'small' }
+
+          it { is_expected.to eq(25) }
+        end
+
+        context 'with params[:size] set to large' do
+          let(:size) { 'large' }
+
+          it { is_expected.to eq(4) }
+        end
       end
 
-      context 'with params[:size] set to small' do
-        let(:size) { 'small' }
-        it { is_expected.to eq(25) }
-      end
+      context 'in archive' do
+        let(:params) { {size: size} }
 
-      context 'with params[:size] set to large' do
-        let(:size) { 'large' }
-        it { is_expected.to eq(4) }
+        context 'with params[:size] set to medium' do
+          let(:size) { 'medium' }
+
+          it { is_expected.to eq(20) }
+
+          context 'with cookie set' do
+            before do
+              @request.cookies[:alchemy_pictures_per_page] = 2
+            end
+
+            it { is_expected.to eq(2) }
+
+            context 'with params[:per_page] given' do
+              let(:params) { {per_page: 8, size: size} }
+
+              it { is_expected.to eq(8) }
+            end
+          end
+        end
+
+        context 'with params[:size] set to small' do
+          let(:size) { 'small' }
+
+          it { is_expected.to eq(60) }
+        end
+
+        context 'with params[:size] set to large' do
+          let(:size) { 'large' }
+
+          it { is_expected.to eq(12) }
+        end
       end
     end
   end


### PR DESCRIPTION
## What is this pull request for?

Fixes picture per page value in picture assignment overlay

### Notable changes

The cookie that stores the pictures per page value for the picture library must not be used in the overlay.
