### PR TITLE
Fix elements window ajax errors

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.dialog.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.dialog.js.coffee
@@ -122,7 +122,7 @@ class window.Alchemy.Dialog
         @show_error(xhr, status)
 
   # Displays an error message
-  show_error: (xhr, status_message) ->
+  show_error: (xhr, status_message, $container = @dialog_body) ->
     error_type = "warning"
     switch xhr.status
       when 0
@@ -143,7 +143,7 @@ class window.Alchemy.Dialog
     $errorDiv.append Alchemy.messageIcon(error_type)
     $errorDiv.append "<h1>#{error_header}</h1>"
     $errorDiv.append "<p>#{error_body}</p>"
-    @dialog_body.html $errorDiv
+    $container.html $errorDiv
 
   # Binds close events on:
   # - Close button

--- a/app/assets/javascripts/alchemy/alchemy.dialog.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.dialog.js.coffee
@@ -135,7 +135,7 @@ class window.Alchemy.Dialog
         error_type = "error"
         if status_message
           error_header = status_message
-          console.error eval(xhr.responseText)
+          console.error(xhr.responseText)
         else
           error_header = "#{xhr.statusText} (#{xhr.status})"
         error_body = "Please check log and try again."

--- a/app/assets/javascripts/alchemy/alchemy.elements_window.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.elements_window.js.coffee
@@ -53,7 +53,7 @@ Alchemy.ElementsWindow =
       if @callback
         @callback.call()
     .fail (xhr, status, error) =>
-      Alchemy.AjaxErrorHandler @element_area, xhr.status, status, error
+      Alchemy.Dialog::show_error(xhr, error, @element_area)
 
   hide: ->
     @$body.removeClass('elements-window-visible');

--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -43,6 +43,10 @@
       height: 140px !important;
     }
   }
+
+  > .message {
+    margin: 2*$default-margin
+  }
 }
 
 #main-content-elements,


### PR DESCRIPTION
If an AJAX error in the elements window happen, we use the `Alchemy.Dialog` `show_error` message function to display a nice message to the user.

Fixes a bug where `AjaxErrorHandler` is not found (which was removed a long while ago)