### PR TITLE
Do not consider nested elements "orphaned"

### DIFF
--- a/lib/alchemy/tasks/tidy.rb
+++ b/lib/alchemy/tasks/tidy.rb
@@ -45,7 +45,7 @@ module Alchemy
 
       def remove_orphaned_elements
         puts "\n## Removing orphaned elements"
-        elements = Alchemy::Element.unscoped.all
+        elements = Alchemy::Element.unscoped.not_nested
         if elements.any?
           orphaned_elements = elements.select do |element|
             element.page.nil? && element.page_id.present?


### PR DESCRIPTION
When removing orphaned nested elements, the parent element will be
deleted first (as it has probably been created first, and the ID will be
lower). As part of the callbacks associated with that, the `dependent:
:destroy` will destroy all child elements. Running `#destroy` on one of
the nested elements inside the parent element will result in an error,
and the user having to re-start the tidy task.

This commit only selects parent elements to be considered "orphaned" so
this does not happen.
