### PR TITLE
Fallback to default local if unavailable locale requested

### DIFF
--- a/lib/alchemy/admin/locale.rb
+++ b/lib/alchemy/admin/locale.rb
@@ -28,7 +28,7 @@ module Alchemy
 
       # Checks if we need to change to locale or not.
       def locale_change_needed?
-        params[:admin_locale].present? || session[:alchemy_locale].blank?
+        params[:admin_locale].present? || session[:alchemy_locale].blank? || available_locale.nil?
       end
 
       # Returns either the most preferred locale that is within the list of available locales or nil

--- a/spec/controllers/alchemy/admin/base_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/base_controller_spec.rb
@@ -56,6 +56,21 @@ describe Alchemy::Admin::BaseController do
     end
   end
 
+  describe '#set_translation' do
+    context 'with unavailable locale in the session' do
+      before do
+        allow(I18n).to receive(:default_locale) { :es }
+        allow(I18n).to receive(:available_locales) { [:es] }
+        allow(controller).to receive(:session) { { alchemy_locale: 'kl'} }
+      end
+
+      it "sets I18n.locale to the default locale" do
+        controller.send(:set_translation)
+        expect(::I18n.locale).to eq(:es)
+      end
+    end
+  end
+
   describe '#is_page_preview?' do
     subject { controller.send(:is_page_preview?) }
 


### PR DESCRIPTION
## What is this pull request for?

If an app that uses Alchemy has it's `::I18n.available_locales` array restricted to only a few locales, but the user's browser or a stale `:alchemy_locale` session value request one that is not listed as available, set the session to the default locale. 

In cases where the app has `enforce_available_locale` set to `true, the previous behaviour would raise an error - which would make Alchemy unusable because of an unavailable locale.


