### PR TITLE
Do not raise if user class is missing

### DIFF
--- a/lib/alchemy/auth_accessors.rb
+++ b/lib/alchemy/auth_accessors.rb
@@ -78,7 +78,7 @@ module Alchemy
     end
   rescue NameError => e
     if e.message =~ /#{Regexp.escape(@@user_class_name)}/
-      abort <<-MSG.strip_heredoc
+      Rails.logger.warn <<-MSG.strip_heredoc
 
         AlchemyCMS cannot find any user class!
 
@@ -88,6 +88,7 @@ module Alchemy
             bundle add alchemy-devise
 
       MSG
+      nil
     else
       raise e
     end

--- a/lib/alchemy/userstamp.rb
+++ b/lib/alchemy/userstamp.rb
@@ -4,7 +4,7 @@
 #
 # It only adds it, if the user model is a active_record model.
 #
-if Alchemy.user_class < ActiveRecord::Base
+if Alchemy.user_class && Alchemy.user_class < ActiveRecord::Base
   Alchemy.user_class.class_eval do
     model_stamper
     stampable stamper_class_name: Alchemy.user_class_name


### PR DESCRIPTION
Currently we cannot boot a Rails app with `alchemy_cms` in the `Gemfile` if a `Alchemy.user_class_name` has not been set.

Instead we log to warning now.

Refs https://github.com/AlchemyCMS/alchemy-solidus/issues/54