### PR TITLE
Expose the element into partials as local object

### DIFF
--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -172,15 +172,17 @@ module Alchemy
         return
       end
 
-      options = {
-        element: element,
-        counter: counter,
-        options: options,
-        locals: options.delete(:locals) || {}
-      }
-
       element.store_page(@page) if part.to_sym == :view
-      render "alchemy/elements/#{element.name}_#{part}", options
+
+      render(
+        partial: "alchemy/elements/#{element.name}_#{part}",
+        object: element,
+        locals: {
+          element: element,
+          counter: counter,
+          options: options
+        }.merge(options.delete(:locals) || {})
+      )
     rescue ActionView::MissingTemplate => e
       warning(%(
         Element #{part} partial not found for #{element.name}.\n

--- a/spec/dummy/app/views/alchemy/elements/_article_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_article_view.html.erb
@@ -1,6 +1,6 @@
-<%- cache(element) do -%>
-  <%= element_view_for(element) do |el| -%>
-    <% if element.has_ingredient?(:intro) %>
+<%- cache(article_view) do -%>
+  <%= element_view_for(article_view) do |el| -%>
+    <% if article_view.has_ingredient?(:intro) %>
       <div class="intro"><%= el.render :intro %></div>
     <% end %>
     <h1 class="headline"><%= el.render :headline %></h1>


### PR DESCRIPTION
## What is this pull request for?

To be consistent with Rails' collection partial renderer we also expose the element as local object named after the element into the view partials.

### Example

Given an element named "article" and a `article_view` element partial, you can now access the element as `article_view` local variable as well as the `element` variable.
