### PR TITLE
FEAT: Render message and warnings in element editor

### DIFF
--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -266,6 +266,7 @@
   }
 
   .message {
+    width: 100%;
     margin: 2*$default-margin 0;
   }
 

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -33,7 +33,8 @@ module Alchemy
       "contents",
       "hint",
       "taggable",
-      "compact"
+      "compact",
+      "message"
     ].freeze
 
     SKIPPED_ATTRIBUTES_ON_COPY = [

--- a/app/views/alchemy/admin/elements/_element.html.erb
+++ b/app/views/alchemy/admin/elements/_element.html.erb
@@ -16,6 +16,12 @@
       <div id="element_<%= element.id %>_errors" class="element_errors"></div>
 
       <div id="element_<%= element.id %>_content" class="element-content-editors">
+        <% element.definition[:message].tap do |message| %>
+          <%= render_message(:info, sanitize(message)) if message %>
+        <% end %>
+        <% element.definition[:warning].tap do |warning| %>
+          <%= render_message(:warning, sanitize(warning)) if warning %>
+        <% end %>
         <%== render_editor(element) %>
       </div>
 

--- a/spec/views/alchemy/admin/elements/element_view_spec.rb
+++ b/spec/views/alchemy/admin/elements/element_view_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'alchemy/admin/elements/_element' do
+  before do
+    allow(element).to receive(:definition) { definition }
+  end
+
+  let(:definition) do
+    {
+      name: 'with_message',
+      message: 'One nice message'
+    }.with_indifferent_access
+  end
+
+  context 'with message given in element definition' do
+    let(:element) { create(:alchemy_element, name: 'with_message') }
+
+    it "renders the message" do
+      render 'alchemy/admin/elements/element', element: element
+      expect(rendered).to have_css('.message:contains("One nice message")')
+    end
+
+    context 'that contains HTML' do
+      let(:definition) do
+        {
+          name: 'with_message',
+          message: '<h1>One nice message</h1>'
+        }.with_indifferent_access
+      end
+
+      it "renders the HTML message" do
+        render 'alchemy/admin/elements/element', element: element
+        expect(rendered).to have_css('.message h1:contains("One nice message")')
+      end
+    end
+  end
+
+  context 'with warning given in element definition' do
+    let(:element) { create(:alchemy_element, name: 'with_warning') }
+
+    let(:definition) do
+      {
+        name: 'with_warning',
+        warning: 'One nice warning'
+      }.with_indifferent_access
+    end
+
+    it "renders the warning" do
+      render 'alchemy/admin/elements/element', element: element
+      expect(rendered).to have_css('.warning:contains("One nice warning")')
+    end
+
+    context 'that contains HTML' do
+      let(:definition) do
+        {
+          name: 'with_warning',
+          warning: '<h1>One nice warning</h1>'
+        }.with_indifferent_access
+      end
+
+      it "renders the HTML warning" do
+        render 'alchemy/admin/elements/element', element: element
+        expect(rendered).to have_css('.warning h1:contains("One nice warning")')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Define a warning or message on the element definition and Alchemy will render an info or warning message in the element editor for you.

The message or warning can even contain simple HTML for formatting.
