### PR TITLE
Disable page publish/view page buttons according to published_at

### DIFF
--- a/app/assets/stylesheets/alchemy/buttons.scss
+++ b/app/assets/stylesheets/alchemy/buttons.scss
@@ -33,6 +33,14 @@ button, input[type="submit"], a.button, input.button {
     margin-right: 2 * $default-margin;
     color: inherit;
   }
+
+  &[disabled] {
+    cursor: not-allowed;
+
+    & + label {
+      display: none;
+    }
+  }
 }
 
 .icon_button {
@@ -79,11 +87,16 @@ button, input[type="submit"], a.button, input.button {
     }
   }
 
-  &.disabled {
+  &.disabled,
+  &[disabled] {
 
     span {
       opacity: 0.3;
       cursor: not-allowed;
+    }
+
+    i {
+      opacity: 0.3;
     }
 
     &:hover {
@@ -121,7 +134,7 @@ button.icon_button {
   margin: 0 2*$default-margin;
 
   &.active, &:active, &:hover {
-   .icon_button {
+   .icon_button:not([disabled]) {
       background-color: $default-border-color;
       cursor: pointer;
     }

--- a/app/views/alchemy/admin/pages/edit.html.erb
+++ b/app/views/alchemy/admin/pages/edit.html.erb
@@ -13,16 +13,6 @@
     <% end %>
   </div>
   <div class="toolbar_spacer"></div>
-  <% unless @page.layoutpage? %>
-    <div class="button_with_label">
-      <%= form_tag alchemy.visit_admin_page_path(@page), id: 'visit_page_form' do %>
-        <%= button_tag class: 'icon_button', disabled: !@page.public? do %>
-          <%= render_icon('external-link-alt') %>
-        <% end %>
-        <label><%= Alchemy.t("Visit page") %></label>
-      <% end %>
-    </div>
-  <% end %>
   <div class="button_with_label">
     <%= link_to_dialog(
       render_icon('info-circle'),
@@ -73,6 +63,16 @@
           <%= render_icon('cloud-upload-alt') %>
         <% end %>
         <label><%= Alchemy.t("Publish page") %></label>
+      <% end %>
+    </div>
+  <% end %>
+  <% unless @page.layoutpage? %>
+    <div class="button_with_label">
+      <%= form_tag alchemy.visit_admin_page_path(@page), id: 'visit_page_form' do %>
+        <%= button_tag class: 'icon_button', disabled: !@page.public? do %>
+          <%= render_icon('external-link-alt') %>
+        <% end %>
+        <label><%= Alchemy.t("Visit page") %></label>
       <% end %>
     </div>
   <% end %>

--- a/app/views/alchemy/admin/pages/edit.html.erb
+++ b/app/views/alchemy/admin/pages/edit.html.erb
@@ -14,14 +14,14 @@
   </div>
   <div class="toolbar_spacer"></div>
   <% unless @page.layoutpage? %>
-  <div class="button_with_label">
-    <%= form_tag alchemy.visit_admin_page_path(@page), id: 'visit_page_form' do %>
-      <button class="icon_button" title="<%= Alchemy.t('Visit page') %>">
-        <%= render_icon('external-link-alt') %>
-      </button>
-      <label><%= Alchemy.t("Visit page") %></label>
-    <% end %>
-  </div>
+    <div class="button_with_label">
+      <%= form_tag alchemy.visit_admin_page_path(@page), id: 'visit_page_form' do %>
+        <%= button_tag class: 'icon_button', disabled: !@page.public? do %>
+          <%= render_icon('external-link-alt') %>
+        <% end %>
+        <label><%= Alchemy.t("Visit page") %></label>
+      <% end %>
+    </div>
   <% end %>
   <div class="button_with_label">
     <%= link_to_dialog(


### PR DESCRIPTION
I was annoyed how the View Page button would allow you to click and get a page error when the page was not published. I would have much rather this button been disabled. 

- View Page / Publish buttons are disabled according to the published_at column
- I moved the view page button next to the publish button to make more sense in context.