### PR TITLE
Use element name local in generators

### DIFF
--- a/lib/rails/generators/alchemy/elements/elements_generator.rb
+++ b/lib/rails/generators/alchemy/elements/elements_generator.rb
@@ -9,6 +9,7 @@ module Alchemy
       def create_partials
         @elements = load_alchemy_yaml('elements.yml')
         return unless @elements
+
         @elements.each do |element|
           @element = element
           @contents = element["contents"] || []

--- a/lib/rails/generators/alchemy/elements/templates/view.html.erb
+++ b/lib/rails/generators/alchemy/elements/templates/view.html.erb
@@ -10,9 +10,7 @@
     <%- end -%>
   <%- end -%>
   <%- if @element['nestable_elements'].present? -%>
-    <%% <%= @element_name %>_view.nested_elements.available.each do |nested_element| %>
-      <%%= render_element(nested_element) %>
-    <%% end %>
+    <%%= render <%= @element_name %>_view.nested_elements.available %>
   <%- end -%>
   <%%- end -%>
 <%%- end -%>

--- a/lib/rails/generators/alchemy/elements/templates/view.html.erb
+++ b/lib/rails/generators/alchemy/elements/templates/view.html.erb
@@ -1,5 +1,5 @@
-<%%- cache(element) do -%>
-  <%%= element_view_for(element) do |el| -%>
+<%%- cache(<%= @element_name %>_view) do -%>
+  <%%= element_view_for(<%= @element_name %>_view) do |el| -%>
   <%- @contents.each do |content| -%>
     <%- if @contents.length > 1 -%>
     <div class="<%= content["name"] %>">
@@ -10,7 +10,7 @@
     <%- end -%>
   <%- end -%>
   <%- if @element['nestable_elements'].present? -%>
-    <%% element.nested_elements.available.each do |nested_element| %>
+    <%% <%= @element_name %>_view.nested_elements.available.each do |nested_element| %>
       <%%= render_element(nested_element) %>
     <%% end %>
   <%- end -%>

--- a/lib/rails/generators/alchemy/elements/templates/view.html.haml
+++ b/lib/rails/generators/alchemy/elements/templates/view.html.haml
@@ -9,6 +9,5 @@
     <%- end -%>
   <%- end -%>
   <%- if @element['nestable_elements'].present? -%>
-    - <%= @element_name -%>_view.nested_elements.available.each do |nested_element|
-      = render_element(nested_element)
+    = render <%= @element_name -%>_view.nested_elements.available
   <%- end -%>

--- a/lib/rails/generators/alchemy/elements/templates/view.html.haml
+++ b/lib/rails/generators/alchemy/elements/templates/view.html.haml
@@ -1,5 +1,5 @@
-- cache(element) do
-  = element_view_for(element) do |el|
+- cache(<%= @element_name -%>_view) do
+  = element_view_for(<%= @element_name -%>_view) do |el|
   <%- @contents.each do |content| -%>
     <%- if @contents.length > 1 -%>
     .<%= content["name"] %>
@@ -9,6 +9,6 @@
     <%- end -%>
   <%- end -%>
   <%- if @element['nestable_elements'].present? -%>
-    - element.nested_elements.available.each do |nested_element|
+    - <%= @element_name -%>_view.nested_elements.available.each do |nested_element|
       = render_element(nested_element)
   <%- end -%>

--- a/lib/rails/generators/alchemy/elements/templates/view.html.slim
+++ b/lib/rails/generators/alchemy/elements/templates/view.html.slim
@@ -9,6 +9,5 @@
     <%- end -%>
   <%- end -%>
   <%- if @element['nestable_elements'].present? -%>
-    - <%= @element_name -%>_view.nested_elements.available.each do |nested_element|
-      = render_element(nested_element)
+    = render <%= @element_name -%>_view.nested_elements.available
   <%- end -%>

--- a/lib/rails/generators/alchemy/elements/templates/view.html.slim
+++ b/lib/rails/generators/alchemy/elements/templates/view.html.slim
@@ -1,5 +1,5 @@
-- cache(element) do
-  = element_view_for(element) do |el|
+- cache(<%= @element_name -%>_view) do
+  = element_view_for(<%= @element_name -%>_view) do |el|
   <%- @contents.each do |content| -%>
     <%- if @contents.length > 1 -%>
     .<%= content["name"] %>
