### PR TITLE
Raise targeted Ruby version to 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ AllCops:
     - 'alchemy_cms.gemspec'
     - 'Rakefile'
 
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 # Really, rubocop?
 Bundler/OrderedGems:

--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.summary               = 'A powerful, userfriendly and flexible CMS for Rails 5'
   gem.description           = 'Alchemy is a powerful, userfriendly and flexible Rails 5 CMS.'
   gem.requirements << 'ImageMagick (libmagick), v6.6 or greater.'
-  gem.required_ruby_version = '>= 2.2.2'
+  gem.required_ruby_version = '>= 2.3.0'
   gem.license               = 'BSD New'
   gem.files                 = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^spec/}) }
   gem.require_paths         = ['lib']


### PR DESCRIPTION
Ruby 2.2 is not supported any more and we want to be able to use Ruby 2.3 features like the save navigation operator.
