### PR TITLE
Only return visible elements from Pages elements relations

### DIFF
--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -8,8 +8,8 @@ module Alchemy
 
       def index
         @page = Page.find(params[:page_id])
-        @elements = @page.elements
-        @fixed_elements = @page.fixed_elements
+        @elements = @page.all_elements.not_nested.unfixed.not_trashed
+        @fixed_elements = @page.all_elements.fixed.not_trashed
       end
 
       def list

--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -51,7 +51,7 @@ module Alchemy
     #
     #   class MyCustomNewsArchive
     #     def elements(page:)
-    #       news_page.elements.available.named('news').order(created_at: :desc)
+    #       news_page.elements.named('news').order(created_at: :desc)
     #     end
     #
     #     private

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -75,7 +75,7 @@ module Alchemy
       foreign_key: :parent_element_id,
       dependent: :destroy
 
-    belongs_to :page, touch: true, inverse_of: :descendent_elements
+    belongs_to :page, touch: true, inverse_of: :all_elements
 
     # A nested element belongs to a parent element.
     belongs_to :parent_element,

--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -7,6 +7,9 @@ module Alchemy
     included do
       attr_accessor :autogenerate_elements
 
+      has_many :all_elements,
+        -> { order(:position) },
+        class_name: 'Alchemy::Element'
       has_many :elements,
         -> { order(:position).not_nested.unfixed.not_trashed },
         class_name: 'Alchemy::Element'

--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -13,9 +13,6 @@ module Alchemy
       has_many :elements,
         -> { order(:position).not_nested.unfixed.not_trashed },
         class_name: 'Alchemy::Element'
-      has_many :elements_including_fixed,
-        -> { order(:position).not_nested.not_trashed },
-        class_name: 'Alchemy::Element'
       has_many :trashed_elements,
         -> { Element.trashed.order(:position) },
         class_name: 'Alchemy::Element'
@@ -45,15 +42,12 @@ module Alchemy
       # @return [Array]
       #
       def copy_elements(source, target)
-        new_elements = []
-        source.elements_including_fixed.each do |source_element|
-          new_element = Element.copy(source_element, {
+        source_elements = source.all_elements.not_nested.not_trashed
+        source_elements.order(:position).map do |source_element|
+          Element.copy(source_element, {
             page_id: target.id
-          })
-          new_element.move_to_bottom
-          new_elements << new_element
+          }).tap(&:move_to_bottom)
         end
-        new_elements
       end
     end
 
@@ -87,7 +81,8 @@ module Alchemy
 
       return [] if @_element_definitions.blank?
 
-      @_existing_element_names = elements_including_fixed.pluck(:name)
+      existing_elements = all_elements.not_nested.not_trashed
+      @_existing_element_names = existing_elements.pluck(:name)
       delete_unique_element_definitions!
       delete_outnumbered_element_definitions!
 
@@ -192,9 +187,10 @@ module Alchemy
     # And if so, it generates them.
     #
     def generate_elements
-      elements_already_on_page = elements_including_fixed.pluck(:name)
+      existing_elements = all_elements.not_nested.not_trashed
+      existing_element_names = existing_elements.pluck(:name).uniq
       definition.fetch('autogenerate', []).each do |element_name|
-        next if elements_already_on_page.include?(element_name)
+        next if existing_element_names.include?(element_name)
         Element.create(page: self, name: element_name)
       end
     end

--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -168,7 +168,7 @@ module Alchemy
     #     feed_elements: [element_name, element_2_name]
     #
     def feed_elements
-      elements.available.named(definition['feed_elements'])
+      elements.named(definition['feed_elements'])
     end
 
     # Returns an array of all EssenceRichtext contents ids from not folded elements

--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -22,14 +22,7 @@ module Alchemy
       has_many :fixed_elements,
         -> { order(:position).fixed.not_trashed },
         class_name: 'Alchemy::Element'
-      has_many :descendent_elements,
-        -> { order(:position).unfixed.not_trashed },
-        class_name: 'Alchemy::Element'
       has_many :contents, through: :elements
-      has_many :descendent_contents,
-        through: :descendent_elements,
-        class_name: 'Alchemy::Content',
-        source: :contents
       has_and_belongs_to_many :to_be_swept_elements, -> { distinct },
         class_name: 'Alchemy::Element',
         join_table: ElementToPage.table_name
@@ -186,8 +179,8 @@ module Alchemy
     # Returns an array of all EssenceRichtext contents ids from not folded elements
     #
     def richtext_contents_ids
-      descendent_contents
-        .where(Element.table_name => {folded: false})
+      Alchemy::Content.joins(:element)
+        .where(Element.table_name => {page_id: id, folded: false})
         .select(&:has_tinymce?)
         .collect(&:id)
     end

--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -11,13 +11,13 @@ module Alchemy
         -> { order(:position) },
         class_name: 'Alchemy::Element'
       has_many :elements,