@@ -9,6 +9,6 @@
     <%- end -%>
   <%- end -%>
   <%- if @element['nestable_elements'].present? -%>
-    - element.nested_elements.available.each do |nested_element|
+    - <%= @element_name -%>_view.nested_elements.available.each do |nested_element|
       = render_element(nested_element)
   <%- end -%>

--- a/spec/dummy/app/views/alchemy/elements/_all_you_can_eat_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_all_you_can_eat_view.html.erb
@@ -1,5 +1,5 @@
-<%- cache(element) do -%>
-  <%= element_view_for(element) do |el| -%>
+<%- cache(all_you_can_eat_view) do -%>
+  <%= element_view_for(all_you_can_eat_view) do |el| -%>
     <div class="essence_text">
       <%= el.render :essence_text %>
     </div>

--- a/spec/dummy/app/views/alchemy/elements/_bild_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_bild_view.html.erb
@@ -1,5 +1,5 @@
-<%- cache(element) do -%>
-  <%= element_view_for(element) do |el| -%>
+<%- cache(bild_view) do -%>
+  <%= element_view_for(bild_view) do |el| -%>
     <%= el.render :image %>
   <%- end -%>
 <%- end -%>

--- a/spec/dummy/app/views/alchemy/elements/_contactform_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_contactform_view.html.erb
@@ -1,5 +1,5 @@
-<%- cache(element) do -%>
-  <%= element_view_for(element) do |el| -%>
+<%- cache(contactform_view) do -%>
+  <%= element_view_for(contactform_view) do |el| -%>
     <div class="mail_from">
       <%= el.render :mail_from %>
     </div>

--- a/spec/dummy/app/views/alchemy/elements/_download_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_download_view.html.erb
@@ -1,5 +1,5 @@
-<%- cache(element) do -%>
-  <%= element_view_for(element) do |el| -%>
+<%- cache(download_view) do -%>
+  <%= element_view_for(download_view) do |el| -%>
     <%= el.render :file %>
   <%- end -%>
 <%- end -%>

--- a/spec/dummy/app/views/alchemy/elements/_erb_element_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_erb_element_view.html.erb
@@ -1,5 +1,5 @@
-<%- cache(element) do -%>
-  <%= element_view_for(element) do |el| -%>
+<%- cache(erb_element_view) do -%>
+  <%= element_view_for(erb_element_view) do |el| -%>
     <%= el.render :text %>
   <%- end -%>
 <%- end -%>

--- a/spec/dummy/app/views/alchemy/elements/_gallery_picture_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_gallery_picture_view.html.erb
@@ -1,5 +1,5 @@
-<%- cache(element) do -%>
-  <%= element_view_for(element, class: 'gallery_image') do |el| -%>
+<%- cache(gallery_picture_view) do -%>
+  <%= element_view_for(gallery_picture_view) do |el| -%>
     <%= el.render :picture, size: '160x120' %>
   <%- end -%>
 <%- end -%>

--- a/spec/dummy/app/views/alchemy/elements/_gallery_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_gallery_view.html.erb
@@ -1,9 +1,7 @@
 <%- cache(gallery_view) do -%>
   <%= element_view_for(gallery_view) do |el| -%>
     <div class="gallery_images">
-      <% gallery_view.nested_elements.available.each do |nested_element| %>
-        <%= render_element(nested_element) %>
-      <% end %>
+      <%= render gallery_view.nested_elements.available %>
     </div>
   <%- end -%>
 <%- end -%>

--- a/spec/dummy/app/views/alchemy/elements/_gallery_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_gallery_view.html.erb
@@ -1,9 +1,9 @@
-<%- cache(element) do -%>
-  <%= element_view_for(element) do |el| -%>
+<%- cache(gallery_view) do -%>
+  <%= element_view_for(gallery_view) do |el| -%>
     <div class="gallery_images">
-      <%- element.nested_elements.available.each do |nested_element| -%>
+      <% gallery_view.nested_elements.available.each do |nested_element| %>
         <%= render_element(nested_element) %>
-      <%- end -%>
+      <% end %>
     </div>
   <%- end -%>
 <%- end -%>

--- a/spec/dummy/app/views/alchemy/elements/_header_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_header_view.html.erb
@@ -1,5 +1,5 @@
-<%- cache(element) do -%>
-  <%= element_view_for(element) do |el| -%>
+<%- cache(header_view) do -%>
+  <%= element_view_for(header_view) do |el| -%>
     <%= el.render :image %>
   <%- end -%>
 <%- end -%>

