### PR TITLE
Set a max-width to preview frame

### DIFF
--- a/app/assets/stylesheets/alchemy/preview_window.scss
+++ b/app/assets/stylesheets/alchemy/preview_window.scss
@@ -16,5 +16,9 @@
 
   .collapsed-menu.elements-window-visible & {
     width: calc(100vw - #{$collapsed-main-menu-width - $default-border-width} - #{$elements-window-width});
+
+    @media screen and (min-width: $large-screen-break-point) {
+      max-width: calc(100vw - #{$collapsed-main-menu-width - $default-border-width} - #{$elements-window-min-width});
+    }
   }
 }


### PR DESCRIPTION
The preview frame needs to have a max width that respects the min width of the elements window id that is visible. Otherwise the preview frame overlaps the elements window on medium screens.
