### PR TITLE
Deprecate render_essence helpers

### DIFF
--- a/app/helpers/alchemy/elements_block_helper.rb
+++ b/app/helpers/alchemy/elements_block_helper.rb
@@ -26,8 +26,15 @@ module Alchemy
     class ElementViewHelper < BlockHelper
       # Renders one of the element's contents.
       #
-      def render(name, *args)
-        helpers.render_essence_view_by_name(element, name.to_s, *args)
+      def render(name, options = {}, html_options = {})
+        content = element.content_by_name(name)
+        return if content.nil?
+
+        helpers.render(content, {
+          content: content,
+          options: options,
+          html_options: html_options
+        })
       end
 
       # Returns one of the element's contents (ie. essence instances).

--- a/app/helpers/alchemy/essences_helper.rb
+++ b/app/helpers/alchemy/essences_helper.rb
@@ -27,6 +27,7 @@ module Alchemy
   #
   # And the +render_essence_editor_by_name+ helper for Alchemy backend views.
   #
+  # @deprecated Use Rails' `render(content)` method directly instead
   module EssencesHelper
     # Renders the +Essence+ view partial from +Element+ by name.
     #
@@ -38,14 +39,22 @@ module Alchemy
     #
     #   <%= render_essence_view_by_name(element, "intro") %>
     #
+    # @deprecated Use Rails' `render(content)` method directly instead
     def render_essence_view_by_name(element, name, options = {}, html_options = {})
       if element.blank?
-        warning('Element is nil')
-        return ""
+        warning('Element is nil') && return
       end
       content = element.content_by_name(name)
-      render_essence_view(content, options, html_options)
+      return if content.nil?
+
+      render content, {
+        content: content,
+        options: options,
+        html_options: html_options
+      }
     end
+    deprecate render_essence_view_by_name: "Use Rails' `render(content)` method directly instead",
+      deprecator: Alchemy::Deprecation
 
     # Renders the +Esssence+ partial for given +Content+.
     #
@@ -62,6 +71,7 @@ module Alchemy
     #   for_view: {}
     #   for_editor: {}
     #
+    # @deprecated Use Rails' `render(content)` method directly instead
     def render_essence(content, part = :view, options = {}, html_options = {})
       options = {for_view: {}, for_editor: {}}.update(options)
       if content.nil?
@@ -69,12 +79,22 @@ module Alchemy
       elsif content.essence.nil?
         return part == :view ? "" : warning('Essence is nil', Alchemy.t(:content_essence_not_found))
       end
-      render partial: "alchemy/essences/#{content.essence_partial_name}_#{part}", locals: {
-        content: content,
-        options: options["for_#{part}".to_sym],
-        html_options: html_options
-      }
+      if part == :view
+        render content, {
+          content: content,
+          options: options[:for_view],
+          html_options: html_options
+        }
+      else
+        render "alchemy/essences/#{content.essence_partial_name}_editor", {
+          content: content,
+          options: options,
+          html_options: html_options
+        }
+      end
     end
+    deprecate render_essence: "Use Rails' `render(content)` method directly instead",
+      deprecator: Alchemy::Deprecation
 
     # Renders the +Esssence+ view partial for given +Content+.
     #
@@ -85,8 +105,15 @@ module Alchemy
     #   :show_caption => false                         # Pass Boolean to show/hide the caption of an EssencePicture. [Default true]
     #   :disable_link => true                          # You can surpress the link of an EssencePicture. Default false
     #
+    # @deprecated Use Rails' `render(content)` method directly instead
     def render_essence_view(content, options = {}, html_options = {})
-      render_essence(content, :view, {for_view: options}, html_options)
+      render content, {
+        content: content,
+        options: options,
+        html_options: html_options
+      }
     end
+    deprecate render_essence_view: "Use Rails' `render(content)` method directly instead",
+      deprecator: Alchemy::Deprecation
   end
 end

