### PR TITLE
Update note about missing user class

### DIFF
--- a/lib/alchemy/auth_accessors.rb
+++ b/lib/alchemy/auth_accessors.rb
@@ -85,7 +85,8 @@ module Alchemy
         Please add a user class and tell Alchemy about it or, if you don't want
         to create your own class, add the `alchemy-devise` gem to your Gemfile.
 
-        gem 'alchemy-devise', '~> 2.1.0'
+            bundle add alchemy-devise
+
       MSG
     else
       raise e


### PR DESCRIPTION
When Alchemy cannot find a user class it prints a warning message
to inform the user what to do.

The version mentioned of the alchemy-devise gem was very old.
