### PR TITLE
Update upgrader

### DIFF
--- a/lib/alchemy/shell.rb
+++ b/lib/alchemy/shell.rb
@@ -49,14 +49,22 @@ module Alchemy
     def display_todos
       return if todos.empty?
 
-      log "\nTODOs:", :message
-      log "------\n", :message
+      log "\n+---------+", :message
+      log "| 📝 TODO |", :message
+      log "+---------+\n", :message
+      puts "\nWe did most of the work for you, but there are still some things left for you to do."
       todos.each_with_index do |todo, i|
         title = "\n#{i + 1}. #{todo[0]}"
         log title, :message
-        puts '-' * title.length
+        puts '=' * title.length
+        puts ""
         log todo[1], :message
       end
+      puts ""
+      puts "============================================================"
+      puts "= ✨ Please take a minute and read the notes from above ✨ ="
+      puts "============================================================"
+      puts ""
     end
 
     # Prints out the given log message with the color due to its type

--- a/lib/alchemy/upgrader/four_point_one.rb
+++ b/lib/alchemy/upgrader/four_point_one.rb
@@ -11,31 +11,31 @@ module Alchemy
       end
 
       def alchemy_4_1_todos
-        notice = <<-NOTE
+        notice = <<-NOTE.strip_heredoc
+          ℹ️  Changed tagging provider to Gutentag
+          ---------------------------------------
 
-        Changed tagging provider to Gutentag
-        ------------------------------------
+          The automatic updater that just ran updated all existing `acts_as_taggable_on_migrations`,
+          so that they don't blow up if the `acts_as_taggable_on` gem is no longer available.
 
-        The automatic updater that just ran updated all existing `acts_as_taggable_on_migrations`,
-        so that they don't blow up if the `acts_as_taggable_on` gem is no longer available.
+          All your existing tags have been migrated to `Gutentag::Tag`s.
 
-        All your existing tags have been migrated to `Gutentag::Tag`s.
 
-        Removed Rails and non-English translations
-        ------------------------------------------
+          ⚠️  Removed Rails and non-English translations
+          ---------------------------------------------
 
-        Removed the Rails translations from our translation files and moved all non-english translation
-        files into the newly introduced `alchemy_i18n` gem.
+          Removed the Rails translations from our translation files and moved all non-english translation
+          files into the newly introduced `alchemy_i18n` gem.
 
-        If you need more translations than the default English one you can either put `alchemy_i18n`
-        in to your apps `Gemfile` or - recommended - copy only the translation files you need into your
-        apps `config/locales` folder.
+          If you need more translations than the default English one you can either put `alchemy_i18n`
+          in to your apps `Gemfile` or - recommended - copy only the translation files you need into your
+          apps `config/locales` folder.
 
-        For the Rails translations either put the rails-i18n gem into your apps Gemfile or - recommended -
-        copy only the translation files you need into your apps config/locales folder.
+          For the Rails translations either put the `rails-i18n` gem into your apps Gemfile or - recommended -
+          copy only the translation files you need into your apps config/locales folder.
 
         NOTE
-        todo notice, 'Alchemy v4.1 changes'
+        todo notice, 'Alchemy v4.1 TODO'
       end
     end
   end

--- a/lib/alchemy/upgrader/four_point_two.rb
+++ b/lib/alchemy/upgrader/four_point_two.rb
@@ -2,6 +2,7 @@ require_relative 'tasks/picture_gallery_upgrader'
 require_relative 'tasks/picture_gallery_migration'
 require_relative 'tasks/cells_upgrader'
 require_relative 'tasks/cells_migration'
+require_relative 'tasks/element_partial_name_variable_updater'
 
 module Alchemy
   class Upgrader::FourPointTwo < Upgrader
@@ -26,10 +27,12 @@ module Alchemy
         Alchemy::Upgrader::Tasks::CellsMigration.new.migrate_cells
       end
 
