### PR TITLE
Fix Cell Migration to maintain positions

### DIFF
--- a/lib/alchemy/upgrader/tasks/cells_migration.rb
+++ b/lib/alchemy/upgrader/tasks/cells_migration.rb
@@ -30,8 +30,10 @@ module Alchemy::Upgrader::Tasks
       elements = Alchemy::Element.where(cell_id: cell.id)
 
       if fixed_element.new_record?
-        fixed_element.nested_elements = elements
         fixed_element.save!
+        Alchemy::Element.acts_as_list_no_update do
+          elements.update_all(parent_element_id: fixed_element.id)
+        end
         puts "Created new fixed element '#{fixed_element.name}' for cell '#{cell.name}'."
       else
         puts "Element for cell '#{cell.name}' already present. Skip"


### PR DESCRIPTION
Acts as list will modify the element's position when assigning them to a
new parent. This change stops that from happening, so that the order of
elements within a cell is not modified when it is migrated to a fixed
element.
