### PR TITLE
Run bundle install on CI even if cache hits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install bundler
         run: |
           gem install bundler
-      - name: Cache Ruby Gems
+      - name: Restore Ruby Gems cache
         id: cache
         uses: actions/cache@preview
         with:
@@ -52,7 +52,6 @@ jobs:
             ${{ runner.os }}-bundle-
       - name: Install bundle
         timeout-minutes: 10
-        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           bundle install --jobs 4 --retry 3 --path vendor/bundle
       - name: Prepare database


### PR DESCRIPTION
Bundler needs to know the bundle path otherwise it wont load any Gems from the cache.
