### PR TITLE
Fix pluralization of resource table header

### DIFF
--- a/app/views/alchemy/admin/resources/_table_header.html.erb
+++ b/app/views/alchemy/admin/resources/_table_header.html.erb
@@ -1,5 +1,6 @@
 <div class="resources-header">
   <h2>
-    <%= pluralize resources_instance_variable.total_count, resource_model.model_name.human %>
+    <%= resources_instance_variable.total_count %>
+    <%= resource_model.model_name.human(count: resources_instance_variable.total_count) %>
   </h2>
 </div>


### PR DESCRIPTION
## What is this pull request for?

Fixes pluralization of resource table header.

Somehow Rails' `pluralize` helper does not pluralize the model name correctly. Using `model_name.human` with `count` option instead.
