### PR TITLE
Render warning message in warning helper

### DIFF
--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -269,22 +269,6 @@
     margin-bottom: 1em;
   }
 
-  .content_editor_error {
-    border: 1px solid #f5b04e;
-    padding: 4px 8px;
-    line-height: 21px;
-    background-color: #f5dea9;
-    margin-top: 4px;
-    border-radius: $default-border-radius;
-
-    .icon.warning {
-      position: relative;
-      top: 2px;
-      margin-right: 8px;
-      vertical-align: top;
-    }
-  }
-
   .autocomplete_tag_list {
     padding: $default-padding 0;
 

--- a/app/helpers/alchemy/base_helper.rb
+++ b/app/helpers/alchemy/base_helper.rb
@@ -11,12 +11,11 @@ module Alchemy
     # Logs a message in the Rails logger (warn level)
     # and optionally displays an error message to the user.
     def warning(message, text = nil)
-      Logger.warn(message, caller(0..0))
+      Logger.warn(message, caller(1..1))
       unless text.nil?
-        warning = content_tag('p', class: 'content_editor_error') do
-          render_icon('warning') + text
+        render_message(:warning) do
+          text.html_safe
         end
-        return warning
       end
     end
 

--- a/app/views/alchemy/essences/_essence_select_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_select_editor.html.erb
@@ -11,7 +11,7 @@
   <%= content_label(content) %>
 
   <% if select_values.nil? %>
-    <%== warning(':select_values is nil',
+    <%= warning(':select_values is nil',
     "<strong>No select values given.</strong>
     <br>Please provide :<code>select_values</code> either as argument to
     <code>render_essence_editor</code> helper or as setting on the content definition in

--- a/spec/helpers/alchemy/admin/essences_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/essences_helper_spec.rb
@@ -37,7 +37,7 @@ describe Alchemy::Admin::EssencesHelper do
         let(:element) { nil }
 
         it "displays a warning" do
-          is_expected.to have_selector(".content_editor_error")
+          is_expected.to have_selector(".warning.message")
           is_expected.to have_content("No element given.")
         end
       end


### PR DESCRIPTION
## What is this pull request for?

Render warning message in `warning` helper

### Notable changes

Removes the `.content_editor_error` css class 
