### PR TITLE
chores: use same _old_ Rubo:cop: version as Hound

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :development, :test do
     gem 'yard'
     gem 'redcarpet'
     gem 'pry-byebug'
-    gem 'rubocop', require: false
+    gem 'rubocop', '0.54', require: false
     gem 'listen'
     gem 'localeapp', '~> 3.0', require: false
     gem 'dotenv', '~> 2.2'


### PR DESCRIPTION
http://help.houndci.com/en/articles/2137566-rubocop

## What is this pull request for?

It pins the rubo:cop: version to the [same _old_ version that Hound is using](http://help.houndci.com/en/articles/2137566-rubocop). It would be nice to use a newer version though. But for now this fixes possible version mismatches.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change — _nope_
