### PR TITLE
Separate render element calls

### DIFF
--- a/app/helpers/alchemy/admin/elements_helper.rb
+++ b/app/helpers/alchemy/admin/elements_helper.rb
@@ -3,15 +3,68 @@
 module Alchemy
   module Admin
     module ElementsHelper
-      include Alchemy::ElementsHelper
       include Alchemy::ElementsBlockHelper
       include Alchemy::Admin::BaseHelper
       include Alchemy::Admin::ContentsHelper
       include Alchemy::Admin::EssencesHelper
 
-      # Renders the element editor partial
+      # Renders a {Alchemy::Element} editor partial.
+      #
+      # A element editor partial is the form presented to the content author in page edit mode.
+      #
+      # The partial is located in <tt>app/views/alchemy/elements</tt>.
+      #
+      # == Partial naming
+      #
+      # The partials have to be named after the name of the element as defined in the <tt>elements.yml</tt> file and has to be suffixed with <tt>_editor</tt>.
+      #
+      # === Example
+      #
+      # Given a headline element
+      #
+      #   # elements.yml
+      #   - name: headline
+      #     contents:
+      #     - name: text
+      #       type: EssenceText
+      #
+      # Then your element editor partial has to be named:
+      #
+      #   app/views/alchemy/elements/_headline_editor.html.{erb|haml|slim}
+      #
+      # === Element partials generator
+      #
+      # You can use this handy generator to let Alchemy generate the partials for you:
+      #
+      #   $ rails generate alchemy:elements --skip
+      #
+      # == Usage
+      #
+      #   <%= render_editor(Alchemy::Element.published.named(:headline).first) %>
+      #
+      # @param [Alchemy::Element] element
+      #   The element you want to render the editor for
+      #
+      # @note If the partial is not found
+      #   <tt>alchemy/elements/_editor_not_found.html.erb</tt> gets rendered.
+      #
       def render_editor(element)
-        render_element(element, :editor)
+        if element.nil?
+          warning('Element is nil')
+          render "alchemy/elements/editor_not_found", {name: 'nil'}
+          return
+        end
+
+        render "alchemy/elements/#{element.name}_editor", element: element
+      rescue ActionView::MissingTemplate => e
+        warning(%(
+          Element editor partial not found for #{element.name}.\n
+          #{e}
+        ))
+        render "alchemy/elements/editor_not_found", {
+          name: element.name,
+          error: "Element editor partial not found.<br>Use <code>rails generate alchemy:elements</code> to generate it."
+        }
       end
 
       # Returns an elements array for select helper.

--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -96,13 +96,13 @@ module Alchemy
       }.update(options)
 
       if options[:sort_by]
-        Alchemy::Deprecation.warn "options[:sort_by] has been removed without replacement. " /
+        Alchemy::Deprecation.warn "options[:sort_by] has been removed without replacement. " \
           "Please implement your own element sorting by passing a custom finder instance to options[:finder]."
       end
 
       if options[:from_cell]
-        Alchemy::Deprecation.warn "options[:from_cell] has been removed without replacement. " /
-          "Please `render element.nested_elements.published` instead."
+        Alchemy::Deprecation.warn "options[:from_cell] has been removed without replacement. " \
+          "Please `render element.nested_elements.available` instead."
       end
 
       finder = options[:finder] || Alchemy::ElementsFinder.new(options)

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -312,8 +312,8 @@ module Alchemy
     # @return [ActiveRecord::Relation]
     def find_elements(options = {}, show_non_public = false)
       if show_non_public
-        Alchemy::Deprecation.warn "Passing true as second argument to page#find_elements to include" /
-          " invisible elements has been removed. Please implement your own ElementsFinder" /
+        Alchemy::Deprecation.warn "Passing true as second argument to page#find_elements to include" \
+          " invisible elements has been removed. Please implement your own ElementsFinder" \
           " and pass it with options[:finder]."
       end
 

--- a/app/views/alchemy/elements/_editor_not_found.html.erb
+++ b/app/views/alchemy/elements/_editor_not_found.html.erb
@@ -1,4 +1,4 @@
 <%= render_message :warning do %>
   <h2><%= Alchemy.t(:element_editor_not_found) %>:</h2>
-  <p><%= error.html_safe %></p>
+  <p><%== local_assigns[:error] %></p>
 <% end %>

--- a/spec/dummy/app/views/alchemy/elements/_headline_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_headline_view.html.erb
@@ -1,3 +1,4 @@
 <%= element_view_for(headline_view, tag: 'h1') do |el| %>
-  <%= el.render(:headline) %>
+  <%= local_assigns[:counter] -%>. <%= el.render(:headline) %>
+  <small><%= local_assigns[:some] -%></small>
 <% end %>

