### PR TITLE
Use Enumerable to find Element Contents

### DIFF
--- a/app/models/alchemy/element/element_contents.rb
+++ b/app/models/alchemy/element/element_contents.rb
@@ -16,13 +16,13 @@ module Alchemy
 
     # All contents from element by given name.
     def contents_by_name(name)
-      contents.where(name: name)
+      contents.select { |c| c.name == name }
     end
     alias_method :all_contents_by_name, :contents_by_name
 
     # All contents from element by given essence type.
     def contents_by_type(essence_type)
-      contents.where(essence_type: Content.normalize_essence_type(essence_type))
+      contents.select { |c| c.essence_type == Content.normalize_essence_type(essence_type) }
     end
     alias_method :all_contents_by_type, :contents_by_type
 


### PR DESCRIPTION
## What is this pull request for? 

Prior to this PR, the `Alchemy::Element` methods `contents_by_type` and `contents_by_name` would
always do an SQL query. With this commit, they can re-use the
`@element.contents` array if it's already loaded.

There is a good chance this does not do that much, and it does not
reduce the amount of SQL queries in the Element spec. I don't feel it
makes sense to test this explicitly either, as the functionality does
not change one bit - only the speed of execution should (in some cases)
improve.
