### PR TITLE
Allow Ransack 1.8 (again)

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'originator',                       ['~> 3.1']
   gem.add_runtime_dependency 'non-stupid-digest-assets',         ['~> 1.0.8']
   gem.add_runtime_dependency 'rails',                            ['~> 5.0', '< 6.0']
-  gem.add_runtime_dependency 'ransack',                          ['~> 2.0']
+  gem.add_runtime_dependency 'ransack',                          ['>= 1.8', '< 3.0']
   gem.add_runtime_dependency 'request_store',                    ['~> 1.2']
   gem.add_runtime_dependency 'responders',                       ['~> 2.0']
   gem.add_runtime_dependency 'select2-rails',                    ['>= 3.5.9.1', '< 4.0']


### PR DESCRIPTION
Somehow in v4.2.1 the Ransack version has been raised to 2.x after 1.8 was already allowed in 4.2.0.