### PR TITLE
Build fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
   RSpec:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby:
           - '2.5.x'

--- a/spec/features/page_feature_spec.rb
+++ b/spec/features/page_feature_spec.rb
@@ -121,14 +121,14 @@ RSpec.describe 'Show page feature:', type: :system do
 
       it "a link to the admin area" do
         within('#alchemy_menubar') do
-          expect(page).to have_selector("li a[href='#{alchemy.admin_dashboard_url}']")
+          expect(page).to have_selector("li a[href='#{alchemy.admin_dashboard_url(host: Capybara.current_host)}']")
         end
       end
 
       it "a link to edit the current page" do
         within('#alchemy_menubar') do
           expect(page).to \
-            have_selector("li a[href='#{alchemy.edit_admin_page_url(public_page)}']")
+            have_selector("li a[href='#{alchemy.edit_admin_page_url(public_page, host: Capybara.current_host)}']")
         end
       end
 


### PR DESCRIPTION
Do not fail other build matrix steps if one fails and add a fix for capybara having another host than the rails test controller.