### PR TITLE
Fix a deprecation warning for Rails 6.1

### DIFF
--- a/app/models/alchemy/language.rb
+++ b/app/models/alchemy/language.rb
@@ -86,7 +86,7 @@ module Alchemy
 
       # Default language for current site
       def default
-        on_current_site.find_by(default: true)
+        unscoped.on_current_site.find_by(default: true)
       end
     end
 


### PR DESCRIPTION
## What is this pull request for?

When you run Specs with Rails 6.0.2 at the moment, you get a deprecation warning with regards to class level method definition of `on_current_site` .

```
DEPRECATION WARNING: Class level methods will no longer inherit scoping from `on_current_site` in Rails 6.1. To continue using the scoped relation, pass it into the block directly. To instead access the full set of models, as Rails 6.1 will, use `Alchemy::Language.unscoped`, or `Alchemy::Language.default_scoped` if a model has default scopes. (called from create_default_language! at /Users/saurabhbhatia/.rvm/gems/ruby-2.5.7/bundler/gems/alchemy_cms-d5d3b52c70cb/app/models/alchemy/site.rb:104)
DEPRECATION WARNING: Class level methods will no longer inherit scoping from `on_current_site` in Rails 6.1. To continue using the scoped relation, pass it into the block directly. To instead access the full set of models, as Rails 6.1 will, use `Alchemy::Language.unscoped`, or `Alchemy::Language.default_scoped` if a model has default scopes. (called from default at /Users/saurabhbhatia/.rvm/gems/ruby-2.5.7/bundler/gems/alchemy_cms-d5d3b52c70cb/app/models/alchemy/language.rb:81)
```

### Notable changes

Used `unscoped` when we make a call to `on_current_site` in Languages model.
