### PR TITLE
Allow "data" key for module navigations

### DIFF
--- a/app/views/alchemy/admin/partials/_main_navigation_entry.html.erb
+++ b/app/views/alchemy/admin/partials/_main_navigation_entry.html.erb
@@ -1,5 +1,5 @@
 <% if can? *navigate_module(navigation) %>
-  <%= content_tag :div, class: main_navigation_css_classes(navigation) do %>
+  <%= content_tag :div, class: main_navigation_css_classes(navigation), data: navigation["data"] do %>
     <%= link_to url_for_module(alchemy_module) do %>
       <% if navigation["image"] %>
         <%= image_tag(navigation["image"]) %>

--- a/spec/views/alchemy/admin/partials/_main_navigation_entry.html.erb_spec.rb
+++ b/spec/views/alchemy/admin/partials/_main_navigation_entry.html.erb_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "alchemy/admin/partials/_main_navigation_entry.html.erb" do
+  let(:alchemy_module) do
+    {
+      engine_name: 'alchemy',
+      name: 'what_a_name',
+      navigation: {
+        controller: 'alchemy/admin/pages',
+        action: 'index',
+        name: 'Pages',
+        image: 'alchemy/alchemy-logo.svg',
+        data: { turbolinks: false },
+        sub_navigation: []
+      }
+    }.with_indifferent_access
+  end
+
+  let(:navigation) { alchemy_module[:navigation] }
+
+  before do
+    allow(view).to receive(:navigation).and_return(navigation)
+    allow(view).to receive(:alchemy_module).and_return(alchemy_module)
+    allow(view).to receive(:can?).and_return(true)
+    view.extend Alchemy::Admin::NavigationHelper
+  end
+
+  it "renders navigation with data attribute" do
+    render
+
+    expect(rendered).to have_selector('div[data-turbolinks="false"]')
+  end
+
+  context 'with no data attribute' do
+    let(:alchemy_module) do
+      {
+        engine_name: 'alchemy',
+        name: 'what_a_name',
+        navigation: {
+          controller: 'alchemy/admin/pages',
+          action: 'index',
+          name: 'Pages',
+          image: 'alchemy/alchemy-logo.svg',
+          sub_navigation: []
+        }
+      }.with_indifferent_access
+    end
+
+    it "renders navigation without data attribute" do
+      render
+
+      expect(rendered).not_to have_selector('div[data-turbolinks="false"]')
+    end
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

This allows specifying a `data` key in module navigations. That way
one can add, for example, `data-turbolinks='false'` to a navigation entry.

In a module definition, it looks like this:

```
alchemy_module = {
  engine_name: 'spree',
  name: 'solidus',
  navigation: {
    controller: 'spree/admin/orders',
    action: 'index',
    name: 'Store',
    image: 'alchemy/solidus/alchemy_module_icon.png',
    data: { turbolinks: false },
    sub_navigation: [
      {
        controller: 'spree/admin/orders',
        action: 'index',
        name: 'Orders',
      }
    ]
  }
}
```

### Screenshots (remove if none)

![grafik](https://user-images.githubusercontent.com/703401/47781833-fb41d680-dcfe-11e8-9f89-1242d933cdb4.png)

