### PR TITLE
add options[:action_url] to picture_overlay to use with custom resources

### DIFF
--- a/app/controllers/alchemy/admin/pictures_controller.rb
+++ b/app/controllers/alchemy/admin/pictures_controller.rb
@@ -144,7 +144,7 @@ module Alchemy
       end
 
       def in_overlay?
-        params[:element_id].present?
+        params[:element_id].present? || options_from_params[:overlay].present?
       end
 
       def archive_overlay

--- a/app/helpers/alchemy/admin/pictures_helper.rb
+++ b/app/helpers/alchemy/admin/pictures_helper.rb
@@ -4,7 +4,12 @@ module Alchemy
   module Admin
     module PicturesHelper
       def create_or_assign_url(picture_to_assign, options)
-        if @content.nil?
+        if options[:action_url].present?
+          main_app.url_for(options[:action_url].merge({
+            picture_id: picture_to_assign.id,
+            options: options.except(:action_url)
+          }))
+        elsif @content.nil?
           {
             controller: :contents,
             action: :create,

--- a/app/helpers/alchemy/admin/tags_helper.rb
+++ b/app/helpers/alchemy/admin/tags_helper.rb
@@ -11,7 +11,7 @@ module Alchemy
       # @return [String]
       #   A HTML string containing <tt><li></tt> tags
       #
-      def render_tag_list(class_name)
+      def render_tag_list(class_name, options = nil)
         raise ArgumentError, 'Please provide a String as class_name' if class_name.nil?
         sorted_tags_from(class_name: class_name).map do |tag|
           content_tag('li', name: tag.name, class: filtered_by_tag?(tag) ? 'active' : nil) do
@@ -19,7 +19,8 @@ module Alchemy
               "#{tag.name} (#{tag.taggings_count})",
               url_for(
                 search_filter_params.except(:page, :tagged_with).merge(
-                  tagged_with: tags_for_filter(current: tag).presence
+                  tagged_with: tags_for_filter(current: tag).presence,
+                  options: options
                 )
               ),
               remote: request.xhr?

--- a/app/views/alchemy/admin/pictures/_filter_bar.html.erb
+++ b/app/views/alchemy/admin/pictures/_filter_bar.html.erb
@@ -17,7 +17,7 @@
   $(function() {
     $('#picture_filter').on('change', function(e) {
       var $this = $(this);
-      var url = '<%= alchemy.admin_pictures_path(search_filter_params.except(:filter).to_h) %>';
+      var url = '<%= alchemy.admin_pictures_path(search_filter_params.except(:filter).merge(options:  options_from_params).to_h) %>';
       if ($this.data('remote') === true) {
         $.get(url, {filter: $this.val()}, null, 'script');
       } else {

--- a/app/views/alchemy/admin/pictures/_tag_list.html.erb
+++ b/app/views/alchemy/admin/pictures/_tag_list.html.erb
@@ -2,12 +2,12 @@
   <h3><%= Alchemy.t("Filter by tag") %></h3>
   <%= js_filter_field '.tag-list li' %>
   <ul>
-    <%= render_tag_list('Alchemy::Picture') %>
+    <%= render_tag_list('Alchemy::Picture', options_from_params) %>
   </ul>
   <% if search_filter_params[:tagged_with].present? %>
     <%= link_to(
       render_icon(:times, size: 'xs') + Alchemy.t('Remove tag filter'),
-      url_for(search_filter_params.except(:tagged_with)),
+      url_for(search_filter_params.except(:tagged_with).merge(options: options_from_params)),
       remote: request.xhr?,
       class: 'secondary button small with_icon'
     ) %>


### PR DESCRIPTION
## What is this pull request for?

This is my idea to allow to open the picture gallery overlay for a custom resource and use it to select one picture (see #1451 for details)

To add a link to open the dialog, I do something like that:
```ruby
<%= link_to_dialog(
  render_icon(:upload),
  alchemy.admin_pictures_path(options: {
    overlay: true,
    action_url: {
      controller: 'admin/configurations',
      action: 'update_image',
      id: configuration.id
    }
  }),
  {
    title: Alchemy.t(:insert_image),
    size: '800x600',
    padding: false
  }
) -%>
```