### PR TITLE
add default styling for number inputs

### DIFF
--- a/app/assets/stylesheets/alchemy/form_fields.scss
+++ b/app/assets/stylesheets/alchemy/form_fields.scss
@@ -1,5 +1,6 @@
 textarea,
 input[type="url"],
+input[type="number"],
 input[type="text"],
 input[type="email"],
 input[type="password"],

--- a/app/assets/stylesheets/alchemy/forms.scss
+++ b/app/assets/stylesheets/alchemy/forms.scss
@@ -25,6 +25,7 @@ form {
     @include clearfix;
 
     > input[type="url"],
+    > input[type="number"],
     > input[type="text"],
     > input[type="email"],
     > input[type="password"],


### PR DESCRIPTION
## What is this pull request for?

This simple PR just adds the rule for having styled [`input` fields with `number` type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number).

### Screenshots (remove if none)

before:
![Screenshot_20190808_103810](https://user-images.githubusercontent.com/372620/62688403-14cc2900-b9c9-11e9-9e6d-6c7ac7ed5d22.png)

after:
![Screenshot_20190808_103741](https://user-images.githubusercontent.com/372620/62688422-1b5aa080-b9c9-11e9-9fba-cdf3be7bac2c.png)
