### PR TITLE
Remove deprecated render element editor helpers

### DIFF
--- a/app/controllers/alchemy/messages_controller.rb
+++ b/app/controllers/alchemy/messages_controller.rb
@@ -34,15 +34,6 @@ module Alchemy
   #
   # Disabling the page caching is strongly recommended!
   #
-  # The editor view for your element should have this layout:
-  #
-  #   <%= element_editor_for(element) do |el| %>
-  #     <%= el.edit :mail_from %>
-  #     <%= el.edit :mail_to %>
-  #     <%= el.edit :subject %>
-  #     <%= el.edit :success_page %>
-  #   <% end %>
-  #
   # Please have a look at the +alchemy/config/config.yml+ file for further Message settings.
   #
   class MessagesController < Alchemy::BaseController

--- a/app/helpers/alchemy/admin/elements_helper.rb
+++ b/app/helpers/alchemy/admin/elements_helper.rb
@@ -3,75 +3,8 @@
 module Alchemy
   module Admin
     module ElementsHelper
-      include Alchemy::ElementsBlockHelper
-      include Alchemy::Admin::BaseHelper
       include Alchemy::Admin::ContentsHelper
       include Alchemy::Admin::EssencesHelper
-
-      # Renders a {Alchemy::Element} editor partial.
-      #
-      # A element editor partial is the form presented to the content author in page edit mode.
-      #
-      # The partial is located in <tt>app/views/alchemy/elements</tt>.
-      #
-      # == Partial naming
-      #
-      # The partials have to be named after the name of the element as defined in the <tt>elements.yml</tt> file and has to be suffixed with <tt>_editor</tt>.
-      #
-      # === Example
-      #
-      # Given a headline element
-      #
-      #   # elements.yml
-      #   - name: headline
-      #     contents:
-      #     - name: text
-      #       type: EssenceText
-      #
-      # Then your element editor partial has to be named:
-      #
-      #   app/views/alchemy/elements/_headline_editor.html.{erb|haml|slim}
-      #
-      # === Element partials generator
-      #
-      # You can use this handy generator to let Alchemy generate the partials for you:
-      #
-      #   $ rails generate alchemy:elements --skip
-      #
-      # == Usage
-      #
-      #   <%= render_editor(Alchemy::Element.published.named(:headline).first) %>
-      #
-      # @param [Alchemy::Element] element
-      #   The element you want to render the editor for
-      #
-      # @note If the partial is not found
-      #   <tt>alchemy/elements/_editor_not_found.html.erb</tt> gets rendered.
-      #
-      # @deprecated Using element editor partials is deprecated and will be removed in Alchemy 5.0
-      def render_editor(element)
-        if element.nil?
-          warning('Element is nil')
-          render "alchemy/elements/editor_not_found", {name: 'nil'}
-          return
-        end
-        Alchemy::Deprecation.warn <<~WARN
-          Using element editor partials is deprecated and will be removed in Alchemy 5.0.
-          You can delete the `app/views/alchemy/elements/_#{element.name}_editor` partial
-          and Alchemy will render the content editors for you.
-        WARN
-
-        render "alchemy/elements/#{element.name}_editor", element: element
-      rescue ActionView::MissingTemplate => e
-        warning(%(
-          Element editor partial not found for #{element.name}.\n
-          #{e}
-        ))
-        render "alchemy/elements/editor_not_found", {
-          name: element.name,
-          error: "Element editor partial not found.<br>Use <code>rails generate alchemy:elements</code> to generate it."
-        }
-      end
 
       # Returns an elements array for select helper.
       #

--- a/app/helpers/alchemy/elements_block_helper.rb
+++ b/app/helpers/alchemy/elements_block_helper.rb
@@ -62,15 +62,6 @@ module Alchemy
       end
     end
 
-    # Block-level helper class for element editors.
-    # @deprecated
-    class ElementEditorHelper < BlockHelper
-      def edit(name)
-        helpers.render_essence_editor_by_name(element, name.to_s)
-      end
-      deprecate :edit, deprecator: Alchemy::Deprecation
-    end
-
     # Block-level helper for element views. Constructs a DOM element wrapping
     # your content element and provides a block helper object you can use for
     # concise access to Alchemy's various helpers.
@@ -139,26 +130,6 @@ module Alchemy
 
       # that's it!
       output
