### PR TITLE
Destroy page-dependent elements

### DIFF
--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -23,6 +23,10 @@ module Alchemy
         -> { order(:position).fixed.available },
         class_name: 'Alchemy::Element',
         inverse_of: :page
+      has_many :dependent_destroyable_elements,
+        -> { not_nested },
+        class_name: 'Alchemy::Element',
+        dependent: :destroy
       has_many :contents, through: :elements
       has_and_belongs_to_many :to_be_swept_elements, -> { distinct },
         class_name: 'Alchemy::Element',

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -338,6 +338,14 @@ module Alchemy
           expect(news_page.elements.pluck(:name)).to include('contactform')
         end
       end
+
+      context 'destruction' do
+        let!(:page) { create(:alchemy_page, autogenerate_elements: true) }
+
+        it 'destroys elements along with itself' do
+          expect { page.destroy! }.to change(Alchemy::Element, :count).from(3).to(0)
+        end
+      end
     end
 
     # ClassMethods (a-z)


### PR DESCRIPTION
## What is this pull request for?

When I delete a page, I do expect its elements to be gone afterwards,
too.

### Notable changes (remove if none)

When deleting pages, all elements with that page will now be deleted, too - even on databases with foreign keys turned off. Also, all Essences related to the page will be deleted. Prior to this commit, this wouldn't work because polymorphic associations cannot take care of their referential integrity like normal associations. 
