### PR TITLE
Migrating to active_model_serializers ~> 0.10.0

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.files                 = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^spec/}) }
   gem.require_paths         = ['lib']
 
-  gem.add_runtime_dependency 'active_model_serializers',         ['~> 0.9.0']
+  gem.add_runtime_dependency 'active_model_serializers',         ['~> 0.10.0']
   gem.add_runtime_dependency 'acts_as_list',                     ['~> 0.3']
   gem.add_runtime_dependency 'awesome_nested_set',               ['~> 3.1']
   gem.add_runtime_dependency 'cancancan',                        ['~> 2.1']

--- a/app/controllers/alchemy/api/contents_controller.rb
+++ b/app/controllers/alchemy/api/contents_controller.rb
@@ -16,7 +16,7 @@ module Alchemy
       if params[:element_id].present?
         @contents = @contents.where(element_id: params[:element_id])
       end
-      respond_with @contents
+      render json: @contents, adapter: :json, root: :contents
     end
 
     # Returns a json object for content

--- a/app/controllers/alchemy/api/elements_controller.rb
+++ b/app/controllers/alchemy/api/elements_controller.rb
@@ -20,7 +20,7 @@ module Alchemy
       if params[:named].present?
         @elements = @elements.named(params[:named])
       end
-      respond_with @elements
+      render json: @elements, adapter: :json, root: :elements
     end
 
     # Returns a json object for element

--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -16,7 +16,7 @@ module Alchemy
       if params[:page_layout].present?
         @pages = @pages.where(page_layout: params[:page_layout])
       end
-      respond_with @pages
+      render json: @pages, adapter: :json, root: :pages
     end
 
     # Returns all pages as nested json object for tree views

--- a/app/serializers/alchemy/attachment_serializer.rb
+++ b/app/serializers/alchemy/attachment_serializer.rb
@@ -2,8 +2,6 @@
 
 module Alchemy
   class AttachmentSerializer < ActiveModel::Serializer
-    self.root = false
-
     attributes :id,
       :name,
       :file_name,

--- a/app/serializers/alchemy/cell_serializer.rb
+++ b/app/serializers/alchemy/cell_serializer.rb
@@ -2,8 +2,6 @@
 
 module Alchemy
   class CellSerializer < ActiveModel::Serializer
-    self.root = false
-
     attributes :id,
       :name,
       :page_id,

--- a/app/serializers/alchemy/content_serializer.rb
+++ b/app/serializers/alchemy/content_serializer.rb
@@ -2,8 +2,6 @@
 
 module Alchemy
   class ContentSerializer < ActiveModel::Serializer
-    self.root = false
-
     attributes :id,
       :name,
       :ingredient,

--- a/app/serializers/alchemy/element_serializer.rb
+++ b/app/serializers/alchemy/element_serializer.rb
@@ -2,8 +2,6 @@
 
 module Alchemy
   class ElementSerializer < ActiveModel::Serializer
-    self.root = false
-
     attributes :id,
       :name,
       :position,

--- a/app/serializers/alchemy/essence_boolean_serializer.rb
+++ b/app/serializers/alchemy/essence_boolean_serializer.rb
@@ -2,8 +2,6 @@
 
 module Alchemy
   class EssenceBooleanSerializer < ActiveModel::Serializer
-    self.root = false
-
     attributes :id,
       :value,
       :created_at,

--- a/app/serializers/alchemy/essence_date_serializer.rb
+++ b/app/serializers/alchemy/essence_date_serializer.rb
@@ -2,8 +2,6 @@
 
 module Alchemy
   class EssenceDateSerializer < ActiveModel::Serializer
-    self.root = false
-
     attributes :id,
       :date,
       :created_at,

--- a/app/serializers/alchemy/essence_file_serializer.rb
+++ b/app/serializers/alchemy/essence_file_serializer.rb
@@ -2,8 +2,6 @@
 
 module Alchemy
   class EssenceFileSerializer < ActiveModel::Serializer
-    self.root = false
-
     attributes :id,
       :title,
       :css_class

--- a/app/serializers/alchemy/essence_html_serializer.rb
+++ b/app/serializers/alchemy/essence_html_serializer.rb
@@ -2,8 +2,6 @@
 
 module Alchemy
   class EssenceHtmlSerializer < ActiveModel::Serializer