--- a/spec/helpers/alchemy/admin/elements_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/elements_helper_spec.rb
@@ -7,10 +7,32 @@ module Alchemy
     let(:page)    { build_stubbed(:alchemy_page, :public) }
     let(:element) { build_stubbed(:alchemy_element, page: page) }
 
-    context "partial rendering" do
-      it "should render an element editor partial" do
-        expect(helper).to receive(:render_element).with(element, :editor)
-        helper.render_editor(element)
+    describe "#render_editor" do
+      subject { render_editor(element) }
+
+      context 'with nil element' do
+        let(:element) { nil }
+
+        it { is_expected.to be_nil }
+      end
+
+      context 'with element record given' do
+        let(:element) do
+          create(:alchemy_element, :with_contents, name: 'headline')
+        end
+
+        it "renders the element's editor partial" do
+          is_expected.to have_selector('div.content_editor > label', text: 'Headline')
+        end
+
+        context 'with element editor partial not found' do
+          let(:element) { build_stubbed(:alchemy_element, name: 'not_present') }
+
+          it "renders the editor not found partial" do
+            is_expected.to have_selector('div.warning')
+            is_expected.to have_content('Element editor partial not found')
+          end
+        end
       end
     end
 

--- a/spec/helpers/alchemy/elements_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_helper_spec.rb
@@ -128,6 +128,28 @@ module Alchemy
         end
       end
 
+      context 'with sort_by option given' do
+        let(:options) do
+          { sort_by: :name }
+        end
+
+        it 'warns about removal of sort_by option' do
+          expect(Alchemy::Deprecation).to receive(:warn)
+          subject
+        end
+      end
+
+      context 'with from_cell option given' do
+        let(:options) do
+          { from_cell: :header }
+        end
+
+        it 'warns about removal of from_cell option' do
+          expect(Alchemy::Deprecation).to receive(:warn)
+          subject
+        end
+      end
+
       context 'with option separator given' do
         let(:options) { {separator: '<hr>'} }
 

--- a/spec/helpers/alchemy/elements_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_helper_spec.rb
@@ -14,16 +14,18 @@ module Alchemy
     end
 
     describe '#render_element' do
-      subject { render_element(element, part) }
+      subject { render_element(element) }
 
       context 'with nil element' do
         let(:element) { nil }
-        let(:part)    { :view }
+
         it { is_expected.to be_nil }
       end
 
-      context 'with view as part given' do
-        let(:part) { :view }
+      context 'with element record given' do
+        let(:element) do
+          create(:alchemy_element, :with_contents, name: 'headline')
+        end
 
         it "renders the element's view partial" do
           is_expected.to have_selector("##{element.name}_#{element.id}")
@@ -38,21 +40,40 @@ module Alchemy
         end
       end
 
-      context 'with editor as part given' do
-        let(:part) { :editor }
+      context 'with options given' do
+        subject { render_element(element, locals: { some: 'thing' }) }
 
-        it "renders the element's editor partial" do
-          expect(helper).to receive(:render_essence_editor_by_name)
-          subject
+        it 'passes them into the view' do
+          is_expected.to match(/thing/)
+        end
+      end
+
+      context 'with counter given' do
+        subject { render_element(element, {}, 2) }
+
+        it 'passes them into the view' do
+          is_expected.to match(/2\./)
+        end
+      end
+
+      context 'with 4 arguments given' do
+        subject { render_element(element, :view, {locals: {some: 'thing'}}, 2) }
+
+        it 'passes options into the view' do
+          Alchemy::Deprecation.silence do
+            is_expected.to match(/thing/)
+          end
         end
 
-        context 'with element editor partial not found' do
-          let(:element) { build_stubbed(:alchemy_element, name: 'not_present') }
-
-          it "renders the editor not found partial" do
-            is_expected.to have_selector('div.warning')
-            is_expected.to have_content('Element editor partial not found')
+        it 'passes counter into the view' do
+          Alchemy::Deprecation.silence do
+            is_expected.to match(/2\./)
           end
+        end
+
+        it 'warns about removal of second parameter' do
+          expect(Alchemy::Deprecation).to receive(:warn)
+          subject
         end
       end
     end

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1124,6 +1124,15 @@ module Alchemy
           expect(subject.map(&:name)).to eq(['news'])
         end
       end
+
+      context 'with second argument set to true' do
+        subject { page.find_elements(options, true) }
+
+        it 'warns about removal of second argument' do
+          expect(Alchemy::Deprecation).to receive(:warn)
+          subject
+        end
+      end
     end
 
     describe '#first_public_child' do


### PR DESCRIPTION
## What is this pull request for?

Decouple `render_element` and `render_editor` helpers by rendering the element editor partial within the `render_editor` helper instead of making use of the `:part = view` parameter.

Closes #1459

### Notable changes

From now on we do not support to render editor partials with the `render_elements` helper anymore. This feature will most likely only and ever be used by us to render the element editor partials. Since this has been refactored recently, we can remove this from the frontend helper.
