### PR TITLE
Add Element views upgrade tasks

### DIFF
--- a/lib/alchemy/upgrader/four_point_four.rb
+++ b/lib/alchemy/upgrader/four_point_four.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative 'tasks/element_views_updater'
+
+module Alchemy
+  class Upgrader::FourPointFour < Upgrader
+    class << self
+      def rename_element_views
+        desc "Remove '_view' suffix from element views."
+        Alchemy::Upgrader::Tasks::ElementViewsUpdater.new.rename_element_views
+      end
+
+      def update_local_variable
+        desc 'Update element views local variable to element name.'
+        Alchemy::Upgrader::Tasks::ElementViewsUpdater.new.update_local_variable
+      end
+
+      def alchemy_4_4_todos
+        notice = <<-NOTE.strip_heredoc
+
+          ℹ️  Element editor partials are deprecated
+          -----------------------------------------
+
+          The element editor partials are not needed anymore. They still work, but in order to
+          prepare the Alchemy 5 upgrade your should consider removing them now.
+
+          In order to update check if you have any messages in your editor partials and move them
+          to either a `warning` or `message` in your element definition.
+
+          Also check if you pass any values to EssenceSelects `select_values`. Move static values
+          to the `settings` of your content definition and either use EssencePage for referencing
+          pages or create a custom essence for other dynamic values.
+
+
+          ℹ️  The `_view` suffix of Element view partials is deprecated
+          -----------------------------------------------------------
+
+          The element view partials do not need the `_view` suffix anymore. Your files have been
+          renamed.
+
+          The local variable in your element views has been replaced by a variable named after the
+          element itself. A "article" element has a "_article.html.erb" partial and therefore
+          a `article` local variable now.
+
+          The former `element` variable is still present, though.
+
+        NOTE
+        todo notice, 'Alchemy v4.4 TODO'
+      end
+    end
+  end
+end

--- a/lib/alchemy/upgrader/tasks/element_views_updater.rb
+++ b/lib/alchemy/upgrader/tasks/element_views_updater.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'alchemy/upgrader'
+
+module Alchemy::Upgrader::Tasks
+  class ElementViewsUpdater < Thor
+    include Thor::Actions
+
+    no_tasks do
+      def rename_element_views
+        puts "-- Removing '_view' suffix from element views"
+
+        Dir.glob("#{elements_view_folder}/*_view.*").each do |file|
+          FileUtils.mv(file, file.to_s.sub(/_view/, ''))
+        end
+      end
+
+      def update_local_variable
+        puts "-- Updating element views local variable to element name"
+
+        Alchemy::Element.definitions.map { |e| e['name'] }.each do |name|
+          view = Dir.glob("#{elements_view_folder}/_#{name}.*").last
+          gsub_file(view, /\b#{name}_view\b/, name)
+        end
+      end
+    end
+
+    private
+
+    def elements_view_folder
+      Rails.root.join('app', 'views', 'alchemy', 'elements')
+    end
+  end
+end

--- a/lib/tasks/alchemy/tidy.rake
+++ b/lib/tasks/alchemy/tidy.rake
@@ -34,5 +34,32 @@ namespace :alchemy do
     task remove_orphaned_contents: [:environment] do
       Alchemy::Tidy.remove_orphaned_contents
     end
+
+    desc "List Alchemy elements usage"
+    task elements_usage: :environment do
+      puts "\n"
+      removable_elements = []
+      names = Alchemy::Element.definitions.map { |e| e['name'] }
+      longest_name = names.max_by { |name| name.to_s.length }.length + 1
+      names.sort.each do |name|
+        names = Alchemy::Element.where(name: name)
+        count = names.count
+        page_count = Alchemy::Page.where(id: names.pluck(:page_id)).published.count
+        if count.zero?
+          removable_elements.push(name)
+        else
+          spacer = ' ' * (longest_name - name.length)
+          puts "#{name}#{spacer}is used\t#{count}\ttime(s) on\t#{page_count}\tpublic page(s)"
+        end
+      end
+      if removable_elements.many?
+        puts "\n"
+        puts "These elements can probably be removed. They are not used anywhere:"
+        puts "\n"
+        removable_elements.each do |name|
+          puts name
+        end
+      end
+    end
   end
 end

--- a/lib/tasks/alchemy/upgrade.rake
+++ b/lib/tasks/alchemy/upgrade.rake
@@ -6,7 +6,8 @@ namespace :alchemy do
   task upgrade: [
     'alchemy:upgrade:prepare',
     'alchemy:upgrade:4.1:run', 'alchemy:upgrade:4.1:todo',
-    'alchemy:upgrade:4.2:run', 'alchemy:upgrade:4.2:todo'
+    'alchemy:upgrade:4.2:run', 'alchemy:upgrade:4.2:todo',
+    'alchemy:upgrade:4.4:run', 'alchemy:upgrade:4.4:todo'
   ] do
     Alchemy::Upgrader.display_todos
   end
@@ -103,6 +104,36 @@ namespace :alchemy do
 
       task :todo do
         Alchemy::Upgrader::FourPointTwo.alchemy_4_2_todos
+      end
+    end
+
+    desc 'Upgrade Alchemy to v4.4'
+    task '4.4' => [
+      'alchemy:upgrade:prepare',
+      'alchemy:upgrade:4.4:run',
+      'alchemy:upgrade:4.4:todo'
+    ] do
+      Alchemy::Upgrader.display_todos
+    end
+
+    namespace '4.4' do
+      task run: [
+        'alchemy:upgrade:4.4:rename_element_views',
+        'alchemy:upgrade:4.4:update_local_variable'
+      ]
+
+      desc "Remove '_view' suffix from element views."
+      task rename_element_views: [:environment] do
+        Alchemy::Upgrader::FourPointFour.rename_element_views
+      end
+
+      desc 'Update element views local variable to element name.'
+      task update_local_variable: [:environment] do
+        Alchemy::Upgrader::FourPointFour.update_local_variable
+      end
+
+      task :todo do
+        Alchemy::Upgrader::FourPointFour.alchemy_4_4_todos
       end
     end
   end


### PR DESCRIPTION
### Add tidy task to list elements usage

Use

    bin/rake alchemy:tidy:elements_usage

to list the usage of elements in your database.

Very helpful to see if elements are actually used and can potentially be removed.

### Add 4.4 upgrade tasks

These tasks help to upgrade the element view partials.
