### PR TITLE
Use Set to collect callbacks in OnPageLayout

### DIFF
--- a/lib/alchemy/on_page_layout.rb
+++ b/lib/alchemy/on_page_layout.rb
@@ -47,7 +47,7 @@ module Alchemy
     # Registers a callback for given page layout
     def self.register_callback(page_layout, callback)
       @callbacks ||= {}
-      @callbacks[page_layout] ||= []
+      @callbacks[page_layout] ||= Set.new
       @callbacks[page_layout] << callback
     end
 


### PR DESCRIPTION
## What is this pull request for?

When using the OnPageLayout mixin outside the ApplicationController
(because one might want to run define those methods only in certain
controllers and not in others), AND using an
`ActiveSupport::Concern`-style mixin to do that, AND including that
mixin in multiple controllers, one ends up with the callback or block
called multiple times. Using a `Set` instead of an Array neatly
circumvents this issue, as it will only add new unique callbacks.

Unfortunately, there is not a good way to test this, as running the
`on_page_layout` class method in any controller will expect the
`Alchemy::PagesController`to have a callback defined, and the test setup
for this spec would make many other specs fail.

Ideally, the Set of Callbacks would not be stored in a module instance
variable on the `OnPageLayout` module, but on the including controller.
That way the functionality (which is extremely useful!) could be scoped
a little more.

