### PR TITLE
Use contents settings for size in EssencePicture#picture_url

### DIFF
--- a/app/models/alchemy/essence_picture.rb
+++ b/app/models/alchemy/essence_picture.rb
@@ -79,7 +79,8 @@ module Alchemy
       {
         format: picture.default_render_format,
         crop_from: crop_from.presence,
-        crop_size: crop_size.presence
+        crop_size: crop_size.presence,
+        size: content.settings[:size]
       }.with_indifferent_access
     end
 

--- a/lib/alchemy/test_support/factories/essence_picture_factory.rb
+++ b/lib/alchemy/test_support/factories/essence_picture_factory.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
 require 'factory_bot'
+require 'alchemy/test_support/factories/content_factory'
 require 'alchemy/test_support/factories/picture_factory'
 
 FactoryBot.define do
   factory :alchemy_essence_picture, class: 'Alchemy::EssencePicture' do
     picture factory: :alchemy_picture
+
+    trait :with_content do
+      association :content, factory: :alchemy_content
+    end
   end
 end

--- a/spec/dummy/app/views/alchemy/elements/_gallery_picture.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_gallery_picture.html.erb
@@ -1,5 +1,5 @@
 <%- cache(gallery_picture) do -%>
   <%= element_view_for(gallery_picture) do |el| -%>
-    <%= el.render :picture, size: '160x120' %>
+    <%= el.render :picture %>
   <%- end -%>
 <%- end -%>

--- a/spec/dummy/config/alchemy/elements.yml
+++ b/spec/dummy/config/alchemy/elements.yml
@@ -140,6 +140,8 @@
   contents:
     - name: picture
       type: EssencePicture
+      settings:
+        size: 160x120
 
 - name: right_column
   fixed: true

--- a/spec/models/alchemy/essence_picture_spec.rb
+++ b/spec/models/alchemy/essence_picture_spec.rb
@@ -54,7 +54,7 @@ module Alchemy
 
       let(:options) { {} }
       let(:picture) { create(:alchemy_picture) }
-      let(:essence) { create(:alchemy_essence_picture, picture: picture) }
+      let(:essence) { create(:alchemy_essence_picture, :with_content, picture: picture) }
 
       context 'with no format in the options' do
         it "includes the image's default render format." do
@@ -116,7 +116,7 @@ module Alchemy
       subject(:picture_url_options) { essence.picture_url_options }
 
       let(:picture) { build_stubbed(:alchemy_picture) }
-      let(:essence) { build_stubbed(:alchemy_essence_picture, picture: picture) }
+      let(:essence) { build_stubbed(:alchemy_essence_picture, :with_content, picture: picture) }
 
       it { is_expected.to be_a(HashWithIndifferentAccess) }
 
@@ -147,6 +147,16 @@ module Alchemy
         it "does not include these crop sizes.", :aggregate_failures do
           expect(picture_url_options[:crop_from]).to be_nil
           expect(picture_url_options[:crop_size]).to be_nil
+        end
+      end
+
+      context 'with content having size setting' do
+        before do
+          expect(essence.content).to receive(:settings) { {size: '30x70'} }
+        end
+
+        it "includes this size." do
+          expect(picture_url_options[:size]).to eq '30x70'
         end
       end
 


### PR DESCRIPTION
Without we would need to pass the settings into the method as options although the essence always knows its content and therefore can read the size value from it.
