### PR TITLE
Eager load associated records

### DIFF
--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -107,13 +107,17 @@ module Alchemy
       def element_includes
         [
           {
-            contents: :essence
+            contents: {
+              essence: :ingredient_association
+            }
           },
           :tags,
           {
             all_nested_elements: [
               {
-                contents: :essence
+                contents: {
+                  essence: :ingredient_association
+                }
               },
               :tags
             ]

--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -8,8 +8,8 @@ module Alchemy
 
       def index
         @page = Page.find(params[:page_id])
-        @elements = @page.all_elements.not_nested.unfixed.not_trashed
-        @fixed_elements = @page.all_elements.fixed.not_trashed
+        @elements = @page.all_elements.not_nested.unfixed.not_trashed.includes(*element_includes)
+        @fixed_elements = @page.all_elements.fixed.not_trashed.includes(*element_includes)
       end
 
       def list
@@ -103,6 +103,23 @@ module Alchemy
       end
 
       private
+
+      def element_includes
+        [
+          {
+            contents: :essence
+          },
+          :tags,
+          {
+            all_nested_elements: [
+              {
+                contents: :essence
+              },
+              :tags
+            ]
+          }
+        ]
+      end
 
       def load_element
         @element = Element.find(params[:id])

--- a/app/controllers/alchemy/api/contents_controller.rb
+++ b/app/controllers/alchemy/api/contents_controller.rb
@@ -16,7 +16,7 @@ module Alchemy
       if params[:element_id].present?
         @contents = @contents.where(element_id: params[:element_id])
       end
-      @contents = @contents.includes(:essence)
+      @contents = @contents.includes(*content_includes)
 
       render json: @contents, adapter: :json, root: 'contents'
     end
@@ -37,10 +37,20 @@ module Alchemy
         @content = Content.where(
           element_id: params[:element_id],
           name: params[:name]
-        ).includes(:essence).first || raise(ActiveRecord::RecordNotFound)
+        ).includes(*content_includes).first || raise(ActiveRecord::RecordNotFound)
       end
       authorize! :show, @content
       respond_with @content
+    end
+
+    private
+
+    def content_includes
+      [
+        {
+          essence: :ingredient_association
+        }
+      ]
     end
   end
 end

--- a/app/controllers/alchemy/api/contents_controller.rb
+++ b/app/controllers/alchemy/api/contents_controller.rb
@@ -16,6 +16,8 @@ module Alchemy
       if params[:element_id].present?
         @contents = @contents.where(element_id: params[:element_id])
       end
+      @contents = @contents.includes(:essence)
+
       render json: @contents, adapter: :json, root: 'contents'
     end
 
@@ -30,9 +32,12 @@ module Alchemy
     #
     def show
       if params[:id]
-        @content = Content.find(params[:id])
+        @content = Content.where(id: params[:id]).includes(:essence).first
       elsif params[:element_id] && params[:name]
-        @content = Content.find_by!(element_id: params[:element_id], name: params[:name])
+        @content = Content.where(
+          element_id: params[:element_id],
+          name: params[:name]
+        ).includes(:essence).first || raise(ActiveRecord::RecordNotFound)
       end
       authorize! :show, @content
       respond_with @content

--- a/app/controllers/alchemy/api/elements_controller.rb
+++ b/app/controllers/alchemy/api/elements_controller.rb
@@ -20,15 +20,36 @@ module Alchemy
       if params[:named].present?
         @elements = @elements.named(params[:named])
       end
+      @elements = @elements.includes(*element_includes)
+
       render json: @elements, adapter: :json, root: 'elements'
     end
 
     # Returns a json object for element
     #
     def show
-      @element = Element.find(params[:id])
+      @element = Element.where(id: params[:id]).includes(*element_includes).first
       authorize! :show, @element
       respond_with @element
+    end
+
+    private
+
+    def element_includes
+      [
+        {
+          nested_elements: [
+            {
+              contents: :essence
+            },
+            :tags
+          ]
+        },
+        {
+          contents: :essence
+        },
+        :tags
+      ]
     end
   end
 end

--- a/app/controllers/alchemy/api/elements_controller.rb
+++ b/app/controllers/alchemy/api/elements_controller.rb
@@ -40,13 +40,17 @@ module Alchemy
         {
           nested_elements: [
             {
-              contents: :essence
+              contents: {
+                essence: :ingredient_association
+              }
             },
             :tags
           ]
         },
         {
-          contents: :essence
+          contents: {
+            essence: :ingredient_association
+          }
         },
         :tags
       ]

