### PR TITLE
Sortable resources tables

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,8 @@ gem 'mysql2', '~> 0.5.1' if ENV['DB'] == 'mysql'
 gem 'pg',     '~> 1.0'   if ENV['DB'] == 'postgresql'
 
 group :development, :test do
-  if ENV['CI']
-    gem 'sprockets', '< 4.0' # Sprockets 4 has serious issues with libsass on Linux machines
+  if ENV['GITHUB_ACTIONS']
+    gem 'sassc', '~> 2.1.0' # https://github.com/sass/sassc-ruby/issues/146
   else
     gem 'launchy'
     gem 'annotate'

--- a/app/assets/stylesheets/alchemy/tables.scss
+++ b/app/assets/stylesheets/alchemy/tables.scss
@@ -57,29 +57,6 @@ th {
   vertical-align: top;
   border-bottom: 1px solid $medium-gray;
   font-weight: bold;
-
-  i {
-    font-style: normal;
-    position: absolute;
-    right: 2px;
-    top: 4px;
-    text-shadow: 1px 1px 1px #fff;
-  }
-
-  a {
-
-    &.sortable {
-      display: block;
-      margin: -4px -8px;
-      padding: 4px 18px 4px 8px;
-      text-shadow: 1px 1px 1px #fff;
-    }
-
-    &.sorted {
-      position: relative;
-      background: $medium-gray;
-    }
-  }
 }
 
 tr.even td {
@@ -141,7 +118,7 @@ td {
     width: 80px;
   }
 
-  &.date {
+  &.date, &.datetime {
     width: 150px;
   }
 

--- a/app/controllers/alchemy/admin/attachments_controller.rb
+++ b/app/controllers/alchemy/admin/attachments_controller.rb
@@ -10,6 +10,7 @@ module Alchemy
 
       def index
         @query = Attachment.ransack(search_filter_params[:q])
+        @query.sorts = 'name asc' if @query.sorts.empty?
         @attachments = @query.result
 
         if search_filter_params[:tagged_with].present?

--- a/app/controllers/alchemy/admin/languages_controller.rb
+++ b/app/controllers/alchemy/admin/languages_controller.rb
@@ -5,6 +5,7 @@ module Alchemy
     class LanguagesController < ResourcesController
       def index
         @query = Language.on_current_site.ransack(search_filter_params[:q])
+        @query.sorts = default_sort_order if @query.sorts.empty?
         @languages = @query.result.page(params[:page] || 1).per(items_per_page)
       end
 

--- a/app/controllers/alchemy/admin/resources_controller.rb
+++ b/app/controllers/alchemy/admin/resources_controller.rb
@@ -22,6 +22,7 @@ module Alchemy
 
       def index
         @query = resource_handler.model.ransack(search_filter_params[:q])
+        @query.sorts = default_sort_order if @query.sorts.empty?
         items = @query.result
 
         if contains_relations?
@@ -161,6 +162,11 @@ module Alchemy
       def items_per_page_options
         per_page = Alchemy::Config.get(:items_per_page)
         [per_page, per_page * 2, per_page * 4]
+      end
+
+      def default_sort_order
+        name = resource_handler.attributes.detect { |attr| attr[:name] == 'name' }
+        name ? 'name asc' : "#{resource_handler.attributes.first[:name]} asc"
       end
     end
   end

--- a/app/controllers/alchemy/admin/tags_controller.rb
+++ b/app/controllers/alchemy/admin/tags_controller.rb
@@ -7,6 +7,7 @@ module Alchemy
 
       def index
         @query = Gutentag::Tag.ransack(search_filter_params[:q])
+        @query.sorts = default_sort_order if @query.sorts.empty?
         @tags = @query
                   .result
                   .page(params[:page] || 1)

--- a/app/views/alchemy/admin/attachments/_files_list.html.erb
+++ b/app/views/alchemy/admin/attachments/_files_list.html.erb
@@ -11,11 +11,11 @@
     <thead>
       <tr>
         <th class="icon"></th>
-        <th class="name"><%= sort_link(@query, :name, hide_indicator: true) %></th>
-        <th class="file_name"><%= sort_link(@query, :file_name, hide_indicator: true) %></th>
+        <th class="name"><%= sort_link(@query, :name) %></th>
+        <th class="file_name"><%= sort_link(@query, :file_name) %></th>
         <th class="file_type"><%= Alchemy::Attachment.human_attribute_name('file_mime_type') %></th>
-        <th class="file_size"><%= sort_link(@query, :file_size, hide_indicator: true) %></th>
-        <th class="date"><%= sort_link(@query, :created_at, hide_indicator: true) %></th>
+        <th class="file_size"><%= sort_link(@query, :file_size) %></th>
+        <th class="date"><%= sort_link(@query, :created_at, default_order: 'desc') %></th>
         <th class="tools"></th>
       </tr>
     </thead>

--- a/app/views/alchemy/admin/languages/_table.html.erb
+++ b/app/views/alchemy/admin/languages/_table.html.erb
@@ -3,13 +3,13 @@
   <thead>
     <tr>
       <th>
-        <%= sort_link @query, :name, hide_indicator: true %>
+        <%= sort_link @query, :name %>
       </th>
       <th>
-        <%= sort_link @query, :language_code, hide_indicator: true %>
+        <%= sort_link @query, :language_code %>
       </th>
       <th>
-        <%= sort_link @query, :country_code, hide_indicator: true %>
+        <%= sort_link @query, :country_code %>
       </th>
       <th>
         <%= Alchemy::Language.human_attribute_name(:code) %>

--- a/app/views/alchemy/admin/resources/_resource.html.erb
+++ b/app/views/alchemy/admin/resources/_resource.html.erb
@@ -1,5 +1,5 @@
 <tr class="<%= cycle('even', 'odd') %>">
-<% resource_handler.attributes.each do |attribute| %>
+<% resource_handler.sorted_attributes.each do |attribute| %>
   <td class="<%= attribute[:type] %> <%= attribute[:name] %>">
   <% if attribute[:type] == :boolean %>
     <%= resource.public_send(attribute[:name]) ? render_icon(:check) : nil %>

--- a/app/views/alchemy/admin/resources/_table.html.erb
+++ b/app/views/alchemy/admin/resources/_table.html.erb
@@ -2,7 +2,7 @@
 <table class="list" id="<%= resource_handler.resources_name %>_list">
   <thead>
     <tr>
-    <% resource_handler.attributes.each do |attribute| %>
+    <% resource_handler.sorted_attributes.each do |attribute| %>
       <th class="<%= attribute[:type] %> <%= attribute[:name] %>">
         <%= sort_link [:resource_url_proxy, @query],
           sortable_resource_header_column(attribute),

--- a/app/views/alchemy/admin/resources/_table.html.erb
+++ b/app/views/alchemy/admin/resources/_table.html.erb
@@ -7,7 +7,7 @@
         <%= sort_link [:resource_url_proxy, @query],
           sortable_resource_header_column(attribute),
           resource_handler.model.human_attribute_name(attribute[:name]),
-          hide_indicator: true %>
+          default_order: attribute[:type].to_s =~ /date|time/ ? 'desc' : 'asc' %>
       </th>
     <% end %>
       <th class="tools"></th>

--- a/app/views/alchemy/admin/tags/index.html.erb
+++ b/app/views/alchemy/admin/tags/index.html.erb
@@ -23,9 +23,9 @@
     <thead>
       <tr>
         <th class="icon"></th>
-        <th class="name"><%= sort_link(@query, :name, hide_indicator: true) %></th>
+        <th class="name"><%= sort_link(@query, :name) %></th>
         <th class="count"><%= Gutentag::Tag.human_attribute_name(:taggings_types) %></th>
-        <th class="count"><%= sort_link(@query, :taggings_count, hide_indicator: true) %></th>
+        <th class="count"><%= sort_link(@query, :taggings_count) %></th>
         <th class="tools"></th>
       </tr>
     </thead>

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -629,7 +629,7 @@ en:
   time:
     formats:
       alchemy:
-        default: "%a, %d %b %Y %H:%M:%S %z"
+        default: "%m.%d.%Y %H:%M"
         essence_date: "%Y-%m-%d"
         page_status: "%m.%d.%Y %H:%M"
         short_datetime: "%d %b %H:%M"

--- a/lib/alchemy/engine.rb
+++ b/lib/alchemy/engine.rb
@@ -25,6 +25,16 @@ module Alchemy
       Gutentag.normaliser = ->(value) { value.to_s }
     end
 
+    # Custom Ransack sort arrows
+    initializer 'alchemy.ransack' do
+      Ransack.configure do |config|
+        config.custom_arrows = {
+          up_arrow: '<i class="fa fas fa-xs fa-arrow-up"></i>',
+          down_arrow: '<i class="fa fas fa-xs fa-arrow-down"></i>'
+        }
+      end
+    end
+
     config.after_initialize do
       require_relative './userstamp'
     end

--- a/lib/alchemy/resource.rb
+++ b/lib/alchemy/resource.rb
@@ -101,8 +101,8 @@ module Alchemy
     attr_accessor :resource_relations, :model_associations
     attr_reader :model
 
-    DEFAULT_SKIPPED_ATTRIBUTES = %w(id updated_at created_at creator_id updater_id)
-    DEFAULT_SKIPPED_ASSOCIATIONS = %w(creator updater)
+    DEFAULT_SKIPPED_ATTRIBUTES = %w(id created_at creator_id)
+    DEFAULT_SKIPPED_ASSOCIATIONS = %w(creator)
     SEARCHABLE_COLUMN_TYPES = [:string, :text]
 
     def initialize(controller_path, module_definition = nil, custom_model = nil)
@@ -166,6 +166,13 @@ module Alchemy
           relation: resource_relation(col.name)
         }.delete_if { |_k, v| v.nil? }
       end.compact
+    end
+
+    def sorted_attributes
+      @_sorted_attributes ||= attributes.
+        sort_by  { |attr| attr[:name] == 'name' ? 0 : 1 }.
+        sort_by! { |attr| attr[:type] == :boolean ? 1 : 0 }.
+        sort_by! { |attr| attr[:name] == 'updated_at' ? 1 : 0 }
     end
 
     def editable_attributes

--- a/spec/controllers/alchemy/admin/resources_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/resources_controller_spec.rb
@@ -48,11 +48,36 @@ describe Admin::EventsController do
       end
 
       context 'with sort parameter given' do
-        let(:params) { {q: {s: "name asc"}} }
+        let(:params) { {q: {s: "name desc"}} }
 
-        it "returns records in the right order" do
+        it "returns records in the defined order" do
           get :index, params: params
-          expect(assigns(:events)).to eq([lustig, peter])
+          expect(assigns(:events)).to eq([peter, lustig])
+        end
+      end
+
+      context 'without sort parameter given' do
+        context 'if resource has name attribute' do
+          it "returns records sorted by name" do
+            get :index
+            expect(assigns(:events)).to eq([lustig, peter])
+          end
+        end
+
+        context 'if resource has no name attribute' do
+          let!(:booking1) { Booking.create!(from: 2.week.from_now) }
+          let!(:booking2) { Booking.create!(from: 1.weeks.from_now) }
+
+          controller(::Alchemy::Admin::ResourcesController) do
+            def resource_handler
+              @_resource_handler ||= Alchemy::Resource.new(controller_path, alchemy_module, Booking)
+            end
+          end
+
+          it "returns records sorted by first attribute" do
+            get :index
+            expect(assigns(:resources)).to eq([booking2, booking1])
+          end
         end
       end
     end

--- a/spec/features/admin/resources_integration_spec.rb
+++ b/spec/features/admin/resources_integration_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Resources", type: :system do
 
       it "lists the new item" do
         expect(page).to have_content "My second event"
-        expect(page).to have_content "03 Mar 2012"
+        expect(page).to have_content "03.12.2020"
       end
 
       it "shows a success message" do

--- a/spec/libraries/resource_spec.rb
+++ b/spec/libraries/resource_spec.rb
@@ -310,6 +310,28 @@ module Alchemy
       end
     end
 
+    describe "#sorted_attributes" do
+      subject { resource.sorted_attributes }
+
+      let(:columns) do
+        [
+          double(:column, {name: 'title', type: :string}),
+          double(:column, {name: 'name', type: :string}),
+          double(:column, {name: 'updated_at', type: :datetime}),
+          double(:column, {name: 'public', type: :boolean})
+        ]
+      end
+
+      it "sorts by name, and updated_at" do
+        is_expected.to eq([
+          {name: "name", type: :string},
+          {name: "title", type: :string},
+          {name: "public", type: :boolean},
+          {name: "updated_at", type: :datetime}
+        ])
+      end
+    end
+
     context "when alchemy_resource_relations defined as class method in the model" do
       let(:resource) { Resource.new("admin/events") }
 


### PR DESCRIPTION
## What is this pull request for?

Add default sort order to resources tables.

### Notable changes

Before we where relying on the default sort order of the database. That is, but does not have to be, the primary column in most databases.

This changes this behavior to introduce a `default_sort_order` that uses the `name` column (if the resource has one) or the first attribute in an ascending sort order.

Also adds a nice little indicator to the sorted column.

### Screenshots

![Screen Shot 2020-03-12 at 16 51 20](https://user-images.githubusercontent.com/42868/76540129-0162ce00-6482-11ea-9bcf-9673b8dad3e6.png)

![Screen Shot 2020-03-12 at 16 52 04](https://user-images.githubusercontent.com/42868/76540138-032c9180-6482-11ea-8b3f-17e31617fdd1.png)

