### PR TITLE
Remove local options from essence editors

### DIFF
--- a/app/controllers/alchemy/admin/base_controller.rb
+++ b/app/controllers/alchemy/admin/base_controller.rb
@@ -9,8 +9,7 @@ module Alchemy
       before_action { enforce_ssl if ssl_required? && !request.ssl? }
       before_action :load_locked_pages
 
-      helper_method :clipboard_empty?, :trash_empty?, :get_clipboard, :is_admin?,
-        :options_from_params
+      helper_method :clipboard_empty?, :trash_empty?, :get_clipboard, :is_admin?
 
       check_authorization
 
@@ -127,18 +126,6 @@ module Alchemy
           format.html { redirect_to url_or_path }
         end
       end
-
-      # Extracts options from params and permits all keys
-      #
-      # If no options are present it returns an empty parameters hash.
-      #
-      # @returns [ActionController::Parameters]
-      def options_from_params
-        @_options_from_params ||= begin
-          (params[:options] || ActionController::Parameters.new).permit!
-        end
-      end
-      deprecate :options_from_params, deprecator: Alchemy::Deprecation
 
       # This method decides if we want to raise an exception or not.
       #

--- a/app/controllers/alchemy/admin/contents_controller.rb
+++ b/app/controllers/alchemy/admin/contents_controller.rb
@@ -9,7 +9,6 @@ module Alchemy
 
       def create
         @content = Content.create(content_params)
-        @html_options = params[:html_options] || {}
       end
 
       private

--- a/app/controllers/alchemy/admin/essence_pictures_controller.rb
+++ b/app/controllers/alchemy/admin/essence_pictures_controller.rb
@@ -19,10 +19,8 @@ module Alchemy
       def crop
         if @picture = @essence_picture.picture
           @content = @essence_picture.content
-          options_from_params[:format] ||= (configuration(:image_store_format) || 'png')
-
           @min_size = sizes_from_essence_or_params
-          @ratio = ratio_from_size_or_params
+          @ratio = ratio_from_size_or_settings
           infer_width_or_height_from_ratio
 
           @default_box = @essence_picture.default_mask(@min_size)
@@ -70,24 +68,24 @@ module Alchemy
 
       # Gets the minimum size of the image to be rendered.
       #
-      # The +render_size+ attribute has preference over the +size+ parameter.
+      # The +render_size+ attribute has preference over the contents +size+ setting.
       #
       def sizes_from_essence_or_params
         if @essence_picture.render_size?
           @essence_picture.sizes_from_string(@essence_picture.render_size)
-        elsif options_from_params[:size]
-          @essence_picture.sizes_from_string(options_from_params[:size])
+        elsif @essence_picture.content.settings[:size]
+          @essence_picture.sizes_from_string(@essence_picture.content.settings[:size])
         else
           { width: 0, height: 0 }
         end
       end
 
-      # Infers the aspect ratio from size or parameters. If you don't want a fixed
+      # Infers the aspect ratio from size or contents settings. If you don't want a fixed
       # aspect ratio, don't specify a size or only width or height.
       #
-      def ratio_from_size_or_params
-        if @min_size.value?(0) && options_from_params[:fixed_ratio].to_s =~ FLOAT_REGEX
-          options_from_params[:fixed_ratio].to_f
+      def ratio_from_size_or_settings
+        if @min_size.value?(0) && @essence_picture.content.settings[:fixed_ratio].to_s =~ FLOAT_REGEX
+          @essence_picture.content.settings[:fixed_ratio].to_f
         elsif !@min_size[:width].zero? && !@min_size[:height].zero?
           @min_size[:width].to_f / @min_size[:height].to_f
         else

