### PR TITLE
Order contents by their position in its element

### DIFF
--- a/app/models/alchemy/content.rb
+++ b/app/models/alchemy/content.rb
@@ -30,13 +30,7 @@ module Alchemy
 
     stampable stamper_class_name: Alchemy.user_class_name
 
-    acts_as_list
-
-    # ActsAsList scope
-    def scope_condition
-      # Fixes a bug with postgresql having a wrong element_id value, if element_id is nil.
-      "element_id = #{element_id || 'null'} AND essence_type = '#{essence_type}'"
-    end
+    acts_as_list scope: [:element_id]
 
     # Essence scopes
     scope :essence_booleans,  -> { where(essence_type: "Alchemy::EssenceBoolean") }

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -60,9 +60,7 @@ module Alchemy
 
     stampable stamper_class_name: Alchemy.user_class_name
 
-    # Content positions are scoped by their essence_type, so positions can be the same for different contents.
-    # In order to get contents in creation order we also order them by id.
-    has_many :contents, -> { order(:position, :id) }, dependent: :destroy, inverse_of: :element
+    has_many :contents, -> { order(:position) }, dependent: :destroy, inverse_of: :element
 
     has_many :all_nested_elements,
       -> { order(:position).not_trashed },

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -398,6 +398,23 @@ module Alchemy
       end
     end
 
+    describe '#contents' do
+      let(:element) { create(:alchemy_element) }
+      let!(:content1) { create(:alchemy_content, element: element) }
+      let!(:content2) { create(:alchemy_content, element: element) }
+
+      subject { element.contents }
+
+      before do
+        content1.update_column(:position, 2)
+        content2.update_column(:position, 1)
+      end
+
+      it 'are ordered by position' do
+        is_expected.to eq([content2, content1])
+      end
+    end
+
     describe '#content_by_type' do
       before(:each) do
         @element = create(:alchemy_element, name: 'headline')


### PR DESCRIPTION
## What is this pull request for?

Always order contents by their position in its element

### Notable changes (remove if none)

Remove the `essence_type` `acts_as_list` scope condition as this feature was removed a long time ago.
