### PR TITLE
Add missing requires to factories

### DIFF
--- a/lib/alchemy/test_support/factories.rb
+++ b/lib/alchemy/test_support/factories.rb
@@ -1,3 +1,5 @@
-Dir[File.dirname(__FILE__) + '/factories/*.rb'].each do |file|
+# frozen_string_literal: true
+
+Dir["#{File.dirname(__FILE__)}/factories/*.rb"].each do |file|
   require file
 end

--- a/lib/alchemy/test_support/factories/attachment_factory.rb
+++ b/lib/alchemy/test_support/factories/attachment_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'factory_bot'
 
 FactoryBot.define do

--- a/lib/alchemy/test_support/factories/content_factory.rb
+++ b/lib/alchemy/test_support/factories/content_factory.rb
@@ -1,4 +1,9 @@
+# frozen_string_literal: true
+
 require 'factory_bot'
+require 'alchemy/test_support/factories/element_factory'
+require 'alchemy/test_support/factories/essence_file_factory'
+require 'alchemy/test_support/factories/essence_picture_factory'
 require 'alchemy/test_support/factories/essence_text_factory'
 
 FactoryBot.define do

--- a/lib/alchemy/test_support/factories/dummy_user_factory.rb
+++ b/lib/alchemy/test_support/factories/dummy_user_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'factory_bot'
 
 FactoryBot.define do

--- a/lib/alchemy/test_support/factories/element_factory.rb
+++ b/lib/alchemy/test_support/factories/element_factory.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 require 'factory_bot'
+require 'alchemy/test_support/factories/page_factory'
 
 FactoryBot.define do
   factory :alchemy_element, class: 'Alchemy::Element' do

--- a/lib/alchemy/test_support/factories/essence_file_factory.rb
+++ b/lib/alchemy/test_support/factories/essence_file_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'factory_bot'
 require 'alchemy/test_support/factories/attachment_factory'
 

--- a/lib/alchemy/test_support/factories/essence_picture_factory.rb
+++ b/lib/alchemy/test_support/factories/essence_picture_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'factory_bot'
 require 'alchemy/test_support/factories/picture_factory'
 

--- a/lib/alchemy/test_support/factories/essence_text_factory.rb
+++ b/lib/alchemy/test_support/factories/essence_text_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'factory_bot'
 
 FactoryBot.define do

--- a/lib/alchemy/test_support/factories/language_factory.rb
+++ b/lib/alchemy/test_support/factories/language_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'factory_bot'
 require 'alchemy/test_support/factories/site_factory'
 

--- a/lib/alchemy/test_support/factories/page_factory.rb
+++ b/lib/alchemy/test_support/factories/page_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'factory_bot'
 require 'alchemy/test_support/factories/language_factory'
 

--- a/lib/alchemy/test_support/factories/picture_factory.rb
+++ b/lib/alchemy/test_support/factories/picture_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'factory_bot'
 
 FactoryBot.define do

--- a/lib/alchemy/test_support/factories/site_factory.rb
+++ b/lib/alchemy/test_support/factories/site_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'factory_bot'
 
 FactoryBot.define do


### PR DESCRIPTION
Add missing requires in factory bot factories

Without these requires it is not possible to only require one of the
factories on its one.