--- a/app/views/alchemy/admin/elements/_element.html.erb
+++ b/app/views/alchemy/admin/elements/_element.html.erb
@@ -27,7 +27,9 @@
         <% else %>
           <%= element_editor_for(element) do %>
             <% element.contents.each do |content| %>
-              <%= render_essence(content, :editor) %>
+              <%= render "alchemy/essences/#{content.essence_partial_name}_editor", {
+                content: content
+              } %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/views/alchemy/essences/_essence_boolean_view.html.erb
+++ b/app/views/alchemy/essences/_essence_boolean_view.html.erb
@@ -1,1 +1,2 @@
+<% content = local_assigns[:content] || local_assigns[:essence_boolean_view] %>
 <%= Alchemy.t(content.ingredient) unless content.ingredient.nil? -%>

--- a/app/views/alchemy/essences/_essence_date_view.html.erb
+++ b/app/views/alchemy/essences/_essence_date_view.html.erb
@@ -1,3 +1,4 @@
+<% content = local_assigns[:content] || local_assigns[:essence_date_view] %>
 <%- date_format = content.settings_value(:date_format,
   local_assigns.fetch(:options, {})) -%>
 <%- if content.ingredient.present? -%>

--- a/app/views/alchemy/essences/_essence_file_view.html.erb
+++ b/app/views/alchemy/essences/_essence_file_view.html.erb
@@ -1,3 +1,4 @@
+<% content = local_assigns[:content] || local_assigns[:essence_file_view] %>
 <%- if attachment = content.ingredient -%>
 <%- html_options = local_assigns.fetch(:html_options, {}) -%>
 <%= link_to(

--- a/app/views/alchemy/essences/_essence_html_view.html.erb
+++ b/app/views/alchemy/essences/_essence_html_view.html.erb
@@ -1,1 +1,2 @@
+<% content = local_assigns[:content] || local_assigns[:essence_html_view] %>
 <%= raw content.ingredient -%>

--- a/app/views/alchemy/essences/_essence_link_view.html.erb
+++ b/app/views/alchemy/essences/_essence_link_view.html.erb
@@ -1,3 +1,4 @@
+<% content = local_assigns[:content] || local_assigns[:essence_link_view] %>
 <%- if content.ingredient.present? -%>
 <%- html_options = {
   target: content.essence.link_target == "blank" ? "_blank" : nil

--- a/app/views/alchemy/essences/_essence_page_view.html.erb
+++ b/app/views/alchemy/essences/_essence_page_view.html.erb
@@ -1,3 +1,4 @@
+<% content = local_assigns[:content] || local_assigns[:essence_page_view] %>
 <% page = content.ingredient %>
 <% if page %>
 <%= link_to page.name, alchemy.show_page_path(urlname: page.urlname) %>

--- a/app/views/alchemy/essences/_essence_picture_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_picture_editor.html.erb
@@ -1,3 +1,5 @@
+<% options = local_assigns.fetch(:options, {}) %>
+
 <%= content_tag :div, id: content.dom_id, data: {"content-id" => content.id}, class: "content_editor essence_picture" do %>
   <%= content_label(content) %>
   <div class="picture_thumbnail">

--- a/app/views/alchemy/essences/_essence_picture_view.html.erb
+++ b/app/views/alchemy/essences/_essence_picture_view.html.erb
@@ -1,3 +1,4 @@
+<% content = local_assigns[:content] || local_assigns[:essence_picture_view] %>
 <%= Alchemy::EssencePictureView.new(
   content,
   local_assigns[:options],

--- a/app/views/alchemy/essences/_essence_richtext_view.html.erb
+++ b/app/views/alchemy/essences/_essence_richtext_view.html.erb
@@ -1,3 +1,4 @@
+<% content = local_assigns[:content] || local_assigns[:essence_richtext_view] %>
 <%- options = local_assigns.fetch(:options, {}) -%>
 <%- plain_text = !!content.settings_value(:plain_text, options) -%>
 <%= raw content.essence.public_send(plain_text ? :stripped_body : :body) -%>

--- a/app/views/alchemy/essences/_essence_select_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_select_editor.html.erb
@@ -1,5 +1,6 @@
 <% select_values = content.settings_value(:select_values, local_assigns.fetch(:options, {})) %>
 <% inline = content.settings_value(:display_inline, local_assigns.fetch(:options, {})) %>
+<% html_options = local_assigns.fetch(:html_options, {}) %>
 
 <%= content_tag :div,
   id: content.dom_id,

--- a/app/views/alchemy/essences/_essence_select_view.html.erb
+++ b/app/views/alchemy/essences/_essence_select_view.html.erb
@@ -1,1 +1,2 @@
+<% content = local_assigns[:content] || local_assigns[:essence_select_view] %>
 <%= content.ingredient %>

--- a/app/views/alchemy/essences/_essence_text_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_text_editor.html.erb
@@ -1,3 +1,6 @@
+<% options = local_assigns.fetch(:options, {}) %>
+<% html_options = local_assigns.fetch(:html_options, {}) %>
+
 <div class="essence_text content_editor<%= options[:display_inline].to_s == 'true' ? ' display_inline' : '' %>" id="<%= content.dom_id %>">
   <%= content_label(content) %>
   <%= text_field_tag(

--- a/app/views/alchemy/essences/_essence_text_view.html.erb
+++ b/app/views/alchemy/essences/_essence_text_view.html.erb
@@ -1,3 +1,4 @@
+<% content = local_assigns[:content] || local_assigns[:essence_text_view] %>
 <%- options = local_assigns.fetch(:options, {}) -%>
 <%- html_options = local_assigns.fetch(:html_options, {}) -%>
 <%- if content.essence.link.blank? ||

--- a/spec/helpers/alchemy/elements_block_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_block_helper_spec.rb
@@ -81,9 +81,18 @@ module Alchemy
       end
 
       describe '#render' do
-        it 'should delegate to the render_essence_view_by_name helper' do
-          expect(scope).to receive(:render_essence_view_by_name).with(element, "title", foo: 'bar')
-          subject.render :title, foo: 'bar'
+        let(:element) { create(:alchemy_element, :with_contents) }
+        let(:content) { element.content_by_name(:headline) }
+
+        it "delegates to Rails' render helper" do
+          expect(scope).to receive(:render).with(content, {
+            content: content,
+            options: {
+              foo: 'bar'
+            },
+            html_options: {}
+          })
+          subject.render(:headline, foo: 'bar')
         end
       end
 

--- a/spec/helpers/alchemy/essences_helper_spec.rb
+++ b/spec/helpers/alchemy/essences_helper_spec.rb
@@ -28,7 +28,6 @@ describe Alchemy::EssencesHelper do
       end
 
       it "renders an essence editor partial" do
-        expect(content).to receive(:form_field_name)
         is_expected.to have_selector 'input[type="text"]'
       end
     end


### PR DESCRIPTION
## What is this pull request for?

Deprecates all `render_essence_view_*` helpers. These are rarely used nowadays, because most of the time the `element_view_for` helper and its `el.render` method is used instead.

### Notable changes (remove if none)

This does not have any effect on your site yet, but it will log deprecation notices.

### Convert all calls of

```rb
render_essence_view(content, { some: 'option' })
```
or
```rb
render_essence(content, :view, { some: 'option' })
```

with

```rb
render(content, { options: { some: 'option' } })
```

and 

```rb
render_essence_view_by_name(element, :title, { some: 'option' })
```

with

```rb
render(element.content_by_name(:title), { options: { some: 'option' } })
```

*) passing `options` is not mandatory, but if you have some you need to pass them as `locals`.

For further documentation on how Rails' `render` partial helper works, please have a look [into the official guides](https://guides.rubyonrails.org/layouts_and_rendering.html#using-partials)