### PR TITLE
Ensure the EssencePage id regexp matches only numbers

### DIFF
--- a/app/models/alchemy/essence_page.rb
+++ b/app/models/alchemy/essence_page.rb
@@ -2,6 +2,8 @@
 
 module Alchemy
   class EssencePage < BaseRecord
+    PAGE_ID = /\A\d+\z/
+
     acts_as_essence(
       ingredient_column: :page,
       preview_text_method: :name
@@ -11,7 +13,7 @@ module Alchemy
 
     def ingredient=(page)
       case page
-      when /\d/
+      when PAGE_ID
         self.page = Alchemy::Page.new(id: page)
       when Alchemy::Page
         self.page = page

--- a/spec/models/alchemy/essence_page_spec.rb
+++ b/spec/models/alchemy/essence_page_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Alchemy::EssencePage, type: :model do
   describe 'ingredient=' do
     subject(:ingredient) { essence.page }
 
-    context 'when value is a String matching a number' do
+    context 'when String value is only a number' do
       let(:value) { '101' }
 
       before do
@@ -39,8 +39,8 @@ RSpec.describe Alchemy::EssencePage, type: :model do
       end
     end
 
-    context 'when value is something else' do
-      let(:value) { 'something' }
+    context 'when value is not only a number' do
+      let(:value) { 'page1' }
 
       it do
         expect {


### PR DESCRIPTION
The former regexp matches any string containing a number, but we want to only match numbers. 

Thanks @mamhoff 