### PR TITLE
Generate views without _view in the filename

### DIFF
--- a/lib/rails/generators/alchemy/elements/elements_generator.rb
+++ b/lib/rails/generators/alchemy/elements/elements_generator.rb
@@ -19,7 +19,7 @@ module Alchemy
             raise "Element name '#{element['name']}' has wrong format. Only lowercase and non whitespace characters allowed."
           end
 
-          conditional_template "view.html.#{template_engine}", "#{elements_dir}/_#{@element_name}_view.html.#{template_engine}"
+          conditional_template "view.html.#{template_engine}", "#{elements_dir}/_#{@element_name}.html.#{template_engine}"
         end
       end
 


### PR DESCRIPTION
## What is this pull request for?

Removes _view portion of element names.

Closes #1717 