### PR TITLE
Scope nodes to sites

### DIFF
--- a/app/controllers/alchemy/admin/nodes_controller.rb
+++ b/app/controllers/alchemy/admin/nodes_controller.rb
@@ -9,6 +9,7 @@ module Alchemy
 
       def new
         @node = Node.new(
+          site: Alchemy::Site.current,
           parent_id: params[:parent_id],
           language: Language.current
         )
@@ -28,6 +29,7 @@ module Alchemy
 
       def resource_params
         params.require(:node).permit(
+          :site_id,
           :parent_id,
           :language_id,
           :page_id,

--- a/app/helpers/alchemy/pages_helper.rb
+++ b/app/helpers/alchemy/pages_helper.rb
@@ -188,7 +188,7 @@ module Alchemy
     # @param [String] - Name of the menu
     # @param [Hash] - A set of options available in your menu partials
     def render_menu(name, options = {})
-      root_node = Alchemy::Node.roots.find_by(name: name)
+      root_node = Alchemy::Node.roots.find_by(name: name, site: Alchemy::Site.current)
       if root_node.nil?
         warning("Menu with name #{name} not found!")
         return

--- a/app/models/alchemy/node.rb
+++ b/app/models/alchemy/node.rb
@@ -7,6 +7,7 @@ module Alchemy
     acts_as_nested_set scope: 'language_id', touch: true
     stampable stamper_class_name: Alchemy.user_class_name
 
+    belongs_to :site, class_name: 'Alchemy::Site'
     belongs_to :language, class_name: 'Alchemy::Language'
     belongs_to :page, class_name: 'Alchemy::Page', optional: true, inverse_of: :nodes
 

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -594,7 +594,10 @@ module Alchemy
     end
 
     def attach_to_menu!
-      Alchemy::Node.find(menu_id).children.create!(
+      current_site_id = Alchemy::Site.current.id
+      node = Alchemy::Node.find_by!(id: menu_id, site_id: current_site_id)
+      node.children.create!(
+        site_id: current_site_id,
         language_id: language_id,
         page_id: id,
         name: name

--- a/app/views/alchemy/admin/nodes/_form.html.erb
+++ b/app/views/alchemy/admin/nodes/_form.html.erb
@@ -12,6 +12,7 @@
     <%= f.input :external %>
     <%= f.hidden_field :parent_id %>
   <% end %>
+  <%= f.hidden_field :site_id %>
   <%= f.hidden_field :language_id %>
   <%= f.submit button_label %>
 <% end %>

--- a/db/migrate/20200226081535_add_site_id_to_alchemy_nodes.rb
+++ b/db/migrate/20200226081535_add_site_id_to_alchemy_nodes.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddSiteIdToAlchemyNodes < ActiveRecord::Migration[5.0]
+  def change
+    add_column :alchemy_nodes, :site_id, :integer, index: true
+    add_index :alchemy_nodes, :site_id
+    reversible do |dir|
+      dir.up do
+        Alchemy::Node.update_all(site_id: Alchemy::Site.first&.id)
+        change_column_null :alchemy_nodes, :site_id, false
+      end
+    end
+    add_foreign_key :alchemy_nodes, :alchemy_sites, column: :site_id, on_delete: :cascade
+  end
+end

--- a/lib/alchemy/test_support/factories/node_factory.rb
+++ b/lib/alchemy/test_support/factories/node_factory.rb
@@ -6,6 +6,7 @@ require 'alchemy/test_support/factories/page_factory'
 
 FactoryBot.define do
   factory :alchemy_node, class: 'Alchemy::Node' do
+    site { Alchemy::Site.default }
     language { Alchemy::Language.default }
     name { 'A Node' }
 

--- a/spec/controllers/alchemy/admin/nodes_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/nodes_controller_spec.rb
@@ -43,7 +43,7 @@ module Alchemy
 
         it "creates node and redirects to index" do
           expect {
-            post :create, params: { node: { name: 'Node', language_id: language.id } }
+            post :create, params: { node: { name: 'Node', language_id: language.id, site_id: language.site_id } }
           }.to change { Alchemy::Node.count }.by(1)
           expect(response).to redirect_to(admin_nodes_path)
         end

--- a/spec/dummy/db/migrate/20200226081535_add_site_id_to_alchemy_nodes.rb
+++ b/spec/dummy/db/migrate/20200226081535_add_site_id_to_alchemy_nodes.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20200226081535_add_site_id_to_alchemy_nodes.rb

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_29_212236) do
+ActiveRecord::Schema.define(version: 2020_02_26_081535) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string "name"
@@ -221,12 +221,14 @@ ActiveRecord::Schema.define(version: 2019_10_29_212236) do
     t.integer "updater_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "site_id", null: false
     t.index ["creator_id"], name: "index_alchemy_nodes_on_creator_id"
     t.index ["language_id"], name: "index_alchemy_nodes_on_language_id"
     t.index ["lft"], name: "index_alchemy_nodes_on_lft"
     t.index ["page_id"], name: "index_alchemy_nodes_on_page_id"
     t.index ["parent_id"], name: "index_alchemy_nodes_on_parent_id"
     t.index ["rgt"], name: "index_alchemy_nodes_on_rgt"
+    t.index ["site_id"], name: "index_alchemy_nodes_on_site_id"
     t.index ["updater_id"], name: "index_alchemy_nodes_on_updater_id"
   end
 
@@ -359,4 +361,5 @@ ActiveRecord::Schema.define(version: 2019_10_29_212236) do
   add_foreign_key "alchemy_essence_pages", "alchemy_pages", column: "page_id"
   add_foreign_key "alchemy_nodes", "alchemy_languages", column: "language_id"
   add_foreign_key "alchemy_nodes", "alchemy_pages", column: "page_id", on_delete: :cascade
+  add_foreign_key "alchemy_nodes", "alchemy_sites", column: "site_id", on_delete: :cascade
 end

--- a/spec/features/admin/menus_features_spec.rb
+++ b/spec/features/admin/menus_features_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "Admin Menus Features", type: :system do
+  before do
+    authorize_user(:as_admin)
+  end
+
+  describe 'adding a new menu' do
+    context 'with multiple sites' do
+      let!(:default_site) { create(:alchemy_site, :default) }
+      let!(:site_2) { create(:alchemy_site, host: 'another-site.com') }
+      let(:node) { Alchemy::Node.last }
+
+      it 'creates menu for current site' do
+        visit alchemy.new_admin_node_path
+
+        fill_in 'Name', with: 'Main Menu'
+        click_button 'create'
+
+        expect(node.site_id).to eq(default_site.id)
+      end
+    end
+  end
+end

--- a/spec/helpers/alchemy/pages_helper_spec.rb
+++ b/spec/helpers/alchemy/pages_helper_spec.rb
@@ -73,6 +73,18 @@ module Alchemy
       context 'if menu does not exist' do
         it { is_expected.to be_nil }
       end
+
+      context 'with multiple sites' do
+        let!(:site_2) { create(:alchemy_site, host: 'another-site.com') }
+        let!(:menu) { create(:alchemy_node, name: name, site: Alchemy::Site.current) }
+        let!(:node) { create(:alchemy_node, parent: menu, url: '/default-site') }
+        let!(:menu_2) { create(:alchemy_node, name: name, site: site_2) }
+        let!(:node_2) { create(:alchemy_node, parent: menu_2, site: site_2, url: '/site-2') }
+
+        it 'renders menu from current site' do
+          is_expected.to have_selector('ul.nav > li.nav-item > a.nav-link[href="/default-site"]')
+        end
+      end
     end
 
     describe "#render_navigation" do


### PR DESCRIPTION
## What is this pull request for?

Scopes nodes to sites

Closes #1734 

### Notable changes

Each `Alchemy::Node` is now scoped to a `Alchemy::Site`. The migration adds the first site to existing nodes. If you want to do differently please alter the migration file before running it.
