### PR TITLE
update description to match dependencies [ci skip]

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |gem|
   gem.authors               = ['Thomas von Deyen', 'Robin Boening', 'Marc Schettke', 'Hendrik Mans', 'Carsten Fregin', 'Martin Meyerhoff']
   gem.email                 = ['alchemy@magiclabs.de']
   gem.homepage              = 'https://alchemy-cms.com'
-  gem.summary               = 'A powerful, userfriendly and flexible CMS for Rails 4'
-  gem.description           = 'Alchemy is a powerful, userfriendly and flexible Rails 4 CMS.'
+  gem.summary               = 'A powerful, userfriendly and flexible CMS for Rails 5'
+  gem.description           = 'Alchemy is a powerful, userfriendly and flexible Rails 5 CMS.'
   gem.requirements << 'ImageMagick (libmagick), v6.6 or greater.'
   gem.required_ruby_version = '>= 2.2.2'
   gem.license               = 'BSD New'


### PR DESCRIPTION
## What is this pull request for?

The description in the gemspec still says this is for Rails 4, even though the gemspec requires Rails 5.

I noticed this will searching rubygems.org, changing the gemspec should cause that to update when a new version is cut.