--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -108,13 +108,17 @@ module Alchemy
             {
               nested_elements: [
                 {
-                  contents: :essence
+                  contents: {
+                    essence: :ingredient_association
+                  }
                 },
                 :tags
               ]
             },
             {
-              contents: :essence
+              contents: {
+                essence: :ingredient_association
+              }
             },
             :tags
           ]

--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -61,12 +61,19 @@ module Alchemy
     private
 
     def load_page
-      @page = Page.find_by(id: params[:id]) ||
-              Language.current.pages.find_by(
-                urlname: params[:urlname],
-                language_code: params[:locale] || Language.current.code
-              ) ||
-              raise(ActiveRecord::RecordNotFound)
+      @page = load_page_by_id || load_page_by_urlname || raise(ActiveRecord::RecordNotFound)
+    end
+
+    def load_page_by_id
+      # The route param is called :urlname although it might be an integer
+      Page.where(id: params[:urlname]).includes(page_includes).first
+    end
+
+    def load_page_by_urlname
+      Language.current.pages.where(
+        urlname: params[:urlname],
+        language_code: params[:locale] || Language.current.code
+      ).includes(page_includes).first
     end
 
     def meta_data

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -77,7 +77,7 @@ module Alchemy
       dependent: :destroy,
       inverse_of: :parent_element
 
-    belongs_to :page, touch: true, inverse_of: :all_elements
+    belongs_to :page, touch: true, inverse_of: :elements
 
     # A nested element belongs to a parent element.
     belongs_to :parent_element,

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -219,7 +219,6 @@ module Alchemy
       return true if page.nil?
       unless touchable_pages.include? page
         touchable_pages << page
-        save
       end
     end
 

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -65,7 +65,7 @@ module Alchemy
     has_many :contents, -> { order(:position, :id) }, dependent: :destroy, inverse_of: :element
 
     has_many :all_nested_elements,
-      -> { order(:position) },
+      -> { order(:position).not_trashed },
       class_name: 'Alchemy::Element',
       foreign_key: :parent_element_id,
       dependent: :destroy
@@ -74,7 +74,8 @@ module Alchemy
       -> { order(:position).available },
       class_name: 'Alchemy::Element',
       foreign_key: :parent_element_id,
-      dependent: :destroy
+      dependent: :destroy,
+      inverse_of: :parent_element
 
     belongs_to :page, touch: true, inverse_of: :all_elements
 
@@ -82,7 +83,8 @@ module Alchemy
     belongs_to :parent_element,
       class_name: 'Alchemy::Element',
       optional: true,
-      touch: true
+      touch: true,
+      inverse_of: :nested_elements
 
     has_and_belongs_to_many :touchable_pages, -> { distinct },
       class_name: 'Alchemy::Page',

--- a/app/models/alchemy/element/element_contents.rb
+++ b/app/models/alchemy/element/element_contents.rb
@@ -16,13 +16,15 @@ module Alchemy
 
     # All contents from element by given name.
     def contents_by_name(name)
-      contents.where(name: name)
+      contents.select { |content| content.name == name.to_s }
     end
     alias_method :all_contents_by_name, :contents_by_name
 
     # All contents from element by given essence type.
     def contents_by_type(essence_type)
-      contents.where(essence_type: Content.normalize_essence_type(essence_type))
+      contents.select do |content|
+        content.essence_type == Content.normalize_essence_type(essence_type)
+      end
     end
     alias_method :all_contents_by_type, :contents_by_type
 
