### PR TITLE
Allow SimpleForm 5

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'request_store',                    ['~> 1.2']
   gem.add_runtime_dependency 'responders',                       ['>= 2.0', '< 4.0']
   gem.add_runtime_dependency 'select2-rails',                    ['>= 3.5.9.1', '< 4.0']
-  gem.add_runtime_dependency 'simple_form',                      ['~> 4.0']
+  gem.add_runtime_dependency 'simple_form',                      ['>= 4.0', '< 6']
   gem.add_runtime_dependency 'turbolinks',                       ['>= 2.5']
 
   gem.add_development_dependency 'capybara',                     ['~> 3.0']


### PR DESCRIPTION
## What is this pull request for?

Allows to use Simple Form 5.0 in 4.3 stable release

Closes #1659 

### Notable changes (remove if none)
- Allows to use Simple Form 5.0

Explain any changes (maybe breaking?) that have been made. 
- Simple Form 4.x has a security vulnerability and should be updated to 5.x, in consequence of dependency constraint an update is not possible.
