### PR TITLE
Adjust issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -20,8 +20,3 @@ Tell us what happens instead
 
 - Alchemy Version:
 - Rails Version:
-- Contents of your `Gemfile.lock`
-
-```ruby
-# Replace with Gemfile.lock content
-```


### PR DESCRIPTION
Changes the Issue Tempalte to not request for Gemfile.lock as it adds so much cruft to the bug report. It already requests the Alchemy+Rails version. The small amout of times a Gemfile.lock is needed it could easily be requested manually.