--- a/app/controllers/alchemy/admin/resources_controller.rb
+++ b/app/controllers/alchemy/admin/resources_controller.rb
@@ -143,8 +143,6 @@ module Alchemy
 
       def common_search_filter_includes
         [
-          # contrary to Rails' documentation passing an empty hash to permit all keys does not work
-          {options: options_from_params.keys},
           {q: [
             resource_handler.search_field_name,
             :s

--- a/app/helpers/alchemy/admin/essences_helper.rb
+++ b/app/helpers/alchemy/admin/essences_helper.rb
@@ -75,14 +75,14 @@ module Alchemy
       deprecate :render_missing_content, deprecator: Alchemy::Deprecation
 
       # Renders a thumbnail for given EssencePicture content with correct cropping and size
-      def essence_picture_thumbnail(content, options = {})
+      def essence_picture_thumbnail(content)
         picture = content.ingredient
         essence = content.essence
 
         return if picture.nil?
 
         image_tag(
-          essence.thumbnail_url(options),
+          essence.thumbnail_url,
           alt: picture.name,
           class: 'img_paddingtop',
           title: Alchemy.t(:image_name) + ": #{picture.name}"
@@ -90,11 +90,11 @@ module Alchemy
       end
 
       # Size value for edit picture dialog
-      def edit_picture_dialog_size(content, options = {})
-        if content.settings_value(:caption_as_textarea, options)
-          content.settings_value(:sizes, options) ? '380x320' : '380x300'
+      def edit_picture_dialog_size(content)
+        if content.settings[:caption_as_textarea]
+          content.settings[:sizes] ? '380x320' : '380x300'
         else
-          content.settings_value(:sizes, options) ? '380x290' : '380x255'
+          content.settings[:sizes] ? '380x290' : '380x255'
         end
       end
 

--- a/app/helpers/alchemy/admin/essences_helper.rb
+++ b/app/helpers/alchemy/admin/essences_helper.rb
@@ -7,22 +7,8 @@ module Alchemy
       include Alchemy::Admin::ContentsHelper
 
       # Renders the Content editor partial from the given Content.
-      # For options see -> render_essence
-      # @deprecated
-      def render_essence_editor(content, options = {}, html_options = {})
-        if !options.empty?
-          Alchemy::Deprecation.warn <<~WARN
-            Passing options to `render_essence_editor` is deprecated and will be removed from Alchemy 5.0.
-            Add your static `#{options.keys}` options to the `#{content.name}` content definitions `settings` of `#{content.element&.name}` element.
-            For dynamic options consider adding your own essence class.
-          WARN
-        end
-        if !html_options.empty?
-          Alchemy::Deprecation.warn <<~WARN
-            Passing html_options to `render_essence_editor` is deprecated and will be removed in Alchemy 5.0 without replacement.
-          WARN
-        end
-        render_essence(content, :editor, {for_editor: options}, html_options)
+      def render_essence_editor(content)
+        render_essence(content, :editor)
       end
       deprecate :render_essence_editor, deprecator: Alchemy::Deprecation
 
@@ -32,16 +18,16 @@ module Alchemy
       # Content creation on the fly:
       #
       # If you update the elements.yml file after creating an element this helper displays a error message with an option to create the content.
-      # @deprecated
-      def render_essence_editor_by_name(element, name, options = {}, html_options = {})
+      #
+      def render_essence_editor_by_name(element, name)
         if element.blank?
           return warning('Element is nil', Alchemy.t(:no_element_given))
         end
         content = element.content_by_name(name)
         if content.nil?
-          render_missing_content(element, name, options)
+          render_missing_content(element, name)
         else
-          render_essence_editor(content, options, html_options)
+          render_essence_editor(content)
         end
       end
       deprecate :render_essence_editor_by_name, deprecator: Alchemy::Deprecation
@@ -68,9 +54,9 @@ module Alchemy
       end
 
       # Renders the missing content partial
-      # @deprecated
-      def render_missing_content(element, name, options)
-        render 'alchemy/admin/contents/missing', {element: element, name: name, options: options}
+      #
+      def render_missing_content(element, name)
+        render 'alchemy/admin/contents/missing', {element: element, name: name}
       end
       deprecate :render_missing_content, deprecator: Alchemy::Deprecation
 

--- a/app/helpers/alchemy/elements_block_helper.rb
+++ b/app/helpers/alchemy/elements_block_helper.rb
@@ -65,8 +65,8 @@ module Alchemy
     # Block-level helper class for element editors.
     # @deprecated
     class ElementEditorHelper < BlockHelper
-      def edit(name, *args)
-        helpers.render_essence_editor_by_name(element, name.to_s, *args)
+      def edit(name)
+        helpers.render_essence_editor_by_name(element, name.to_s)
       end
       deprecate :edit, deprecator: Alchemy::Deprecation
     end

--- a/app/models/alchemy/content.rb
+++ b/app/models/alchemy/content.rb
@@ -255,7 +255,7 @@ module Alchemy
     #
     # If the value is a symbol it gets passed through i18n
     # inside the +alchemy.default_content_texts+ scope
-    def default_text(default)
+    def default_value(default = definition[:default])
       case default
       when Symbol
         Alchemy.t(default, scope: :default_content_texts)

--- a/app/models/alchemy/essence_picture.rb
+++ b/app/models/alchemy/essence_picture.rb
@@ -85,11 +85,11 @@ module Alchemy
     # image displayed in the frontend.
     #
     # @return [String]
-    def thumbnail_url(options = {})
+    def thumbnail_url
       return if picture.nil?
 
-      crop = crop_values_present? || content.settings_value(:crop, options)
-      size = render_size || content.settings_value(:size, options)
+      crop = crop_values_present? || content.settings[:crop]
+      size = render_size || content.settings[:size]
 
       options = {
         size: thumbnail_size(size, crop),
@@ -132,12 +132,12 @@ module Alchemy
       picture_url(content.settings)
     end
 
-    # Show image cropping link for content and options?
-    def allow_image_cropping?(options = {})
-      content && content.settings_value(:crop, options) && picture &&
+    # Show image cropping link for content
+    def allow_image_cropping?
+      content && content.settings[:crop] && picture &&
         picture.can_be_cropped_to(
-          content.settings_value(:size, options),
-          content.settings_value(:upsample, options)
+          content.settings[:size],
+          content.settings[:upsample]
         )
     end
 

--- a/app/views/alchemy/admin/attachments/_archive_overlay.html.erb
+++ b/app/views/alchemy/admin/attachments/_archive_overlay.html.erb
@@ -7,8 +7,7 @@
       in_dialog: true,
       redirect_url: admin_attachments_path(
         element_id: @element.try(:id),
-        content_id: @content.try(:id),
-        options: options_from_params
+        content_id: @content.try(:id)
       ) %>
   <% end %>
   <%= render 'alchemy/admin/partials/remote_search_form' %>

--- a/app/views/alchemy/admin/attachments/_file_to_assign.html.erb
+++ b/app/views/alchemy/admin/attachments/_file_to_assign.html.erb
@@ -1,8 +1,7 @@
 <li class="assign_file_file <%= cycle('even', 'odd') %>">
   <%= link_to alchemy.assign_admin_essence_files_path(
       attachment_id: file_to_assign.id,
-      content_id: @content.id,
-      options: options_from_params
+      content_id: @content.id
     ),
     remote: true,
     method: 'put' do %>

--- a/app/views/alchemy/admin/contents/_missing.html.erb
+++ b/app/views/alchemy/admin/contents/_missing.html.erb
@@ -7,9 +7,7 @@
         content: {
           element_id: element.id,
           name: name
-        },
-        was_missing: true,
-        options: options
+        }
       ),
       'data-create-missing-content' => true,
       class: 'small button' %>

--- a/app/views/alchemy/admin/contents/create.js.erb
+++ b/app/views/alchemy/admin/contents/create.js.erb
@@ -1,6 +1,4 @@
-var editor_html = '<%= j(render "alchemy/essences/#{@content.essence_partial_name}_editor", {
-  content: @content, options: options_from_params, html_options: @html_options
-}) %>';
+var editor_html = '<%= j render("alchemy/essences/#{@content.essence_partial_name}_editor", content: @content) %>';
 
 $("[data-element-<%= @content.element_id %>-missing-content=\"<%= @content.name %>\"]").replaceWith(editor_html);
 

--- a/app/views/alchemy/admin/essence_files/assign.js.erb
+++ b/app/views/alchemy/admin/essence_files/assign.js.erb
@@ -1,8 +1,7 @@
 $('#<%= @content.dom_id %>').replaceWith('<%= j(
   render "alchemy/essences/essence_file_editor",
     formats: [:html],
-    content: @content,
-    options: options_from_params
+    content: @content
 ) %>');
 Alchemy.closeCurrentDialog();
 Alchemy.setElementDirty($('#element_<%= @content.element.id %>'));

--- a/app/views/alchemy/admin/essence_files/edit.html.erb
+++ b/app/views/alchemy/admin/essence_files/edit.html.erb
@@ -1,4 +1,4 @@
-<% css_classes = @content.settings_value(:css_classes, local_assigns.fetch(:options, {})) %>
+<% css_classes = @content.settings[:css_classes] %>
 
 <%= alchemy_form_for [:admin, @essence_file] do |f| %>
   <%= f.input :link_text %>

--- a/app/views/alchemy/admin/essence_pictures/assign.js.erb
+++ b/app/views/alchemy/admin/essence_pictures/assign.js.erb
@@ -2,8 +2,7 @@ $('#picture_to_assign_<%= @picture.id %> a').attr('href', '#').off('click');
 $('#<%= @content.dom_id -%>').replaceWith('<%= j(
   render(
     "alchemy/essences/essence_picture_editor",
-    content: @content,
-    options: options_from_params
+    content: @content
   )
 ) %>');
 Alchemy.closeCurrentDialog();

--- a/app/views/alchemy/admin/essence_pictures/crop.html.erb
+++ b/app/views/alchemy/admin/essence_pictures/crop.html.erb
@@ -12,7 +12,7 @@
   </div>
   <%= form_for(
     @essence_picture,
-    url: alchemy.admin_essence_picture_path(@essence_picture, options: options_from_params),
+    url: alchemy.admin_essence_picture_path(@essence_picture),
     id: 'image_cropper_form',
     remote: true
   ) do |f| %>

--- a/app/views/alchemy/admin/essence_pictures/edit.html.erb
+++ b/app/views/alchemy/admin/essence_pictures/edit.html.erb
@@ -1,20 +1,20 @@
 <%= alchemy_form_for @essence_picture,
-    url: alchemy.admin_essence_picture_path(@essence_picture, options: options_from_params) do |f| %>
+    url: alchemy.admin_essence_picture_path(@essence_picture) do |f| %>
   <%= hidden_field_tag 'content_id', @content.id %>
-  <%= f.input :caption, as: options_from_params[:caption_as_textarea] ? 'text' : 'string' %>
+  <%= f.input :caption, as: @content.settings[:caption_as_textarea] ? 'text' : 'string' %>
   <%= f.input :title %>
   <%= f.input :alt_tag %>
-  <%- if options_from_params[:sizes].present? -%>
+  <%- if @content.settings[:sizes].present? -%>
     <%= f.input :render_size,
       collection: [
-        [Alchemy.t('Layout default'), options_from_params[:size]]
-      ] + options_from_params[:sizes].to_a,
+        [Alchemy.t('Layout default'), @content.settings[:size]]
+      ] + @content.settings[:sizes].to_a,
       include_blank: false,
       input_html: {class: 'alchemy_selectbox'} %>
   <%- end -%>