-    self.root = false
-
     attributes :id,
       :source,
       :created_at,

--- a/app/serializers/alchemy/essence_link_serializer.rb
+++ b/app/serializers/alchemy/essence_link_serializer.rb
@@ -2,8 +2,6 @@
 
 module Alchemy
   class EssenceLinkSerializer < ActiveModel::Serializer
-    self.root = false
-
     attributes :id,
       :link,
       :link_title,

--- a/app/serializers/alchemy/essence_picture_serializer.rb
+++ b/app/serializers/alchemy/essence_picture_serializer.rb
@@ -2,8 +2,6 @@
 
 module Alchemy
   class EssencePictureSerializer < ActiveModel::Serializer
-    self.root = false
-
     attributes :id,
       :picture_id,
       :caption,

--- a/app/serializers/alchemy/essence_richtext_serializer.rb
+++ b/app/serializers/alchemy/essence_richtext_serializer.rb
@@ -2,8 +2,6 @@
 
 module Alchemy
   class EssenceRichtextSerializer < ActiveModel::Serializer
-    self.root = false
-
     attributes :id,
       :body,
       :stripped_body,

--- a/app/serializers/alchemy/essence_select_serializer.rb
+++ b/app/serializers/alchemy/essence_select_serializer.rb
@@ -2,8 +2,6 @@
 
 module Alchemy
   class EssenceSelectSerializer < ActiveModel::Serializer
-    self.root = false
-
     attributes :id,
       :value,
       :created_at,

--- a/app/serializers/alchemy/essence_text_serializer.rb
+++ b/app/serializers/alchemy/essence_text_serializer.rb
@@ -2,8 +2,6 @@
 
 module Alchemy
   class EssenceTextSerializer < ActiveModel::Serializer
-    self.root = false
-
     attributes :id,
       :body,
       :link,

--- a/app/serializers/alchemy/legacy_element_serializer.rb
+++ b/app/serializers/alchemy/legacy_element_serializer.rb
@@ -2,8 +2,6 @@
 
 module Alchemy
   class LegacyElementSerializer < ActiveModel::Serializer
-    self.root = false
-
     attributes :id,
       :name,
       :position,

--- a/app/serializers/alchemy/page_serializer.rb
+++ b/app/serializers/alchemy/page_serializer.rb
@@ -2,8 +2,6 @@
 
 module Alchemy
   class PageSerializer < ActiveModel::Serializer
-    self.root = false
-
     attributes :id,
       :name,
       :urlname,
@@ -17,7 +15,8 @@ module Alchemy
       :updated_at,
       :status
 
-    has_many :elements, :cells
+    has_many :elements
+    has_many :cells
 
     def elements
       if object.has_cells?

--- a/app/serializers/alchemy/page_tree_serializer.rb
+++ b/app/serializers/alchemy/page_tree_serializer.rb
@@ -67,7 +67,7 @@ module Alchemy
       }
 
       if opts[:elements]
-        p_hash.update(elements: ActiveModel::ArraySerializer.new(page_elements(page)))
+        p_hash.update(elements: ActiveModel::Serializer::CollectionSerializer.new(page_elements(page)))
       end
 
       if opts[:ability].can?(:index, :alchemy_admin_pages)

--- a/app/serializers/alchemy/picture_serializer.rb
+++ b/app/serializers/alchemy/picture_serializer.rb
@@ -2,8 +2,6 @@
 
 module Alchemy
   class PictureSerializer < ActiveModel::Serializer
-    self.root = false
-
     attributes :id,
       :name,
       :image_file_name,

--- a/spec/controllers/alchemy/api/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/api/elements_controller_spec.rb
@@ -21,7 +21,6 @@ module Alchemy
         expect(response.content_type).to eq('application/json')
 
         result = JSON.parse(response.body)
-
         expect(result).to have_key('elements')
         expect(result['elements'].last['nested_elements']).to_not be_empty
         expect(result['elements'].size).to eq(Alchemy::Element.not_nested.count)


### PR DESCRIPTION
## What is this pull request for?

Migrated active_model_serializers to ~> 0.10.0
as 0.9.0 which is currently used is breaking serialization in rails 5.2