-        -> { order(:position).not_nested.unfixed.not_trashed },
+        -> { order(:position).not_nested.unfixed.available },
         class_name: 'Alchemy::Element'
       has_many :trashed_elements,
         -> { Element.trashed.order(:position) },
         class_name: 'Alchemy::Element'
       has_many :fixed_elements,
-        -> { order(:position).fixed.not_trashed },
+        -> { order(:position).fixed.available },
         class_name: 'Alchemy::Element'
       has_many :contents, through: :elements
       has_and_belongs_to_many :to_be_swept_elements, -> { distinct },

--- a/spec/controllers/alchemy/admin/trash_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/trash_controller_spec.rb
@@ -44,14 +44,11 @@ module Alchemy
         end
 
         context "and with an unique element on the page" do
-          let(:unique) { build_stubbed(:alchemy_element, :unique) }
-          let(:page) { build_stubbed(:alchemy_page, :public) }
+          let!(:page) { create(:alchemy_page, :public) }
+          let!(:unique) { create(:alchemy_element, :unique, page: page) }
 
           before do
             allow(Page).to receive(:find).and_return(page)
-            allow(page).to receive(:elements_including_fixed) do
-              double(pluck: [unique.name])
-            end
           end
 
           it "unique elements should not be draggable" do

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -976,6 +976,61 @@ module Alchemy
           expect(page.elements).to_not include(nestable_element.nested_elements.first)
         end
       end
+
+      context 'with trashed elements' do
+        let(:trashed_element) { create(:alchemy_element, page: page) }
+
+        before do
+          trashed_element.trash!
+        end
+
+        it 'does not contain trashed elements' do
+          expect(page.elements).to_not include(trashed_element)
+        end
+      end
+
+      context 'with hidden elements' do
+        let(:hidden_element) { create(:alchemy_element, page: page, public: false) }
+
+        it 'does not contain hidden elements' do
+          expect(page.elements).to_not include(hidden_element)
+        end
+      end
+    end
+
+    describe "#fixed_elements" do
+      let(:page) { create(:alchemy_page) }
+      let!(:element_1) { create(:alchemy_element, fixed: true, page: page) }
+      let!(:element_2) { create(:alchemy_element, fixed: true, page: page) }
+      let!(:element_3) { create(:alchemy_element, fixed: true, page: page) }
+
+      before do
+        element_3.move_to_top
+      end
+
+      it 'returns a ordered active record collection of fixed elements on that page' do
+        expect(page.fixed_elements).to eq([element_3, element_1, element_2])
+      end
+
+      context 'with trashed fixed elements' do
+        let(:trashed_element) { create(:alchemy_element, page: page, fixed: true) }
+
+        before do
+          trashed_element.trash!
+        end
+
+        it 'does not contain trashed fixed elements' do
+          expect(page.fixed_elements).to_not include(trashed_element)
+        end
+      end
+
+      context 'with hidden fixed elements' do
+        let(:hidden_element) { create(:alchemy_element, page: page, fixed: true, public: false) }
+
+        it 'does not contain hidden fixed elements' do
+          expect(page.fixed_elements).to_not include(hidden_element)
+        end
+      end
     end
 
     describe '#element_definitions' do

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -908,6 +908,59 @@ module Alchemy
       end
     end
 
+    describe "#all_elements" do
+      let(:page) { create(:alchemy_page) }
+      let!(:element_1) { create(:alchemy_element, page: page) }
+      let!(:element_2) { create(:alchemy_element, page: page) }
+      let!(:element_3) { create(:alchemy_element, page: page) }
+
+      before do
+        element_3.move_to_top
+      end
+
+      it 'returns a ordered active record collection of elements on that page' do
+        expect(page.all_elements).to eq([element_3, element_1, element_2])
+      end
+
+      context 'with nestable elements' do
+        let!(:nestable_element) do
+          create(:alchemy_element, page: page)
+        end
+
+        let!(:nested_element) do
+          create(:alchemy_element, name: 'slide', parent_element: nestable_element, page: page)
+        end
+
+        it 'contains nested elements of an element' do
+          expect(page.all_elements).to include(nested_element)
+        end
+      end
+
+      context 'with trashed elements' do
+        let(:trashed_element) { create(:alchemy_element, page: page).tap(&:trash!) }
+
+        it 'contains trashed elements' do
+          expect(page.all_elements).to include(trashed_element)
+        end
+      end
+
+      context 'with hidden elements' do
+        let(:hidden_element) { create(:alchemy_element, page: page, public: false) }
+
+        it 'contains hidden elements' do
+          expect(page.all_elements).to include(hidden_element)
+        end
+      end
+
+      context 'with fixed elements' do
+        let(:fixed_element) { create(:alchemy_element, page: page, fixed: true) }
+
+        it 'contains hidden elements' do
+          expect(page.all_elements).to include(fixed_element)
+        end
+      end
+    end
+
     describe "#elements" do
       let(:page) { create(:alchemy_page) }
       let!(:element_1) { create(:alchemy_element, page: page) }

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -990,60 +990,6 @@ module Alchemy
       end
     end
 