-  <%- if options_from_params[:css_classes].present? -%>
+  <%- if @content.settings[:css_classes].present? -%>
     <%= f.input :css_class,
-      collection: options_from_params[:css_classes],
+      collection: @content.settings[:css_classes],
       include_blank: Alchemy.t('None'),
       input_html: {class: 'alchemy_selectbox'} %>
   <%- else -%>

--- a/app/views/alchemy/admin/essence_pictures/update.js.erb
+++ b/app/views/alchemy/admin/essence_pictures/update.js.erb
@@ -3,7 +3,7 @@
   Alchemy.closeCurrentDialog();
   Alchemy.setElementDirty('#element_<%= @content.element.id %>');
 <% if @content.ingredient %>
-  $('.thumbnail_background img', '#<%= @content.dom_id %>').replaceWith('<%= essence_picture_thumbnail(@content, options_from_params) %>');
+  $('.thumbnail_background img', '#<%= @content.dom_id %>').replaceWith('<%= essence_picture_thumbnail(@content) %>');
   Alchemy.ImageLoader('#<%= @content.dom_id %> .thumbnail_background');
 <% end %>
 })(jQuery);

--- a/app/views/alchemy/admin/partials/_remote_search_form.html.erb
+++ b/app/views/alchemy/admin/partials/_remote_search_form.html.erb
@@ -1,6 +1,5 @@
 <%= search_form_for @query, url: url_for(
     action: 'index',
-    options: options_from_params,
     size: @size
   ), remote: true, html: {class: 'search_form', id: nil} do |f| %>
   <%= hidden_field_tag("element_id", @element.blank? ? "" : @element.id) %>
