### PR TITLE
Use SimpleForm field for datepicker in resources form

### DIFF
--- a/app/views/alchemy/admin/resources/_form.html.erb
+++ b/app/views/alchemy/admin/resources/_form.html.erb
@@ -5,14 +5,6 @@
         label_method: relation[:attr_method],
         include_blank: Alchemy.t(:blank, scope: 'resources.relation_select'),
         input_html: {class: 'alchemy_selectbox'} %>
-    <% elsif attribute[:type].to_s =~ /(date|time)/ %>
-      <div class="input <%= attribute[:type] %>">
-        <label class="control-label">
-          <%= f.object.class.human_attribute_name(attribute[:name]) %>
-        </label>
-        <%= alchemy_datepicker resource_instance_variable, attribute[:name],
-          type: attribute[:type] %>
-      </div>
     <% else %>
       <%= f.input attribute[:name], resource_attribute_field_options(attribute) %>
     <% end %>

--- a/lib/alchemy/resources_helper.rb
+++ b/lib/alchemy/resources_helper.rb
@@ -102,19 +102,19 @@ module Alchemy
     # Returns a options hash for simple_form input fields.
     def resource_attribute_field_options(attribute)
       options = {hint: resource_handler.help_text_for(attribute)}
-      case attribute[:type].to_s
+      input_type = attribute[:type].to_s
+      case input_type
       when 'boolean'
         options
-      when 'date', 'datetime'
-        options.merge as: 'string',
+      when 'date', 'time', 'datetime'
+        date = resource_instance_variable.send(attribute[:name]) || Time.current
+        options.merge(
+          as: 'string',
           input_html: {
-            type: attribute[:type].to_s,
-            value: l(resource_instance_variable.send(attribute[:name]) || Time.current,
-              format: "#{attribute[:type]}picker".to_sym
-            )
+            'data-datepicker-type' => input_type,
+            value: date ? date.iso8601 : nil
           }
-      when 'time'
-        options.merge(as: 'time')
+        )
       when 'text'
         options.merge(as: 'text', input_html: {rows: 4})
       else


### PR DESCRIPTION
Former we used Rails' default text field builder. Using a simple form `field` builder instead and pass necessary datepicker options into that builder.

This way we get all the nice features from simple form like error messages and required field indicators on these fields as well.
