### PR TITLE
Add ContentEditor decorator

### DIFF
--- a/app/decorators/alchemy/content_editor.rb
+++ b/app/decorators/alchemy/content_editor.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Alchemy
+  class ContentEditor < SimpleDelegator
+    alias_method :content, :__getobj__
+
+    def to_partial_path
+      "alchemy/essences/#{essence_partial_name}_editor"
+    end
+
+    # Returns a string to be passed to Rails form field tags to ensure we have same params layout everywhere.
+    #
+    # === Example:
+    #
+    #   <%= text_field_tag content_editor.form_field_name, content_editor.ingredient %>
+    #
+    # === Options:
+    #
+    # You can pass an Essence column_name. Default is 'ingredient'
+    #
+    # ==== Example:
+    #
+    #   <%= text_field_tag content_editor.form_field_name(:link), content_editor.ingredient %>
+    #
+    def form_field_name(essence_column = 'ingredient')
+      "contents[#{id}][#{essence_column}]"
+    end
+
+    def form_field_id(essence_column = 'ingredient')
+      "contents_#{id}_#{essence_column}"
+    end
+
+    # Fixes Rails partial renderer calling to_model on the object
+    # which reveals the delegated content instead of this decorator.
+    def respond_to?(method_name)
+      return false if method_name == :to_model
+
+      super
+    end
+  end
+end

--- a/app/helpers/alchemy/essences_helper.rb
+++ b/app/helpers/alchemy/essences_helper.rb
@@ -86,9 +86,9 @@ module Alchemy
           html_options: html_options
         }
       else
