### PR TITLE
Fix picture gallery migration task

### DIFF
--- a/lib/alchemy/upgrader/tasks/picture_gallery_migration.rb
+++ b/lib/alchemy/upgrader/tasks/picture_gallery_migration.rb
@@ -20,7 +20,7 @@ module Alchemy
       gallery_contents = element.contents.where("#{Content.table_name}.name LIKE 'essence_picture_%'").order("#{Content.table_name}.position ASC")
 
       if gallery_contents.any?
-        if element.nestable_elements.any?
+        if element.nestable_elements.any? { |el| el != "#{element.name}_picture" }
           parent = create_gallery_element(element)
         else
           parent = element


### PR DESCRIPTION
## What is this pull request for?

Fixes migration for the case where no intermediate gallery element is
necessary, because the gallery element didn't had nestable elements.

### Notable changes

Only build an intermediate gallery element if the are nestable elements
other than the gallery picture element.