@@ -99,7 +101,7 @@ module Alchemy
         log_warning "Element #{name} is missing the content definition for #{content_name}"
         nil
       else
-        content_definitions.detect { |d| d['name'] == content_name }
+        content_definitions.detect { |d| d['name'] == content_name.to_s }
       end
     end
 
@@ -134,7 +136,7 @@ module Alchemy
     def content_for_rss_meta(type)
       definition = content_definitions.detect { |c| c["rss_#{type}"] }
       return if definition.blank?
-      contents.find_by(name: definition['name'])
+      contents.detect { |content| content.name == definition['name'] }
     end
 
     # creates the contents for this element as described in the elements.yml

--- a/app/models/alchemy/element/presenters.rb
+++ b/app/models/alchemy/element/presenters.rb
@@ -96,8 +96,8 @@ module Alchemy
     private
 
     def preview_text_from_nested_elements(maxlength)
-      return unless nested_elements.present?
-      nested_elements.first.preview_text(maxlength)
+      return if all_nested_elements.empty?
+      all_nested_elements.first.preview_text(maxlength)
     end
 
     def preview_text_from_preview_content(maxlength)

--- a/app/models/alchemy/essence_page.rb
+++ b/app/models/alchemy/essence_page.rb
@@ -6,10 +6,14 @@ module Alchemy
 
     acts_as_essence(
       ingredient_column: :page,
-      preview_text_method: :name
+      preview_text_method: :name,
+      belongs_to: {
+        class_name: 'Alchemy::Page',
+        foreign_key: :page_id,
+        inverse_of: :essence_pages,
+        optional: true
+      }
     )
-
-    belongs_to :page, class_name: 'Alchemy::Page', optional: true
 
     def ingredient=(page)
       case page

--- a/app/models/alchemy/essence_picture.rb
+++ b/app/models/alchemy/essence_picture.rb
@@ -25,9 +25,13 @@
 
 module Alchemy
   class EssencePicture < BaseRecord
-    acts_as_essence ingredient_column: 'picture'
+    acts_as_essence ingredient_column: :picture, belongs_to: {
+      class_name: 'Alchemy::Picture',
+      foreign_key: :picture_id,
+      inverse_of: :essence_pictures,
+      optional: true
+    }
 
-    belongs_to :picture, optional: true
     delegate :image_file_width, :image_file_height, :image_file, to: :picture
     before_save :fix_crop_values
     before_save :replace_newlines

--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -9,16 +9,20 @@ module Alchemy
 
       has_many :all_elements,
         -> { order(:position) },
-        class_name: 'Alchemy::Element'
+        class_name: 'Alchemy::Element',
+        inverse_of: :page
       has_many :elements,
         -> { order(:position).not_nested.unfixed.available },
-        class_name: 'Alchemy::Element'
+        class_name: 'Alchemy::Element',
+        inverse_of: :page
       has_many :trashed_elements,
         -> { Element.trashed.order(:position) },
-        class_name: 'Alchemy::Element'
+        class_name: 'Alchemy::Element',
+        inverse_of: :page
       has_many :fixed_elements,
         -> { order(:position).fixed.available },
-        class_name: 'Alchemy::Element'
+        class_name: 'Alchemy::Element',
+        inverse_of: :page
       has_many :contents, through: :elements
       has_and_belongs_to_many :to_be_swept_elements, -> { distinct },
         class_name: 'Alchemy::Element',

--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -30,7 +30,11 @@ module Alchemy
     include Alchemy::Picture::Transformations
     include Alchemy::Picture::Url
 
-    has_many :essence_pictures, class_name: 'Alchemy::EssencePicture', foreign_key: 'picture_id'
+    has_many :essence_pictures,
+      class_name: 'Alchemy::EssencePicture',
+      foreign_key: 'picture_id',
+      inverse_of: :ingredient_association
+
     has_many :contents, through: :essence_pictures
     has_many :elements, through: :contents
     has_many :pages, through: :elements

