### PR TITLE
Change image cropping handling

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.image_cropper.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.image_cropper.js.coffee
@@ -34,8 +34,6 @@ Alchemy.ImageCropper =
 
   reset: ->
     Alchemy.ImageCropper.api.setSelect Alchemy.ImageCropper.default_box
-    Alchemy.ImageCropper.crop_from_field.val ""
-    Alchemy.ImageCropper.crop_size_field.val ""
 
   destroy: ->
     if Alchemy.ImageCropper.api

--- a/app/controllers/alchemy/admin/essence_pictures_controller.rb
+++ b/app/controllers/alchemy/admin/essence_pictures_controller.rb
@@ -19,7 +19,7 @@ module Alchemy
       def crop
         if @picture = @essence_picture.picture
           @content = @essence_picture.content
-          options_from_params[:format] ||= (configuration(:image_store_format) || 'png')
+          options_from_params[:format] ||= configuration(:image_store_format) || @picture.image_file_format || 'png'
 
           @min_size = sizes_from_essence_or_params
           @ratio = ratio_from_size_or_params

--- a/app/models/alchemy/essence_picture.rb
+++ b/app/models/alchemy/essence_picture.rb
@@ -88,12 +88,11 @@ module Alchemy
     def thumbnail_url(options = {})
       return if picture.nil?
 
-      crop = crop_values_present? || content.settings_value(:crop, options)
-      size = render_size || content.settings_value(:size, options)
+      crop = crop_values_present? && content.settings_value(:crop, options).present?
 
       options = {
-        size: thumbnail_size(size, crop),
-        crop: !!crop,
+        size: thumbnail_size(crop),
+        crop: crop,
         crop_from: crop_from.presence,
         crop_size: crop_size.presence,
         flatten: true,

--- a/app/models/alchemy/picture/url.rb
+++ b/app/models/alchemy/picture/url.rb
@@ -44,9 +44,10 @@ module Alchemy
       size = options[:size]
       upsample = !!options[:upsample]
 
-      return image unless size.present? && has_convertible_format?
+      return image unless (options[:crop] || size) && has_convertible_format?
 
-      if options[:crop]
+      if options[:crop] && options[:crop_size]
+        size = size || options[:crop_size]
         crop(size, options[:crop_from], options[:crop_size], upsample)
       else
         resize(size, upsample)

--- a/app/views/alchemy/essences/shared/_essence_picture_tools.html.erb
+++ b/app/views/alchemy/essences/shared/_essence_picture_tools.html.erb
@@ -12,7 +12,7 @@
       padding: false
     }, {title: Alchemy.t('Edit Picturemask')} %>
 <%- else -%>
-  <a href="#" class="disabled" tabindex="-1"><%= render_icon(:crop) %></a>
+  <a href="#" class="disabled" onclick="javascript: return false;" tabindex="-1"><%= render_icon(:crop) %></a>
 <%- end -%>
 
 <%= link_to_dialog render_icon('file-image', style: 'regular'),

--- a/db/migrate/20181030082614_remove_alchemy_cells.rb
+++ b/db/migrate/20181030082614_remove_alchemy_cells.rb
@@ -1,5 +1,10 @@
 class RemoveAlchemyCells < ActiveRecord::Migration[5.2]
   def change
+    remove_reference :alchemy_elements, :cell, index: true, foreign_key: {
+      to_table: :alchemy_cells,
+      on_update: :cascade,
+      on_delete: :cascade
+    }
     drop_table :alchemy_cells do |t|
       t.integer "page_id", null: false
       t.string "name"
@@ -7,10 +12,5 @@ class RemoveAlchemyCells < ActiveRecord::Migration[5.2]
       t.datetime "updated_at", null: false, precision: 6
       t.index ["page_id"], name: "index_alchemy_cells_on_page_id"
     end
-    remove_reference :alchemy_elements, :cell, index: true, foreign_key: {
-      to_table: :alchemy_cells,
-      on_update: :cascade,
-      on_delete: :cascade
-    }
   end
 end

--- a/spec/controllers/alchemy/admin/essence_pictures_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/essence_pictures_controller_spec.rb
@@ -167,6 +167,28 @@ module Alchemy
             expect(assigns(:ratio)).to eq(80.0 / 60.0)
           end
         end
+
+        context 'without configured output format' do
+          before do
+            picture.image_file_format = 'jpg'
+          end
+
+          it 'keeps the original image format' do
+            get :crop, params: {id: 1, options: {}}
+            expect(assigns(:_options_from_params)[:format]).to eq('jpg')
+          end
+        end
+
+        context 'with output format configured in essence' do
+          before do
+            picture.image_file_format = 'png'
+          end
+
+          it 'changes the output format' do
+            get :crop, params: {id: 1, options: { format: 'jpg' }}
+            expect(assigns(:_options_from_params)[:format]).to eq('jpg')
+          end
+        end
       end
     end
 

