### PR TITLE
Use the defined layout in ApplicationController for page previews

### DIFF
--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -49,7 +49,7 @@ module Alchemy
         Page.current_preview = @page
         # Setting the locale to pages language, so the page content has it's correct translations.
         ::I18n.locale = @page.language.locale
-        render layout: 'application'
+        render(layout: Alchemy::Config.get(:admin_page_preview_layout) || 'application')
       end
 
       def info

--- a/config/alchemy/config.yml
+++ b/config/alchemy/config.yml
@@ -195,3 +195,6 @@ format_matchers:
   email: !ruby/regexp '/\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/'
   url: !ruby/regexp '/\A[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?\z/ix'
   link_url: !ruby/regexp '/^(mailto:|\/|[a-z]+:\/\/)/'
+
+# The layout used for rendering the +alchemy/admin/pages#show+ action.
+admin_page_preview_layout: application

--- a/spec/dummy/app/views/layouts/custom.html.erb
+++ b/spec/dummy/app/views/layouts/custom.html.erb
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Custom Layout</title>
+</head>
+<body>
+  <%= yield %>
+</body>
+</html>

--- a/spec/requests/alchemy/admin/pages_controller_spec.rb
+++ b/spec/requests/alchemy/admin/pages_controller_spec.rb
@@ -289,6 +289,19 @@ module Alchemy
           get admin_page_path(page)
           expect(response).to render_template(layout: 'application')
         end
+
+        context 'when layout is set to custom' do
+          before do
+            allow(Alchemy::Config).to receive(:get) do |arg|
+              arg == :admin_page_preview_layout ? 'custom' : Alchemy::Config.parameter(arg)
+            end
+          end
+
+          it "it renders custom layout instead" do
+            get admin_page_path(page)
+            expect(response).to render_template(layout: 'custom')
+          end
+        end
       end
 
       describe '#order' do


### PR DESCRIPTION
If you configure your ApplicationController to use a different layout than the default `application` layout then the previews will stop working. This PR allows the preview to utilize the same layout as ApplicationController has defined.

Solves #1313 