### PR TITLE
Use media_type over content_type in specs

### DIFF
--- a/lib/alchemy/test_support/shared_uploader_examples.rb
+++ b/lib/alchemy/test_support/shared_uploader_examples.rb
@@ -1,7 +1,7 @@
 RSpec.shared_examples_for "having a json uploader error message" do
   it "renders json response with error message" do
     subject
-    expect(response.content_type).to eq('application/json')
+    expect(response.media_type).to eq('application/json')
     expect(response.status).to eq(422)
     json = JSON.parse(response.body)
     expect(json).to have_key('growl_message')

--- a/spec/controllers/alchemy/admin/attachments_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/attachments_controller_spec.rb
@@ -89,7 +89,7 @@ module Alchemy
 
         it "renders json response with success message" do
           subject
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
           expect(response.status).to eq(201)
           json = JSON.parse(response.body)
           expect(json).to have_key('growl_message')
@@ -136,7 +136,7 @@ module Alchemy
 
           it "renders json response with success message" do
             subject
-            expect(response.content_type).to eq('application/json')
+            expect(response.media_type).to eq('application/json')
             expect(response.status).to eq(202)
             json = JSON.parse(response.body)
             expect(json).to have_key('growl_message')

--- a/spec/controllers/alchemy/admin/pictures_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/pictures_controller_spec.rb
@@ -123,7 +123,7 @@ module Alchemy
 
         it "renders json response with success message" do
           subject
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
           expect(response.status).to eq(201)
           json = JSON.parse(response.body)
           expect(json).to have_key('growl_message')

--- a/spec/controllers/alchemy/api/contents_controller_spec.rb
+++ b/spec/controllers/alchemy/api/contents_controller_spec.rb
@@ -15,7 +15,7 @@ module Alchemy
         get :index, params: {format: :json}
 
         expect(response.status).to eq(200)
-        expect(response.content_type).to eq('application/json')
+        expect(response.media_type).to eq('application/json')
 
         result = JSON.parse(response.body)
 
@@ -31,7 +31,7 @@ module Alchemy
           get :index, params: {element_id: other_element.id, format: :json}
 
           expect(response.status).to eq(200)
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
 
           result = JSON.parse(response.body)
 
@@ -46,7 +46,7 @@ module Alchemy
           get :index, params: {element_id: element.id, format: :json}
 
           expect(response.status).to eq(200)
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
 
           result = JSON.parse(response.body)
 
@@ -64,7 +64,7 @@ module Alchemy
           get :index, params: {format: :json}
 
           expect(response.status).to eq(200)
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
 
           result = JSON.parse(response.body)
 
@@ -88,7 +88,7 @@ module Alchemy
           get :show, params: {id: content.id, format: :json}
 
           expect(response.status).to eq(200)
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
 
           result = JSON.parse(response.body)
 
@@ -101,7 +101,7 @@ module Alchemy
           it "responds with 403" do
             get :show, params: {id: content.id, format: :json}
 
-            expect(response.content_type).to eq('application/json')
+            expect(response.media_type).to eq('application/json')
             expect(response.status).to eq(403)
 
             result = JSON.parse(response.body)
@@ -121,7 +121,7 @@ module Alchemy
           get :show, params: {element_id: element.id, name: content.name, format: :json}
 
           expect(response.status).to eq(200)
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
 
           result = JSON.parse(response.body)
 
@@ -134,7 +134,7 @@ module Alchemy
           get :show, params: {element_id: '', name: '', format: :json}
 
           expect(response.status).to eq(404)
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
 
           result = JSON.parse(response.body)
 

--- a/spec/controllers/alchemy/api/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/api/elements_controller_spec.rb
@@ -18,7 +18,7 @@ module Alchemy
         get :index, params: {format: :json}
 
         expect(response.status).to eq(200)