--- a/app/views/alchemy/admin/elements/_element.html.erb
+++ b/app/views/alchemy/admin/elements/_element.html.erb
@@ -54,7 +54,7 @@
               'droppable-elements' => element.nestable_elements.join(' ')
             } do %>
         <%= render partial: 'alchemy/admin/elements/element',
-           collection: element.all_nested_elements.not_trashed %>
+           collection: element.all_nested_elements %>
       <% end %>
 
       <% if element.expanded? || element.fixed? %>

--- a/lib/alchemy/essence.rb
+++ b/lib/alchemy/essence.rb
@@ -3,6 +3,18 @@
 require 'active_record'
 
 module Alchemy #:nodoc:
+  # A bogus association that skips eager loading for essences not having an ingredient association
+  class IngredientAssociation < ActiveRecord::Associations::BelongsToAssociation
+    # Skip eager loading if called by Rails' preloader
+    def klass
+      if caller.any? { |line| line =~ /preloader\.rb/ }
+        nil
+      else
+        super
+      end
+    end
+  end
+
   module Essence #:nodoc:
     def self.included(base)
       base.extend(ClassMethods)
@@ -30,6 +42,8 @@ module Alchemy #:nodoc:
         configuration = {
           ingredient_column: 'body'
         }.update(options)
+
+        @_classes_with_ingredient_association ||= []
 
         class_eval <<-RUBY, __FILE__, __LINE__ + 1
           attr_writer :validation_errors
@@ -66,7 +80,30 @@ module Alchemy #:nodoc:
             '#{configuration[:preview_text_column] || configuration[:ingredient_column]}'
           end
         RUBY
+
+        if configuration[:belongs_to]
+          class_eval <<-RUBY, __FILE__, __LINE__ + 1
+            belongs_to :ingredient_association, #{configuration[:belongs_to]}
+
+            alias_method :#{configuration[:ingredient_column]}, :ingredient_association
+            alias_method :#{configuration[:ingredient_column]}=, :ingredient_association=
+          RUBY
+
+          @_classes_with_ingredient_association << self
+        end
       end
+
+      # Overwrite ActiveRecords method to return a bogus association class that skips eager loading
+      # for essence classes that do not have an ingredient association
+      def _reflect_on_association(name)
+        if name == :ingredient_association && !in?(@_classes_with_ingredient_association)
+          OpenStruct.new(association_class: Alchemy::IngredientAssociation)
+        else
+          super
+        end
+      end
+
+      private
 
       # Register the current class as has_many association on +Alchemy::Page+ and +Alchemy::Element+ models
       def register_as_essence_association!
@@ -231,4 +268,5 @@ module Alchemy #:nodoc:
     end
   end
 end
-ActiveRecord::Base.class_eval { include Alchemy::Essence } if defined?(Alchemy::Essence)
+
+ActiveRecord::Base.include(Alchemy::Essence)

--- a/lib/alchemy/test_support/essence_shared_examples.rb
+++ b/lib/alchemy/test_support/essence_shared_examples.rb
@@ -10,6 +10,18 @@ RSpec.shared_examples_for "an essence" do
   let(:content) { Alchemy::Content.new(name: 'foo') }
   let(:content_definition) { {'name' => 'foo'} }
 
+  describe 'eager loading' do
+    before do
+      2.times { described_class.create! }
+    end
+
+    it 'does not throw error if eager loaded' do
+      expect {
+        described_class.all.includes(:ingredient_association).to_a
+      }.to_not raise_error
+    end
+  end
+
   it "touches the content after update" do
     element = FactoryBot.create(:alchemy_element)
     content = FactoryBot.create(:alchemy_content, element: element, essence: essence, essence_type: essence.class.name)

--- a/spec/controllers/alchemy/api/contents_controller_spec.rb
+++ b/spec/controllers/alchemy/api/contents_controller_spec.rb
@@ -80,10 +80,6 @@ module Alchemy
         let(:element) { create(:alchemy_element, page: page) }
         let(:content) { create(:alchemy_content, element: element) }
 
