### PR TITLE
Remove invalid bytecode handler

### DIFF
--- a/lib/alchemy/routing_constraints.rb
+++ b/lib/alchemy/routing_constraints.rb
@@ -17,8 +17,6 @@ module Alchemy
       @params = @request.params
 
       handable_format? && no_rails_route?
-    rescue ArgumentError => e
-      handle_invalid_byte_sequence(e)
     end
 
     private
@@ -35,16 +33,8 @@ module Alchemy
     # We don't want to handle the Rails info routes.
     def no_rails_route?
       return true if !%w(development test).include?(Rails.env)
-      (@params['urlname'] =~ /\Arails\//).nil?
-    end
 
-    # Handle invalid byte sequence in UTF-8 errors with 400 status.
-    def handle_invalid_byte_sequence(error)
-      if error.message =~ /invalid byte sequence/
-        raise ActionController::BadRequest
-      else
-        raise
-      end
+      (@params['urlname'] =~ /\Arails\//).nil?
     end
   end
 end

--- a/spec/features/page_feature_spec.rb
+++ b/spec/features/page_feature_spec.rb
@@ -73,12 +73,6 @@ RSpec.describe 'Show page feature:', type: :system do
     end
   end
 
-  context "with invalid byte code char in urlname parameter" do
-    it "should raise BadRequest (400) error" do
-      expect { visit '/%ed' }.to raise_error(ActionController::BadRequest)
-    end
-  end
-
   describe "menubar" do
     context "rendering for guest users" do
       it "is prohibited" do


### PR DESCRIPTION
## What is this pull request for?

We introduced this handler to handle the gnarly "Invalid Byte Sequence"
`ArgumentError` from requests having invalid encoding.

Finally Rails 5.1.7 and 5.2.3 handles this in the framework 🎉 

Everybody not able to update or still using Rails 5.0 should install a
Rack middleware like https://github.com/cfabianski/rack-uri_sanitizer and/or https://github.com/whitequark/rack-utf8_sanitizer.