### PR TITLE
Cell Migrator: Maintain element order in fixed elements

### DIFF
--- a/lib/alchemy/upgrader/tasks/cells_migration.rb
+++ b/lib/alchemy/upgrader/tasks/cells_migration.rb
@@ -27,7 +27,7 @@ module Alchemy::Upgrader::Tasks
       # bust element definitions insta cache
       Alchemy::Element.instance_variable_set('@definitions', nil)
       fixed_element = Alchemy::Element.find_or_initialize_by(fixed: true, name: cell.name, page: cell.page)
-      elements = Alchemy::Element.where(cell_id: cell.id)
+      elements = Alchemy::Element.where(cell_id: cell.id).order(position: :asc)
 
       if fixed_element.new_record?
         fixed_element.nested_elements = elements


### PR DESCRIPTION
If migrating from cells to elements, maintain the order of the nested elements.
