### PR TITLE
Remove references to nonexistent "scaffold" generator

### DIFF
--- a/app/models/alchemy/element/definitions.rb
+++ b/app/models/alchemy/element/definitions.rb
@@ -30,7 +30,7 @@ module Alchemy
         if ::File.exist?(definitions_file_path)
           ::YAML.safe_load(ERB.new(File.read(definitions_file_path)).result, YAML_WHITELIST_CLASSES, [], true) || []
         else
-          raise LoadError, "Could not find elements.yml file! Please run `rails generate alchemy:scaffold`"
+          raise LoadError, "Could not find elements.yml file! Please run `rails generate alchemy:install`"
         end
       end
 

--- a/lib/alchemy/page_layout.rb
+++ b/lib/alchemy/page_layout.rb
@@ -163,7 +163,7 @@ module Alchemy
         if File.exist?(layouts_file_path)
           YAML.safe_load(ERB.new(File.read(layouts_file_path)).result, YAML_WHITELIST_CLASSES, [], true) || []
         else
-          raise LoadError, "Could not find page_layouts.yml file! Please run `rails generate alchemy:scaffold`"
+          raise LoadError, "Could not find page_layouts.yml file! Please run `rails generate alchemy:install`"
         end
       end
 


### PR DESCRIPTION
## What is this pull request for?

Fixes an error message to reference a generator that exists.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
