### PR TITLE
Image cropping

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.image_cropper.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.image_cropper.js.coffee
@@ -34,8 +34,6 @@ Alchemy.ImageCropper =
 
   reset: ->
     Alchemy.ImageCropper.api.setSelect Alchemy.ImageCropper.default_box
-    Alchemy.ImageCropper.crop_from_field.val ""
-    Alchemy.ImageCropper.crop_size_field.val ""
 
   destroy: ->
     if Alchemy.ImageCropper.api

--- a/app/controllers/alchemy/admin/essence_pictures_controller.rb
+++ b/app/controllers/alchemy/admin/essence_pictures_controller.rb
@@ -19,7 +19,7 @@ module Alchemy
       def crop
         if @picture = @essence_picture.picture
           @content = @essence_picture.content
-          options_from_params[:format] ||= (configuration(:image_store_format) || 'png')
+          options_from_params[:format] ||= configuration(:image_store_format) || @picture.image_file_format || 'png'
 
           @min_size = sizes_from_essence_or_params
           @ratio = ratio_from_size_or_params

--- a/app/models/alchemy/essence_picture.rb
+++ b/app/models/alchemy/essence_picture.rb
@@ -88,12 +88,11 @@ module Alchemy
     def thumbnail_url(options = {})
       return if picture.nil?
 
