### PR TITLE
Remove temp ransack repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,9 +12,6 @@ gem 'mysql2', '~> 0.5.1' if ENV['DB'] == 'mysql'
 gem 'pg',     '~> 1.0'   if ENV['DB'] == 'postgresql'
 gem 'sassc-rails'
 
-# Temporary fix until a new Ransack version gets released.
-gem 'ransack', github: 'activerecord-hackery/ransack', ref: '8daa87a0389d380f7c9fd7ea9cb5bda634d5dc7d'
-
 group :development, :test do
   gem 'simplecov', require: false
   gem 'bootsnap', require: false


### PR DESCRIPTION
Ransack 2.11.1 with Rails 5.2.2 support has been released
