### PR TITLE
Use a Sprockets 3/4 manifest file

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'responders',                       ['>= 2.0', '< 4.0']
   gem.add_runtime_dependency 'select2-rails',                    ['>= 3.5.9.1', '< 4.0']
   gem.add_runtime_dependency 'simple_form',                      ['>= 4.0', '< 6']
+  gem.add_runtime_dependency 'sprockets',                        ['>= 3.0', '< 5']
   gem.add_runtime_dependency 'turbolinks',                       ['>= 2.5']
 
   gem.add_development_dependency 'capybara',                     ['~> 3.0']

--- a/app/assets/config/alchemy_manifest.js
+++ b/app/assets/config/alchemy_manifest.js
@@ -1,0 +1,15 @@
+//= link alchemy/admin/all.css
+//= link alchemy/admin/all.js
+//= link alchemy/preview.js
+//= link alchemy/menubar.css
+//= link alchemy/menubar.js
+//= link alchemy/print.css
+//= link alchemy/welcome.css
+//= link tinymce/plugins/alchemy_link/plugin.min.js
+//= link tinymce/tinymce.min.js
+//= link_directory ../stylesheets/tinymce/skins/alchemy/ .css
+//= link_directory ../stylesheets/tinymce/skins/alchemy/img/
+//= link_directory ../stylesheets/tinymce/skins/alchemy/fonts/
+//= link_tree ../images/alchemy/
+//= link_tree ../../../vendor/assets/fonts/
+//= link_tree ../../../vendor/assets/images/

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,14 +1,2 @@
 # Add Alchemy assets for precompiling
-Rails.application.config.assets.precompile += [
-  'alchemy/admin/all.css',
-  'alchemy/admin/all.js',
-  'alchemy/alchemy-logo.svg',
-  'alchemy/favicon.ico',
-  'alchemy/preview.js',
-  'alchemy/menubar.css',
-  'alchemy/menubar.js',
-  'alchemy/print.css',
-  'alchemy/welcome.css',
-  'Jcrop.gif',
-  'tinymce/*'
-]
+Rails.application.config.assets.precompile << 'alchemy_manifest.js'


### PR DESCRIPTION
## What is this pull request for?

Instead of using the Rails.config.assets array to define assets
files we need to precompile as individual files we use the Sprockets
3 recommended manifest file.

### Notable changes

No changes to apps. Just internally changes how we define asset entry files.
