### PR TITLE
Preload assets in tests

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths         = ['lib']
 
   gem.add_runtime_dependency 'active_model_serializers',         ['~> 0.10.0']
-  gem.add_runtime_dependency 'acts_as_list',                     ['~> 0.3']
+  gem.add_runtime_dependency 'acts_as_list',                     ['>= 0.3', '< 2']
   gem.add_runtime_dependency 'awesome_nested_set',               ['~> 3.1']
   gem.add_runtime_dependency 'cancancan',                        ['>= 2.1', '< 4.0']
   gem.add_runtime_dependency 'coffee-rails',                     ['~> 4.0', '< 5.0']

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,6 +75,15 @@ RSpec.configure do |config|
     driven_by :rack_test
   end
 
+  config.when_first_matching_example_defined(type: :system) do
+    config.before :suite do
+      # Preload assets
+      # This should avoid capybara timeouts, and avoid counting asset compilation
+      # towards the timing of the first feature spec.
+      Rails.application.precompiled_assets
+    end
+  end
+
   config.before(:each, type: :system, js: true) do
     driven_by :selenium_chrome_headless
   end


### PR DESCRIPTION
Preload assets in tests if necessary to prevent Capybara timeouts