--- a/spec/models/alchemy/essence_picture_spec.rb
+++ b/spec/models/alchemy/essence_picture_spec.rb
@@ -178,8 +178,15 @@ module Alchemy
         thumbnail_url
       end
 
-      context 'when crop sizes are present' do
+      context 'when crop sizes are present and cropping is enabled' do
+        let(:settings) do
+          {
+            crop: true
+          }
+        end
+
         before do
+          allow(content).to receive(:settings) { settings }
           allow(essence).to receive(:crop_size).and_return('200x200')
           allow(essence).to receive(:crop_from).and_return('10x10')
         end
@@ -187,6 +194,20 @@ module Alchemy
         it "passes these crop sizes to the picture's url method." do
           expect(picture).to receive(:url).with(
             hash_including(crop_from: '10x10', crop_size: '200x200', crop: true)
+          )
+          thumbnail_url
+        end
+      end
+
+      context 'when crop sizes are present and cropping is disabled' do
+        before do
+          allow(essence).to receive(:crop_size).and_return('200x200')
+          allow(essence).to receive(:crop_from).and_return('10x10')
+        end
+
+        it "passes these crop sizes to the picture's url method." do
+          expect(picture).to receive(:url).with(
+            hash_including(crop_from: '10x10', crop_size: '200x200', crop: false)
           )
           thumbnail_url
         end
@@ -203,6 +224,11 @@ module Alchemy
         context 'when crop is explicitely enabled in the options' do
           let(:options) do
             {crop: true}
+          end
+
+          before do
+            allow(essence).to receive(:crop_size).and_return('200x200')
+            allow(essence).to receive(:crop_from).and_return('10x10')
           end
 
           it "it enables cropping." do
@@ -244,6 +270,14 @@ module Alchemy
         let(:essence) { build_stubbed(:alchemy_essence_picture) }
 
         it { is_expected.to be_nil }
+      end
+
+      context 'with crop values given' do
+        let(:essence) { build_stubbed(:alchemy_essence_picture, crop_from: '0x0', crop_size: '100x100') }
+
+        it "returns a hash containing cropping coordinates" do
+          is_expected.to eq({x1: 0, y1: 0, x2: 100, y2: 100})
+        end
       end
     end
 

--- a/spec/support/transformation_examples.rb
+++ b/spec/support/transformation_examples.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 module Alchemy
   shared_examples_for "has image transformations" do
     describe "#thumbnail_size" do
-      context "picture is 300x400 and has no crop size" do
+      context "picture is 400x300 and has no crop size" do
         it "should return the correct recalculated size value" do
           allow(picture).to receive(:image_file_width) { 400 }
           allow(picture).to receive(:image_file_height) { 300 }
@@ -25,15 +25,15 @@ module Alchemy
 
       context "picture has crop_size of 400x300" do
         it "scales to 400x300 if that is the size of the cropped image" do
-          allow(picture).to receive(:crop_size) { "400x300" }
-          expect(picture.thumbnail_size).to eq('160x120')
+          allow(picture).to receive(:crop_size) { '400x300' }
+          expect(picture.thumbnail_size(true)).to eq('160x120')
         end
       end
 
       context "picture has crop_size of 0x0" do
         it "returns default thumbnail size" do
-          allow(picture).to receive(:crop_size) { "0x0" }
-          expect(picture.thumbnail_size).to eq('160x120')
+          allow(picture).to receive(:crop_size) { '0x0' }
+          expect(picture.thumbnail_size(true)).to eq('160x120')
         end
       end
     end


### PR DESCRIPTION
## What is this pull request for?

Changing image cropping handling to allow new size variations for the picture essence settings. Fix some unexpected behavior in the cropper editor.

Now the following scenarios can be implemented:
1. Image is adjusted to the specified width and height according to the aspect ratio of the image
`size: 1920x1280`
2. Fixed width, variable height, aspect ratio of the image is maintained
`size: 1920x`
3. When cropping is activated and the width is set, the height is calculated based on the cropping area.
`crop: true`
`size: 1920x`
4. When cropping is activated and the width and height is set, the cropping area has a fixed ratio and it is not possible in the cropping editor, to scale to a lower resolution.
`crop: true`
`size: 1920x1280`
5. When only cropping is activated, the cropping area can be set at will. The cropping region is not resized to a specific size.
`crop: true`
6. When cropping is activated and a fixed ratio is given, you can only crop an area based on the given image ratio
`crop: true`
`fixed_ratio: 1.5`
7. When cropping is activated and a fixed ratio is given and a fixed width is provided, you can only crop an area based on the given image ratio, and afterwards the cropped area gets scaled to the given width
`crop: true`
`size: 1920x`
`fixed_ratio: 1.5`

The following combinations for the size attribute are available
- `size: 1920x1280`
- `size: 1920x` fixed width and variable height
- `size: x1280` variable width and fixed height


Fix migration remove_alchemy_cells. Remove foreign key before drop table.