### PR TITLE
Allow importing to a different port

### DIFF
--- a/lib/alchemy/tasks/helpers.rb
+++ b/lib/alchemy/tasks/helpers.rb
@@ -58,6 +58,9 @@ module Alchemy
         if (host = database_config['host']) && (host != 'localhost')
           command << "--host='#{host}'"
         end
+        if (port = database_config['port'])
+          command << "--port=#{port}"
+        end
         command.join(' ')
       end
 

--- a/spec/tasks/helpers_spec.rb
+++ b/spec/tasks/helpers_spec.rb
@@ -181,6 +181,13 @@ module Alchemy
           it { is_expected.to include("PGPASSWORD='123456'") }
         end
 
+        context "when a port is set in the config file" do
+          before do
+            allow(File).to receive(:read).and_return("test:\n  port: 5433")
+          end
+          it { is_expected.to include("--port=5433") }
+        end
+
         context "when a host is set in the config file" do
           context "and the host is localhost" do
             it { is_expected.not_to include("--host=") }


### PR DESCRIPTION
## What is this pull request for?

This allows me to import to a database running on port 12345, which I
sometimes do need.

### Notable changes (remove if none)

Port is now respected when importing

### Screenshots

Remove if no visual changes have been made.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