-        before do
-          expect(Content).to receive(:find).and_return(content)
-        end
-
         it "returns content as json" do
           get :show, params: {id: content.id, format: :json}
 

--- a/spec/controllers/alchemy/api/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/api/elements_controller_spec.rb
@@ -109,12 +109,8 @@ module Alchemy
     end
 
     describe '#show' do
-      let(:page)    { build_stubbed(:alchemy_page) }
-      let(:element) { build_stubbed(:alchemy_element, page: page, position: 1) }
-
-      before do
-        expect(Element).to receive(:find).and_return(element)
-      end
+      let(:page)    { create(:alchemy_page) }
+      let(:element) { create(:alchemy_element, page: page, position: 1) }
 
       it "returns element as json" do
         get :show, params: {id: element.id, format: :json}
@@ -128,7 +124,7 @@ module Alchemy
       end
 
       context 'requesting an restricted element' do
-        let(:page) { build_stubbed(:alchemy_page, restricted: true) }
+        let(:page) { create(:alchemy_page, restricted: true) }
 
         it "responds with 403" do
           get :show, params: {id: element.id, format: :json}

--- a/spec/controllers/alchemy/api/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/api/pages_controller_spec.rb
@@ -193,11 +193,7 @@ module Alchemy
 
     describe '#show' do
       context 'for existing page' do
-        let(:page) { build_stubbed(:alchemy_page, :public, urlname: 'a-page') }
-
-        before do
-          expect(Page).to receive(:find_by).and_return(page)
-        end
+        let(:page) { create(:alchemy_page, :public, urlname: 'a-page') }
 
         it "returns page as json" do
           get :show, params: {urlname: page.urlname, format: :json}
@@ -211,7 +207,7 @@ module Alchemy
         end
 
         context 'requesting an restricted page' do
-          let(:page) { build_stubbed(:alchemy_page, restricted: true, urlname: 'a-page') }
+          let(:page) { create(:alchemy_page, restricted: true, urlname: 'a-page') }
 
           it "responds with 403" do
             get :show, params: {urlname: page.urlname, format: :json}
@@ -227,7 +223,7 @@ module Alchemy
         end
 
         context 'requesting a not public page' do
-          let(:page) { build_stubbed(:alchemy_page, urlname: 'a-page') }
+          let(:page) { create(:alchemy_page, urlname: 'a-page') }
 
           it "responds with 403" do
             get :show, params: {urlname: page.urlname, format: :json}
@@ -270,7 +266,7 @@ module Alchemy
         let(:page) { create(:alchemy_page, :public) }
 
         it "responds with json" do
-          get :show, params: {id: page.id, format: :json}
+          get :show, params: {urlname: page.id, format: :json}
 
           expect(response.status).to eq(200)
           expect(response.media_type).to eq('application/json')

--- a/spec/dummy/config/initializers/active_record_query_trace.rb
+++ b/spec/dummy/config/initializers/active_record_query_trace.rb
@@ -4,7 +4,7 @@ if Rails.env.development?
   ActiveRecordQueryTrace.level = :custom
   ActiveRecordQueryTrace.backtrace_cleaner = ->(trace) do
     trace.reject do |line|
-      line =~ /\b(active_record_query_trace|active_support|active_record|rack-mini-profiler)\b/
+      line =~ /\b(active_record_query_trace|active_support|action_view|active_record|rack-mini-profiler)\b/
     end
   end
 end

--- a/spec/libraries/elements_finder_spec.rb
+++ b/spec/libraries/elements_finder_spec.rb
@@ -157,12 +157,16 @@ RSpec.describe Alchemy::ElementsFinder do
       let!(:visible_element) { create(:alchemy_element, public: true, page: page) }
       let!(:hidden_element) { create(:alchemy_element, public: false, page: page) }
 