-      crop = crop_values_present? || content.settings_value(:crop, options)
-      size = render_size || content.settings_value(:size, options)
+      crop = crop_values_present? && content.settings_value(:crop, options).present?
 
       options = {
-        size: thumbnail_size(size, crop),
-        crop: !!crop,
+        size: thumbnail_size(crop),
+        crop: crop,
         crop_from: crop_from.presence,
         crop_size: crop_size.presence,
         flatten: true,

--- a/app/models/alchemy/essence_picture.rb
+++ b/app/models/alchemy/essence_picture.rb
@@ -88,11 +88,12 @@ module Alchemy
     def thumbnail_url(options = {})
       return if picture.nil?
 
-      crop = crop_values_present? && content.settings_value(:crop, options).present?
+      crop = content.settings_value(:crop, options)
+      size = render_size || content.settings_value(:size, options)
 
       options = {
-        size: thumbnail_size(crop),
-        crop: crop,
+        size: thumbnail_size(size, crop),
+        crop: !!crop,
         crop_from: crop_from.presence,
         crop_size: crop_size.presence,
         flatten: true,

--- a/app/models/alchemy/picture/transformations.rb
+++ b/app/models/alchemy/picture/transformations.rb
@@ -196,10 +196,10 @@ module Alchemy
       "#{dimensions[:width]}x#{dimensions[:height]}"
     end
 
-    # Returns true if both dimensions of the base image are bigger than the dimensions hash.
+    # Returns true if both dimensions of the base image are bigger or equal than the dimensions hash.
     #
     def is_bigger_than(dimensions)
-      image_file_width > dimensions[:width] && image_file_height > dimensions[:height]
+      image_file_width >= dimensions[:width] && image_file_height >= dimensions[:height]
     end
 
     # Returns true is one dimension of the base image is smaller than the dimensions hash.

--- a/app/models/alchemy/picture/transformations.rb
+++ b/app/models/alchemy/picture/transformations.rb
@@ -211,11 +211,9 @@ module Alchemy
     # Uses imagemagick to make a centercropped thumbnail. Does not scale the image up.
     #
     def center_crop(dimensions, upsample)
-      if is_smaller_than(sizes_from_string(dimensions)) && upsample == false
-        dimensions = sizes_from_string(dimensions)
-        dimensions = dimensions_to_string(reduce_to_image(dimensions))
-      end
-      image_file.thumb("#{dimensions}#")
+      dimensions = sizes_from_string(dimensions)
+      dimensions = reduce_to_image(dimensions) if is_smaller_than(dimensions) && upsample == false
+      image_file.thumb("#{dimensions_to_string(dimensions)}#")
     end
 
     # Use imagemagick to custom crop an image. Uses -thumbnail for better performance when resizing.

--- a/app/models/alchemy/picture/transformations.rb
+++ b/app/models/alchemy/picture/transformations.rb
@@ -30,10 +30,17 @@ module Alchemy
 
     # Returns a size value String for the thumbnail used in essence picture editors.
     #
-    def thumbnail_size(crop = false)
+    def thumbnail_size(size = nil, crop = false)
       # only if crop is set do we need to actually parse the size string, otherwise
       # we take the base image size.
-      size = crop ? sizes_from_string(crop_size) : image_size
+      size = if crop && crop_size
+               sizes_from_string(crop_size)
+             elsif crop
+               sizes_from_string(size)
+             else
+               image_size
+             end
+
       size = size_when_fitting({width: THUMBNAIL_WIDTH, height: THUMBNAIL_HEIGHT}, size)
       "#{size[:width]}x#{size[:height]}"
     end

--- a/app/models/alchemy/picture/transformations.rb
+++ b/app/models/alchemy/picture/transformations.rb
@@ -16,8 +16,11 @@ module Alchemy
     #
     def default_mask(mask_arg)
       mask = mask_arg.dup
-      mask[:width] = image_file_width if mask[:width].zero?
-      mask[:height] = image_file_height if mask[:height].zero?
+
+      if mask[:width].zero? || mask[:height].zero?
+        mask[:width] = image_file_width
+        mask[:height] = image_file_height
+      end
 
       crop_size = size_when_fitting({width: image_file_width, height: image_file_height}, mask)
       top_left = get_top_left_crop_corner(crop_size)
@@ -27,19 +30,10 @@ module Alchemy
 
     # Returns a size value String for the thumbnail used in essence picture editors.
     #
-    def thumbnail_size(size_string = "0x0", crop = false)
-      size = sizes_from_string(size_string)
-
+    def thumbnail_size(crop = false)
       # only if crop is set do we need to actually parse the size string, otherwise
       # we take the base image size.
-      if crop
-        size[:width] = get_base_dimensions[:width] if size[:width].zero?
-        size[:height] = get_base_dimensions[:height] if size[:height].zero?
-        size = reduce_to_image(size)
-      else
-        size = get_base_dimensions
-      end
-
+      size = crop ? sizes_from_string(crop_size) : image_size
       size = size_when_fitting({width: THUMBNAIL_WIDTH, height: THUMBNAIL_HEIGHT}, size)
       "#{size[:width]}x#{size[:height]}"
     end
@@ -48,14 +42,12 @@ module Alchemy
     # parameters. When they can't be parsed, it just crops from the center.
     #
     def crop(size, crop_from = nil, crop_size = nil, upsample = false)
-      raise "No size given!" if size.empty?
-      render_to = sizes_from_string(size)
       if crop_from && crop_size
         top_left = point_from_string(crop_from)
         crop_dimensions = sizes_from_string(crop_size)
-        xy_crop_resize(render_to, top_left, crop_dimensions, upsample)
+        xy_crop_resize(size, top_left, crop_dimensions, upsample)
       else
-        center_crop(render_to, upsample)
+        center_crop(size, upsample)
       end
     end
 
@@ -127,10 +119,10 @@ module Alchemy
       respond_to?(:render_size) && render_size.present?
     end
 
-    # Returns true if the class we're included in has a meaningful crop_size attribute
+    # Returns true if the class we're included in has a meaningful crop_size attribute and cropping is activated
     #
     def crop_size?
-      respond_to?(:crop_size) && !crop_size.nil? && !crop_size.empty?
+      respond_to?(:crop_size) && crop_size.present?
     end
 
     private
@@ -162,24 +154,13 @@ module Alchemy
       }
     end
 
-    # Gets the base dimensions (the dimensions of the Picture before scaling).
-    # If anything is missing, it gets padded with zero (Integer 0).
-    # This is the order of precedence: crop_size > image_size
-    def get_base_dimensions
-      if crop_size?
-        sizes_from_string(crop_size)
-      else
-        image_size
-      end
-    end
-
     # This function takes a target and a base dimensions hash and returns
     # the dimensions of the image when the base dimensions hash fills
     # the target.
     #
     # Aspect ratio will be preserved.
     #
-    def size_when_fitting(target, dimensions = get_base_dimensions)
+    def size_when_fitting(target, dimensions = image_size)
       zoom = [
         dimensions[:width].to_f / target[:width],
         dimensions[:height].to_f / target[:height]
@@ -230,10 +211,11 @@ module Alchemy
     # Uses imagemagick to make a centercropped thumbnail. Does not scale the image up.
     #
     def center_crop(dimensions, upsample)
-      if is_smaller_than(dimensions) && upsample == false
-        dimensions = reduce_to_image(dimensions)
+      if is_smaller_than(sizes_from_string(dimensions)) && upsample == false
+        dimensions = sizes_from_string(dimensions)
+        dimensions = dimensions_to_string(reduce_to_image(dimensions))
       end
-      image_file.thumb("#{dimensions_to_string(dimensions)}#")
+      image_file.thumb("#{dimensions}#")
     end
 
     # Use imagemagick to custom crop an image. Uses -thumbnail for better performance when resizing.
@@ -242,7 +224,7 @@ module Alchemy
       crop_argument = "-crop #{dimensions_to_string(crop_dimensions)}"
       crop_argument += "+#{top_left[:x]}+#{top_left[:y]}"
 
-      resize_argument = "-resize #{dimensions_to_string(dimensions)}"
+      resize_argument = "-resize #{dimensions}"
       resize_argument += ">" unless upsample
       image_file.convert "#{crop_argument} #{resize_argument}"
     end

--- a/app/models/alchemy/picture/url.rb
+++ b/app/models/alchemy/picture/url.rb
@@ -44,9 +44,10 @@ module Alchemy
       size = options[:size]
       upsample = !!options[:upsample]
 
-      return image unless size.present? && has_convertible_format?
+      return image unless (options[:crop] || size) && has_convertible_format?
 
       if options[:crop]
+        size ||= options[:crop_size]
         crop(size, options[:crop_from], options[:crop_size], upsample)
       else
         resize(size, upsample)

--- a/app/models/alchemy/picture/url.rb
+++ b/app/models/alchemy/picture/url.rb
@@ -40,11 +40,12 @@ module Alchemy
     private
 
     # Returns the processed image dependent of size and cropping parameters
+    #
     def processed_image(image, options = {})
+      return image unless is_processable(options)
+
       size = options[:size]
       upsample = !!options[:upsample]
-
-      return image unless (options[:crop] || size) && has_convertible_format?
 
       if options[:crop]
         size ||= options[:crop_size]
@@ -52,6 +53,12 @@ module Alchemy
       else
         resize(size, upsample)
       end
+    end
+
+    # Returns if an image can be cropped or resized
+    #
+    def is_processable(options)
+      (options[:crop] || options[:size]) && has_convertible_format?
     end
 
     # Returns the encoded image

--- a/app/views/alchemy/essences/shared/_essence_picture_tools.html.erb
+++ b/app/views/alchemy/essences/shared/_essence_picture_tools.html.erb
@@ -12,7 +12,7 @@
       padding: false
     }, {title: Alchemy.t('Edit Picturemask')} %>
 <%- else -%>
-  <a href="#" class="disabled" tabindex="-1"><%= render_icon(:crop) %></a>
+  <a href="#" class="disabled" onclick="javascript: return false;" tabindex="-1"><%= render_icon(:crop) %></a>
 <%- end -%>
 
 <%= link_to_dialog render_icon('file-image', style: 'regular'),

--- a/spec/controllers/alchemy/admin/essence_pictures_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/essence_pictures_controller_spec.rb
@@ -167,6 +167,28 @@ module Alchemy
             expect(assigns(:ratio)).to eq(80.0 / 60.0)
           end
         end
+
+        context 'without configured output format' do
+          before do
+            picture.image_file_format = 'jpg'
+          end
+
+          it 'keeps the original image format' do
+            get :crop, params: {id: 1, options: {}}
+            expect(assigns(:_options_from_params)[:format]).to eq('jpg')
+          end
+        end
+
+        context 'with output format configured in essence' do
+          before do
+            picture.image_file_format = 'png'
+          end
+
+          it 'changes the output format' do
+            get :crop, params: {id: 1, options: { format: 'jpg' }}
+            expect(assigns(:_options_from_params)[:format]).to eq('jpg')
+          end
+        end
       end
     end
 

--- a/spec/models/alchemy/essence_picture_spec.rb
+++ b/spec/models/alchemy/essence_picture_spec.rb
@@ -178,8 +178,15 @@ module Alchemy
         thumbnail_url
       end
 
-      context 'when crop sizes are present' do
+      context 'when crop sizes are present and cropping is enabled' do
+        let(:settings) do
+          {
+            crop: true
+          }
+        end
+
         before do
+          allow(content).to receive(:settings) { settings }
           allow(essence).to receive(:crop_size).and_return('200x200')
           allow(essence).to receive(:crop_from).and_return('10x10')
         end
@@ -187,6 +194,20 @@ module Alchemy
         it "passes these crop sizes to the picture's url method." do
           expect(picture).to receive(:url).with(
             hash_including(crop_from: '10x10', crop_size: '200x200', crop: true)
+          )
+          thumbnail_url
+        end
+      end
+
+      context 'when crop sizes are present and cropping is disabled' do
+        before do
+          allow(essence).to receive(:crop_size).and_return('200x200')
+          allow(essence).to receive(:crop_from).and_return('10x10')
+        end
+
+        it "passes these crop sizes to the picture's url method." do
+          expect(picture).to receive(:url).with(
+            hash_including(crop_from: '10x10', crop_size: '200x200', crop: false)
           )
           thumbnail_url
         end
@@ -203,6 +224,11 @@ module Alchemy
         context 'when crop is explicitely enabled in the options' do
           let(:options) do
             {crop: true}
+          end
+
+          before do
+            allow(essence).to receive(:crop_size).and_return('200x200')
+            allow(essence).to receive(:crop_from).and_return('10x10')
           end
 
           it "it enables cropping." do
@@ -244,6 +270,14 @@ module Alchemy
         let(:essence) { build_stubbed(:alchemy_essence_picture) }
 
         it { is_expected.to be_nil }
+      end
+
+      context 'with crop values given' do
+        let(:essence) { build_stubbed(:alchemy_essence_picture, crop_from: '0x0', crop_size: '100x100') }
+
+        it "returns a hash containing cropping coordinates" do
+          is_expected.to eq({x1: 0, y1: 0, x2: 100, y2: 100})
+        end
       end
     end
 

--- a/spec/models/alchemy/essence_picture_spec.rb
+++ b/spec/models/alchemy/essence_picture_spec.rb
@@ -220,23 +220,32 @@ module Alchemy
           )
           thumbnail_url
         end
