### PR TITLE
Add anchor link tab to link overlay

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.link_dialog.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.link_dialog.js.coffee
@@ -20,12 +20,12 @@ class window.Alchemy.LinkDialog extends Alchemy.Dialog
     # Store some jQuery objects for further reference
     @$page_anchor = $('#page_anchor', @dialog_body)
     @$internal_urlname = $('#internal_urlname', @dialog_body)
-    @$internal_anchor = $('#internal_anchor', @dialog_body)
+    @$anchor_link = $('#anchor_link', @dialog_body)
     @$external_url = $('#external_url', @dialog_body)
     @$public_filename = $('#public_filename', @dialog_body)
     @$overlay_tabs = $('#overlay_tabs', @dialog_body)
     @$page_container = $('#page_selector_container')
-    @initInternalAnchors()
+    @initAnchorLinks()
     # if we edit an existing link
     if @link_object
       # we select the correct tab
@@ -42,6 +42,8 @@ class window.Alchemy.LinkDialog extends Alchemy.Dialog
           url = @$external_url.val()
         when 'file'
           url = @$public_filename.val()
+        when 'anchor'
+          url = @$anchor_link.val()
         else
           url = $("##{@link_type}_urlname").val()
       # Create the link
@@ -70,14 +72,12 @@ class window.Alchemy.LinkDialog extends Alchemy.Dialog
         @$internal_urlname.val('/' + url)
       false
     # Select the current page in the tree
-    @selectInternalLinkTab()
+    @initInternalLinkTab()
 
   # Sets the page selected and scrolls it in the viewport.
   selectPage: (page_id) ->
     # deselect any selected page from page tree
     @deselectPage()
-    # reset the internal anchor select
-    @$internal_anchor.select2('val', '')
     $('#sitemap_sitename_' + page_id).addClass('selected_page')
     @$page_container.scrollTo("#sitemap_sitename_#{page_id}", {duration: 400, offset: -10})
 
@@ -149,6 +149,10 @@ class window.Alchemy.LinkDialog extends Alchemy.Dialog
       # Handles a file link.
       tab = $('#overlay_tab_file_link')
       @$public_filename.select2('val', @$link[0].pathname + @$link[0].search)
