### PR TITLE
Only return visible elements from Elements nested_elements relation

### DIFF
--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -102,7 +102,7 @@ module Alchemy
 
       if options[:from_cell]
         Alchemy::Deprecation.warn "options[:from_cell] has been removed without replacement. " \
-          "Please `render element.nested_elements.available` instead."
+          "Please `render element.nested_elements` instead."
       end
 
       finder = options[:finder] || Alchemy::ElementsFinder.new(options)

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -63,7 +63,12 @@ module Alchemy
     # In order to get contents in creation order we also order them by id.
     has_many :contents, -> { order(:position, :id) }, dependent: :destroy
 
-    # Elements can have other elements nested inside
+    has_many :all_nested_elements,
+      -> { order(:position) },
+      class_name: 'Alchemy::Element',
+      foreign_key: :parent_element_id,
+      dependent: :destroy
+
     has_many :nested_elements,
       -> { order(:position).not_trashed },
       class_name: 'Alchemy::Element',

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -70,7 +70,7 @@ module Alchemy
       dependent: :destroy
 
     has_many :nested_elements,
-      -> { order(:position).not_trashed },
+      -> { order(:position).available },
       class_name: 'Alchemy::Element',
       foreign_key: :parent_element_id,
       dependent: :destroy

--- a/app/views/alchemy/admin/elements/_element.html.erb
+++ b/app/views/alchemy/admin/elements/_element.html.erb
@@ -37,7 +37,8 @@
             class: "nested-elements", data: {
               'droppable-elements' => element.nestable_elements.join(' ')
             } do %>
-        <%= render partial: 'alchemy/admin/elements/element', collection: element.nested_elements %>
+        <%= render partial: 'alchemy/admin/elements/element',
+           collection: element.all_nested_elements.not_trashed %>
       <% end %>
 
       <% if element.expanded? || element.fixed? %>

--- a/lib/alchemy/upgrader/tasks/cells_upgrader.rb
+++ b/lib/alchemy/upgrader/tasks/cells_upgrader.rb
@@ -114,9 +114,9 @@ module Alchemy::Upgrader::Tasks
       if Dir.exist? cells_view_folder
         puts "-- Update cell views"
         Dir.glob("#{cells_view_folder}/*").each do |view|
-          gsub_file(view, /elements\.published/, 'elements.available')
+          gsub_file(view, /elements\.published/, 'elements')
           gsub_file(view, /cell\.elements(.+)/, 'element.nested_elements\1')
-          gsub_file(view, /render_elements[\(\s]?:?from_cell:?\s?(=>)?\s?cell\)?/, 'render element.nested_elements.available')
+          gsub_file(view, /render_elements[\(\s]?:?from_cell:?\s?(=>)?\s?cell\)?/, 'render element.nested_elements')
           gsub_file(view, /cell/, 'element')
         end
       else

--- a/lib/alchemy/upgrader/tasks/picture_gallery_upgrader.rb
+++ b/lib/alchemy/upgrader/tasks/picture_gallery_upgrader.rb
@@ -91,22 +91,22 @@ module Alchemy::Upgrader::Tasks
     def find_gallery_pictures_rendering
       puts '5. Find element views that use gallery pictures:'
 
-      erb_snippet = '   <%= render element.nested_elements.available %>'
+      erb_snippet = '   <%= render element.nested_elements %>'
       erb_views = erb_element_partials(:view).select do |view|
         next if File.read(view).match(GALLERY_PICTURES_ERB_REGEXP).nil?
 
         inject_into_file view,
-          "<%# TODO: Move the content of next block into its nestable element view and `render element.nested_elements.available` instead %>\n",
+          "<%# TODO: Move the content of next block into its nestable element view and `render element.nested_elements` instead %>\n",
           before: GALLERY_PICTURES_ERB_REGEXP
         true
       end
 
-      haml_slim_snippet = '   = element.nested_elements.available'
+      haml_slim_snippet = '   = element.nested_elements'
       haml_views = haml_slim_element_partials(:view).select do |view|
         next if File.read(view).match(GALLERY_PICTURES_HAML_REGEXP).nil?
 
         inject_into_file view,
-          "-# TODO: Move the content of next block into its nestable element view and `render element.nested_elements.available` instead\n",
+          "-# TODO: Move the content of next block into its nestable element view and `render element.nested_elements` instead\n",
           before: GALLERY_PICTURES_HAML_REGEXP
         true
       end

--- a/lib/rails/generators/alchemy/elements/templates/view.html.erb
+++ b/lib/rails/generators/alchemy/elements/templates/view.html.erb
@@ -10,7 +10,7 @@
     <%- end -%>
   <%- end -%>
   <%- if @element['nestable_elements'].present? -%>
-    <%%= render <%= @element_name %>_view.nested_elements.available %>
+    <%%= render <%= @element_name %>_view.nested_elements %>
   <%- end -%>
   <%%- end -%>
 <%%- end -%>

--- a/lib/rails/generators/alchemy/elements/templates/view.html.haml
+++ b/lib/rails/generators/alchemy/elements/templates/view.html.haml
@@ -9,5 +9,5 @@
     <%- end -%>
   <%- end -%>
   <%- if @element['nestable_elements'].present? -%>
