### PR TITLE
Validate nodes name if page is absent

### DIFF
--- a/app/models/alchemy/node.rb
+++ b/app/models/alchemy/node.rb
@@ -10,6 +10,7 @@ module Alchemy
     belongs_to :language, class_name: 'Alchemy::Language'
     belongs_to :page, class_name: 'Alchemy::Page', optional: true, inverse_of: :nodes
 
+    validates :name, presence: true, if: -> { page.nil? }
     validates :url, format: { with: VALID_URL_REGEX }, unless: -> { url.nil? }
 
     # Returns the name

--- a/lib/alchemy/test_support/factories/node_factory.rb
+++ b/lib/alchemy/test_support/factories/node_factory.rb
@@ -7,13 +7,11 @@ require 'alchemy/test_support/factories/page_factory'
 FactoryBot.define do
   factory :alchemy_node, class: 'Alchemy::Node' do
     language { Alchemy::Language.default }
-
-    trait :with_name do
-      name { 'A Node' }
-    end
+    name { 'A Node' }
 
     trait :with_page do
       association :page, factory: :alchemy_page
+      name { nil }
     end
 
     trait :with_url do

--- a/spec/models/alchemy/node_spec.rb
+++ b/spec/models/alchemy/node_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 module Alchemy
   describe Node do
-    it "is only valid with language given" do
+    it "is only valid with language and name given" do
       expect(Node.new).to be_invalid
       expect(build(:alchemy_node)).to be_valid
     end
@@ -97,14 +97,6 @@ module Alchemy
 
         it "returns the name from name attribute" do
           expect(node.name).to eq('Google')
-        end
-
-        context 'and without name set' do
-          let(:node) { build_stubbed(:alchemy_node) }
-
-          it do
-            expect(node.name).to be_nil
-          end
         end
       end
     end


### PR DESCRIPTION
If we do not have a page attached to a menu node we must have a name set.
