### PR TITLE
Fix hover label width for collapsed nav

### DIFF
--- a/app/assets/stylesheets/alchemy/navigation.scss
+++ b/app/assets/stylesheets/alchemy/navigation.scss
@@ -49,7 +49,8 @@
         position: absolute;
         top: 0;
         left: $collapsed-main-menu-width - 1;
-        width: $main-menu-width + 1;
+        min-width: $main-menu-width + 1;
+        max-width: 350px;
         padding-left: 4*$default-padding;
       }
     }


### PR DESCRIPTION
The collapsed nav items hover label width was not being set correctly causing my multi-word items to break down to multiple lines. This PR fixes the intended behaviour. Note I am using Firefox.