+      end
 
-        context 'when crop is explicitely enabled in the options' do
-          let(:options) do
-            {crop: true}
-          end
+      context 'when crop is explicitly enabled in the options' do
+        let(:options) do
+          {crop: true}
+        end
 
+        context 'and crop size and crop from are present' do
           before do
             allow(essence).to receive(:crop_size).and_return('200x200')
             allow(essence).to receive(:crop_from).and_return('10x10')
           end
 
-          it "it enables cropping." do
+          it 'enables cropping' do
             expect(picture).to receive(:url).with(
               hash_including(crop: true)
             )
             thumbnail_url
           end
+        end
+
+        it 'skips cropping if crop size and crop from are missing' do
+          expect(picture).to receive(:url).with(
+            hash_including(crop: false)
+          )
+          thumbnail_url
         end
       end
 

--- a/spec/models/alchemy/essence_picture_spec.rb
+++ b/spec/models/alchemy/essence_picture_spec.rb
@@ -220,32 +220,18 @@ module Alchemy
           )
           thumbnail_url
         end
-      end
 
-      context 'when crop is explicitly enabled in the options' do
-        let(:options) do
-          {crop: true}
-        end
-
-        context 'and crop size and crop from are present' do
-          before do
-            allow(essence).to receive(:crop_size).and_return('200x200')
-            allow(essence).to receive(:crop_from).and_return('10x10')
+        context 'when crop is explicitely enabled in the options' do
+          let(:options) do
+            {crop: true}
           end
 