-      let(:page_2) { create(:alchemy_page, :public, page_layout: 'standard') }
-      let!(:visible_element_2) { create(:alchemy_element, public: true, page: page_2) }
-      let!(:hidden_element_2) { create(:alchemy_element, public: false, page: page_2) }
+      it 'returns all public elements from page with given page layout' do
+        is_expected.to eq([visible_element])
+      end
 
-      it 'returns all public elements from all pages with given page layout' do
-        is_expected.to eq([visible_element, visible_element_2])
+      context 'that is not found' do
+        subject { finder.elements(page: 'foobaz') }
+
+        it 'returns empty active record relation' do
+          is_expected.to eq(Alchemy::Element.none)
+        end
       end
     end
 

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -538,7 +538,7 @@ module Alchemy
 
         before do
           allow(nested_element).to receive(:contents) { [content_2] }
-          allow(element).to receive(:nested_elements) { [nested_element] }
+          allow(element).to receive(:all_nested_elements) { [nested_element] }
         end
 
         context 'when parent element has contents' do
@@ -914,8 +914,8 @@ module Alchemy
           create(:alchemy_element, parent_element: element, page: page).tap(&:trash!)
         end
 
-        it 'includes them' do
-          expect(subject).to include(trashed_nested_element)
+        it 'does not include them' do
+          expect(subject).to_not include(trashed_nested_element)
         end
       end
     end

--- a/spec/models/alchemy/essence_page_spec.rb
+++ b/spec/models/alchemy/essence_page_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe Alchemy::EssencePage, type: :model do
     let(:ingredient_value) { page }
   end
 
+  describe 'eager loading' do
+    let!(:essence_pages) { create_list(:alchemy_essence_page, 2) }
+
+    it 'eager loads pages' do
+      essences = described_class.all.includes(:ingredient_association)
+      expect(essences[0].association(:ingredient_association)).to be_loaded
+    end
+  end
+
   describe 'ingredient=' do
     subject(:ingredient) { essence.page }
 

--- a/spec/models/alchemy/essence_picture_spec.rb
+++ b/spec/models/alchemy/essence_picture_spec.rb
@@ -9,6 +9,15 @@ module Alchemy
       let(:ingredient_value) { Picture.new }
     end
 
+    describe 'eager loading' do
+      let!(:essence_pictures) { create_list(:alchemy_essence_picture, 2) }
+
+      it 'eager loads pictures' do
+        essences = described_class.all.includes(:ingredient_association)
+        expect(essences[0].association(:ingredient_association)).to be_loaded
+      end
+    end
+
     it_behaves_like "has image transformations" do
       let(:picture) { build_stubbed(:alchemy_essence_picture) }
     end

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -842,13 +842,13 @@ module Alchemy
     end
 
     describe '#available_elements_within_current_scope' do
-      let(:page) { build_stubbed(:alchemy_page, page_layout: 'columns') }
+      let(:page) { create(:alchemy_page, page_layout: 'columns') }
       let(:nestable_element) { create(:alchemy_element, :with_nestable_elements) }
       let(:currently_available_elements) { page.available_elements_within_current_scope(nestable_element) }
 
       context "When unique element is already nested" do
         before do
-          nestable_element.nested_elements << create(:alchemy_element, name: 'slide', unique: true)
+          nestable_element.nested_elements << create(:alchemy_element, name: 'slide', unique: true, page: page)
           page.elements << nestable_element
         end
 


### PR DESCRIPTION
## What is this pull request for?

In several places we now take advantage of Rails eager loading by setting `includes` while loading elements and `inverse_of`s on associations, so Active Record knows how to reverse-lookup an object.

This dramatically reduces the number of database hits and removes a lot of N+1 especially in the pages and elements API.

This explicitly does not eager load contents and its essence during loading elements from the page in the non-api HTML requests. Why? We cache element views and if we would eager load elements contents and essences we would do this even if we don't need to. This reduces the number of db queries for cached pages, but still produces N+1 for non-cached elements. I think this is a good compromise for the most common case.

### Notable changes

In the elements finder I removed the "feature" of loading elements from multiple pages with the same page layout name at once. I doubt this "feature" is actually used by anyone.
