### PR TITLE
Use where.not instead of Arel

### DIFF
--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -98,7 +98,7 @@ module Alchemy
     scope :not_restricted,    -> { joins(:page).merge(Page.not_restricted) }
     scope :available,         -> { published.not_trashed }
     scope :named,             ->(names) { where(name: names) }
-    scope :excluded,          ->(names) { where(arel_table[:name].not_in(names)) }
+    scope :excluded,          ->(names) { where.not(name: names) }
     scope :fixed,             -> { where(fixed: true) }
     scope :unfixed,           -> { where(fixed: false) }
     scope :from_current_site, -> { where(Language.table_name => {site_id: Site.current || Site.default}).joins(page: 'language') }

--- a/app/models/alchemy/page/page_scopes.rb
+++ b/app/models/alchemy/page/page_scopes.rb
@@ -66,7 +66,7 @@ module Alchemy
       # Returns all content pages.
       #
       scope :contentpages, -> {
-        where(layoutpage: [false, nil]).where(Page.arel_table[:parent_id].not_eq(nil))
+        where(layoutpage: [false, nil]).where.not(parent_id: nil)
       }
 
       # Returns all public contentpages that are not locked.


### PR DESCRIPTION
No need to use Arel because ActiveRecord supports `where.not` now.