-    describe "#descendent_elements" do
-      let!(:page) do
-        create(:alchemy_page)
-      end
-
-      let!(:element_1) do
-        create(:alchemy_element, page: page)
-      end
-
-      let!(:element_2) do
-        create(:alchemy_element, :with_nestable_elements, page: page, parent_element_id: element_1.id)
-      end
-
-      let!(:element_3) do
-        create(:alchemy_element, page: page)
-      end
-
-      it 'returns an active record collection of all elements including nested elements on that page' do
-        expect(page.descendent_elements.count).to eq(4)
-      end
-    end
-
-    describe "#descendent_contents" do
-      let!(:page) do
-        create(:alchemy_page)
-      end
-
-      let!(:element_1) do
-        create :alchemy_element,
-          :with_nestable_elements,
-          :with_contents, {
-            name: 'slider',
-            page: page
-          }
-      end
-
-      let!(:element_2) do
-        create :alchemy_element,
-          :with_contents, {
-            name: 'slide',
-            page: page,
-            parent_element_id: element_1.id
-          }
-      end
-
-      let!(:element_3) do
-        create(:alchemy_element, :with_contents, name: 'slide', page: page)
-      end
-
-      it 'returns an active record collection of all content including nested elements on that page' do
-        expect(page.descendent_contents.count).to eq(6)
-      end
-    end
-
     describe '#element_definitions' do
       let(:page) { build_stubbed(:alchemy_page) }
       subject { page.element_definitions }

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -558,8 +558,8 @@ module Alchemy
         before { page.elements << create(:alchemy_element, :fixed) }
 
         it "the copy should have source fixed elements" do
-          expect(subject.elements_including_fixed).not_to be_empty
-          expect(subject.elements_including_fixed.count).to eq(page.elements_including_fixed.count)
+          expect(subject.fixed_elements).not_to be_empty
+          expect(subject.fixed_elements.count).to eq(page.fixed_elements.count)
         end
       end
 
@@ -778,7 +778,7 @@ module Alchemy
     describe '#available_element_definitions' do
       subject { page.available_element_definitions }
 
-      let(:page) { build_stubbed(:alchemy_page, :public) }
+      let(:page) { create(:alchemy_page, :public) }
 
       it "returns all element definitions of available elements" do
         expect(subject).to be_an(Array)
@@ -786,13 +786,7 @@ module Alchemy
       end
 
       context "with unique elements already on page" do
-        let(:element) { build_stubbed(:alchemy_element, :unique) }
-
-        before do
-          allow(page).to receive(:elements_including_fixed) do
-            double(pluck: [element.name])
-          end
-        end
+        let!(:element) { create(:alchemy_element, :unique, page: page) }
 
         it "does not return unique element definitions" do
           expect(subject.collect { |e| e['name'] }).to include('article')
@@ -801,13 +795,15 @@ module Alchemy
       end
 
       context 'limited amount' do
-        let(:page) { build_stubbed(:alchemy_page, page_layout: 'columns') }
-        let(:unique_element) do
-          build_stubbed(:alchemy_element, :unique, name: 'unique_headline')
+        let(:page) { create(:alchemy_page, page_layout: 'columns') }
+
+        let!(:unique_element) do
+          create(:alchemy_element, :unique, name: 'unique_headline', page: page)
         end
-        let(:element_1) { build_stubbed(:alchemy_element, name: 'column_headline') }
-        let(:element_2) { build_stubbed(:alchemy_element, name: 'column_headline') }
-        let(:element_3) { build_stubbed(:alchemy_element, name: 'column_headline') }
+
+        let!(:element_1) { create(:alchemy_element, name: 'column_headline', page: page) }
+        let!(:element_2) { create(:alchemy_element, name: 'column_headline', page: page) }
+        let!(:element_3) { create(:alchemy_element, name: 'column_headline', page: page) }
 
         before do
           allow(Element).to receive(:definitions).and_return([
@@ -828,14 +824,6 @@ module Alchemy
             'elements' => ['column_headline', 'unique_headline'],
             'autogenerate' => ['unique_headline', 'column_headline', 'column_headline', 'column_headline']
           })
-          allow(page).to receive(:elements_including_fixed) do
-            double(pluck: [
-              unique_element.name,
-              element_1.name,
-              element_2.name,
-              element_3.name
-            ])
-          end
         end
 
         it "should be readable" do


### PR DESCRIPTION
## What is this pull request for?

Only return visible elements from `Page`s `elements` and `fixed_elements` relations.
Before we only return not trashed elements, but as discussed in #1587 is is very confusing to have hidden elements returned as well. 

Refs #1587

### Notable changes

This now always return not-trashed and visible elements from `page.elements` calls. If - for any reason - you want to have all elements (even trashed and invisible elements) you have to use the newly introduced `all_elements` relation.