@@ -17,7 +16,6 @@
         action: 'index',
         element_id: @element.blank? ? '' : @element.id,
         content_id: @content.blank? ? '' : @content.id,
-        options: options_from_params,
         size: @size,
         overlay: true
       ),

--- a/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
+++ b/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
@@ -9,8 +9,7 @@
         size: search_filter_params[:size],
         filter: 'last_upload',
         content_id: @content.try(:id),
-        element_id: @element.try(:id),
-        options: options_from_params
+        element_id: @element.try(:id)
       ) %>
     <div class="toolbar_spacer"></div>
   <% end %>
@@ -23,7 +22,6 @@
           content_id: @content,
           element_id: @element,
           q: search_filter_params[:q],
-          options: options_from_params,
           filter: search_filter_params[:filter],
           tagged_with: search_filter_params[:tagged_with]
         }),
@@ -40,7 +38,6 @@
           content_id: @content,
           element_id: @element,
           q: search_filter_params[:q],
-          options: options_from_params,
           filter: search_filter_params[:filter],
           tagged_with: search_filter_params[:tagged_with]
         }),
@@ -57,7 +54,6 @@
           content_id: @content,
           element_id: @element,
           q: search_filter_params[:q],
-          options: options_from_params,
           filter: search_filter_params[:filter],
           tagged_with: search_filter_params[:tagged_with]
         }),

--- a/app/views/alchemy/admin/pictures/_overlay_picture_list.html.erb
+++ b/app/views/alchemy/admin/pictures/_overlay_picture_list.html.erb
@@ -5,6 +5,6 @@
 <% else %>
   <%= render partial: 'picture_to_assign',
     collection: @pictures,
-    locals: {options: options_from_params, size: @size} %>
+    locals: {size: @size} %>
   <%= paginate @pictures, theme: 'alchemy', remote: true, hide_per_page_select: true %>
 <% end %>

--- a/app/views/alchemy/admin/pictures/_picture_to_assign.html.erb
+++ b/app/views/alchemy/admin/pictures/_picture_to_assign.html.erb
@@ -6,8 +6,7 @@
     ),
     alchemy.assign_admin_essence_pictures_path(
       picture_id: picture_to_assign.id,
-      content_id: @content,
-      options: options
+      content_id: @content
     ),
     remote: true,
     onclick: '$(self).attr("href", "#").off("click"); return false',

--- a/app/views/alchemy/essences/_essence_boolean_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_boolean_editor.html.erb
@@ -1,11 +1,6 @@
 <div class="content_editor essence_boolean" id="<%= content.dom_id %>" data-content-id="<%= content.id %>">
   <input type="hidden" value="0" name="<%= content.form_field_name %>">
-  <%= check_box_tag content.form_field_name, 1,
-    content.ingredient.presence || content.settings_value(
-      :default_value, local_assigns.fetch(:options, {})
-    ),
-    class: local_assigns.fetch(:html_options, {})[:class],
-    style: local_assigns.fetch(:html_options, {})[:style] %>
+  <%= check_box_tag content.form_field_name, 1, content.ingredient %>
   <label for="<%= content.form_field_id %>" style="display: inline">
     <%= render_content_name(content) %>
   </label>

--- a/app/views/alchemy/essences/_essence_date_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_date_editor.html.erb
@@ -4,7 +4,7 @@
     content.essence, :date, {
       name: content.form_field_name,
       id: content.form_field_id,
-      value: content.settings_value(:default_value, local_assigns.fetch(:options, {}))
+      value: content.ingredient
     }
   ) %>
   <label for="<%= content.form_field_id %>" class="essence_date--label">

