### PR TITLE
Fix page tagging condition: should_attach_to_menu? 

### DIFF
--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -602,7 +602,7 @@ module Alchemy
     end
 
     def should_attach_to_menu?
-      menu_id && nodes.none?
+      menu_id.present? && nodes.none?
     end
   end
 end

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -2364,6 +2364,13 @@ module Alchemy
           expect { page.save }.not_to change { page.nodes.count }
         end
       end
+
+      context 'if menu_id is empty' do
+        it 'does not raise error' do
+          page.menu_id = ""
+          expect { page.save }.not_to raise_error
+        end
+      end
     end
 
     describe '#nodes' do


### PR DESCRIPTION
## What is this pull request for?

When tagging a page I got this error due to menu_id being an empty string, so i updated the condition.

```
"MENU_ID"
""
  Alchemy::Node Load (0.5ms)  SELECT "alchemy_nodes".* FROM "alchemy_nodes" WHERE "alchemy_nodes"."id" = $1 LIMIT $2  [["id", nil], ["LIMIT", 1]]
   (0.3ms)  ROLLBACK

ActiveRecord::RecordNotFound Couldn't find Alchemy::Node with 'id'= in /app/_docker/data/bundle/ruby/2.7.0/gems/activerecord-6.0.2.1/lib/active_record/core.rb:177:in `find'
/app/_docker/data/bundle/ruby/2.7.0/gems/alchemy_cms-4.4.1/app/models/alchemy/page.rb:599:in `attach_to_menu!'
```