### PR TITLE
Remove custom JS logging

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.base.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.base.js.coffee
@@ -76,12 +76,6 @@ $.extend Alchemy,
       dropdownAutoWidth: true
     return
 
-  # Logs errors to js console, if present.
-  log_error: (e) ->
-    if window["console"]
-      console.error e
-    return
-
   getUrlParam: (name) ->
     results = new RegExp("[\\?&]" + name + "=([^&#]*)").exec(window.location.href)
     results[1] or 0  if results

--- a/app/assets/javascripts/alchemy/alchemy.base.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.base.js.coffee
@@ -76,12 +76,6 @@ $.extend Alchemy,
       dropdownAutoWidth: true
     return
 
-  # Logs exception to js console, if present.
-  debug: (e) ->
-    if window["console"]
-      console.warn(e)
-    return
-
   # Logs errors to js console, if present.
   log_error: (e) ->
     if window["console"]

--- a/app/assets/javascripts/alchemy/alchemy.i18n.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.i18n.js.coffee
@@ -23,7 +23,7 @@ Alchemy.I18n =
       else
         translation
     else
-      Alchemy.debug "Translations for locale #{Alchemy.locale} not found!"
+      console.warn "Translations for locale #{Alchemy.locale} not found!"
       key
 
 # Global utility method for translating a given string

--- a/app/assets/javascripts/alchemy/alchemy.sitemap.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.sitemap.js.coffee
@@ -55,7 +55,7 @@ Alchemy.Sitemap =
         self.options.ready()
 
     request.fail (jqXHR, status) ->
-      Alchemy.debug("Request failed: " + status)
+      console.warn("Request failed: " + status)
 
   # Filters the sitemap
   filter: (term) ->

--- a/app/assets/javascripts/alchemy/alchemy.tinymce.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.tinymce.js.coffee
@@ -59,7 +59,7 @@ $.extend Alchemy.Tinymce,
       textarea.closest('.tinymce_container').prepend spinner.spin().el
       tinymce.init(config)
     else
-      Alchemy.debug('No tinymce configuration found for', id)
+      console.warn('No tinymce configuration found for', id)
 
   # Gets called after an editor instance gets intialized
   #

--- a/app/assets/javascripts/alchemy/alchemy.tinymce.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.tinymce.js.coffee
@@ -51,7 +51,7 @@ $.extend Alchemy.Tinymce,
     # remove editor instance, if already initialized
     editor.remove() if editor
     if textarea.length == 0
-      Alchemy.log_error "Could not initialize TinyMCE for textarea#tinymce_#{id}!"
+      console.warn "Could not initialize TinyMCE for textarea#tinymce_#{id}!"
       return
     config = @getConfig(id, textarea[0].classList[1])
     if config


### PR DESCRIPTION
## What is this pull request for?

Removes `Alchemy.debug` and `Alchemy.log_error` and replaces calls with `console.warn`.