-        render "alchemy/essences/#{content.essence_partial_name}_editor", {
+        render Alchemy::ContentEditor.new(content), {
           content: content,
-          options: options,
+          options: options[:for_editor],
           html_options: html_options
         }
       end

--- a/app/models/alchemy/content.rb
+++ b/app/models/alchemy/content.rb
@@ -178,28 +178,6 @@ module Alchemy
       definition['validate'].present?
     end
 
-    # Returns a string to be passed to Rails form field tags to ensure we have same params layout everywhere.
-    #
-    # === Example:
-    #
-    #   <%= text_field_tag content.form_field_name, content.ingredient %>
-    #
-    # === Options:
-    #
-    # You can pass an Essence column_name. Default is 'ingredient'
-    #
-    # ==== Example:
-    #
-    #   <%= text_field_tag content.form_field_name(:link), content.ingredient %>
-    #
-    def form_field_name(essence_column = 'ingredient')
-      "contents[#{id}][#{essence_column}]"
-    end
-
-    def form_field_id(essence_column = 'ingredient')
-      "contents_#{id}_#{essence_column}"
-    end
-
     # Returns a string used as dom id on html elements.
     def dom_id
       return '' if essence.nil?

--- a/app/views/alchemy/admin/contents/create.js.erb
+++ b/app/views/alchemy/admin/contents/create.js.erb
@@ -1,4 +1,4 @@
-var editor_html = '<%= j render("alchemy/essences/#{@content.essence_partial_name}_editor", content: @content) %>';
+var editor_html = '<%= j render(Alchemy::ContentEditor.new(@content)) %>';
 
 $("[data-element-<%= @content.element_id %>-missing-content=\"<%= @content.name %>\"]").replaceWith(editor_html);
 

--- a/app/views/alchemy/admin/elements/_element.html.erb
+++ b/app/views/alchemy/admin/elements/_element.html.erb
@@ -25,13 +25,7 @@
         <% if lookup_context.exists?("#{element.name}_editor", ["alchemy/elements"], true) %>
           <%= render_editor(element) %>
         <% else %>
-          <%= element_editor_for(element) do %>
-            <% element.contents.each do |content| %>
-              <%= render "alchemy/essences/#{content.essence_partial_name}_editor", {
-                content: content
-              } %>
-            <% end %>
-          <% end %>
+          <%= render element.contents.map { |content| Alchemy::ContentEditor.new(content) } %>
         <% end %>
       </div>
 

--- a/app/views/alchemy/admin/essence_files/assign.js.erb
+++ b/app/views/alchemy/admin/essence_files/assign.js.erb
@@ -1,7 +1,3 @@
-$('#<%= @content.dom_id %>').replaceWith('<%= j(
-  render "alchemy/essences/essence_file_editor",
-    formats: [:html],
-    content: @content
-) %>');
+$('#<%= @content.dom_id %>').replaceWith('<%= j render(Alchemy::ContentEditor.new(@content)) %>');
 Alchemy.closeCurrentDialog();
 Alchemy.setElementDirty($('#element_<%= @content.element.id %>'));

--- a/app/views/alchemy/admin/essence_pictures/assign.js.erb
+++ b/app/views/alchemy/admin/essence_pictures/assign.js.erb
@@ -1,9 +1,4 @@
 $('#picture_to_assign_<%= @picture.id %> a').attr('href', '#').off('click');
-$('#<%= @content.dom_id -%>').replaceWith('<%= j(
-  render(
-    "alchemy/essences/essence_picture_editor",
-    content: @content
-  )
-) %>');
+$('#<%= @content.dom_id -%>').replaceWith('<%= j render(Alchemy::ContentEditor.new(@content)) %>');
 Alchemy.closeCurrentDialog();
 Alchemy.setElementDirty('#element_<%= @content.element.id %>');

--- a/app/views/alchemy/essences/_essence_boolean_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_boolean_editor.html.erb
@@ -1,8 +1,8 @@
-<div class="content_editor essence_boolean" id="<%= content.dom_id %>" data-content-id="<%= content.id %>">
-  <input type="hidden" value="0" name="<%= content.form_field_name %>">
-  <%= check_box_tag content.form_field_name, 1, content.ingredient %>
-  <label for="<%= content.form_field_id %>" style="display: inline">
-    <%= render_content_name(content) %>
+<div class="content_editor essence_boolean" id="<%= essence_boolean_editor.dom_id %>" data-content-id="<%= essence_boolean_editor.id %>">
+  <input type="hidden" value="0" name="<%= essence_boolean_editor.form_field_name %>">
+  <%= check_box_tag essence_boolean_editor.form_field_name, 1, essence_boolean_editor.ingredient %>
+  <label for="<%= essence_boolean_editor.form_field_id %>" style="display: inline">
+    <%= render_content_name(essence_boolean_editor) %>
   </label>
-  <%= render_hint_for(content) %>
+  <%= render_hint_for(essence_boolean_editor) %>
 </div>

--- a/app/views/alchemy/essences/_essence_date_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_date_editor.html.erb
@@ -1,13 +1,13 @@
-<div class="content_editor essence_date" id="<%= content.dom_id %>" data-content-id="<%= content.id %>">
-  <%= content_label(content) %>
+<div class="content_editor essence_date" id="<%= essence_date_editor.dom_id %>" data-content-id="<%= essence_date_editor.id %>">
+  <%= content_label(essence_date_editor) %>
   <%= alchemy_datepicker(
-    content.essence, :date, {
-      name: content.form_field_name,
-      id: content.form_field_id,
-      value: content.ingredient
+    essence_date_editor.essence, :date, {
+      name: essence_date_editor.form_field_name,
+      id: essence_date_editor.form_field_id,
+      value: essence_date_editor.ingredient
     }
   ) %>
-  <label for="<%= content.form_field_id %>" class="essence_date--label">
+  <label for="<%= essence_date_editor.form_field_id %>" class="essence_date--label">
     <i class="icon far fa-calendar-alt fa-fw fa-lg"></i>
   </label>
 </div>

--- a/app/views/alchemy/essences/_essence_file_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_file_editor.html.erb
@@ -1,8 +1,8 @@
 <% dialog_link = link_to_dialog render_icon(:file, style: 'regular'),
   alchemy.admin_attachments_path(
-    content_id: content.id,
-    only: content.settings[:only],
-    except: content.settings[:except]
+    content_id: essence_file_editor.id,
+    only: essence_file_editor.settings[:only],
+    except: essence_file_editor.settings[:except]
   ),
   {
     title: Alchemy.t(:assign_file),
@@ -12,31 +12,31 @@
   class: 'file_icon',
   title: Alchemy.t(:assign_file) %>
 
-<div class="content_editor essence_file" id="<%= content.dom_id %>" data-content-id="<%= content.id %>">
-  <%= content_label(content) %>
-  <div class="file" id="file_<%= content.id %>">
-    <% if content.ingredient %>
+<div class="content_editor essence_file" id="<%= essence_file_editor.dom_id %>" data-content-id="<%= essence_file_editor.id %>">
+  <%= content_label(essence_file_editor) %>
+  <div class="file" id="file_<%= essence_file_editor.id %>">
+    <% if essence_file_editor.ingredient %>
       <div class="file_icon">
-        <%= render_icon(content.ingredient.icon_css_class) %>
+        <%= render_icon(essence_file_editor.ingredient.icon_css_class) %>
       </div>
     <% else %>
       <%= dialog_link %>
     <% end %>
     <div class="file_name">
-      <%= content.ingredient.try(:name) ||
+      <%= essence_file_editor.ingredient.try(:name) ||
         ("&#x2190;" + Alchemy.t(:assign_file_from_archive)).html_safe %>
     </div>
     <div class="essence_file_tools">
       <%= dialog_link %>
       <%= link_to_dialog render_icon(:edit),
-        alchemy.edit_admin_essence_file_path(id: content.essence.id),
+        alchemy.edit_admin_essence_file_path(id: essence_file_editor.essence.id),
         {
           title: Alchemy.t(:edit_file_properties),
           size: '400x215'
         },
         title: Alchemy.t(:edit_file_properties) %>
     </div>
-    <%= hidden_field_tag content.form_field_name(:attachment_id),
-      content.ingredient && content.ingredient.id %>
+    <%= hidden_field_tag essence_file_editor.form_field_name(:attachment_id),
+      essence_file_editor.ingredient && essence_file_editor.ingredient.id %>
   </div>
 </div>

--- a/app/views/alchemy/essences/_essence_html_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_html_editor.html.erb
@@ -1,7 +1,7 @@
-<div class="content_editor essence_html_editor" data-content-id="<%= content.id %>">
-  <%= content_label(content) %>
+<div class="content_editor essence_html_editor" data-content-id="<%= essence_html_editor.id %>">
+  <%= content_label(essence_html_editor) %>
   <%= text_area_tag(
-    content.form_field_name,
-    content.ingredient
+    essence_html_editor.form_field_name,
+    essence_html_editor.ingredient
   ) %>
 </div>

--- a/app/views/alchemy/essences/_essence_link_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_link_editor.html.erb
@@ -1,23 +1,23 @@
-<div class="content_editor essence_link" id="<%= content.dom_id %>" data-content-id="<%= content.id %>">
-  <%= content_label(content) %>
-  <%= text_field_tag '', content.ingredient,
+<div class="content_editor essence_link" id="<%= essence_link_editor.dom_id %>" data-content-id="<%= essence_link_editor.id %>">
+  <%= content_label(essence_link_editor) %>
+  <%= text_field_tag '', essence_link_editor.ingredient,
     class: "thin_border text_with_icon disabled",
     name: nil,
     id: nil,
     disabled: true
   %>
-  <%= hidden_field_tag content.form_field_name(:link),
-    content.essence.link %>
-  <%= hidden_field_tag content.form_field_name(:link_title),
-    content.essence.link_title %>
-  <%= hidden_field_tag content.form_field_name(:link_class_name),
-    content.essence.link_class_name %>
-  <%= hidden_field_tag content.form_field_name(:link_target),
-    content.essence.link_target %>
-  <%= render 'alchemy/essences/shared/linkable_essence_tools', content: content %>
+  <%= hidden_field_tag essence_link_editor.form_field_name(:link),
+    essence_link_editor.essence.link %>
+  <%= hidden_field_tag essence_link_editor.form_field_name(:link_title),
+    essence_link_editor.essence.link_title %>
+  <%= hidden_field_tag essence_link_editor.form_field_name(:link_class_name),
+    essence_link_editor.essence.link_class_name %>
+  <%= hidden_field_tag essence_link_editor.form_field_name(:link_target),
+    essence_link_editor.essence.link_target %>
+  <%= render 'alchemy/essences/shared/linkable_essence_tools', content: essence_link_editor.content %>
 </div>
 <script type="text/javascript" charset="utf-8">
-  $('#<%= content.form_field_id(:link) %>').on('change', function() {
-    $('#<%= content.dom_id %> input.text_with_icon').val($(this).val());
+  $('#<%= essence_link_editor.form_field_id(:link) %>').on('change', function() {
+    $('#<%= essence_link_editor.dom_id %> input.text_with_icon').val($(this).val());
   });
 </script>

--- a/app/views/alchemy/essences/_essence_page_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_page_editor.html.erb
@@ -1,9 +1,9 @@
-<div class="content_editor essence_page" id="<%= content.dom_id %>" data-content-id="<%= content.id %>">
-  <%= content_label(content) %>
+<div class="content_editor essence_page" id="<%= essence_page_editor.dom_id %>" data-content-id="<%= essence_page_editor.id %>">
+  <%= content_label(essence_page_editor) %>
   <%= select_tag(
-    content.form_field_name,
+    essence_page_editor.form_field_name,
     pages_for_select,
-    id: content.form_field_id,
+    id: essence_page_editor.form_field_id,
     class: 'alchemy_selectbox full_width'
   ) %>
 </div>

--- a/app/views/alchemy/essences/_essence_picture_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_picture_editor.html.erb
@@ -1,41 +1,41 @@
 <% options = local_assigns.fetch(:options, {}) %>
 
-<%= content_tag :div, id: content.dom_id, data: {"content-id" => content.id}, class: "content_editor essence_picture" do %>
-  <%= content_label(content) %>
+<%= content_tag :div, id: essence_picture_editor.dom_id, data: {"content-id" => essence_picture_editor.id}, class: "content_editor essence_picture" do %>
+  <%= content_label(essence_picture_editor) %>
   <div class="picture_thumbnail">
     <span class="picture_tool delete">
       <%= link_to render_icon(:times), '#',
-        onclick: "return Alchemy.removePicture('##{content.form_field_id(:picture_id)}');" %>
+        onclick: "return Alchemy.removePicture('##{essence_picture_editor.form_field_id(:picture_id)}');" %>
     </span>
     <div class="picture_image">
       <div class="thumbnail_background">
-        <%- if content.ingredient -%>
-          <%= essence_picture_thumbnail(content) %>
+        <%- if essence_picture_editor.ingredient -%>
+          <%= essence_picture_thumbnail(essence_picture_editor) %>
         <% else %>
           <%= render_icon(:image, style: 'regular') %>
         <% end %>
       </div>
     </div>
-    <%- if content.essence.css_class.present? -%>
+    <%- if essence_picture_editor.essence.css_class.present? -%>
       <div class="essence_picture_css_class">
-        <%= Alchemy.t("alchemy.essence_pictures.css_classes.#{content.essence.css_class}",
-          default: content.essence.css_class.camelcase) %>
+        <%= Alchemy.t("alchemy.essence_pictures.css_classes.#{essence_picture_editor.essence.css_class}",
+          default: essence_picture_editor.essence.css_class.camelcase) %>
       </div>
     <%- end -%>
     <div class="edit_images_bottom">
       <%= render 'alchemy/essences/shared/essence_picture_tools', {
-        content: content
+        content: essence_picture_editor.content
       } %>
     </div>
   </div>
-  <%= hidden_field_tag content.form_field_name(:picture_id),
-    content.ingredient.try!(:id) %>
-  <%= hidden_field_tag content.form_field_name(:link),
-    content.essence.link %>
-  <%= hidden_field_tag content.form_field_name(:link_title),
-    content.essence.link_title %>
-  <%= hidden_field_tag content.form_field_name(:link_class_name),
-    content.essence.link_class_name %>
-  <%= hidden_field_tag content.form_field_name(:link_target),
-    content.essence.link_target %>
+  <%= hidden_field_tag essence_picture_editor.form_field_name(:picture_id),
+    essence_picture_editor.ingredient.try!(:id) %>
+  <%= hidden_field_tag essence_picture_editor.form_field_name(:link),
+    essence_picture_editor.essence.link %>
+  <%= hidden_field_tag essence_picture_editor.form_field_name(:link_title),
+    essence_picture_editor.essence.link_title %>
+  <%= hidden_field_tag essence_picture_editor.form_field_name(:link_class_name),
+    essence_picture_editor.essence.link_class_name %>
+  <%= hidden_field_tag essence_picture_editor.form_field_name(:link_target),
+    essence_picture_editor.essence.link_target %>
 <% end %>

--- a/app/views/alchemy/essences/_essence_richtext_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_richtext_editor.html.erb
@@ -1,11 +1,11 @@
-<div class="content_editor essence_richtext" id="<%= content.dom_id %>">
-  <%= content_label(content) %>
+<div class="content_editor essence_richtext" id="<%= essence_richtext_editor.dom_id %>">
+  <%= content_label(essence_richtext_editor) %>
   <div class="tinymce_container">
     <%= text_area_tag(
-      content.form_field_name,
-      content.ingredient || '',
-      class: content.tinymce_class_name,
-      id: "tinymce_#{content.id}"
+      essence_richtext_editor.form_field_name,
+      essence_richtext_editor.ingredient || '',
+      class: essence_richtext_editor.tinymce_class_name,
+      id: "tinymce_#{essence_richtext_editor.id}"
     ) %>
   </div>
 </div>

--- a/app/views/alchemy/essences/_essence_select_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_select_editor.html.erb
@@ -1,13 +1,13 @@
-<% select_values = content.settings[:select_values] %>
+<% select_values = essence_select_editor.settings[:select_values] %>
 
 <%= content_tag :div,
-  id: content.dom_id,
+  id: essence_select_editor.dom_id,
   class: [
     "content_editor",
     "essence_select",
-    content.settings[:display_inline] ? 'display_inline' : nil
-  ].compact, data: {content_id: content.id} do %>
-  <%= content_label(content) %>
+    essence_select_editor.settings[:display_inline] ? 'display_inline' : nil
+  ].compact, data: {content_id: essence_select_editor.id} do %>
+  <%= content_label(essence_select_editor) %>
 
   <% if select_values.nil? %>
     <%= warning(':select_values is nil',
@@ -18,11 +18,11 @@
   <% else %>
     <%
     if select_values.is_a?(Hash)
-      options_tags = grouped_options_for_select(select_values, content.ingredient)
+      options_tags = grouped_options_for_select(select_values, essence_select_editor.ingredient)
     else
-      options_tags = options_for_select(select_values, content.ingredient)
+      options_tags = options_for_select(select_values, essence_select_editor.ingredient)
     end %>
-    <%= select_tag content.form_field_name, options_tags, {
+    <%= select_tag essence_select_editor.form_field_name, options_tags, {
       class: ["alchemy_selectbox", "essence_editor_select"]
     } %>
   <% end %>

--- a/app/views/alchemy/essences/_essence_text_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_text_editor.html.erb
@@ -1,16 +1,16 @@
-<div class="essence_text content_editor<%= content.settings[:display_inline] ? ' display_inline' : '' %>" id="<%= content.dom_id %>">
-  <%= content_label(content) %>
+<div class="essence_text content_editor<%= essence_text_editor.settings[:display_inline] ? ' display_inline' : '' %>" id="<%= essence_text_editor.dom_id %>">
+  <%= content_label(essence_text_editor) %>
   <%= text_field_tag(
-    content.form_field_name,
-    content.ingredient,
-    class: "thin_border #{content.settings[:linkable] ? ' text_with_icon' : ''}",
-    type: content.settings[:input_type] || "text"
+    essence_text_editor.form_field_name,
+    essence_text_editor.ingredient,
+    class: "thin_border #{essence_text_editor.settings[:linkable] ? ' text_with_icon' : ''}",
+    type: essence_text_editor.settings[:input_type] || "text"
   ) %>
-  <% if content.settings[:linkable] %>
-    <%= hidden_field_tag content.form_field_name(:link), content.essence.link %>
-    <%= hidden_field_tag content.form_field_name(:link_title), content.essence.link_title %>
-    <%= hidden_field_tag content.form_field_name(:link_class_name), content.essence.link_class_name %>
-    <%= hidden_field_tag content.form_field_name(:link_target), content.essence.link_target %>
-    <%= render 'alchemy/essences/shared/linkable_essence_tools', content: content %>
+  <% if essence_text_editor.settings[:linkable] %>
+    <%= hidden_field_tag essence_text_editor.form_field_name(:link), essence_text_editor.essence.link %>
+    <%= hidden_field_tag essence_text_editor.form_field_name(:link_title), essence_text_editor.essence.link_title %>
+    <%= hidden_field_tag essence_text_editor.form_field_name(:link_class_name), essence_text_editor.essence.link_class_name %>
+    <%= hidden_field_tag essence_text_editor.form_field_name(:link_target), essence_text_editor.essence.link_target %>
+    <%= render 'alchemy/essences/shared/linkable_essence_tools', content: essence_text_editor.content %>
   <% end %>
 </div>

--- a/lib/rails/generators/alchemy/essence/essence_generator.rb
+++ b/lib/rails/generators/alchemy/essence/essence_generator.rb
@@ -33,6 +33,7 @@ CLASSMETHOD
 
       def copy_templates
         essence_name = @essence_name.classify.demodulize.underscore
+        @essence_editor_local = "#{essence_name}_editor"
         template "view.html.erb", "#{@essence_view_path}/_#{essence_name}_view.html.erb"
         template "editor.html.erb", "#{@essence_view_path}/_#{essence_name}_editor.html.erb"
       end

--- a/lib/rails/generators/alchemy/essence/templates/editor.html.erb
+++ b/lib/rails/generators/alchemy/essence/templates/editor.html.erb
@@ -1,14 +1,14 @@
 <%%#
   Available locals:
-  * content (The object the essence is linked to the element)
+  * <%= @essence_editor_local %> - A Alchemy::ContentEditor instance
 
   Please consult Alchemy::Content.rb docs for further methods on the content object
 %>
-<div class="content_editor <%= @essence_name.classify.demodulize.underscore %>" id="<%%= content.dom_id %>" data-content-id="<%%= content.id %>">
-  <%%= content_label(content) %>
+<div class="content_editor <%= @essence_name.classify.demodulize.underscore %>" id="<%%= <%= @essence_editor_local %>.dom_id %>" data-content-id="<%%= <%= @essence_editor_local %>.id %>">
+  <%%= content_label(<%= @essence_editor_local %>) %>
   <%%= text_field_tag(
-    content.form_field_name,
-    content.ingredient,
-    id: content.form_field_id
+    <%= @essence_editor_local %>.form_field_name,
+    <%= @essence_editor_local %>.ingredient,
+    id: <%= @essence_editor_local %>.form_field_id
   ) %>
 </div>

--- a/spec/decorators/alchemy/content_editor_spec.rb
+++ b/spec/decorators/alchemy/content_editor_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Alchemy::ContentEditor do
+  let(:essence) { Alchemy::EssenceText.new }
+  let(:content) { Alchemy::Content.new(id: 1, essence: essence) }
+  let(:content_editor) { described_class.new(content) }
+
+  describe '#content' do
+    it 'returns content object' do
+      expect(content_editor.content).to eq(content)
+    end
+  end
+
+  describe '#to_partial_path' do
+    subject { content_editor.to_partial_path }
+
+    it 'returns the editor partial path' do
+      is_expected.to eq('alchemy/essences/essence_text_editor')
+    end
+  end
+
+  describe '#form_field_name' do
+    it "returns a name value for form fields with ingredient as default" do
+      expect(content_editor.form_field_name).to eq('contents[1][ingredient]')
+    end
+
+    context 'with a essence column given' do
+      it "returns a name value for form fields for that column" do
+        expect(content_editor.form_field_name(:link_title)).to eq('contents[1][link_title]')
+      end
+    end
+  end
+
+  describe '#form_field_id' do
+    it "returns a id value for form fields with ingredient as default" do
+      expect(content_editor.form_field_id).to eq('contents_1_ingredient')
+    end
+
+    context 'with a essence column given' do
+      it "returns a id value for form fields for that column" do
+        expect(content_editor.form_field_id(:link_title)).to eq('contents_1_link_title')
+      end
+    end
+  end
+
+  describe '#respond_to?(:to_model)' do
+    subject { content_editor.respond_to?(:to_model) }
+
+    it { is_expected.to be(false) }
+  end
+end

--- a/spec/models/alchemy/content_spec.rb
+++ b/spec/models/alchemy/content_spec.rb
@@ -373,34 +373,6 @@ module Alchemy
       end
     end
 
-    describe '#form_field_name' do
-      let(:content) { Content.new(id: 1) }
-
-      it "returns a name value for form fields with ingredient as default" do
-        expect(content.form_field_name).to eq('contents[1][ingredient]')
-      end
-
-      context 'with a essence column given' do
-        it "returns a name value for form fields for that column" do
-          expect(content.form_field_name(:link_title)).to eq('contents[1][link_title]')
-        end
-      end
-    end
-
-    describe '#form_field_id' do
-      let(:content) { Content.new(id: 1) }
-
-      it "returns a id value for form fields with ingredient as default" do
-        expect(content.form_field_id).to eq('contents_1_ingredient')
-      end
-
-      context 'with a essence column given' do
-        it "returns a id value for form fields for that column" do
-          expect(content.form_field_id(:link_title)).to eq('contents_1_link_title')
-        end
-      end
-    end
-
     it_behaves_like "having a hint" do
       let(:subject) { Content.new }
     end

--- a/spec/views/essences/essence_boolean_editor_spec.rb
+++ b/spec/views/essences/essence_boolean_editor_spec.rb
@@ -20,9 +20,15 @@ describe 'alchemy/essences/_essence_boolean_editor' do
     allow(view).to receive(:render_hint_for).and_return('')
   end
 
-  it "renders an unchecked checkbox" do
-    render partial: "alchemy/essences/essence_boolean_editor", locals: {content: content}
-    expect(rendered).to have_selector('input[type="checkbox"]')
+  subject do
+    render partial: "alchemy/essences/essence_boolean_editor", locals: {
+      essence_boolean_editor: Alchemy::ContentEditor.new(content)
+    }
+    rendered
+  end
+
+  it "renders a checkbox" do
+    is_expected.to have_selector('input[type="checkbox"]')
   end
 
   context 'with default value given in content settings' do
@@ -35,8 +41,7 @@ describe 'alchemy/essences/_essence_boolean_editor' do
     end
 
     it "checks the checkbox" do
-      render partial: "alchemy/essences/essence_boolean_editor", locals: {content: content}
-      expect(rendered).to have_selector('input[type="checkbox"][checked="checked"]')
+      is_expected.to have_selector('input[type="checkbox"][checked="checked"]')
     end
   end
 end

--- a/spec/views/essences/essence_date_editor_spec.rb
+++ b/spec/views/essences/essence_date_editor_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'alchemy/essences/_essence_date_editor' do
   end
 
   it "renders a datepicker" do
-    render 'alchemy/essences/essence_date_editor', content: content
+    render 'alchemy/essences/essence_date_editor', essence_date_editor: Alchemy::ContentEditor.new(content)
     expect(rendered).to have_css('input[type="text"][data-datepicker-type="date"].date')
   end
 end

--- a/spec/views/essences/essence_file_editor_spec.rb
+++ b/spec/views/essences/essence_file_editor_spec.rb
@@ -8,7 +8,9 @@ describe 'alchemy/essences/_essence_file_editor' do
   let(:content) { build_stubbed(:alchemy_content, essence: essence) }
 
   subject do
-    render partial: "alchemy/essences/essence_file_editor", locals: {content: content}
+    render partial: "alchemy/essences/essence_file_editor", locals: {
+      essence_file_editor: Alchemy::ContentEditor.new(content)
+    }
     rendered
   end
 

--- a/spec/views/essences/essence_link_editor_spec.rb
+++ b/spec/views/essences/essence_link_editor_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'alchemy/essences/_essence_link_editor' do
+  let(:essence) { Alchemy::EssenceLink.new(link: 'http://alchemy-cms.com') }
+  let(:content) { Alchemy::Content.new(essence: essence) }
+  let(:settings) { {} }
+
+  before do
+    view.class.send :include, Alchemy::Admin::BaseHelper
+    allow(view).to receive(:content_label).and_return("1e Zahl")
+    render partial: "alchemy/essences/essence_link_editor", locals: {
+      essence_link_editor: Alchemy::ContentEditor.new(content)
+    }
+  end
+
+  it "renders a disabled text input field" do
+    expect(rendered).to have_selector('input[type="text"][disabled]')
+  end
+
+  it "renders link buttons" do
+    expect(rendered).to have_selector('input[type="hidden"][name="contents[][link]"]')
+    expect(rendered).to have_selector('input[type="hidden"][name="contents[][link_title]"]')
+    expect(rendered).to have_selector('input[type="hidden"][name="contents[][link_class_name]"]')
+    expect(rendered).to have_selector('input[type="hidden"][name="contents[][link_target]"]')
+  end
+end

--- a/spec/views/essences/essence_page_editor_spec.rb
+++ b/spec/views/essences/essence_page_editor_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'alchemy/essences/_essence_page_editor' do
   end
 
   it "renders a page select box" do
-    render 'alchemy/essences/essence_page_editor', content: content
+    render 'alchemy/essences/essence_page_editor', essence_page_editor: Alchemy::ContentEditor.new(content)
     expect(rendered).to have_css('select.alchemy_selectbox.full_width')
   end
 end

--- a/spec/views/essences/essence_picture_editor_spec.rb
+++ b/spec/views/essences/essence_picture_editor_spec.rb
@@ -34,7 +34,7 @@ describe "essences/_essence_picture_editor" do
   subject do
     allow(content).to receive(:settings) { settings }
     render partial: "alchemy/essences/essence_picture_editor",
-      locals: {content: content}
+      locals: {essence_picture_editor: Alchemy::ContentEditor.new(content)}
     rendered
   end
 

--- a/spec/views/essences/essence_select_editor_spec.rb
+++ b/spec/views/essences/essence_select_editor_spec.rb
@@ -11,16 +11,20 @@ RSpec.describe 'alchemy/essences/_essence_select_editor' do
     allow(view).to receive(:content_label).and_return(content.name)
   end
 
+  subject do
+    render 'alchemy/essences/essence_select_editor', essence_select_editor: Alchemy::ContentEditor.new(content)
+    rendered
+  end
+
   context 'if no select values are set' do
     it 'renders a warning' do
-      render 'alchemy/essences/essence_select_editor', content: content
-      expect(rendered).to have_css('.warning')
+      is_expected.to have_css('.warning')
     end
   end
 
   context 'if select values are set' do
     before do
-      allow(content).to receive(:settings) do
+      expect(content).to receive(:settings).at_least(:once) do
         {
           select_values: %w(red blue yellow)
         }
@@ -28,8 +32,7 @@ RSpec.describe 'alchemy/essences/_essence_select_editor' do
     end
 
     it "renders a select box" do
-      render 'alchemy/essences/essence_select_editor', content: content
-      expect(rendered).to have_css('select.alchemy_selectbox')
+      is_expected.to have_css('select.alchemy_selectbox')
     end
   end
 end

--- a/spec/views/essences/essence_text_editor_spec.rb
+++ b/spec/views/essences/essence_text_editor_spec.rb
@@ -7,15 +7,13 @@ describe 'alchemy/essences/_essence_text_editor' do
   let(:content) { Alchemy::Content.new(essence: essence) }
   let(:settings) { {} }
 
-  subject do
-    render partial: "alchemy/essences/essence_text_editor", locals: { content: content }
-  end
-
   before do
     view.class.send :include, Alchemy::Admin::BaseHelper
     allow(view).to receive(:content_label).and_return("1e Zahl")
     allow(content).to receive(:settings) { settings }
-    subject
+    render partial: "alchemy/essences/essence_text_editor", locals: {
+      essence_text_editor: Alchemy::ContentEditor.new(content)
+    }
   end
 
   context 'with no input type set' do


### PR DESCRIPTION
## What is this pull request for?

Adds a ContentEditor decorator so we can make use of Rails collection partial rendering for essence editor partials.

### Notable changes

This make it necessary to replace the local `content` variable with the essence editor partial name. So, for example the `EssenceText` editor partial now has an `essence_text_editor` variable instead of a `content` variable. This variable holds the `Alchemy::ContentEditor` instance which is a simple delegator to the `Alchemy::Content` instance.