-      def alchemy_4_2_todos
-        notice = <<-NOTE
+      def update_element_views_variable_name
+        desc 'Update element views to use element partial name variable.'
+        Alchemy::Upgrader::Tasks::ElementPartialNameVariableUpdater.new.update_element_views
+      end
 
-        Element's "picture_gallery" feature removed
+      def alchemy_4_2_todos
         ----------------------------------------------
 
         The `picture_gallery` feature of elements was removed and has been replaced by nestable elements.

--- a/lib/alchemy/upgrader/four_point_two.rb
+++ b/lib/alchemy/upgrader/four_point_two.rb
@@ -33,38 +33,52 @@ module Alchemy
       end
 
       def alchemy_4_2_todos
-        ----------------------------------------------
+        notice = <<-NOTE.strip_heredoc
+          ⚠️  Element's "picture_gallery" feature removed
+          ----------------------------------------------
 
-        The `picture_gallery` feature of elements was removed and has been replaced by nestable elements.
+          The `picture_gallery` feature of elements was removed and has been replaced by nestable elements.
 
-        The automatic updater that just ran updated your `config/alchemy/elements.yml`. A backup was made.
-        Nevertheless, you should have a look into it and double check the changes.
+          The automatic updater that just ran updated your `config/alchemy/elements.yml`. A backup was made.
+          Nevertheless, you should have a look into it and double check the changes.
 
-        We created nested elements for each gallery picture we found in your database.
+          We created nested elements for each gallery picture we found in your database.
 
-        We also updated your element view partials so they have hints about how to render the child elements.
+          We also updated your element view partials so they have hints about how to render the child elements.
 
-        Cells replaced by fixed nestable elements
-        -----------------------------------------
+          🚨 PLEASE LOOK INTO YOUR ELEMENT VIEW PARTIALS AND FOLLOW THE INSTRUCTIONS!
 
-        The Cells feature has been replaced by fixed nestable elements.
 
-        The automatic updater that just ran updated your `config/alchemy/elements.yml`.
-        Nevertheless, you should have a look into it and double check the changes.
+          ⚠️️  Cells replaced by fixed nestable elements
+          --------------------------------------------
 
-        We defined new fixed elements for each cell former defined in `cells.yml`
-        and put its `elements` into the `nestable_elements` collection of the new elements definition.
+          The Cells feature has been replaced by fixed nestable elements.
 
-        We also updated your element view partials so they render the child elements.
+          The automatic updater that just ran updated your `config/alchemy/elements.yml`.
+          Nevertheless, you should have a look into it and double check the changes.
 
-        Please review and fix markup, if necessary.
+          We defined new fixed elements for each cell former defined in `cells.yml`
+          and put its `elements` into the `nestable_elements` collection of the new elements definition.
 
-        PLEASE DOUBLE CHECK YOUR ELEMENT PARTIALS AND ADJUST ACCORDINGLY!
+          We also updated your element view partials so they render the child elements.
 
-        As always `git diff` is your friend.
+          Please review and fix markup, if necessary.
+
+          🚨 PLEASE DOUBLE CHECK YOUR ELEMENT PARTIALS AND ADJUST ACCORDINGLY!
+
+          As always `git diff` is your friend.
+
+
+          ℹ️  Element views use element partial name as local variable
+          -----------------------------------------------------------
+
+          The local `element` variable in your element views has been replaced by a variable named after the partial.
+          A "article" element has a "_article_view.html.erb" partial and therefore a `article_view` local variable now.
+
+          The former `element` variable is still present, though.
 
         NOTE
-        todo notice, 'Alchemy v4.2 changes'
+        todo notice, 'Alchemy v4.2 TODO'
       end
     end
   end

