### PR TITLE
Adjust install generator to latest changes

### DIFF
--- a/lib/rails/generators/alchemy/install/files/_article.html.erb
+++ b/lib/rails/generators/alchemy/install/files/_article.html.erb
@@ -1,5 +1,5 @@
-<%- cache(element) do -%>
-  <%= element_view_for(element, tag: 'article') do |el| -%>
+<%- cache(article) do -%>
+  <%= element_view_for(article, tag: 'article') do |el| -%>
     <h2><%= el.render :headline %></h2>
     <%= el.render :picture, size: '1200x600' %>
     <%= el.render :text %>

--- a/lib/rails/generators/alchemy/install/files/_article_editor.html.erb
+++ b/lib/rails/generators/alchemy/install/files/_article_editor.html.erb
@@ -1,5 +1,0 @@
-<%= element_editor_for(element) do |el| -%>
-  <%= el.edit :headline %>
-  <%= el.edit :picture, crop: true, fixed_ratio: false %>
-  <%= el.edit :text %>
-<%- end -%>

--- a/lib/rails/generators/alchemy/install/install_generator.rb
+++ b/lib/rails/generators/alchemy/install/install_generator.rb
@@ -41,13 +41,7 @@ module Alchemy
           create_file "app/assets/stylesheets/application.css", "/*\n#{stylesheet_require} */\n"
         end
 
-        [
-          "_article_editor.html.erb",
-          "_article_view.html.erb"
-        ].each do |file|
-          copy_file file, "app/views/alchemy/elements/#{file}"
-        end
-
+        copy_file "_article.html.erb", "app/views/alchemy/elements/_article.html.erb"
         copy_file "_standard.html.erb", "app/views/alchemy/page_layouts/_standard.html.erb"
 
         %w(de en es).each do |locale|


### PR DESCRIPTION
Following the changes from #1648 and #1643 

The element editor partials are not necessary anymore and deprecated. As well as the element partial with a `view` suffix.
