### PR TITLE
Fix image gallery individual image CSS height

### DIFF
--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -308,7 +308,7 @@
   .essence_picture {
     margin: 1px;
     float: left;
-    height: 126px;
+    height: 148px;
 
     .picture_thumbnail { margin: 0 }
   }


### PR DESCRIPTION
Prior to this, the controls were not visible on large galleries.

### Screenshots (remove if none)

Before
![grafik](https://user-images.githubusercontent.com/703401/58700559-ace1dc80-83a0-11e9-8811-9472c76de561.png)

After
![grafik](https://user-images.githubusercontent.com/703401/58700598-ca16ab00-83a0-11e9-90be-9b2ff4ba5376.png)
