### PR TITLE
Cell Upgrader: Match quotation marks in cell name string

### DIFF
--- a/lib/alchemy/upgrader/tasks/cells_upgrader.rb
+++ b/lib/alchemy/upgrader/tasks/cells_upgrader.rb
@@ -129,7 +129,7 @@ module Alchemy::Upgrader::Tasks
       Dir.glob("#{alchemy_views_folder}/**/*").each do |view|
         next if File.directory?(view)
         gsub_file(view, /render_cell[\(\s]?([:'"]?[a-z_]+['"]?)\)?/, 'render_elements(only: \1, fixed: true)')
-        gsub_file(view, /render_elements[\(\s](.*):?from_cell:?\s?(=>)?\s?['"]([a-z_]+)['"]\)?/, 'render_elements(\1only: \3, fixed: true)')
+        gsub_file(view, /render_elements[\(\s](.*):?from_cell:?\s?(=>)?\s?(['"][a-z_]+['"])\)?/, 'render_elements(\1only: \3, fixed: true)')
       end
     end
 


### PR DESCRIPTION
We were matching only the name of the cell in question. We need the quotation marks around it as well though, because otherwise we get and undefined method error from:
```
render_elements(from_page: "page", only: mycell, fixed: true)
```
With this change, this turns into this: 
```
render_elements(from_page: "page", only: "mycell", fixed: true)

```