--- a/app/views/alchemy/essences/_essence_file_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_file_editor.html.erb
@@ -1,9 +1,8 @@
 <% dialog_link = link_to_dialog render_icon(:file, style: 'regular'),
   alchemy.admin_attachments_path(
     content_id: content.id,
-    only: content.settings_value(:only, local_assigns.fetch(:options, {})),
-    except: content.settings_value(:except, local_assigns.fetch(:options, {})),
-    options: local_assigns.fetch(:options, {})
+    only: content.settings[:only],
+    except: content.settings[:except]
   ),
   {
     title: Alchemy.t(:assign_file),
@@ -30,10 +29,7 @@
     <div class="essence_file_tools">
       <%= dialog_link %>
       <%= link_to_dialog render_icon(:edit),
-        alchemy.edit_admin_essence_file_path(
-          id: content.essence.id,
-          options: local_assigns.fetch(:options, {})
-        ),
+        alchemy.edit_admin_essence_file_path(id: content.essence.id),
         {
           title: Alchemy.t(:edit_file_properties),
           size: '400x215'

--- a/app/views/alchemy/essences/_essence_picture_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_picture_editor.html.erb
@@ -10,7 +10,7 @@
     <div class="picture_image">
       <div class="thumbnail_background">
         <%- if content.ingredient -%>
-          <%= essence_picture_thumbnail(content, options) %>
+          <%= essence_picture_thumbnail(content) %>
         <% else %>
           <%= render_icon(:image, style: 'regular') %>
         <% end %>
@@ -24,8 +24,7 @@
     <%- end -%>
     <div class="edit_images_bottom">
       <%= render 'alchemy/essences/shared/essence_picture_tools', {
-        content: content,
-        options: options
+        content: content
       } %>
     </div>
   </div>

--- a/app/views/alchemy/essences/_essence_select_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_select_editor.html.erb
@@ -1,21 +1,19 @@
-<% select_values = content.settings_value(:select_values, local_assigns.fetch(:options, {})) %>
-<% inline = content.settings_value(:display_inline, local_assigns.fetch(:options, {})) %>
-<% html_options = local_assigns.fetch(:html_options, {}) %>
+<% select_values = content.settings[:select_values] %>
 
 <%= content_tag :div,
   id: content.dom_id,
   class: [
     "content_editor",
     "essence_select",
-    inline ? 'display_inline' : nil
+    content.settings[:display_inline] ? 'display_inline' : nil
   ].compact, data: {content_id: content.id} do %>
   <%= content_label(content) %>
 
   <% if select_values.nil? %>
     <%= warning(':select_values is nil',
     "<strong>No select values given.</strong>
-    <br>Please provide :<code>select_values</code> either as argument to
-    <code>render_essence_editor</code> helper or as setting on the content definition in
+    <br>Please provide <code>select_values</code> on the
+    content definition <code>settings</code> in
     <code>elements.yml</code>.") %>
   <% else %>
     <%
@@ -25,8 +23,7 @@
       options_tags = options_for_select(select_values, content.ingredient)
     end %>
     <%= select_tag content.form_field_name, options_tags, {
-      class: ["alchemy_selectbox", "essence_editor_select", html_options[:class]].compact,
-      style: html_options[:style]
+      class: ["alchemy_selectbox", "essence_editor_select"]
     } %>
   <% end %>
 <% end %>

--- a/app/views/alchemy/essences/_essence_text_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_text_editor.html.erb
@@ -1,14 +1,10 @@
-<% options = local_assigns.fetch(:options, {}) %>
-<% html_options = local_assigns.fetch(:html_options, {}) %>
-
-<div class="essence_text content_editor<%= options[:display_inline].to_s == 'true' ? ' display_inline' : '' %>" id="<%= content.dom_id %>">
+<div class="essence_text content_editor<%= content.settings[:display_inline] ? ' display_inline' : '' %>" id="<%= content.dom_id %>">
   <%= content_label(content) %>
   <%= text_field_tag(
     content.form_field_name,
     content.ingredient,
-    class: ["thin_border #{content.settings[:linkable] ? ' text_with_icon' : ''}", html_options[:class]].join(' '),
-    style: html_options[:style],
-    type: content.settings_value(:input_type) || "text"
+    class: "thin_border #{content.settings[:linkable] ? ' text_with_icon' : ''}",
+    type: content.settings[:input_type] || "text"
   ) %>
   <% if content.settings[:linkable] %>
     <%= hidden_field_tag content.form_field_name(:link), content.essence.link %>

--- a/app/views/alchemy/essences/shared/_essence_picture_tools.html.erb
+++ b/app/views/alchemy/essences/shared/_essence_picture_tools.html.erb
@@ -1,11 +1,8 @@
-<% linkable = content.settings_value(:linkable, options) != false %>
+<% linkable = content.settings[:linkable] != false %>
 
-<% if content.essence && content.essence.allow_image_cropping?(options) %>
+<% if content.essence && content.essence.allow_image_cropping? %>
   <%= link_to_dialog render_icon(:crop),
-    alchemy.crop_admin_essence_picture_path(
-      content.essence,
-      options: content.settings.update(options)
-    ), {
+    alchemy.crop_admin_essence_picture_path(content.essence), {
       size: "1080x615",
       title: Alchemy.t('Edit Picturemask'),
       image_loader: false,
@@ -19,8 +16,7 @@
   alchemy.admin_pictures_path(
     element_id: content.element,
     content_id: content.id,
-    swap: true,
-    options: options
+    swap: true
   ),
   {
     title: (content.ingredient ? Alchemy.t(:swap_image) : Alchemy.t(:insert_image)),
@@ -51,9 +47,8 @@
 <%= link_to_dialog render_icon(:edit),
   alchemy.edit_admin_essence_picture_path(
     id: content.essence.id,
-    content_id: content.id,
-    options: options
+    content_id: content.id
   ), {
     title: Alchemy.t(:edit_image_properties),
-    size: edit_picture_dialog_size(content, options)
+    size: edit_picture_dialog_size(content)
   }, title: Alchemy.t(:edit_image_properties) %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -29,7 +29,7 @@
       "file": "app/views/alchemy/admin/contents/create.js.erb",
       "line": 1,
       "link": "http://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => \"alchemy/essences/#{Content.create(Element.find(params[:content][:element_id]), content_params).essence_partial_name}_editor\", { :content => Content.create(Element.find(params[:content][:element_id]), content_params), :options => options_from_params, :html_options => ((params[:html_options] or {})) })",
+      "code": "render(action => \"alchemy/essences/#{Content.create(Element.find(params[:content][:element_id]), content_params).essence_partial_name}_editor\", { :content => Content.create(Element.find(params[:content][:element_id]), content_params) })",
       "render_path": [{"type":"controller","class":"Alchemy::Admin::ContentsController","method":"create","line":21,"file":"app/controllers/alchemy/admin/contents_controller.rb"}],
       "location": {
         "type": "template",

--- a/lib/alchemy/essence.rb
+++ b/lib/alchemy/essence.rb
@@ -179,7 +179,7 @@ module Alchemy #:nodoc:
         end
       end
 
-      # Returns the value stored from the database column that is configured as ingredient column.
+      # Sets the value stored in the database column that is configured as ingredient column.
       def ingredient=(value)
         if respond_to?(ingredient_setter_method)
           send(ingredient_setter_method, value)

--- a/lib/rails/generators/alchemy/essence/templates/editor.html.erb
+++ b/lib/rails/generators/alchemy/essence/templates/editor.html.erb
@@ -1,7 +1,6 @@
 <%%#
   Available locals:
   * content (The object the essence is linked to the element)
-  * html_options
 
   Please consult Alchemy::Content.rb docs for further methods on the content object
 %>

--- a/spec/controllers/alchemy/admin/base_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/base_controller_spec.rb
@@ -3,35 +3,6 @@
 require 'rails_helper'
 
 describe Alchemy::Admin::BaseController do
-  describe '#options_from_params' do
-    subject { controller.send(:options_from_params) }
-
-    before do
-      expect(controller).to receive(:params).at_least(:once) do
-        ActionController::Parameters.new(options: options)
-      end
-    end
-
-    context "params[:options] are Rails parameters" do
-      let(:options) do
-        ActionController::Parameters.new('hello' => 'world')
-      end
-
-      it "returns the options as permitted parameters with indifferent access" do
-        expect(subject).to be_permitted
-        expect(subject[:hello]).to eq('world')
-      end
-    end
-
-    context "params[:options] is nil" do
-      let(:options) { nil }
-
-      it "returns an empty permitted parameters hash" do
-        is_expected.to eq(ActionController::Parameters.new.permit!)
-      end
-    end
-  end
-
   describe '#raise_exception?' do
     subject { controller.send(:raise_exception?) }
 

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -24,6 +24,8 @@ en:
       essence_richtext: This content type (Essence) represents richtext
       essence_select: This content type (Essence) represents values the editor can choose from
       essence_text: This content type (Essence) represents a simple line of text
+    default_content_texts:
+      welcome: Welcome to my site
 
   activerecord:
     models:

--- a/spec/helpers/alchemy/elements_block_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_block_helper_spec.rb
@@ -137,8 +137,8 @@ module Alchemy
 
       describe '#edit' do
         it "should delegate to the render_essence_editor_by_name helper" do
-          expect(scope).to receive(:render_essence_editor_by_name).with(element, "title", foo: 'bar')
-          subject.edit :title, foo: 'bar'
+          expect(scope).to receive(:render_essence_editor_by_name).with(element, "title")
+          subject.edit(:title)
         end
       end
     end

--- a/spec/models/alchemy/essence_picture_spec.rb
+++ b/spec/models/alchemy/essence_picture_spec.rb
@@ -149,9 +149,11 @@ module Alchemy
     end
 
     describe '#thumbnail_url' do
-      subject(:thumbnail_url) { essence.thumbnail_url(options) }
+      subject(:thumbnail_url) { essence.thumbnail_url }
 
-      let(:options) { {} }
+      let(:settings) do
+        {}
+      end
 
       let(:picture) do
         build_stubbed(:alchemy_picture)
@@ -166,6 +168,7 @@ module Alchemy
       end
 
       before do
+        allow(content).to receive(:settings) { settings }
         allow(essence).to receive(:content) { content }
       end
 
@@ -200,9 +203,9 @@ module Alchemy
           thumbnail_url
         end
 
-        context 'when crop is explicitely enabled in the options' do
-          let(:options) do
-            {crop: true}
+        context 'when crop is explicitely enabled in the settings' do
+          let(:settings) do
+            { crop: true }
           end
 
           it "it enables cropping." do
@@ -211,14 +214,6 @@ module Alchemy
             )
             thumbnail_url
           end
-        end
-      end
-
-      context 'with other options' do
-        let(:options) { {foo: 'baz'} }
-
-        it 'drops them' do
-          expect(thumbnail_url).to_not match /\?foo=baz/
         end
       end
 
@@ -336,7 +331,7 @@ module Alchemy
 
             context "with crop set to true" do
               before do
-                allow(content).to receive(:settings_value) { true }
+                allow(content).to receive(:settings) { {crop: true} }
               end
 
               it { is_expected.to be(true) }

--- a/spec/views/essences/essence_boolean_editor_spec.rb
+++ b/spec/views/essences/essence_boolean_editor_spec.rb
@@ -3,28 +3,36 @@
 require 'rails_helper'
 
 describe 'alchemy/essences/_essence_boolean_editor' do
-  let(:essence) { Alchemy::EssenceBoolean.new(ingredient: false) }
-  let(:content) { Alchemy::Content.new(essence: essence, name: 'Boolean') }
+  let(:element) { create(:alchemy_element, name: 'all_you_can_eat') }
+  let(:content) { Alchemy::Content.create(name: 'essence_boolean', type: 'EssenceBoolean', element: element) }
+
+  let(:content_definition) do
+    {
+      name: 'essence_boolean',
+      type: 'EssenceBoolean'
+    }.with_indifferent_access
+  end
 
   before do
+    expect(element).to receive(:content_definition_for) { content_definition }
+    allow_any_instance_of(Alchemy::Content).to receive(:definition) { content_definition }
     allow(view).to receive(:render_content_name).and_return(content.name)
     allow(view).to receive(:render_hint_for).and_return('')
   end
 
-  it "renders a checkbox" do
+  it "renders an unchecked checkbox" do
     render partial: "alchemy/essences/essence_boolean_editor", locals: {content: content}
     expect(rendered).to have_selector('input[type="checkbox"]')
   end
 
-  context 'with default value given in view local options' do
-    it "checks the checkbox" do
-      render partial: "alchemy/essences/essence_boolean_editor", locals: {content: content, options: {default_value: true}}
-      expect(rendered).to have_selector('input[type="checkbox"][checked="checked"]')
-    end
-  end
-
   context 'with default value given in content settings' do
-    before { allow(content).to receive(:settings).and_return({default_value: true}) }
+    let(:content_definition) do
+      {
+        name: 'essence_boolean',
+        type: 'EssenceBoolean',
+        default: true
+      }.with_indifferent_access
+    end
 
     it "checks the checkbox" do
       render partial: "alchemy/essences/essence_boolean_editor", locals: {content: content}

--- a/spec/views/essences/essence_date_editor_spec.rb
+++ b/spec/views/essences/essence_date_editor_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'alchemy/essences/_essence_date_editor' do
+  let(:content) { Alchemy::Content.new(essence: essence) }
+  let(:essence) { Alchemy::EssenceDate.new }
+
+  before do
+    view.class.send(:include, Alchemy::Admin::BaseHelper)
+    allow(view).to receive(:content_label).and_return(content.name)
+  end
+
+  it "renders a datepicker" do
+    render 'alchemy/essences/essence_date_editor', content: content
+    expect(rendered).to have_css('input[type="text"][data-datepicker-type="date"].date')
+  end
+end

--- a/spec/views/essences/essence_picture_editor_spec.rb
+++ b/spec/views/essences/essence_picture_editor_spec.rb
@@ -22,7 +22,7 @@ describe "essences/_essence_picture_editor" do
     )
   end
 
-  let(:options) { Hash.new }
+  let(:settings) { Hash.new }
 
   before do
     view.class.send(:include, Alchemy::Admin::BaseHelper)
@@ -32,8 +32,9 @@ describe "essences/_essence_picture_editor" do
   end
 
   subject do
+    allow(content).to receive(:settings) { settings }
     render partial: "alchemy/essences/essence_picture_editor",
-      locals: {content: content, options: options}
+      locals: {content: content}
     rendered
   end
 
@@ -45,8 +46,10 @@ describe "essences/_essence_picture_editor" do
   end
 
   context "with settings[:deletable] being false" do
-    let(:options) do
-      {linkable: false}
+    let(:settings) do
+      {
+        linkable: false
+      }
     end
 
     it 'should not render a button to link and unlink the picture' do

--- a/spec/views/essences/essence_select_editor_spec.rb
+++ b/spec/views/essences/essence_select_editor_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'alchemy/essences/_essence_select_editor' do
+  let(:content) { Alchemy::Content.new(essence: essence) }
+  let(:essence) { Alchemy::EssenceSelect.new }
+
+  before do
+    view.class.send(:include, Alchemy::Admin::BaseHelper)
+    allow(view).to receive(:content_label).and_return(content.name)
+  end
+
+  context 'if no select values are set' do
+    it 'renders a warning' do
+      render 'alchemy/essences/essence_select_editor', content: content
+      expect(rendered).to have_css('.warning')
+    end
+  end
+
+  context 'if select values are set' do
+    before do
+      allow(content).to receive(:settings) do
+        {
+          select_values: %w(red blue yellow)
+        }
+      end
+    end
+
+    it "renders a select box" do
+      render 'alchemy/essences/essence_select_editor', content: content
+      expect(rendered).to have_css('select.alchemy_selectbox')
+    end
+  end
+end

--- a/spec/views/essences/essence_text_editor_spec.rb
+++ b/spec/views/essences/essence_text_editor_spec.rb
@@ -5,28 +5,49 @@ require 'rails_helper'
 describe 'alchemy/essences/_essence_text_editor' do
   let(:essence) { Alchemy::EssenceText.new(body: '1234') }
   let(:content) { Alchemy::Content.new(essence: essence) }
+  let(:settings) { {} }
+
+  subject do
+    render partial: "alchemy/essences/essence_text_editor", locals: { content: content }
+  end
+
+  before do
+    view.class.send :include, Alchemy::Admin::BaseHelper
+    allow(view).to receive(:content_label).and_return("1e Zahl")
+    allow(content).to receive(:settings) { settings }
+    subject
+  end
 
   context 'with no input type set' do
-    before do
-      allow(view).to receive(:content_label).and_return("1e Zahl")
-      allow(content).to receive(:settings).and_return({})
-    end
-
     it "renders an input field of type number" do
-      render partial: "alchemy/essences/essence_text_editor", locals: {content: content, options: {}, html_options: {}}
       expect(rendered).to have_selector('input[type="text"]')
     end
   end
 
   context 'with a different input type set' do
-    before do
-      allow(view).to receive(:content_label).and_return("1e Zahl")
-      allow(content).to receive(:settings).and_return({input_type: "number"})
+    let(:settings) do
+      {
+        input_type: "number"
+      }
     end
 
     it "renders an input field of type number" do
-      render partial: "alchemy/essences/essence_text_editor", locals: {content: content, options: {}, html_options: {}}
       expect(rendered).to have_selector('input[type="number"]')
+    end
+  end
+
+  context 'with settings linkable set to true' do
+    let(:settings) do
+      {
+        linkable: true
+      }
+    end
+
+    it "renders link buttons" do
+      expect(rendered).to have_selector('input[type="hidden"][name="contents[][link]"]')
+      expect(rendered).to have_selector('input[type="hidden"][name="contents[][link_title]"]')
+      expect(rendered).to have_selector('input[type="hidden"][name="contents[][link_class_name]"]')
+      expect(rendered).to have_selector('input[type="hidden"][name="contents[][link_target]"]')
     end
   end
 end


### PR DESCRIPTION
## What is this pull request for?

Why? Passing around `options` hashes from the element editor views into the essence editor views and even in the params is error prone and not necessary in most of the time. We already have the `settings` key on the contents definition in the `elements.yml`.

### Notable changes

This removes the local `options` and `html_options` hashes passed to the essence editor partials. Stop passing local `options` from all element editor partials into essence editors.

Please set all options you have passed into the essence editor on the content definition itself.

#### Example

```erb
<%= element_editor_for(element) do |el| %>
  <%= el.edit :image, size: '2000x800', crop: true %>
<% end %>
```

will become

```yaml
- name: hero
  contents:
    - name: image
      type: EssencePicture
      settings:
        size: 2000x800
        crop: true
```

### Q: But what about dynamic options?

Sometimes you want to pass dynamic instead of static options into the essence editor. Like for a selection of pages you want to let chose an editor from.

#### A: Create an essence for this

Using an essence for multiple purposes is often not the best way of implementing those use cases. Imagine a event select for instance.

Instead of storing the `Event#id` in a string column of the `EssenceText` or `EssenceSelect` you should add your own custom essence (say `EssenceEvent`) and add a `event_id` foreign key and set the `event` as `ingredient_column`.

Another good example is [the Alchemy Solidus extension](https://github.com/AlchemyCMS/alchemy-solidus). It provides [`EssenceSpreeProduct`](https://github.com/AlchemyCMS/alchemy-solidus/blob/master/app/models/alchemy/essence_spree_product.rb) and [`EssenceSpreeTaxon`](https://github.com/AlchemyCMS/alchemy-solidus/blob/master/app/models/alchemy/essence_spree_taxon.rb) essences to work with.

This is a much more reliable approach of using dynamic values in your Alchemy instance.

#### B: Use `EssencePage` to reference pages

If you want to reference a page you can use the newly introduced `EssencePage`.