-    end
-
-    # Block-level helper for element editors. Provides a block helper object
-    # you can use for concise access to Alchemy's various helpers.
-    #
-    # === Example:
-    #
-    #   <%= element_editor_for(element) do |el| %>
-    #     <%= el.edit :title %>
-    #     <%= el.edit :body %>
-    #     <%= el.edit :target_url %>
-    #   <% end %>
-    #
-    # @param [Alchemy::Element] element
-    #   The element to display.
-    #
-    def element_editor_for(element)
-      capture do
-        yield ElementEditorHelper.new(self, element: element) if block_given?
-      end
     end
   end
 end

--- a/app/views/alchemy/admin/elements/_element.html.erb
+++ b/app/views/alchemy/admin/elements/_element.html.erb
@@ -22,11 +22,7 @@
         <% element.definition[:warning].tap do |warning| %>
           <%= render_message(:warning, sanitize(warning)) if warning %>
         <% end %>
-        <% if lookup_context.exists?("#{element.name}_editor", ["alchemy/elements"], true) %>
-          <%= render_editor(element) %>
-        <% else %>
-          <%= render element.contents.map { |content| Alchemy::ContentEditor.new(content) } %>
-        <% end %>
+        <%= render element.contents.map { |content| Alchemy::ContentEditor.new(content) } %>
       </div>
 
       <% if element.taggable? %>

--- a/app/views/alchemy/elements/_editor_not_found.html.erb
+++ b/app/views/alchemy/elements/_editor_not_found.html.erb
@@ -1,4 +1,0 @@
-<%= render_message :warning do %>
-  <h2><%= Alchemy.t(:element_editor_not_found) %>:</h2>
-  <p><%== local_assigns[:error] %></p>
-<% end %>

--- a/spec/helpers/alchemy/admin/elements_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/elements_helper_spec.rb
@@ -4,40 +4,6 @@ require 'rails_helper'
 
 module Alchemy
   describe Admin::ElementsHelper do
-    let(:page)    { build_stubbed(:alchemy_page, :public) }
-    let(:element) { build_stubbed(:alchemy_element, page: page) }
-
-    describe "#render_editor" do
-      subject { render_editor(element) }
-
-      context 'with nil element' do
-        let(:element) { nil }
-
-        it { is_expected.to be_nil }
-      end
-
-      context 'with element record given' do
-        let(:element) do
-          create(:alchemy_element, :with_contents, name: 'headline')
-        end
-
-        it "renders the element's editor partial" do
-          element_editor_partial_name = "alchemy/elements/#{element.name}_editor"
-          expect(helper).to receive(:render).with(element_editor_partial_name, element: element) { '' }
-          subject
-        end
-
-        context 'with element editor partial not found' do
-          let(:element) { build_stubbed(:alchemy_element, name: 'not_present') }
-
-          it "renders the editor not found partial" do
-            is_expected.to have_selector('div.warning')
-            is_expected.to have_content('Element editor partial not found')
-          end
-        end
-      end
-    end
-
     describe "#elements_for_select" do
       context "passing element instances" do
         let(:element_objects) do

--- a/spec/helpers/alchemy/elements_block_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_block_helper_spec.rb
@@ -59,19 +59,6 @@ module Alchemy
       end
     end
 
-    describe '#element_editor_for' do
-      it "should yield an instance of ElementEditorHelper" do
-        expect { |b| element_editor_for(element, &b) }.
-          to yield_with_args(ElementsBlockHelper::ElementEditorHelper)
-      end
-
-      it "should not add any extra elements" do
-        expect(element_editor_for(element) do
-          'view'
-        end).to eq('view')
-      end
-    end
-
     describe 'ElementsBlockHelper::ElementViewHelper' do
       let(:scope) { double }
       subject { ElementsBlockHelper::ElementViewHelper.new(scope, element: element) }
@@ -123,22 +110,6 @@ module Alchemy
             and_return(mock_model('Content', essence: mock_model('EssenceText')))
 
           subject.essence :title
-        end
-      end
-    end
-
-    describe 'ElementsBlockHelper::ElementEditorHelper' do
-      let(:scope) { double }
-      subject { ElementsBlockHelper::ElementEditorHelper.new(scope, element: element) }
-
-      it 'should have a reference to the specified element' do
-        subject.element == element
-      end
-
-      describe '#edit' do
-        it "should delegate to the render_essence_editor_by_name helper" do
-          expect(scope).to receive(:render_essence_editor_by_name).with(element, "title")
-          subject.edit(:title)
         end
       end
     end


### PR DESCRIPTION
After deprecating Element editor partials in Alchemy 4.4 with #1643 we now remove them in Alchemy 5.0