### PR TITLE
Run CI build with latest stable Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ addons:
 cache:
   bundler: true
 rvm:
-- 2.3.5
-- 2.4.2
-- 2.5.0
+- 2.4.5
+- 2.5.3
+- 2.6.0
 before_install:
   - gem install bundler
 before_script:


### PR DESCRIPTION
## What is this pull request for?

Run CI build with latest stable Ruby versions

### Notable changes

Builds now for Ruby 2.4.5, 2.5.3 and 2.6.0 and dropped builds for Ruby 2.3.5