-          it 'enables cropping' do
+          it "it enables cropping." do
             expect(picture).to receive(:url).with(
               hash_including(crop: true)
             )
             thumbnail_url
           end
-        end
-
-        it 'skips cropping if crop size and crop from are missing' do
-          expect(picture).to receive(:url).with(
-            hash_including(crop: false)
-          )
-          thumbnail_url
         end
       end
 

--- a/spec/models/alchemy/picture_url_spec.rb
+++ b/spec/models/alchemy/picture_url_spec.rb
@@ -103,7 +103,7 @@ module Alchemy
               let(:options) do
                 {
                   size: '250x',
-                  crop: true,
+                  crop: true
                 }
               end
 

--- a/spec/models/alchemy/picture_url_spec.rb
+++ b/spec/models/alchemy/picture_url_spec.rb
@@ -84,6 +84,36 @@ module Alchemy
             expect(job[1]).to include("160x120#")
           end
 
+          context 'and size has a variable dimension' do
+            context 'and is bigger than the source image' do
+              let(:options) do
+                {
+                  size: '1920x',
+                  crop: true
+                }
+              end
+
+              it 'applies the correct crop dimensions' do
+                job = decode_dragon_fly_job(url)
+                expect(job[1]).to include('500x0#')
+              end
+            end
+
+            context 'and is smaller than the source image' do
+              let(:options) do
+                {
+                  size: '250x',
+                  crop: true,
+                }
+              end
+
+              it 'applies the correct crop dimensions' do
+                job = decode_dragon_fly_job(url)
+                expect(job[1]).to include('250x0#')
+              end
+            end
+          end
+
           context "and crop_from and crop_size is passed in" do
             let(:options) do
               {

--- a/spec/support/transformation_examples.rb
+++ b/spec/support/transformation_examples.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 module Alchemy
   shared_examples_for "has image transformations" do
     describe "#thumbnail_size" do
-      context "picture is 300x400 and has no crop size" do
+      context "picture is 400x300 and has no crop size" do
         it "should return the correct recalculated size value" do
           allow(picture).to receive(:image_file_width) { 400 }
           allow(picture).to receive(:image_file_height) { 300 }
@@ -25,15 +25,15 @@ module Alchemy
 
       context "picture has crop_size of 400x300" do
         it "scales to 400x300 if that is the size of the cropped image" do
-          allow(picture).to receive(:crop_size) { "400x300" }
-          expect(picture.thumbnail_size).to eq('160x120')
+          allow(picture).to receive(:crop_size) { '400x300' }
+          expect(picture.thumbnail_size(true)).to eq('160x120')
         end
       end
 
       context "picture has crop_size of 0x0" do
         it "returns default thumbnail size" do
-          allow(picture).to receive(:crop_size) { "0x0" }
-          expect(picture.thumbnail_size).to eq('160x120')
+          allow(picture).to receive(:crop_size) { '0x0' }
+          expect(picture.thumbnail_size(true)).to eq('160x120')
         end
       end
     end

--- a/spec/support/transformation_examples.rb
+++ b/spec/support/transformation_examples.rb
@@ -25,15 +25,20 @@ module Alchemy
 
       context "picture has crop_size of 400x300" do
         it "scales to 400x300 if that is the size of the cropped image" do
-          allow(picture).to receive(:crop_size) { '400x300' }
-          expect(picture.thumbnail_size(true)).to eq('160x120')
+          allow(picture).to receive(:image_file_width) { 400 }
+          allow(picture).to receive(:image_file_height) { 300 }
+          allow(picture).to receive(:crop_size) { "400x300" }
+
+          expect(picture.thumbnail_size).to eq('160x120')
         end
       end
 
-      context "picture has crop_size of 0x0" do
+      context "picture has no crop_size" do
         it "returns default thumbnail size" do
-          allow(picture).to receive(:crop_size) { '0x0' }
-          expect(picture.thumbnail_size(true)).to eq('160x120')
+          allow(picture).to receive(:image_file_width) { 400 }
+          allow(picture).to receive(:image_file_height) { 300 }
+
+          expect(picture.thumbnail_size).to eq('160x120')
         end
       end
     end


### PR DESCRIPTION
## What is this pull request for?

Change image cropping handling to allow new size variations for the picture essence settings. Fix some unexpected behavior in the cropping editor.

Now the following scenarios are implemented:
1. Image is adjusted to the specified width and height according to the aspect ratio of the image
`size: 1920x1280`
2. Fixed width, variable height, aspect ratio of the image is maintained
`size: 1920x`
3. When cropping is activated and the width is set, the height is calculated based on the cropping area.
`crop: true`
`size: 1920x`
4. When cropping is activated and the width and height is set, the cropping area has a fixed ratio and it is not possible in the cropping editor, to scale to a lower resolution.
`crop: true`
`size: 1920x1280`
5. When only cropping is activated, the cropping area can be set freely. The cropping area is not resized to a specific size.
`crop: true`
6. When cropping is activated and a fixed ratio is given, you can only crop an area based on the given image ratio. No resizing will be applied
`crop: true`
`fixed_ratio: 1.5`
7. When cropping is activated and a fixed ratio is given and a fixed width is provided, you can only crop an area based on the given image ratio, and afterwards the cropped area gets scaled to the given width
`crop: true`
`size: 1920x`
`fixed_ratio: 1.5`

The following combinations for the size attribute are available
- `size: 1920x1280`
- `size: 1920x` fixed width and variable height
- `size: x1280` variable width and fixed height