### PR TITLE
bugfix: fix syntax in non-erb templates

### DIFF
--- a/lib/rails/generators/alchemy/menus/templates/wrapper.html.haml
+++ b/lib/rails/generators/alchemy/menus/templates/wrapper.html.haml
@@ -3,4 +3,4 @@
     = render partial: options[:node_partial_name],
       collection: menu.children.includes(:page, :children),
       locals: { options: options },
-      as: 'node' %>
+      as: 'node'

--- a/lib/rails/generators/alchemy/menus/templates/wrapper.html.slim
+++ b/lib/rails/generators/alchemy/menus/templates/wrapper.html.slim
@@ -3,4 +3,4 @@
     = render partial: options[:node_partial_name],
       collection: menu.children.includes(:page, :children),
       locals: { options: options },
-      as: 'node' %>
+      as: 'node'


### PR DESCRIPTION
## What is this pull request for?

it fixes the syntax in non-erb templates

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change — _no, the correct way would be to add [`haml-lint`](https://github.com/sds/haml-lint) and add it to the CI pipeline. It also integrates with RuboCop._