--- a/spec/dummy/app/views/alchemy/elements/_headline_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_headline_view.html.erb
@@ -1,1 +1,3 @@
-<h1 id="<%= element_dom_id(element) %>" <%= element_preview_code(element) -%>><%= render_essence_view_by_name(element, 'headline') %></h1>
+<%= element_view_for(headline_view, tag: 'h1') do |el| %>
+  <%= el.render(:headline) %>
+<% end %>

--- a/spec/dummy/app/views/alchemy/elements/_left_column_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_left_column_view.html.erb
@@ -1,7 +1,5 @@
 <%- cache(left_column_view) do -%>
   <%= element_view_for(left_column_view) do |el| -%>
-    <% left_column_view.nested_elements.available.each do |nested_element| %>
-      <%= render_element(nested_element) %>
-    <% end %>
+    <%= render left_column_view.nested_elements.available %>
   <%- end -%>
 <%- end -%>

--- a/spec/dummy/app/views/alchemy/elements/_left_column_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_left_column_view.html.erb
@@ -1,6 +1,6 @@
-<%- cache(element) do -%>
-  <%= element_view_for(element) do |el| -%>
-    <% element.nested_elements.available.each do |nested_element| %>
+<%- cache(left_column_view) do -%>
+  <%= element_view_for(left_column_view) do |el| -%>
+    <% left_column_view.nested_elements.available.each do |nested_element| %>
       <%= render_element(nested_element) %>
     <% end %>
   <%- end -%>

--- a/spec/dummy/app/views/alchemy/elements/_right_column_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_right_column_view.html.erb
@@ -1,6 +1,7 @@
-<%- cache(element) do -%>
-  <%= element_view_for(element) do |el| -%>
-    <% element.nested_elements.available.each do |nested_element| %>
+<%- cache(right_column_view) do -%>
+  <%= element_view_for(right_column_view) do |el| -%>
+    <%= el.render :title %>
+    <% right_column_view.nested_elements.available.each do |nested_element| %>
       <%= render_element(nested_element) %>
     <% end %>
   <%- end -%>

--- a/spec/dummy/app/views/alchemy/elements/_right_column_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_right_column_view.html.erb
@@ -1,8 +1,6 @@
 <%- cache(right_column_view) do -%>
   <%= element_view_for(right_column_view) do |el| -%>
     <%= el.render :title %>
-    <% right_column_view.nested_elements.available.each do |nested_element| %>
-      <%= render_element(nested_element) %>
-    <% end %>
+    <%= render right_column_view.nested_elements.available %>
   <%- end -%>
 <%- end -%>

--- a/spec/dummy/app/views/alchemy/elements/_search_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_search_view.html.erb
@@ -1,4 +1,4 @@
-<%- cache(element) do -%>
-  <%= element_view_for(element) do |el| -%>
+<%- cache(search_view) do -%>
+  <%= element_view_for(search_view) do |el| -%>
   <%- end -%>
 <%- end -%>

--- a/spec/dummy/app/views/alchemy/elements/_slider_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_slider_view.html.erb
@@ -1,5 +1,5 @@
-<%- cache(element) do -%>
-  <%= element_view_for(element) do |el| -%>
-    <%= render element.nested_elements %>
+<%- cache(slider_view) do -%>
+  <%= element_view_for(slider_view) do |el| -%>
+    <%= render slider_view.nested_elements.available %>
   <%- end -%>
 <%- end -%>

--- a/spec/dummy/app/views/alchemy/elements/_text_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_text_view.html.erb
@@ -1,5 +1,5 @@
-<%- cache(element) do -%>
-  <%= element_view_for(element) do |el| -%>
+<%- cache(text_view) do -%>
+  <%= element_view_for(text_view) do |el| -%>
     <%= el.render :text %>
   <%- end -%>
 <%- end -%>


### PR DESCRIPTION
## What is this pull request for?

Use the element as local variable in the generated element view partials.

### Notable changes

Instead of using the `element` local (that is still available) we generate new element view partials with the element name as local variable. This way we are consistent with Rails' partial rendering. This is extremely useful for nested elements that now can be rendered in a fast way

```erb
<%= render article_view.nested_elements.available %>
```

instead of

```erb
<%= article_view.nested_elements.available do |nested_element| %>
  <%= render_element nested_element %>
<% end %>
```
