### PR TITLE
Allow Ransack 1.x (master)

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'originator',                       ['~> 3.1']
   gem.add_runtime_dependency 'non-stupid-digest-assets',         ['~> 1.0.8']
   gem.add_runtime_dependency 'rails',                            ['~> 5.0', '< 6.0']
-  gem.add_runtime_dependency 'ransack',                          ['~> 2.0']
+  gem.add_runtime_dependency 'ransack',                          ['>= 1.8', '< 3.0']
   gem.add_runtime_dependency 'request_store',                    ['~> 1.2']
   gem.add_runtime_dependency 'responders',                       ['~> 2.0']
   gem.add_runtime_dependency 'select2-rails',                    ['>= 3.5.9.1', '< 4.0']


### PR DESCRIPTION
Ransack 2.0 has no breaking changes for us. The only breaking change was the removal of Rails 4.2 support, which we do not support anyways.

In order to allow to use Alchemy >= 4.1 with Solidus < 2.7 we need to still support Ransack 1.x
