### PR TITLE
Maximize element window if tinymce is fullscreen

### DIFF
--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -13,6 +13,11 @@
   .elements-window-visible & {
     transform: translate3d(0, 0, 0);
   }
+
+  // Fix for Tinymce fullscreen window positioning issues (GH#1511)
+  .mce-fullscreen & {
+    width: calc(100vw - #{$collapsed-main-menu-width - $default-border-width});
+  }
 }
 
 #element_area {

--- a/app/assets/stylesheets/tinymce/skins/alchemy/skin.min.css.scss
+++ b/app/assets/stylesheets/tinymce/skins/alchemy/skin.min.css.scss
@@ -67,6 +67,8 @@
   overflow: hidden;
   height: 100%;
   z-index: 100;
+  background: #fff;
+  border-radius: 0;
 
   .mce-resizehandle {
     display: none;
@@ -332,21 +334,6 @@ div.mce-tinymce-inline {
     right: 10px;
     left: auto;
   }
-}
-
-.mce-fullscreen {
-  border: 0;
-  padding: 0;
-  margin: 0;
-  overflow: hidden;
-  background: #fff;
-  height: 100%;
-}
-
-div.mce-fullscreen {
-  position: fixed;
-  top: 0;
-  left: 0;
 }
 
 #mce-modal-block {

--- a/app/assets/stylesheets/tinymce/skins/alchemy/skin.min.css.scss
+++ b/app/assets/stylesheets/tinymce/skins/alchemy/skin.min.css.scss
@@ -28,9 +28,6 @@
   direction: ltr;
 }
 
-.mce-widget button {
-}
-
 .mce-container *[unselectable] {
   user-select: none;
 }


### PR DESCRIPTION
Fixes a weird css issue with the Tinymce editor in fullscreen.

Closes #1511

### Notable changes (remove if none)

Usually a DOM element with `display: fixed` will be positioned 
relatively to the body, no matter what container it is in. Not in this case.
Somehow the element window is the positioned parent of the tinymce editor in fullscreen.

Fixed by maximizing the elements window when the tinymce editor is in fullscreen.

This has the nice side effect of having a transition between the two states of the tinymce editor.