### PR TITLE
WIP: add ordering & form type controll over resource attributes

### DIFF
--- a/lib/alchemy/resources_helper.rb
+++ b/lib/alchemy/resources_helper.rb
@@ -115,6 +115,10 @@ module Alchemy
             value: date ? date.iso8601 : nil
           }
         )
+      when 'richtext'
+        options.merge(as: 'text', input_html: { rows: 4, class: 'tinymce' })
+      when 'number'
+        options.merge(as: 'string', input_html: { type: 'number' })
       when 'text'
         options.merge(as: 'text', input_html: {rows: 4})
       else

--- a/lib/alchemy/resources_helper.rb
+++ b/lib/alchemy/resources_helper.rb
@@ -102,7 +102,7 @@ module Alchemy
     # Returns a options hash for simple_form input fields.
     def resource_attribute_field_options(attribute)
       options = {hint: resource_handler.help_text_for(attribute)}
-      input_type = attribute[:type].to_s
+      input_type = (attribute[:input_type] || attribute[:type]).to_s
       case input_type
       when 'boolean'
         options


### PR DESCRIPTION
This PR is not complete because there aren't any specs for it. But I'm not sure whether I will be able to add them in the nearer future. Sorry. So feel free to add them and merge if you find it useful.

However, it enables some configuration with the default resource form:

Adding a  method `.alchemy_resource_attribute_types` to the resource will allow to override the simple form type.
For example

```ruby
    def alchemy_resource_attribute_types
      {
        'my_next_novel' => richtext',
        'banana_count' => 'number'
      }
    end
```

Similar to that someone can add a `.attribute_order` method to a resource and the attributes will be ordered (all non mentioned will be appended in the end):

```ruby
    def attribute_order
      %w[first_attribute a_second_one foo]
    end
```