### PR TITLE
Increase size of editor column

### DIFF
--- a/app/assets/stylesheets/alchemy/_variables.scss
+++ b/app/assets/stylesheets/alchemy/_variables.scss
@@ -136,7 +136,7 @@ $table-row-even-background-color: $white !default;
 $table-row-odd-background-color: rgba($white, 0.5) !default;
 $table-row-hover-color: rgba($light_yellow, 0.5) !default;
 
-$elements-window-width: 400px !default;
+$elements-window-width: 450px !default;
 $element-header-bg-color: $medium-gray !default;
 $top-menu-height: 75px !default;
 


### PR DESCRIPTION
The editor column seemed excessively small. I widened it from 400px to 450px to be easier on the eyes.