### PR TITLE
Use console.warn for Alchemy.debug

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.base.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.base.js.coffee
@@ -103,8 +103,7 @@ $.extend Alchemy,
   # Logs exception to js console, if present.
   debug: (e) ->
     if window["console"]
-      console.debug e
-      console.trace()
+      console.warn(e)
     return
 
   # Logs errors to js console, if present.


### PR DESCRIPTION
## What is this pull request for?

Use `console.warn` for `Alchemy.debug`

We use `Alchemy.debug` in our JS to warn users about things that fail.

Closes #1452 