### PR TITLE
Render new page when there is a flash message

### DIFF
--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -155,10 +155,10 @@ module Alchemy
     end
 
     def set_expiration_headers
-      if @page.cache_page?
-        expires_in @page.expiration_time, public: !@page.restricted, must_revalidate: true
-      else
+      if must_not_cache?
         expires_now
+      else
+        expires_in @page.expiration_time, public: !@page.restricted, must_revalidate: true
       end
     end
 
@@ -190,10 +190,15 @@ module Alchemy
     # or the cache is stale, because it's been republished by the user.
     #
     def render_fresh_page?
-      !@page.cache_page? || stale?(etag: page_etag,
+      must_not_cache? || stale?(etag: page_etag,
         last_modified: @page.published_at,
         public: !@page.restricted,
         template: 'pages/show')
+    end
+
+    # don't cache pages if we have flash message to display or the page has caching disabled
+    def must_not_cache?
+      flash.present? || !@page.cache_page?
     end
 
     def page_not_found!

--- a/spec/requests/alchemy/page_request_caching_spec.rb
+++ b/spec/requests/alchemy/page_request_caching_spec.rb
@@ -109,6 +109,30 @@ RSpec.describe 'Page request caching' do
       end
     end
 
+    context "but a flash message is present" do
+      before do
+        allow_any_instance_of(ActionDispatch::Flash::FlashHash).to receive(:present?) do
+          true
+        end
+      end
+
+      it "sets no-cache header" do
+        get "/#{page.urlname}"
+        expect(response.headers).to have_key('Cache-Control')
+        expect(response.headers['Cache-Control']).to eq('no-cache')
+      end
+
+      it "does not set etag header" do
+        get "/#{page.urlname}"
+        expect(response.headers).to_not have_key('ETag')
+      end
+
+      it "does not set last-modified header" do
+        get "/#{page.urlname}"
+        expect(response.headers).to_not have_key('Last-Modified')
+      end
+    end
+
     after do
       Rails.application.config.action_controller.perform_caching = false
     end


### PR DESCRIPTION
- render new page only when there is a flash message, otherwise render
old page
- needed when you have flash messages in place

## What is this pull request for?
When you have flash messages in place this is needed so that flash messages do not get cached and re-rendered when from cache, otherwise the flash message keeps displaying even though there was no flash message in a new request.

