### PR TITLE
Fail spec prepare task if sub command fails

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -39,14 +39,15 @@ namespace :alchemy do
   namespace :spec do
     desc "Prepares database for testing Alchemy"
     task :prepare do
-      system <<-BASH
-cd spec/dummy
-export RAILS_ENV=test
-bin/rake db:create
-bin/rake db:environment:set
-bin/rake db:migrate:reset
-cd -
-BASH
+      result = system <<~BASH
+        cd spec/dummy && \
+        export RAILS_ENV=test && \
+        bin/rake db:create && \
+        bin/rake db:environment:set && \
+        bin/rake db:migrate:reset && \
+        cd -
+      BASH
+      result || fail
     end
   end
 


### PR DESCRIPTION
In order to stop CI servers if one of the preparation tasks is failing we need to pass the result to the invoking rake task.
