### PR TITLE
fix `render_menu` for custom controllers

### DIFF
--- a/app/helpers/alchemy/pages_helper.rb
+++ b/app/helpers/alchemy/pages_helper.rb
@@ -90,7 +90,7 @@ module Alchemy
         node_partial_name: "#{root_node.view_folder_name}/node"
       }.merge(options)
 
-      render(root_node, menu: root_node, node: root_node, options: options)
+      render(root_node.to_partial_path, menu: root_node, node: root_node, options: options)
     rescue ActionView::MissingTemplate => e
       warning <<~WARN
         Menu partial not found for #{name}.

--- a/spec/dummy/app/controllers/ns/locations_controller.rb
+++ b/spec/dummy/app/controllers/ns/locations_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Ns
+  class LocationsController < ApplicationController
+    include Alchemy::ControllerActions
+
+    def index
+    end
+  end
+end

--- a/spec/dummy/app/views/ns/locations/index.html
+++ b/spec/dummy/app/views/ns/locations/index.html
@@ -1,0 +1,1 @@
+Just an example for a custom controller

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -5,6 +5,9 @@ Rails.application.routes.draw do
   mount JasmineRails::Engine => "/specs" if defined?(JasmineRails)
 
   get '/login' => 'login#new', as: 'login'
+  namespace :ns do
+    resources :locations, only: :index
+  end
 
   namespace :admin do
     resources :events

--- a/spec/features/page_feature_spec.rb
+++ b/spec/features/page_feature_spec.rb
@@ -150,6 +150,13 @@ RSpec.describe 'Show page feature:', type: :system do
           expect(page).to have_selector('li a[href="/page-1"], li a[href="/page-2"]')
         end
       end
+
+      it 'shows the navigation in a custom controller' do
+        visit '/ns/locations'
+        within('nav ul') do
+          expect(page).to have_selector('li a[href="/page-1"], li a[href="/page-2"]')
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## What is this pull request for?

without `partial:` the current controller name will be prepended to the
view path.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change — yes, but it requires Devise as `test` dependency


**EDIT:** Sorry, I guess I misnamed it. It seems to be working within a custom controller. It does not work within _devise_ controllers.