### PR TITLE
Deprecate local options in essence editors

### DIFF
--- a/app/controllers/alchemy/admin/base_controller.rb
+++ b/app/controllers/alchemy/admin/base_controller.rb
@@ -138,6 +138,7 @@ module Alchemy
           (params[:options] || ActionController::Parameters.new).permit!
         end
       end
+      deprecate :options_from_params, deprecator: Alchemy::Deprecation
 
       # This method decides if we want to raise an exception or not.
       #

--- a/app/helpers/alchemy/admin/essences_helper.rb
+++ b/app/helpers/alchemy/admin/essences_helper.rb
@@ -9,6 +9,18 @@ module Alchemy
       # Renders the Content editor partial from the given Content.
       # For options see -> render_essence
       def render_essence_editor(content, options = {}, html_options = {})
+        if !options.empty?
+          Alchemy::Deprecation.warn <<~WARN
+            Passing options to `render_essence_editor` is deprecated and will be removed from Alchemy 5.0.
+            Add your static `#{options.keys}` options to the `#{content.name}` content definitions `settings` of `#{content.element&.name}` element.
+            For dynamic options consider adding your own essence class.
+          WARN
+        end
+        if !html_options.empty?
+          Alchemy::Deprecation.warn <<~WARN
+            Passing html_options to `render_essence_editor` is deprecated and will be removed in Alchemy 5.0 without replacement.
+          WARN
+        end
         render_essence(content, :editor, {for_editor: options}, html_options)
       end
 

--- a/spec/dummy/app/views/alchemy/elements/_article_editor.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_article_editor.html.erb
@@ -1,6 +1,6 @@
 <%= element_editor_for(element) do |el| -%>
   <%= el.edit :intro %>
   <%= el.edit :headline %>
-  <%= el.edit :image, size: "450x300", crop: true, fixed_ratio: false %>
+  <%= el.edit :image %>
   <%= el.edit :text %>
 <%- end -%>

--- a/spec/dummy/config/alchemy/elements.yml
+++ b/spec/dummy/config/alchemy/elements.yml
@@ -20,6 +20,10 @@
       linkable: true
   - name: image
     type: EssencePicture
+    settings:
+      size: 450x300
+      crop: true
+      fixed_ratio: false
   - name: text
     type: EssenceRichtext
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,7 +34,7 @@ ActionMailer::Base.delivery_method = :test
 ActionMailer::Base.perform_deliveries = true
 ActionMailer::Base.default_url_options[:host] = "test.com"
 
-ActiveSupport::Deprecation.silenced = false
+Alchemy::Deprecation.silenced = true
 
 Rails.backtrace_cleaner.remove_silencers!
 # Disable rails loggin for faster IO. Remove this if you want to have a test.log


### PR DESCRIPTION
## What is this pull request for?

This deprecates the local `options` and `html_options` hashes passed to the essence editor partials.

Why? Passing around `options` hashes from the element editor views into the essence editor views and even in the params is error prone and not necessary in most of the time. We already have the `settings` key on the contents definition in the `elements.yml`.

### Notable changes

This currently has no effect on your code. It just logs deprecation notices. In order to prepare for Alchemy 5.0 stop passing local `options` from all element editor partials into essence editors.

Please set all options you have passed into the essence editor on the content definition itself.

#### Example

```erb
<%= element_editor_for(element) do |el| %>
  <%= el.edit :image, size: '2000x800', crop: true %>
<% end %>
```

will become

```yaml
- name: hero
  contents:
    - name: image
      type: EssencePicture
      settings:
        size: 2000x800
        crop: true
```

### Q: But what about dynamic options?

Sometimes you want to pass dynamic instead of static options into the essence editor. Like for a selection of pages you want to let chose an editor from.

#### A: Create an essence for this

Using an essence for multiple purposes is often not the best way of implementing those use cases. Imagine a event select for instance.

Instead of storing the `Event#id` in a string column of the `EssenceText` or `EssenceSelect` you should add your own custom essence (say `EssenceEvent`) and add a `event_id` foreign key and set the `event` as `ingredient_column`.

Another good example is [the Alchemy Solidus extension](https://github.com/AlchemyCMS/alchemy-solidus). It provides [`EssenceSpreeProduct`](https://github.com/AlchemyCMS/alchemy-solidus/blob/master/app/models/alchemy/essence_spree_product.rb) and [`EssenceSpreeTaxon`](https://github.com/AlchemyCMS/alchemy-solidus/blob/master/app/models/alchemy/essence_spree_taxon.rb) essences to work with.

This is a much more reliable approach of using dynamic values in your Alchemy instance.

#### B: Use `EssencePage` to reference pages

If you want to reference a page you can use the newly introduced `EssencePage`.