### PR TITLE
Use strings as JSON root keys in API controllers

### DIFF
--- a/app/controllers/alchemy/api/contents_controller.rb
+++ b/app/controllers/alchemy/api/contents_controller.rb
@@ -16,7 +16,7 @@ module Alchemy
       if params[:element_id].present?
         @contents = @contents.where(element_id: params[:element_id])
       end
-      render json: @contents, adapter: :json, root: :contents
+      render json: @contents, adapter: :json, root: 'contents'
     end
 
     # Returns a json object for content

--- a/app/controllers/alchemy/api/elements_controller.rb
+++ b/app/controllers/alchemy/api/elements_controller.rb
@@ -20,7 +20,7 @@ module Alchemy
       if params[:named].present?
         @elements = @elements.named(params[:named])
       end
-      render json: @elements, adapter: :json, root: :elements
+      render json: @elements, adapter: :json, root: 'elements'
     end
 
     # Returns a json object for element

--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -16,7 +16,7 @@ module Alchemy
       if params[:page_layout].present?
         @pages = @pages.where(page_layout: params[:page_layout])
       end
-      render json: @pages, adapter: :json, root: :pages
+      render json: @pages, adapter: :json, root: 'pages'
     end
 
     # Returns all pages as nested json object for tree views


### PR DESCRIPTION
## What is this pull request for?

ActiveModelSerializers 0.10.10 has a bug that assumes root keys are
always Strings. A fix has been merged but not released yet. Using
String instead of a Symbol for now.

See https://github.com/rails-api/active_model_serializers/issues/2341
