### PR TITLE
Add a configurable logout method (default: delete)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,12 @@ The best practice is to use an initializer:
 
 ```ruby
 # config/initializers/alchemy.rb
-Alchemy.user_class_name     = 'YourUserClass'       # Defaults to 'User'
-Alchemy.current_user_method = 'current_admin_user'  # Defaults to 'current_user'
-Alchemy.signup_path         = '/your/signup/path'   # Defaults to '/signup'
-Alchemy.login_path          = '/your/login/path'    # Defaults to '/login'
-Alchemy.logout_path         = '/your/logout/path'   # Defaults to '/logout'
+Alchemy.user_class_name     = 'YourUserClass'          # Defaults to 'User'
+Alchemy.current_user_method = 'current_admin_user'     # Defaults to 'current_user'
+Alchemy.signup_path         = '/your/signup/path'      # Defaults to '/signup'
+Alchemy.login_path          = '/your/login/path'       # Defaults to '/login'
+Alchemy.logout_path         = '/your/logout/path'      # Defaults to '/logout'
+Alchemy.logout_method       = 'http_verb_for_logout'   # Defaults to 'delete'
 ```
 
 The only thing Alchemy needs to know from your user class is the `alchemy_roles` method.

--- a/app/views/alchemy/_menubar.html.erb
+++ b/app/views/alchemy/_menubar.html.erb
@@ -4,7 +4,7 @@
       <li><%= link_to Alchemy.t(:to_alchemy), alchemy.admin_dashboard_url %></li>
       <li><%= link_to Alchemy.t(:edit_page), alchemy.edit_admin_page_url(@page) %></li>
       <li>
-        <%= form_tag Alchemy.logout_path, method: 'delete' do %>
+        <%= form_tag Alchemy.logout_path, method: Alchemy.logout_method do %>
           <%= button_tag Alchemy.t(:logout) %>
         <% end %>
       </li>

--- a/app/views/alchemy/admin/leave.html.erb
+++ b/app/views/alchemy/admin/leave.html.erb
@@ -5,7 +5,7 @@
   <label><%= Alchemy.t("Do you want to") %></label>
   <%= link_to Alchemy.t('stay logged in'), alchemy.root_path, class: 'button secondary' %>
 </p>
-<%= form_tag Alchemy.logout_path, method: 'delete', class: 'buttons' do %>
+<%= form_tag Alchemy.logout_path, method: Alchemy.logout_method, class: 'buttons' do %>
   <label><%= Alchemy.t('or to completely') %></label>
   <%= button_tag Alchemy.t(:logout), autofocus: true %>
 <% end %>

--- a/lib/alchemy/auth_accessors.rb
+++ b/lib/alchemy/auth_accessors.rb
@@ -9,6 +9,7 @@
 # +Alchemy.signup_path defaults to +'/signup'+
 # +Alchemy.login_path defaults to +'/login'+
 # +Alchemy.logout_path defaults to +'/logout'+
+# +Alchemy.logout_method defaults to +'delete'+
 #
 # Anyway, you can tell Alchemy about your authentication model configuration:
 #
@@ -18,6 +19,7 @@
 #   3. The path to the signup form - @see: Alchemy.signup_path
 #   4. The path to the login form - @see: Alchemy.login_path
 #   5. The path to the logout method - @see: Alchemy.logout_path
+#   6. The http verb for the logout method - @see: Alchemy.logout_method
 #
 # == Example
 #
@@ -27,6 +29,7 @@
 #     Alchemy.signup_path = '/auth/signup'
 #     Alchemy.login_path = '/auth/login'
 #     Alchemy.logout_path = '/auth/logout'
+#     Alchemy.logout_method = 'get'
 #
 # If you don't have your own user model or don't want to provide one,
 # add the `alchemy-devise` gem into your App's Gemfile.
@@ -42,7 +45,8 @@ module Alchemy
     :current_user_method,
     :signup_path,
     :login_path,
-    :logout_path
+    :logout_path,
+    :logout_method
 
   # Defaults
   #
@@ -51,6 +55,7 @@ module Alchemy
   @@signup_path = '/signup'
   @@login_path = '/login'
   @@logout_path = '/logout'
+  @@logout_method = 'delete'
 
   # Returns the user class
   #

--- a/spec/features/page_feature_spec.rb
+++ b/spec/features/page_feature_spec.rb
@@ -135,7 +135,11 @@ RSpec.describe 'Show page feature:', type: :system do
       it "a form and button to logout of alchemy" do
         within('#alchemy_menubar') do
           expect(page).to \
-            have_selector("li form[action='#{Alchemy.logout_path}'], li button[type='submit']")
+            have_selector("li form[action='#{Alchemy.logout_path}'][method='post']")
+          expect(page).to \
+            have_selector("li form[action='#{Alchemy.logout_path}'] > button[type='submit']")
+          expect(page).to \
+            have_selector("li form[action='#{Alchemy.logout_path}'] > input[type='hidden'][name='_method'][value='#{Alchemy.logout_method}']")
         end
       end
     end

--- a/spec/libraries/auth_accessors_spec.rb
+++ b/spec/libraries/auth_accessors_spec.rb
@@ -37,6 +37,10 @@ module Alchemy
       it 'has default value for Alchemy.logout_path' do
         expect(Alchemy.logout_path).to eq('/logout')
       end
+
+      it 'has default value for Alchemy.logout_method' do
+        expect(Alchemy.logout_method).to eq('delete')
+      end
     end
   end
 end


### PR DESCRIPTION
## What is this pull request for?

I added the possibility to edit the logout http verb. In solidus, for exampe, the logout method is GET and not DELETE.

Closes #1588 

### Notable changes (remove if none)

I think this should not break anything because I kept the default (`delete`).