+    else if @$link.attr('href').match(/^#/)
+      # Handles an anchor link.
+      tab = $('#overlay_tab_anchor_link')
+      @$anchor_link.select2('val', @$link.attr('href'))
     else
       # Handles an internal link.
       tab = $('#overlay_tab_internal_link')
@@ -156,7 +160,7 @@ class window.Alchemy.LinkDialog extends Alchemy.Dialog
     @$overlay_tabs.tabs('option', 'active', $('#overlay_tabs > div').index(tab))
 
   # Handles actions for internal link tab.
-  selectInternalLinkTab: ->
+  initInternalLinkTab: ->
     return unless @$link
     url = @$link.attr('href').split('#')
     urlname = url[0]
@@ -166,11 +170,6 @@ class window.Alchemy.LinkDialog extends Alchemy.Dialog
       @$page_anchor.val("##{anchor}")
       # and update the url field
       @$internal_urlname.val("#{urlname}##{anchor}")
-      # if we linked an internal anchor
-      if @$internal_urlname.val().match(/^#/)
-        # we select the correct value from anchors select
-        value = @$internal_urlname.val()
-        @$internal_anchor.select2 'val', value.replace(/^#/, '')
     else
       @$internal_urlname.val(urlname)
     $sitemap_line = $('.sitemap_sitename').closest('[name="'+urlname+'"]')
@@ -225,20 +224,16 @@ class window.Alchemy.LinkDialog extends Alchemy.Dialog
     $('#errors', @dialog_body).show()
 
   # Populates the internal anchors select
-  initInternalAnchors: ->
+  initAnchorLinks: ->
     frame = document.getElementById('alchemy_preview_window')
     elements = frame.contentDocument.getElementsByTagName('*')
     if elements.length > 0
       for element in elements
         if element.id
-          @$internal_anchor.append("<option value='#{element.id}'>##{element.id}</option>")
+          @$anchor_link.append("<option value='##{element.id}'>##{element.id}</option>")
     else
-      @$internal_anchor.html("<option>#{Alchemy.t('No anchors found')}</option>")
-    @$internal_anchor.change (e) =>
-      # deselect any selected page from page tree
-      @deselectPage()
-      # store the internal anchor as urlname
-      $("#internal_urlname").val("##{e.target.value}")
+      @$anchor_link.html("<option>#{Alchemy.t('No anchors found')}</option>")
+    return
 
   # Public class methods
 

--- a/app/views/alchemy/admin/pages/_anchor_link.html.erb
+++ b/app/views/alchemy/admin/pages/_anchor_link.html.erb
@@ -1,0 +1,22 @@
+<%= form_tag do %>
+  <%= render_message do %>
+    <p><%= Alchemy.t(:anchor_link_headline) %></p>
+  <% end %>
+  <div class="input select">
+    <label for="anchor_link" class="control-label">
+      <%= Alchemy.t(:anchor) %>
+    </label>
+    <%= select_tag(:anchor_link,
+      options_for_select([[Alchemy.t('Please choose'), '']]),
+      class: 'alchemy_selectbox') %>
+  </div>
+  <div class="input text">
+    <label for="anchor_link_title" class="control-label">
+      <%= Alchemy.t(:link_title) %>
+    </label>
+    <%= text_field_tag "anchor_link_title", '', class: 'link_title' %>
+  </div>
+  <div class="submit">
+    <%= link_to Alchemy.t(:apply), '', class: 'create-link button', 'data-link-type' => 'anchor' %>
+  </div>
+<% end %>

--- a/app/views/alchemy/admin/pages/_internal_link.html.erb
+++ b/app/views/alchemy/admin/pages/_internal_link.html.erb
@@ -2,20 +2,11 @@
   <%= render_message do %>
     <h3><%= Alchemy.t(:internal_link_headline) %></h3>
     <p><%= Alchemy.t(:internal_link_page_elements_explanation) %></p>
-    <p><%= Alchemy.t(:internal_link_page_anchors_explanation) %></p>
   <% end %>
   <div id="page_selector_container">
     <% if @page_root %>
       <%= render 'sitemap', page_partial: 'page_for_links', full: true %>
     <% end %>
-  </div>
-  <div class="input select">
-    <label for="internal_anchor" class="control-label">
-      <%= Alchemy.t(:anchor) %>
-    </label>
-    <%= select_tag(:internal_anchor,
-      options_for_select([[Alchemy.t('Please choose'), '']]),
-      class: 'alchemy_selectbox') %>
   </div>
   <div class="input text">
     <label for="internal_link_title" class="control-label">

--- a/app/views/alchemy/admin/pages/link.html.erb
+++ b/app/views/alchemy/admin/pages/link.html.erb
@@ -1,11 +1,15 @@
 <div id="overlay_tabs">
   <ul>
     <li><a href="#overlay_tab_internal_link"><%= Alchemy.t('link_overlay_tab_label.internal') %></a></li>
+    <li><a href="#overlay_tab_anchor_link"><%= Alchemy.t('link_overlay_tab_label.anchor') %></a></li>
     <li><a href="#overlay_tab_external_link"><%= Alchemy.t('link_overlay_tab_label.external') %></a></li>
     <li><a href="#overlay_tab_file_link"><%= Alchemy.t('link_overlay_tab_label.file') %></a></li>
   </ul>
   <div id="overlay_tab_internal_link">
     <%= render partial: 'internal_link' %>
+  </div>
+  <div id="overlay_tab_anchor_link">
+    <%= render partial: 'anchor_link' %>
   </div>
   <div id="overlay_tab_external_link">
     <%= render partial: 'external_link' %>

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -159,6 +159,7 @@ en:
 
     add_nested_element: "Add %{name}"
     anchor: 'Anchor'
+    anchor_link_headline: "You can link to an element anchor from the actual page."
     attribute_fixed: Value can't be changed for this page type
     back: 'back'
     create_tree_as_new_language: "Create %{language} as a new language tree"
@@ -401,7 +402,6 @@ en:
     image_title: "Title-tag"
     internal_link_headline: "Choose a page to link to."
     internal_link_page_elements_explanation: "Additionally you can click right beside a page on 'Show Elements' to link to an anchor of an element from that page."
-    internal_link_page_anchors_explanation: "Alternatively you can link to an anchor of the actual page."
     "item copied to clipboard": "Copied %{name} to clipboard"
     "item moved to clipboard": "Moved %{name} to clipboard"
     "item removed from clipboard": "Removed %{name} from clipboard"
@@ -415,6 +415,7 @@ en:
     legacy_url_info_text: "A link is a redirect from an old URL to the current URL of this page. This redirect happens with a <a href='https://support.google.com/webmasters/answer/93633' target='_blank'>301 status code</a>."
     link_image: "Link this image."
     link_overlay_tab_label:
+      anchor: "Anchor"
       contactform: "Contact form"
       external: "External"
       file: "File"


### PR DESCRIPTION
## What is this pull request for?

Adds a dedicated "Anchor" link tab to the link overlay

### Notable changes (remove if none)

Instead of having complicated code that handles anchor links for current
page we add a dedicated Anchor link tab for this feature.

### Screenshots

![Screen Shot 2019-11-25 at 12 10 30](https://user-images.githubusercontent.com/42868/69535666-b4172b00-0f7c-11ea-87c8-9c77f8e78909.png)