-        expect(response.content_type).to eq('application/json')
+        expect(response.media_type).to eq('application/json')
 
         result = JSON.parse(response.body)
         expect(result).to have_key('elements')
@@ -34,7 +34,7 @@ module Alchemy
           get :index, params: {page_id: other_page.id, format: :json}
 
           expect(response.status).to eq(200)
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
 
           result = JSON.parse(response.body)
 
@@ -49,7 +49,7 @@ module Alchemy
           get :index, params: {page_id: '', format: :json}
 
           expect(response.status).to eq(200)
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
 
           result = JSON.parse(response.body)
 
@@ -65,7 +65,7 @@ module Alchemy
           get :index, params: {named: 'news', format: :json}
 
           expect(response.status).to eq(200)
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
 
           result = JSON.parse(response.body)
 
@@ -80,7 +80,7 @@ module Alchemy
           get :index, params: {named: '', format: :json}
 
           expect(response.status).to eq(200)
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
 
           result = JSON.parse(response.body)
 
@@ -98,7 +98,7 @@ module Alchemy
           get :index, params: {format: :json}
 
           expect(response.status).to eq(200)
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
 
           result = JSON.parse(response.body)
 
@@ -120,7 +120,7 @@ module Alchemy
         get :show, params: {id: element.id, format: :json}
 
         expect(response.status).to eq(200)
-        expect(response.content_type).to eq('application/json')
+        expect(response.media_type).to eq('application/json')
 
         result = JSON.parse(response.body)
 
@@ -134,7 +134,7 @@ module Alchemy
           get :show, params: {id: element.id, format: :json}
 
           expect(response.status).to eq(403)
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
 
           result = JSON.parse(response.body)
 

--- a/spec/controllers/alchemy/api/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/api/pages_controller_spec.rb
@@ -13,7 +13,7 @@ module Alchemy
         get :index, params: {format: :json}
 
         expect(response.status).to eq(200)
-        expect(response.content_type).to eq('application/json')
+        expect(response.media_type).to eq('application/json')
 
         result = JSON.parse(response.body)
 
@@ -28,7 +28,7 @@ module Alchemy
           get :index, params: {page_layout: 'news', format: :json}
 
           expect(response.status).to eq(200)
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
 
           result = JSON.parse(response.body)
 
@@ -42,7 +42,7 @@ module Alchemy
           get :index, params: {page_layout: '', format: :json}
 
           expect(response.status).to eq(200)
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
 
           result = JSON.parse(response.body)
 
@@ -60,7 +60,7 @@ module Alchemy
           get :index, params: {format: :json}
 
           expect(response.status).to eq(200)
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
 
           result = JSON.parse(response.body)
 
@@ -77,7 +77,7 @@ module Alchemy
         get :nested, params: {format: :json}
 
         expect(response.status).to eq(200)
-        expect(response.content_type).to eq('application/json')
+        expect(response.media_type).to eq('application/json')
 
         result = JSON.parse(response.body)
 
@@ -105,7 +105,7 @@ module Alchemy
           get :nested, params: {format: :json}
 
           expect(response.status).to eq(200)
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
 
           result = JSON.parse(response.body)
 
@@ -130,7 +130,7 @@ module Alchemy
           get :nested, params: {page_id: page.id, format: :json}
 
           expect(response.status).to eq(200)
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
 
           result = JSON.parse(response.body)
 
@@ -144,7 +144,7 @@ module Alchemy
           get :nested, params: {elements: 'true', format: :json}
 
           expect(response.status).to eq(200)
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
 
           result = JSON.parse(response.body)
 
@@ -183,7 +183,7 @@ module Alchemy
           get :show, params: {urlname: page.urlname, format: :json}
 
           expect(response.status).to eq(200)
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
 
           result = JSON.parse(response.body)
 
@@ -197,7 +197,7 @@ module Alchemy
             get :show, params: {urlname: page.urlname, format: :json}
 
             expect(response.status).to eq(403)
