### PR TITLE
Allow admins to switch all languages

### DIFF
--- a/app/views/alchemy/admin/partials/_language_tree_select.html.erb
+++ b/app/views/alchemy/admin/partials/_language_tree_select.html.erb
@@ -1,4 +1,4 @@
-<%- if multi_language? -%>
+<% if can?(:switch_language, Alchemy::Page) && @languages.many? %>
 <div class="button_with_label">
   <%= form_tag switch_language_admin_pages_path, method: 'get' do %>
     <%= select_tag(

--- a/spec/features/admin/language_tree_feature_spec.rb
+++ b/spec/features/admin/language_tree_feature_spec.rb
@@ -4,21 +4,45 @@ require 'rails_helper'
 
 RSpec.describe 'Language tree feature', type: :system, js: true do
   let(:klingon) { create(:alchemy_language, :klingon) }
+  let(:user) { build(:alchemy_dummy_user, :as_admin) }
 
   before do
     create(:alchemy_page, :language_root)
-    authorize_user(:as_admin)
+    authorize_user(user)
+  end
+
+  context "with a single language" do
+    it "one should not be able to switch the language tree" do
+      visit('/admin/pages')
+      expect(page).to_not have_selector('label', text: Alchemy.t("Language tree"))
+    end
   end
 
   context "in a multilangual environment" do
-    before do
-      create(:alchemy_page, :language_root, name: 'Klingon', language: klingon)
-    end
+    context 'even if one language is not public' do
+      let(:klingon) { create(:alchemy_language, :klingon, public: false) }
 
-    it "one should be able to switch the language tree" do
-      visit('/admin/pages')
-      select2 'Klingon', from: 'Language tree'
-      expect(page).to have_selector('#sitemap', text: 'Klingon')
+      before do
+        create(:alchemy_page, :language_root, name: 'Klingon', language: klingon)
+      end
+
+      context 'and an author' do
+        let(:user) { build(:alchemy_dummy_user, :as_author) }
+
+        it "one should not be able to switch the language tree" do
+          visit('/admin/pages')
+          expect(page).to_not have_selector('label', text: Alchemy.t("Language tree"))
+        end
+      end
+
+      context 'and an editor' do
+        let(:user) { build(:alchemy_dummy_user, :as_editor) }
+
+        it "one should be able to switch the language tree" do
+          visit('/admin/pages')
+          expect(page).to have_selector('label', text: Alchemy.t("Language tree"))
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## What is this pull request for?

Admins and editors should be able to switch languages even if they are
not public, so they can start preparing content.

Closes #1535