--- a/lib/alchemy/upgrader/tasks/cells_upgrader.rb
+++ b/lib/alchemy/upgrader/tasks/cells_upgrader.rb
@@ -114,8 +114,9 @@ module Alchemy::Upgrader::Tasks
       if Dir.exist? cells_view_folder
         puts "-- Update cell views"
         Dir.glob("#{cells_view_folder}/*").each do |view|
-          gsub_file(view, /cell\.elements/, 'element.nested_elements.published')
-          gsub_file(view, /render_elements\(?from_cell:\scell\)?/, 'render element.nested_elements.published')
+          gsub_file(view, /elements\.published/, 'elements.available')
+          gsub_file(view, /cell\.elements(.+)/, 'element.nested_elements\1')
+          gsub_file(view, /render_elements[\(\s]?:?from_cell:?\s?(=>)?\s?cell\)?/, 'render element.nested_elements.available')
           gsub_file(view, /cell/, 'element')
         end
       else

--- a/lib/alchemy/upgrader/tasks/element_partial_name_variable_updater.rb
+++ b/lib/alchemy/upgrader/tasks/element_partial_name_variable_updater.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'alchemy/upgrader'
+
+module Alchemy::Upgrader::Tasks
+  class ElementPartialNameVariableUpdater < Thor
+    include Thor::Actions
+
+    no_tasks do
+      def update_element_views
+        puts "-- Update element views local variable to partial name"
+        Dir.glob("#{elements_view_folder}/*_view.*").each do |view|
+          variable_name = File.basename(view).gsub(/^_([\w-]*)\..*$/, '\1')
+          gsub_file(view, /cache\(?element([,\s\w:\-,=>'"\?\/]*)\)?/, "cache(#{variable_name}\\1)")
+          gsub_file(view, /render_essence_view_by_name\(?element([,\s\w:\-,=>'"\?\/]*)\)?/, "render_essence_view_by_name(#{variable_name}\\1)")
+          gsub_file(view, /element_view_for\(?element([,\s\w:\-,=>'"\?\/]*)\)?/, "element_view_for(#{variable_name}\\1)")
+          gsub_file(view, /element\.([\w\?]+)/, "#{variable_name}.\\1")
+        end
+      end
+    end
+
+    private
+
+    def elements_view_folder
+      Rails.root.join('app', 'views', 'alchemy', 'elements')
+    end
+  end
+end

--- a/lib/tasks/alchemy/upgrade.rake
+++ b/lib/tasks/alchemy/upgrade.rake
@@ -72,7 +72,8 @@ namespace :alchemy do
         'alchemy:upgrade:4.2:convert_picture_galleries',
         'alchemy:upgrade:4.2:migrate_picture_galleries',
         'alchemy:upgrade:4.2:convert_cells',
-        'alchemy:upgrade:4.2:migrate_cells'
+        'alchemy:upgrade:4.2:migrate_cells',
+        'alchemy:upgrade:4.2:update_element_partial_name_variable'
       ]
 
       desc 'Convert `picture_gallery` element definitions to `nestable_elements`.'
@@ -93,6 +94,11 @@ namespace :alchemy do
       desc 'Migrate existing cells to fixed nestable elements.'
       task migrate_cells: ['alchemy:install:migrations', 'db:migrate'] do
         Alchemy::Upgrader::FourPointTwo.migrate_cells
+      end
+
+      desc 'Update element views to use element partial name variable.'
+      task :update_element_partial_name_variable do
+        Alchemy::Upgrader::FourPointTwo.update_element_views_variable_name
       end
 
       task :todo do


### PR DESCRIPTION
## What is this pull request for?

Update the upgrader tasks and add an upgrader that replaces the local `element` variable in the element view partials with the elements `partial_name` and therefore follow Rails conventions.

### Notable changes

- Replace `elements.published` with `elements.available` in cell views
- Capture all method calls in `cell.elements` replacement
- Update regex of `render_elements from_cell` replacement for Ruby 1.8 Hash syntax
- Make the upgrade todos more pleasent to read and use a more prominent layout.