-            expect(response.content_type).to eq('application/json')
+            expect(response.media_type).to eq('application/json')
 
             result = JSON.parse(response.body)
 
@@ -213,7 +213,7 @@ module Alchemy
             get :show, params: {urlname: page.urlname, format: :json}
 
             expect(response.status).to eq(403)
-            expect(response.content_type).to eq('application/json')
+            expect(response.media_type).to eq('application/json')
 
             result = JSON.parse(response.body)
 
@@ -228,7 +228,7 @@ module Alchemy
           get :show, params: {urlname: 'not-existing', format: :json}
 
           expect(response.status).to eq(404)
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
 
           result = JSON.parse(response.body)
 
@@ -253,7 +253,7 @@ module Alchemy
           get :show, params: {id: page.id, format: :json}
 
           expect(response.status).to eq(200)
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
 
           result = JSON.parse(response.body)
 

--- a/spec/controllers/alchemy/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/pages_controller_spec.rb
@@ -216,7 +216,7 @@ module Alchemy
 
       it "should render a rss feed" do
         get :show, params: {urlname: page.urlname, format: :rss}
-        expect(response.content_type).to eq('application/rss+xml')
+        expect(response.media_type).to eq('application/rss+xml')
       end
 
       it "should include content" do

--- a/spec/requests/alchemy/admin/pages_controller_spec.rb
+++ b/spec/requests/alchemy/admin/pages_controller_spec.rb
@@ -107,7 +107,7 @@ module Alchemy
           get_tree
 
           expect(response.status).to eq(200)
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
 
           result = JSON.parse(response.body)
 
@@ -151,7 +151,7 @@ module Alchemy
             get tree_admin_pages_path(id: page_1.id, full: 'false')
 
             expect(response.status).to eq(200)
-            expect(response.content_type).to eq('application/json')
+            expect(response.media_type).to eq('application/json')
 
             result = JSON.parse(response.body)
             page = result['pages'].first['children'].first
@@ -169,7 +169,7 @@ module Alchemy
             get_tree
 
             expect(response.status).to eq(200)
-            expect(response.content_type).to eq('application/json')
+            expect(response.media_type).to eq('application/json')
 
             result = JSON.parse(response.body)
 

--- a/spec/requests/alchemy/admin/resources_requests_spec.rb
+++ b/spec/requests/alchemy/admin/resources_requests_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Resource requests' do
   describe 'csv export' do
     it 'returns valid csv file' do
       get '/admin/events.csv'
-      expect(response.content_type).to eq('text/csv')
+      expect(response.media_type).to eq('text/csv')
       expect(response.body).to include(';')
     end
 

--- a/spec/requests/alchemy/sitemap_spec.rb
+++ b/spec/requests/alchemy/sitemap_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Requests for PagesController#sitemap' do
 
   it 'renders valid xml sitemap' do
     get '/sitemap.xml'
-    expect(response.content_type).to eq('application/xml')
+    expect(response.media_type).to eq('application/xml')
     xml_doc = Nokogiri::XML(response.body)
     expect(xml_doc.namespaces).to have_key('xmlns')
     expect(xml_doc.namespaces['xmlns']).to eq('http://www.sitemaps.org/schemas/sitemap/0.9')
@@ -16,7 +16,7 @@ RSpec.describe 'Requests for PagesController#sitemap' do
 
   it 'lastmod dates are ISO 8601 timestamps' do
     get '/sitemap.xml'
-    expect(response.content_type).to eq('application/xml')
+    expect(response.media_type).to eq('application/xml')
     xml_doc = Nokogiri::XML(response.body)
     xml_doc.css('urlset url lastmod').each do |timestamps|
       expect(timestamps.text).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/)


### PR DESCRIPTION
Rails 6 changed the usage of `content_type`. It now includes the complete header in contrary to `media_type` that only returns the MIME type.

See https://github.com/rails/rails/pull/36034
