### PR TITLE
Programmatic menus

### DIFF
--- a/app/models/alchemy/node.rb
+++ b/app/models/alchemy/node.rb
@@ -29,6 +29,28 @@ module Alchemy
 
         roots.where(language_id: Language.current.id)
       end
+
+      def available_menu_names
+        read_definitions_file
+      end
+
+      private
+
+      # Reads the element definitions file named +menus.yml+ from +config/alchemy/+ folder.
+      #
+      def read_definitions_file
+        if ::File.exist?(definitions_file_path)
+          ::YAML.safe_load(File.read(definitions_file_path)) || []
+        else
+          raise LoadError, "Could not find menus.yml file! Please run `rails generate alchemy:install`"
+        end
+      end
+
+      # Returns the +menus.yml+ file path
+      #
+      def definitions_file_path
+        Rails.root.join 'config/alchemy/menus.yml'
+      end
     end
 
     # Returns the url

--- a/app/views/alchemy/admin/nodes/_form.html.erb
+++ b/app/views/alchemy/admin/nodes/_form.html.erb
@@ -1,10 +1,15 @@
 <%= alchemy_form_for([:admin, node]) do |f| %>
-  <%= f.input :name, input_html: {
-    autofocus: true,
-    value: node.page && node.read_attribute(:name).blank? ? nil : node.name,
-    placeholder: node.page ? node.page.name : nil
-  } %>
-  <% unless node.root? %>
+  <% if node.root? %>
+    <%= f.input :name,
+      collection: Alchemy::Node.available_menu_names.map { |n| [I18n.t(n, scope: [:alchemy, :menu_names]), n] },
+      include_blank: false,
+      input_html: { class: 'alchemy_selectbox' } %>
+  <% else %>
+    <%= f.input :name, input_html: {
+      autofocus: true,
+      value: node.page && node.read_attribute(:name).blank? ? nil : node.name,
+      placeholder: node.page ? node.page.name : nil
+    } %>
     <%= f.input :page_id, label: Alchemy::Page.model_name.human, input_html: { class: 'alchemy_selectbox' } %>
     <%= f.input :url, input_html: { disabled: node.page }, hint: Alchemy.t(:node_url_hint) %>
     <%= f.input :title %>

--- a/app/views/alchemy/admin/nodes/_node.html.erb
+++ b/app/views/alchemy/admin/nodes/_node.html.erb
@@ -57,7 +57,11 @@
       <% end %>
     </span>
     <div class="node_name">
-      <%= node.name || '&nbsp;'.html_safe %>
+      <% if node.root? %>
+        <%= I18n.t(node.name, scope: [:alchemy, :menu_names]) %>
+      <% else %>
+        <%= node.name || '&nbsp;'.html_safe %>
+      <% end %>
       <span class="node_page">
       <% if node.page %>
         <i class="icon far fa-file"></i>

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -49,6 +49,14 @@ en:
     #
     content_names:
 
+
+    # === Translations for menu names
+    # Used for the translations of the names of root menu nodes.
+    #
+    menu_names:
+      main_menu: Main Menu
+      footer_menu: Footer Menu
+
     # === Translations for content validations
     # Used when a user did not enter (correct) values to the content field.
     #

--- a/lib/rails/generators/alchemy/install/install_generator.rb
+++ b/lib/rails/generators/alchemy/install/install_generator.rb
@@ -18,7 +18,7 @@ module Alchemy
       end
 
       def copy_yml_files
-        %w(elements page_layouts).each do |file|
+        %w(elements page_layouts menus).each do |file|
           template "#{__dir__}/templates/#{file}.yml.tt", "config/alchemy/#{file}.yml"
         end
       end

--- a/lib/rails/generators/alchemy/install/templates/menus.yml.tt
+++ b/lib/rails/generators/alchemy/install/templates/menus.yml.tt
@@ -1,0 +1,8 @@
+# == In this configuration, you set up Alchemy's menu names.
+#
+# For further information please see http://guides.alchemy-cms.com/stable/menus.html
+
+<%- unless @options[:skip_demo_files] -%>
+- main_menu
+- footer_menu
+<%- end -%>

--- a/lib/rails/generators/alchemy/menus/menus_generator.rb
+++ b/lib/rails/generators/alchemy/menus/menus_generator.rb
@@ -9,14 +9,14 @@ module Alchemy
       source_root File.expand_path('templates', __dir__)
 
       def create_partials
-        menus = Alchemy::Node.roots
+        menus = Alchemy::Node.available_menu_names
         return unless menus
 
         menus.each do |menu|
           conditional_template "wrapper.html.#{template_engine}",
-            "app/views/#{menu.view_folder_name}/_wrapper.html.#{template_engine}"
+            "app/views/alchemy/menus/#{menu}/_wrapper.html.#{template_engine}"
           conditional_template "node.html.#{template_engine}",
-            "app/views/#{menu.view_folder_name}/_node.html.#{template_engine}"
+            "app/views/alchemy/menus/#{menu}/_node.html.#{template_engine}"
         end
       end
     end

--- a/spec/dummy/config/alchemy/menus.yml
+++ b/spec/dummy/config/alchemy/menus.yml
@@ -1,0 +1,2 @@
+- main_menu
+- footer_menu

--- a/spec/features/admin/menus_features_spec.rb
+++ b/spec/features/admin/menus_features_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Admin Menus Features", type: :system do
       it 'creates menu' do
         visit alchemy.admin_nodes_path
 
-        fill_in 'Name', with: 'Main Menu'
+        select 'Main Menu', from: 'Name'
         click_button 'create'
 
         expect(page).to have_selector('.node_name', text: 'Main Menu')
@@ -31,7 +31,7 @@ RSpec.describe "Admin Menus Features", type: :system do
       it 'creates menu for current site' do
         visit alchemy.new_admin_node_path
 
-        fill_in 'Name', with: 'Main Menu'
+        select 'Main Menu', from: 'Name'
         click_button 'create'
 
         expect(node.site_id).to eq(default_site.id)

--- a/spec/models/alchemy/node_spec.rb
+++ b/spec/models/alchemy/node_spec.rb
@@ -29,6 +29,12 @@ module Alchemy
       end
     end
 
+    describe '.available_menu_names' do
+      subject { described_class.available_menu_names }
+
+      it { is_expected.to contain_exactly('main_menu', 'footer_menu') }
+    end
+
     describe '#url' do
       it 'is valid with leading slash' do
         expect(build(:alchemy_node, url: '/something')).to be_valid


### PR DESCRIPTION
## What is this pull request for?

This decouples partial generation and UI translations of menus from database contents. This is desirable so that 
a) We keep with the general philosophy that users should not be able to do stuff in the admin that makes template changes necessary
b) We can use the same template for menus in multiple languages. 

### Notable changes (remove if none)

Root nodes now have a string like 'main_menu' as their name, and that is translated. 

### Screenshots

![grafik](https://user-images.githubusercontent.com/703401/77163185-d691fe80-6aad-11ea-96c7-f56e1c7a7199.png)

After changing the admin locale to German with no German translations: 
![grafik](https://user-images.githubusercontent.com/703401/77163348-2b357980-6aae-11ea-9696-923d8ed7edd7.png)



## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (minimal tbh)