-    = render <%= @element_name -%>_view.nested_elements.available
+    = render <%= @element_name -%>_view.nested_elements
   <%- end -%>

--- a/lib/rails/generators/alchemy/elements/templates/view.html.slim
+++ b/lib/rails/generators/alchemy/elements/templates/view.html.slim
@@ -9,5 +9,5 @@
     <%- end -%>
   <%- end -%>
   <%- if @element['nestable_elements'].present? -%>
-    = render <%= @element_name -%>_view.nested_elements.available
+    = render <%= @element_name -%>_view.nested_elements
   <%- end -%>

--- a/spec/dummy/app/views/alchemy/elements/_gallery_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_gallery_view.html.erb
@@ -1,7 +1,7 @@
 <%- cache(gallery_view) do -%>
   <%= element_view_for(gallery_view) do |el| -%>
     <div class="gallery_images">
-      <%= render gallery_view.nested_elements.available %>
+      <%= render gallery_view.nested_elements %>
     </div>
   <%- end -%>
 <%- end -%>

--- a/spec/dummy/app/views/alchemy/elements/_left_column_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_left_column_view.html.erb
@@ -1,5 +1,5 @@
 <%- cache(left_column_view) do -%>
   <%= element_view_for(left_column_view) do |el| -%>
-    <%= render left_column_view.nested_elements.available %>
+    <%= render left_column_view.nested_elements %>
   <%- end -%>
 <%- end -%>

--- a/spec/dummy/app/views/alchemy/elements/_right_column_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_right_column_view.html.erb
@@ -1,6 +1,6 @@
 <%- cache(right_column_view) do -%>
   <%= element_view_for(right_column_view) do |el| -%>
     <%= el.render :title %>
-    <%= render right_column_view.nested_elements.available %>
+    <%= render right_column_view.nested_elements %>
   <%- end -%>
 <%- end -%>

--- a/spec/dummy/app/views/alchemy/elements/_slider_view.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_slider_view.html.erb
@@ -1,5 +1,5 @@
 <%- cache(slider_view) do -%>
   <%= element_view_for(slider_view) do |el| -%>
-    <%= render slider_view.nested_elements.available %>
+    <%= render slider_view.nested_elements %>
   <%- end -%>
 <%- end -%>

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -908,10 +908,32 @@ module Alchemy
       subject { element.nested_elements }
 
       context 'with nestable_elements defined' do
-        let(:element) { create(:alchemy_element, :with_nestable_elements) }
+        let!(:page) { create(:alchemy_page) }
+        let!(:element) { create(:alchemy_element, page: page) }
+        let!(:nested_element) { create(:alchemy_element, parent_element: element, page: page) }
 
-        it 'returns an AR scope containing nested elements' do
-          expect(subject.count).to eq(1)
+        it 'returns nested elements' do
+          expect(subject).to eq([nested_element])
+        end
+
+        context 'with hidden nested elements' do
+          let!(:hidden_nested_element) do
+            create(:alchemy_element, parent_element: element, page: page, public: false)
+          end
+
+          it 'does not include them' do
+            expect(subject).to eq([nested_element])
+          end
+        end
+
+        context 'with trashed nested elements' do
+          let!(:hidden_trashed_element) do
+            create(:alchemy_element, parent_element: element, page: page).tap(&:trash!)
+          end
+
+          it 'does not include them' do
+            expect(subject).to eq([nested_element])
+          end
         end
       end
     end

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -872,6 +872,38 @@ module Alchemy
       end
     end
 
+    describe "#all_nested_elements" do
+      subject { element.all_nested_elements }
+
+      let!(:page) { create(:alchemy_page) }
+      let!(:element) { create(:alchemy_element, page: page) }
+      let!(:nested_element) { create(:alchemy_element, parent_element: element, page: page) }
+
+      it 'returns nested elements' do
+        expect(subject).to eq([nested_element])
+      end
+
+      context 'with hidden nested elements' do
+        let!(:hidden_nested_element) do
+          create(:alchemy_element, parent_element: element, page: page, public: false)
+        end
+
+        it 'includes them' do
+          expect(subject).to include(hidden_nested_element)
+        end
+      end
+
+      context 'with trashed nested elements' do
+        let!(:trashed_nested_element) do
+          create(:alchemy_element, parent_element: element, page: page).tap(&:trash!)
+        end
+
+        it 'includes them' do
+          expect(subject).to include(trashed_nested_element)
+        end
+      end
+    end
+
     describe "#nested_elements" do
       subject { element.nested_elements }
 


### PR DESCRIPTION
## What is this pull request for?

Only return visible elements from `Element`s `nested_elements` relation.
Before we only return not trashed elements, but as discussed in #1587 is is very confusing to have hidden elements returned as well. 

Closes #1587

### Notable changes

This now always return not-trashed and visible elements from `element.nested_elements` calls. If - for any reason - you want to have all elements (even trashed and invisible elements) you have to use the newly introduced `all_nested_elements` relation.
