### PR TITLE
Remove implicit Site and Language creation

### DIFF
--- a/app/controllers/alchemy/admin/base_controller.rb
+++ b/app/controllers/alchemy/admin/base_controller.rb
@@ -144,7 +144,7 @@ module Alchemy
         @current_alchemy_site ||= begin
           site_id = params[:site_id] || session[:alchemy_site_id]
           site = Site.find_by(id: site_id) || super
-          session[:alchemy_site_id] = site.id
+          session[:alchemy_site_id] = site&.id
           site
         end
       end

--- a/app/controllers/alchemy/admin/languages_controller.rb
+++ b/app/controllers/alchemy/admin/languages_controller.rb
@@ -3,6 +3,11 @@
 module Alchemy
   module Admin
     class LanguagesController < ResourcesController
+      before_action unless: -> { Alchemy::Site.any? } do
+        flash[:warning] = Alchemy.t('Please create a site first.')
+        redirect_to admin_sites_path
+      end
+
       def index
         @query = Language.on_current_site.ransack(search_filter_params[:q])
         @query.sorts = default_sort_order if @query.sorts.empty?

--- a/app/controllers/alchemy/admin/layoutpages_controller.rb
+++ b/app/controllers/alchemy/admin/layoutpages_controller.rb
@@ -4,6 +4,12 @@ module Alchemy
   module Admin
     class LayoutpagesController < Alchemy::Admin::BaseController
       authorize_resource class: :alchemy_admin_layoutpages
+
+      before_action unless: -> { Alchemy::Language.current }, only: :index do
+        flash[:warning] = Alchemy.t('Please create a language first.')
+        redirect_to admin_languages_path
+      end
+
       helper Alchemy::Admin::PagesHelper
 
       def index

--- a/app/controllers/alchemy/admin/layoutpages_controller.rb
+++ b/app/controllers/alchemy/admin/layoutpages_controller.rb
@@ -5,10 +5,7 @@ module Alchemy
     class LayoutpagesController < Alchemy::Admin::BaseController
       authorize_resource class: :alchemy_admin_layoutpages
 
-      before_action unless: -> { Alchemy::Language.current }, only: :index do
-        flash[:warning] = Alchemy.t('Please create a language first.')
-        redirect_to admin_languages_path
-      end
+      include Alchemy::Admin::LanguageNeededRedirect
 
       helper Alchemy::Admin::PagesHelper
 

--- a/app/controllers/alchemy/admin/nodes_controller.rb
+++ b/app/controllers/alchemy/admin/nodes_controller.rb
@@ -3,10 +3,7 @@
 module Alchemy
   module Admin
     class NodesController < Admin::ResourcesController
-      before_action unless: -> { Alchemy::Language.current }, only: :index do
-        flash[:warning] = Alchemy.t('Please create a language first.')
-        redirect_to admin_languages_path
-      end
+      include Alchemy::Admin::LanguageNeededRedirect
 
       def index
         @root_nodes = Node.language_root_nodes

--- a/app/controllers/alchemy/admin/nodes_controller.rb
+++ b/app/controllers/alchemy/admin/nodes_controller.rb
@@ -3,6 +3,11 @@
 module Alchemy
   module Admin
     class NodesController < Admin::ResourcesController
+      before_action unless: -> { Alchemy::Language.current }, only: :index do
+        flash[:warning] = Alchemy.t('Please create a language first.')
+        redirect_to admin_languages_path
+      end
+
       def index
         @root_nodes = Node.language_root_nodes
       end

--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -15,10 +15,7 @@ module Alchemy
         authorize! :index, :alchemy_admin_pages
       end
 
-      before_action unless: -> { Alchemy::Language.current }, only: :index do
-        flash[:warning] = Alchemy.t('Please create a language first.')
-        redirect_to admin_languages_path
-      end
+      include Alchemy::Admin::LanguageNeededRedirect
 
       before_action :set_translation,
         except: [:show]

--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -60,6 +60,8 @@ module Alchemy
     end
 
     def load_page_by_urlname
+      return unless Language.current
+
       Language.current.pages.where(
         urlname: params[:urlname],
         language_code: params[:locale] || Language.current.code

--- a/app/controllers/alchemy/base_controller.rb
+++ b/app/controllers/alchemy/base_controller.rb
@@ -26,7 +26,7 @@ module Alchemy
     # Sets +I18n.locale+ to current Alchemy language.
     #
     def set_locale
-      ::I18n.locale = Language.current.locale
+      ::I18n.locale = Language.current&.locale
     end
 
     def not_found_error!(msg = "Not found \"#{request.fullpath}\"")

--- a/app/controllers/alchemy/base_controller.rb
+++ b/app/controllers/alchemy/base_controller.rb
@@ -26,6 +26,7 @@ module Alchemy
     # Sets +I18n.locale+ to current Alchemy language.
     #
     def set_locale
+      return unless Language.current
       ::I18n.locale = Language.current&.locale
     end
 

--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -108,6 +108,8 @@ module Alchemy
     # @return NilClass
     #
     def load_page
+      page_not_found! unless Language.current
+
       @page ||= Language.current.pages.contentpages.find_by(
         urlname: params[:urlname],
         language_code: params[:locale] || Language.current.code

--- a/app/controllers/concerns/alchemy/admin/language_needed_redirect.rb
+++ b/app/controllers/concerns/alchemy/admin/language_needed_redirect.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Alchemy
+  module Admin
+    module LanguageNeededRedirect
+      extend ActiveSupport::Concern
+
+      included do
+        before_action unless: -> { Alchemy::Language.current }, only: :index do
+          flash[:warning] = Alchemy.t('Please create a language first.')
+          redirect_to admin_languages_path
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/alchemy/site_redirects.rb
+++ b/app/controllers/concerns/alchemy/site_redirects.rb
@@ -16,7 +16,7 @@ module Alchemy
     end
 
     def needs_redirect_to_primary_host?
-      current_alchemy_site.redirect_to_primary_host? &&
+      current_alchemy_site&.redirect_to_primary_host? &&
         current_alchemy_site.host != '*' &&
         current_alchemy_site.host != request.host
     end

--- a/app/helpers/alchemy/base_helper.rb
+++ b/app/helpers/alchemy/base_helper.rb
@@ -71,6 +71,11 @@ module Alchemy
     # If a String is given, it tries to find the page via page_layout
     # Logs a warning if no page is given.
     def page_or_find(page)
+      unless Language.current
+        warning("No default language set up")
+        return nil
+      end
+
       if page.is_a?(String)
         page = Language.current.pages.find_by(page_layout: page)
       end

--- a/app/models/alchemy/language.rb
+++ b/app/models/alchemy/language.rb
@@ -81,6 +81,8 @@ module Alchemy
 
       # The root page of the current language.
       def current_root_page
+        return unless current
+
         current.pages.language_roots.first
       end
 

--- a/app/models/alchemy/site.rb
+++ b/app/models/alchemy/site.rb
@@ -25,9 +25,6 @@ module Alchemy
 
     scope :published, -> { where(public: true) }
 
-    # Callbacks
-    before_create :create_default_language!, unless: -> { languages.any? }
-
     # concerns
     include Alchemy::Site::Layout
 
@@ -64,7 +61,7 @@ module Alchemy
       end
 
       def default
-        Site.first || create_default_site!
+        Site.first
       end
 
       def find_for_host(host)
@@ -80,38 +77,6 @@ module Alchemy
         all.find do |site|
           site.aliases.split.include?(host) if site.aliases.present?
         end
-      end
-
-      private
-
-      def create_default_site!
-        default_site = Alchemy::Config.get(:default_site)
-        if default_site
-          create!(name: default_site['name'], host: default_site['host'])
-        else
-          raise DefaultSiteNotFoundError
-        end
-      end
-    end
-
-    private
-
-    # If no languages are present, create a default language based
-    # on the host app's Alchemy configuration.
-    def create_default_language!
-      default_language = Alchemy::Config.get(:default_language)
-      if default_language
-        languages.build(
-          name:           default_language['name'],
-          language_code:  default_language['code'],
-          locale:         default_language['code'],
-          frontpage_name: default_language['frontpage_name'],
-          page_layout:    default_language['page_layout'],
-          public:         true,
-          default:        true
-        )
-      else
-        raise DefaultLanguageNotFoundError
       end
     end
   end

--- a/config/alchemy/config.yml
+++ b/config/alchemy/config.yml
@@ -85,7 +85,7 @@ default_site:
   name: Default Site
   host: '*'
 
-# This is the default language when a new site gets created.
+# This is the default language when seeding.
 default_language:
   code: en
   name: English

--- a/lib/alchemy/configuration_methods.rb
+++ b/lib/alchemy/configuration_methods.rb
@@ -28,7 +28,8 @@ module Alchemy
     # matches the current I18n.locale then the prefix os omitted.
     # Also, if only one published language exists.
     #
-    def prefix_locale?(locale = Language.current.code)
+    def prefix_locale?(locale = Language.current&.code)
+      return false unless locale
       multi_language? && locale != ::I18n.default_locale.to_s
     end
 

--- a/lib/alchemy/page_layout.rb
+++ b/lib/alchemy/page_layout.rb
@@ -153,6 +153,7 @@ module Alchemy
       #     page_layouts: [default_intro]
       #
       def available_on_site?(layout)
+        return false unless Alchemy::Site.current
         Alchemy::Site.current.definition.blank? ||
           Alchemy::Site.current.definition.fetch('page_layouts', []).include?(layout['name'])
       end

--- a/lib/alchemy/seeder.rb
+++ b/lib/alchemy/seeder.rb
@@ -30,6 +30,8 @@ module Alchemy
           log "There are already pages present in your database. " \
               "Please use `rake db:reset' if you want to rebuild your database.", :skip
         else
+          create_default_site! unless Alchemy::Site.default
+          create_default_language! unless Alchemy::Language.default
           seed_pages if contentpages.present?
           seed_layoutpages if layoutpages.present?
         end
@@ -106,6 +108,35 @@ module Alchemy
         log "Created page: #{page.name}"
         children.each do |child|
           create_page(child, parent: page)
+        end
+      end
+
+      # If no languages are present, create a default language based
+      # on the host app's Alchemy configuration.
+      def create_default_language!
+        default_language = Alchemy::Config.get(:default_language)
+        if default_language
+          Alchemy::Language.create!(
+            name:           default_language['name'],
+            language_code:  default_language['code'],
+            locale:         default_language['code'],
+            frontpage_name: default_language['frontpage_name'],
+            page_layout:    default_language['page_layout'],
+            public:         true,
+            default:        true,
+            site:           Alchemy::Site.default
+          )
+        else
+          raise DefaultLanguageNotFoundError
+        end
+      end
+
+      def create_default_site!
+        default_site = Alchemy::Config.get(:default_site)
+        if default_site
+          Alchemy::Site.create!(name: default_site['name'], host: default_site['host'])
+        else
+          raise DefaultSiteNotFoundError
         end
       end
     end

--- a/lib/alchemy/test_support/factories/language_factory.rb
+++ b/lib/alchemy/test_support/factories/language_factory.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
 
     public { true }
 
-    site { Alchemy::Site.default }
+    site { Alchemy::Site.default || create(:alchemy_site, :default) }
 
     trait :klingon do
       name { 'Klingon' }

--- a/lib/alchemy/test_support/factories/node_factory.rb
+++ b/lib/alchemy/test_support/factories/node_factory.rb
@@ -6,8 +6,8 @@ require 'alchemy/test_support/factories/page_factory'
 
 FactoryBot.define do
   factory :alchemy_node, class: 'Alchemy::Node' do
-    site { Alchemy::Site.default }
-    language { Alchemy::Language.default }
+    site { Alchemy::Site.default || create(:alchemy_site) }
+    language { Alchemy::Language.default || create(:alchemy_language) }
     name { 'A Node' }
 
     trait :with_page do

--- a/lib/alchemy/test_support/factories/page_factory.rb
+++ b/lib/alchemy/test_support/factories/page_factory.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
 
     parent_id do
       (Alchemy::Page.find_by(language_root: true) ||
-        FactoryBot.create(:alchemy_page, :language_root)).id
+        FactoryBot.create(:alchemy_page, :language_root, language: language)).id
     end
 
     # This speeds up creating of pages dramatically.

--- a/spec/controllers/alchemy/admin/languages_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/languages_controller_spec.rb
@@ -10,6 +10,13 @@ describe Alchemy::Admin::LanguagesController do
   end
 
   describe "#index" do
+    context 'without a site' do
+      it "redirects to the sites admin" do
+        get :index
+        expect(response).to redirect_to(admin_sites_path)
+      end
+    end
+
     context "with multiple sites" do
       let!(:default_site_language) do
         create(:alchemy_language)
@@ -31,6 +38,8 @@ describe Alchemy::Admin::LanguagesController do
     end
 
     context "editor users" do
+      let!(:site) { create(:alchemy_site) }
+
       before do
         authorize_user(:as_editor)
       end
@@ -43,10 +52,21 @@ describe Alchemy::Admin::LanguagesController do
   end
 
   describe "#new" do
-    it "has default language's page_layout set" do
-      get :new
-      expect(assigns(:language).page_layout).
-        to eq(Alchemy::Config.get(:default_language)['page_layout'])
+   context 'without a site' do
+      it "redirects to the sites admin" do
+        get :index
+        expect(response).to redirect_to(admin_sites_path)
+      end
+    end
+
+    context 'with a site' do
+      let!(:site) { create(:alchemy_site) }
+
+      it "has default language's page_layout set" do
+        get :new
+        expect(assigns(:language).page_layout).
+          to eq(Alchemy::Config.get(:default_language)['page_layout'])
+      end
     end
   end
 

--- a/spec/controllers/alchemy/admin/nodes_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/nodes_controller_spec.rb
@@ -11,6 +11,13 @@ module Alchemy
     end
 
     describe '#index' do
+      context 'if no language is present' do
+        it 'redirects to the language admin' do
+          get :index
+          expect(response).to redirect_to(admin_languages_path)
+        end
+      end
+
       context 'if root nodes present' do
         let!(:root_node)  { create(:alchemy_node) }
         let!(:child_node) { create(:alchemy_node, parent_id: root_node.id) }

--- a/spec/controllers/alchemy/base_controller_spec.rb
+++ b/spec/controllers/alchemy/base_controller_spec.rb
@@ -19,9 +19,10 @@ module Alchemy
       context 'without Language.current set' do
         before { Alchemy::Language.current = nil }
 
-        it "sets the ::I18n.locale to default language code" do
-          controller.send(:set_locale)
-          expect(::I18n.locale).to eq(Language.default.code.to_sym)
+        it "does not set the ::I18n.locale" do
+          expect {
+            controller.send(:set_locale)
+          }.not_to change { ::I18n.locale }
         end
       end
     end

--- a/spec/controllers/alchemy/base_controller_spec.rb
+++ b/spec/controllers/alchemy/base_controller_spec.rb
@@ -37,11 +37,17 @@ module Alchemy
     describe "#multi_language?" do
       subject { controller.multi_language? }
 
+      context "if no language exists" do
+        it { is_expected.to be(false) }
+      end
+
       context "if less than two published languages exists" do
+        let!(:language) { create(:alchemy_language) }
         it { is_expected.to be(false) }
       end
 
       context "if more than one published language exists" do
+        let!(:language) { create(:alchemy_language) }
         let!(:language_2) do
           create(:alchemy_language, :klingon)
         end
@@ -70,13 +76,14 @@ module Alchemy
       subject(:prefix_locale?) { controller.prefix_locale? }
 
       context "if multi_language? is true" do
-        before do
-          expect(controller).to receive(:multi_language?) { true }
+        let!(:language) { create(:alchemy_language) }
+        let!(:language_2) do
+          create(:alchemy_language, :klingon)
         end
 
         context "and current language is not the default locale" do
           before do
-            allow(Alchemy::Language).to receive(:current) { double(code: 'en') }
+            allow(Alchemy::Language).to receive(:current) { double(code: 'kl') }
             allow(::I18n).to receive(:default_locale) { :de }
           end
 
@@ -114,9 +121,7 @@ module Alchemy
       end
 
       context "if multi_language? is false" do
-        before do
-          expect(controller).to receive(:multi_language?) { false }
-        end
+        let!(:language) { create(:alchemy_language) }
 
         it { expect(prefix_locale?).to be(false) }
       end

--- a/spec/controllers/alchemy/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/pages_controller_spec.rb
@@ -7,7 +7,7 @@ module Alchemy
   describe PagesController do
     routes { Alchemy::Engine.routes }
 
-    let(:default_language) { Language.default }
+    let(:default_language) { create(:alchemy_language) }
 
     let(:default_language_root) do
       create(:alchemy_page, :language_root, language: default_language, name: 'Home')
@@ -28,81 +28,75 @@ module Alchemy
     end
 
     describe "#index" do
-      before do
-        default_language_root
+      context 'without a site or language present' do
+        it 'returns a 404' do
+          expect { get(:index) }.to raise_exception(
+            ActionController::RoutingError,
+           'Alchemy::Page not found "/"'
+          )
+        end
       end
 
-      it 'renders :show template' do
-        expect(get(:index)).to render_template(:show)
-      end
-
-      context 'requesting nothing' do
-        it 'loads default language root page' do
-          get :index
-          expect(assigns(:page)).to eq(default_language_root)
+      context 'with site and language root present' do
+        before do
+          default_language_root
         end
 
-        it 'sets @root_page to default language root' do
-          get :index
-          expect(assigns(:root_page)).to eq(default_language_root)
+        it 'renders :show template' do
+          expect(get(:index)).to render_template(:show)
         end
 
-        context 'and the root page is not public' do
-          before do
-            default_language_root.update!(public_on: nil)
+        context 'requesting nothing' do
+          it 'loads default language root page' do
+            get :index
+            expect(assigns(:page)).to eq(default_language_root)
           end
 
-          context 'and redirect_to_public_child is set to false' do
+          it 'sets @root_page to default language root' do
+            get :index
+            expect(assigns(:root_page)).to eq(default_language_root)
+          end
+
+          context 'and the root page is not public' do
             before do
-              stub_alchemy_config(:redirect_to_public_child, false)
+              default_language_root.update!(public_on: nil)
             end
 
-            it 'raises routing error (404)' do
-              expect {
-                get :index
-              }.to raise_error(ActionController::RoutingError)
-            end
-
-            context "when a page layout callback is set" do
+            context 'and redirect_to_public_child is set to false' do
               before do
-                ApplicationController.extend Alchemy::OnPageLayout
-                ApplicationController.class_eval do
-                  on_page_layout('index') { "do something" }
-                end
+                stub_alchemy_config(:redirect_to_public_child, false)
               end
 
-              it 'raises routing error (404) and no "undefined method for nil" error' do
+              it 'raises routing error (404)' do
                 expect {
                   get :index
                 }.to raise_error(ActionController::RoutingError)
               end
-            end
-          end
 
-          context 'and redirect_to_public_child is set to true' do
-            before do
-              stub_alchemy_config(:redirect_to_public_child, true)
-            end
+              context "when a page layout callback is set" do
+                before do
+                  ApplicationController.extend Alchemy::OnPageLayout
+                  ApplicationController.class_eval do
+                    on_page_layout('index') { "do something" }
+                  end
+                end
 
-            context 'that has a public child' do
-              let!(:public_child) do
-                create(:alchemy_page, :public, parent: default_language_root)
-              end
-
-              it 'loads this page' do
-                get :index
-                expect(assigns(:page)).to eq(public_child)
+                it 'raises routing error (404) and no "undefined method for nil" error' do
+                  expect {
+                    get :index
+                  }.to raise_error(ActionController::RoutingError)
+                end
               end
             end
 
-            context 'that has a non public child' do
-              let!(:non_public_child) do
-                create(:alchemy_page, parent: default_language_root)
+            context 'and redirect_to_public_child is set to true' do
+              before do
+                stub_alchemy_config(:redirect_to_public_child, true)
               end
 
               context 'that has a public child' do
                 let!(:public_child) do
-                  create(:alchemy_page, :public, parent: non_public_child)
+                  create(:alchemy_page, :public, parent: default_language_root)
                 end
 
                 it 'loads this page' do
@@ -112,235 +106,252 @@ module Alchemy
               end
 
               context 'that has a non public child' do
-                before do
-                  create(:alchemy_page, parent: non_public_child)
+                let!(:non_public_child) do
+                  create(:alchemy_page, parent: default_language_root)
                 end
 
-                it 'raises routing error (404)' do
-                  expect {
+                context 'that has a public child' do
+                  let!(:public_child) do
+                    create(:alchemy_page, :public, parent: non_public_child)
+                  end
+
+                  it 'loads this page' do
                     get :index
-                  }.to raise_error(ActionController::RoutingError)
+                    expect(assigns(:page)).to eq(public_child)
+                  end
+                end
+
+                context 'that has a non public child' do
+                  before do
+                    create(:alchemy_page, parent: non_public_child)
+                  end
+
+                  it 'raises routing error (404)' do
+                    expect {
+                      get :index
+                    }.to raise_error(ActionController::RoutingError)
+                  end
                 end
               end
             end
           end
         end
-      end
 
-      context 'requesting non default locale' do
-        let!(:deutsch) do
-          create(:alchemy_language, name: 'Deutsch', code: 'de', default: false)
-        end
+        context 'requesting non default locale' do
+          let!(:english) do
+            create(:alchemy_language, :english, default: false)
+          end
 
-        let!(:startseite) do
-          create :alchemy_page, :language_root,
-            language: deutsch,
-            name: 'Startseite'
-        end
+          let!(:start_page) do
+            create :alchemy_page, :language_root,
+              language: english,
+              name: 'Start Page'
+          end
 
-        before do
-          allow(::I18n).to receive(:default_locale) { 'en' }
-        end
+          before do
+            allow(::I18n).to receive(:default_locale) { 'de' }
+          end
 
-        it 'loads the root page of that language' do
-          get :index, params: {locale: 'de'}
-          expect(assigns(:page)).to eq(startseite)
-        end
+          it 'loads the root page of that language' do
+            get :index, params: {locale: 'en'}
+            expect(assigns(:page)).to eq(start_page)
+          end
 
-        it 'sets @root_page to root page of that language' do
-          get :index, params: {locale: 'de'}
-          expect(assigns(:root_page)).to eq(startseite)
-        end
-      end
-    end
-
-    describe 'requesting a not yet public page' do
-      let(:not_yet_public) do
-        create :alchemy_page,
-          parent: default_language_root,
-          public_on: 1.day.from_now
-      end
-
-      it "renders 404" do
-        expect {
-          get :show, params: {urlname: not_yet_public.urlname}
-        }.to raise_error(ActionController::RoutingError)
-      end
-    end
-
-    describe 'requesting a no longer public page' do
-      let(:no_longer_public) do
-        create :alchemy_page,
-          parent: default_language_root,
-          public_on: 2.days.ago,
-          public_until: 1.day.ago
-      end
-
-      it "renders 404" do
-        expect {
-          get :show, params: {urlname: no_longer_public.urlname}
-        }.to raise_error(ActionController::RoutingError)
-      end
-    end
-
-    describe 'requesting a still public page' do
-      let(:still_public_page) do
-        create :alchemy_page,
-          parent: default_language_root,
-          public_on: 2.days.ago,
-          public_until: 1.day.from_now
-      end
-
-      it "renders page" do
-        get :show, params: {urlname: still_public_page.urlname}
-        expect(response).to be_successful
-      end
-    end
-
-    describe 'requesting a page without time limit' do
-      let(:still_public_page) do
-        create :alchemy_page,
-          parent: default_language_root,
-          public_on: 2.days.ago,
-          public_until: nil
-      end
-
-      it "renders page" do
-        get :show, params: {urlname: still_public_page.urlname}
-        expect(response).to be_successful
-      end
-    end
-
-    context "requested for a page containing a feed" do
-      render_views
-
-      it "should render a rss feed" do
-        get :show, params: {urlname: page.urlname, format: :rss}
-        expect(response.media_type).to eq('application/rss+xml')
-      end
-
-      it "should include content" do
-        page.elements.first.content_by_name('news_headline').essence.update_columns(body: 'Peters Petshop')
-        get :show, params: {urlname: 'news', format: :rss}
-        expect(response.body).to match /Peters Petshop/
-      end
-    end
-
-    context "requested for a page that does not contain a feed" do
-      it "should render xml 404 error" do
-        get :show, params: {urlname: default_language_root.urlname, format: :rss}
-        expect(response.status).to eq(404)
-      end
-    end
-
-    describe "Layout rendering" do
-      context "with ajax request" do
-        it "should not render a layout" do
-          get :show, params: {urlname: page.urlname}, xhr: true
-          expect(response).to render_template(:show)
-          expect(response).not_to render_template(layout: 'application')
-        end
-      end
-    end
-
-    describe "url nesting" do
-      render_views
-
-      let(:catalog)  { create(:alchemy_page, :public, name: "Catalog", urlname: 'catalog', parent: default_language_root, language: default_language, visible: true) }
-      let(:products) { create(:alchemy_page, :public, name: "Products", urlname: 'products', parent: catalog, language: default_language, visible: true) }
-      let(:product)  { create(:alchemy_page, :public, name: "Screwdriver", urlname: 'screwdriver', parent: products, language: default_language, autogenerate_elements: true, visible: true) }
-
-      before do
-        allow(Alchemy.user_class).to receive(:admins).and_return(OpenStruct.new(count: 1))
-        stub_alchemy_config(:url_nesting, true)
-        product.elements.find_by_name('article').contents.essence_texts.first.essence.update_column(:body, 'screwdriver')
-      end
-
-      context "with correct levelnames in params" do
-        it "should show the requested page" do
-          get :show, params: {urlname: 'catalog/products/screwdriver'}
-          expect(response.status).to eq(200)
-          expect(response.body).to have_content("screwdriver")
+          it 'sets @root_page to root page of that language' do
+            get :index, params: {locale: 'en'}
+            expect(assigns(:root_page)).to eq(start_page)
+          end
         end
       end
 
-      context "with incorrect levelnames in params" do
-        it "should render a 404 page" do
+      describe 'requesting a not yet public page' do
+        let(:not_yet_public) do
+          create :alchemy_page,
+            parent: default_language_root,
+            public_on: 1.day.from_now
+        end
+
+        it "renders 404" do
           expect {
-            get :show, params: {urlname: 'catalog/faqs/screwdriver'}
+            get :show, params: {urlname: not_yet_public.urlname}
           }.to raise_error(ActionController::RoutingError)
         end
       end
-    end
 
-    context "when a non-existent page is requested" do
-      it "should rescue a RoutingError with rendering a 404 page." do
-        expect {
-          get :show, params: {urlname: 'doesntexist'}
-        }.to raise_error(ActionController::RoutingError)
-      end
-    end
-
-    describe "while redirecting" do
-      context "not in multi language mode" do
-        before do
-          allow_any_instance_of(PagesController).to receive(:multi_language?).and_return(false)
+      describe 'requesting a no longer public page' do
+        let(:no_longer_public) do
+          create :alchemy_page,
+            parent: default_language_root,
+            public_on: 2.days.ago,
+            public_until: 1.day.ago
         end
 
-        context "with no lang parameter present" do
-          it "should store defaults language id in the session." do
-            get :show, params: {urlname: page.urlname}
-            expect(controller.session[:alchemy_language_id]).to eq(Language.default.id)
-          end
-
-          it "should store default language as class var." do
-            get :show, params: {urlname: page.urlname}
-            expect(Language.current).to eq(Language.default)
-          end
+        it "renders 404" do
+          expect {
+            get :show, params: {urlname: no_longer_public.urlname}
+          }.to raise_error(ActionController::RoutingError)
         end
       end
-    end
 
-    context 'in an environment with multiple languages' do
-      let(:klingon) { create(:alchemy_language, :klingon) }
+      describe 'requesting a still public page' do
+        let(:still_public_page) do
+          create :alchemy_page,
+            parent: default_language_root,
+            public_on: 2.days.ago,
+            public_until: 1.day.from_now
+        end
 
-      context 'having two pages with the same url names in different languages' do
+        it "renders page" do
+          get :show, params: {urlname: still_public_page.urlname}
+          expect(response).to be_successful
+        end
+      end
+
+      describe 'requesting a page without time limit' do
+        let(:still_public_page) do
+          create :alchemy_page,
+            parent: default_language_root,
+            public_on: 2.days.ago,
+            public_until: nil
+        end
+
+        it "renders page" do
+          get :show, params: {urlname: still_public_page.urlname}
+          expect(response).to be_successful
+        end
+      end
+
+      context "requested for a page containing a feed" do
         render_views
 
-        let!(:klingon_page) { create(:alchemy_page, :public, language: klingon, name: "same-name", autogenerate_elements: true) }
-        let!(:english_page) { create(:alchemy_page, :public, language: default_language, name: "same-name") }
+        it "should render a rss feed" do
+          get :show, params: {urlname: page.urlname, format: :rss}
+          expect(response.media_type).to eq('application/rss+xml')
+        end
+
+        it "should include content" do
+          page.elements.first.content_by_name('news_headline').essence.update_columns(body: 'Peters Petshop')
+          get :show, params: {urlname: 'news', format: :rss}
+          expect(response.body).to match /Peters Petshop/
+        end
+      end
+
+      context "requested for a page that does not contain a feed" do
+        it "should render xml 404 error" do
+          get :show, params: {urlname: default_language_root.urlname, format: :rss}
+          expect(response.status).to eq(404)
+        end
+      end
+
+      describe "Layout rendering" do
+        context "with ajax request" do
+          it "should not render a layout" do
+            get :show, params: {urlname: page.urlname}, xhr: true
+            expect(response).to render_template(:show)
+            expect(response).not_to render_template(layout: 'application')
+          end
+        end
+      end
+
+      describe "url nesting" do
+        render_views
+
+        let(:catalog)  { create(:alchemy_page, :public, name: "Catalog", urlname: 'catalog', parent: default_language_root, language: default_language, visible: true) }
+        let(:products) { create(:alchemy_page, :public, name: "Products", urlname: 'products', parent: catalog, language: default_language, visible: true) }
+        let(:product)  { create(:alchemy_page, :public, name: "Screwdriver", urlname: 'screwdriver', parent: products, language: default_language, autogenerate_elements: true, visible: true) }
 
         before do
-          # Set a text in an essence rendered on the page so we can match against that
-          klingon_page.essence_texts.first.update_column(:body, 'klingon page')
+          allow(Alchemy.user_class).to receive(:admins).and_return(OpenStruct.new(count: 1))
+          stub_alchemy_config(:url_nesting, true)
+          product.elements.find_by_name('article').contents.essence_texts.first.essence.update_column(:body, 'screwdriver')
         end
 
-        it 'renders the page related to its language' do
-          get :show, params: {urlname: "same-name", locale: klingon_page.language_code}
-          expect(response.body).to have_content("klingon page")
+        context "with correct levelnames in params" do
+          it "should show the requested page" do
+            get :show, params: {urlname: 'catalog/products/screwdriver'}
+            expect(response.status).to eq(200)
+            expect(response.body).to have_content("screwdriver")
+          end
+        end
+
+        context "with incorrect levelnames in params" do
+          it "should render a 404 page" do
+            expect {
+              get :show, params: {urlname: 'catalog/faqs/screwdriver'}
+            }.to raise_error(ActionController::RoutingError)
+          end
         end
       end
-    end
 
-    describe '#page_etag' do
-      subject { controller.send(:page_etag) }
-
-      before do
-        expect(page).to receive(:cache_key).and_return('aaa')
-        controller.instance_variable_set('@page', page)
+      context "when a non-existent page is requested" do
+        it "should rescue a RoutingError with rendering a 404 page." do
+          expect {
+            get :show, params: {urlname: 'doesntexist'}
+          }.to raise_error(ActionController::RoutingError)
+        end
       end
 
-      it "returns the etag for response headers" do
-        expect(subject).to eq('aaa')
+      describe "while redirecting" do
+        context "not in multi language mode" do
+          before do
+            allow_any_instance_of(PagesController).to receive(:multi_language?).and_return(false)
+          end
+
+          context "with no lang parameter present" do
+            it "should store defaults language id in the session." do
+              get :show, params: {urlname: page.urlname}
+              expect(controller.session[:alchemy_language_id]).to eq(Language.default.id)
+            end
+
+            it "should store default language as class var." do
+              get :show, params: {urlname: page.urlname}
+              expect(Language.current).to eq(Language.default)
+            end
+          end
+        end
       end
 
-      context 'with user logged in' do
+      context 'in an environment with multiple languages' do
+        let(:klingon) { create(:alchemy_language, :klingon) }
+
+        context 'having two pages with the same url names in different languages' do
+          render_views
+
+          let!(:klingon_page) { create(:alchemy_page, :public, language: klingon, name: "same-name", autogenerate_elements: true) }
+          let!(:english_page) { create(:alchemy_page, :public, language: default_language, name: "same-name") }
+
+          before do
+            # Set a text in an essence rendered on the page so we can match against that
+            klingon_page.essence_texts.first.update_column(:body, 'klingon page')
+          end
+
+          it 'renders the page related to its language' do
+            get :show, params: {urlname: "same-name", locale: klingon_page.language_code}
+            expect(response.body).to have_content("klingon page")
+          end
+        end
+      end
+
+      describe '#page_etag' do
+        subject { controller.send(:page_etag) }
+
         before do
-          authorize_user(mock_model(Alchemy.user_class, cache_key: 'bbb'))
+          expect(page).to receive(:cache_key).and_return('aaa')
+          controller.instance_variable_set('@page', page)
         end
 
-        it "returns another etag for response headers" do
-          expect(subject).to eq('aaabbb')
+        it "returns the etag for response headers" do
+          expect(subject).to eq('aaa')
+        end
+
+        context 'with user logged in' do
+          before do
+            authorize_user(mock_model(Alchemy.user_class, cache_key: 'bbb'))
+          end
+
+          it "returns another etag for response headers" do
+            expect(subject).to eq('aaabbb')
+          end
         end
       end
     end

--- a/spec/features/admin/languages_features_spec.rb
+++ b/spec/features/admin/languages_features_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "Admin Languages Features", type: :system do
   describe 'creating a new language' do
     context 'when selected locale is not an available locale' do
       before do
+        create(:alchemy_site)
         allow(::I18n).to receive(:available_locales) { [:de, :en] }
       end
 

--- a/spec/features/admin/menus_features_spec.rb
+++ b/spec/features/admin/menus_features_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Admin Menus Features", type: :system do
 
   describe 'adding a new menu' do
     context 'on the index page' do
-      let!(:default_site) { create(:alchemy_site, :default) }
+      let!(:default_language) { create(:alchemy_language) }
 
       it 'creates menu' do
         visit alchemy.admin_nodes_path
@@ -25,7 +25,9 @@ RSpec.describe "Admin Menus Features", type: :system do
   describe 'adding a new menu' do
     context 'with multiple sites' do
       let!(:default_site) { create(:alchemy_site, :default) }
+      let!(:default_language) { create(:alchemy_language, site: default_site) }
       let!(:site_2) { create(:alchemy_site, host: 'another-site.com') }
+      let!(:site_2_language) { create(:alchemy_language, site: site_2) }
       let(:node) { Alchemy::Node.last }
 
       it 'creates menu for current site' do

--- a/spec/features/admin/navigation_feature_spec.rb
+++ b/spec/features/admin/navigation_feature_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'Admin navigation feature', type: :system do
   end
 
   context 'editor users' do
+    let!(:default_site) { create(:alchemy_site) }
     before { authorize_user(:as_editor) }
 
     it "can access the languages page" do

--- a/spec/features/page_feature_spec.rb
+++ b/spec/features/page_feature_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Show page feature:', type: :system do
-  let!(:default_language) { Alchemy::Language.default }
+  let!(:default_language) { create(:alchemy_language) }
 
   let!(:default_language_root) do
     create(:alchemy_page, :language_root, language: default_language, name: 'Home')

--- a/spec/features/page_redirects_spec.rb
+++ b/spec/features/page_redirects_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Requesting a page' do
-  let!(:default_language) { Alchemy::Language.default }
+  let!(:default_language) { create(:alchemy_language, :english, default: true) }
 
   let!(:default_language_root) do
     create(:alchemy_page, :language_root, language: default_language, name: 'Home')

--- a/spec/helpers/alchemy/pages_helper_spec.rb
+++ b/spec/helpers/alchemy/pages_helper_spec.rb
@@ -201,13 +201,13 @@ module Alchemy
           context "with options[:reverse]" do
             context "set to false" do
               it "should render the language links in an ascending order" do
-                expect(helper.language_links(reverse: false)).to have_selector("a.en + a.kl")
+                expect(helper.language_links(reverse: false)).to have_selector("a.de + a.kl")
               end
             end
 
             context "set to true" do
               it "should render the language links in a descending order" do
-                expect(helper.language_links(reverse: true)).to have_selector("a.kl + a.en")
+                expect(helper.language_links(reverse: true)).to have_selector("a.kl + a.de")
               end
             end
           end

--- a/spec/libraries/configuration_methods_spec.rb
+++ b/spec/libraries/configuration_methods_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Alchemy::ConfigurationMethods do
+  let(:controller) do
+    class SomeController < ActionController::Base
+      include Alchemy::ConfigurationMethods
+    end
+
+    SomeController.new
+  end
+
+  describe '#prefix_locale?' do
+    subject { controller.prefix_locale? }
+
+    context 'if no languages are present' do
+      it { is_expected.to be false }
+    end
+
+    context 'if one language is present' do
+      let!(:language) { create(:alchemy_language) }
+
+      it { is_expected.to be false }
+    end
+
+    context 'if more than one language is present' do
+      let!(:german) { create(:alchemy_language) }
+      let!(:english) { create(:alchemy_language, :english) }
+
+      subject { controller.prefix_locale?(args) }
+
+      around do |example|
+        old_locale = I18n.default_locale
+        ::I18n.default_locale = 'de'
+        example.run
+        ::I18n.default_locale = old_locale
+      end
+
+      context 'and it is called with the default language' do
+        let(:args) { 'de' }
+        it { is_expected.to be false }
+      end
+
+      context 'and it is called with the non-default language' do
+        let(:args) { 'en' }
+
+        it { is_expected.to be true }
+      end
+
+      context 'and it is called with bogus stuff' do
+        let(:args) { 'kl' }
+
+        it { is_expected.to be true }
+      end
+    end
+  end
+end

--- a/spec/libraries/controller_actions_spec.rb
+++ b/spec/libraries/controller_actions_spec.rb
@@ -54,7 +54,7 @@ describe 'Alchemy::ControllerActions', type: 'controller' do
   end
 
   describe "#set_alchemy_language" do
-    let(:default_language) { Alchemy::Language.default }
+    let!(:default_language) { create(:alchemy_language, code: :en) }
     let(:klingon)          { create(:alchemy_language, :klingon) }
 
     after do
@@ -115,7 +115,7 @@ describe 'Alchemy::ControllerActions', type: 'controller' do
         end
 
         let(:french_language) do
-          french_site.default_language
+          create(:alchemy_language, site: french_site, code: :fr)
         end
 
         before do

--- a/spec/libraries/page_layout_spec.rb
+++ b/spec/libraries/page_layout_spec.rb
@@ -85,7 +85,8 @@ module Alchemy
     end
 
     describe '.selectable_layouts' do
-      let(:language) { Language.default }
+      let(:site) { create(:alchemy_site) }
+      let(:language) { create(:alchemy_language, code: :de) }
       before { language }
       subject { PageLayout.selectable_layouts(language.id) }
 
@@ -105,14 +106,12 @@ module Alchemy
       end
 
       context "with sites layouts present" do
-        let(:site) { Site.new }
-
-        let(:definitions) do
-          [{'name' => 'default_site', 'page_layouts' => %w(index)}]
+        let(:definition) do
+          {'name' => 'default_site', 'page_layouts' => %w(index)}
         end
 
         before do
-          allow(Site).to receive(:definitions).and_return(definitions)
+          allow_any_instance_of(Site).to receive(:definition).and_return(definition)
         end
 
         it "should only return layouts for site" do

--- a/spec/models/alchemy/language_spec.rb
+++ b/spec/models/alchemy/language_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 module Alchemy
   describe Language do
-    let(:default_language) { Alchemy::Language.default }
+    let(:default_language) { create(:alchemy_language) }
     let(:language)         { create(:alchemy_language, :klingon) }
     let(:page)             { create(:alchemy_page, language: language) }
 

--- a/spec/models/alchemy/node_spec.rb
+++ b/spec/models/alchemy/node_spec.rb
@@ -19,8 +19,8 @@ module Alchemy
       end
 
       context 'with current language present' do
-        let(:root_node)  { create(:alchemy_node) }
-        let(:child_node) { create(:alchemy_node, parent_id: root_node.id) }
+        let!(:root_node)  { create(:alchemy_node) }
+        let!(:child_node) { create(:alchemy_node, parent_id: root_node.id) }
 
         it "returns root nodes from current language" do
           expect(Node.language_root_nodes).to include(root_node)

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 module Alchemy
   describe Page do
     let(:rootpage)      { Page.root }
-    let(:language)      { Language.default }
+    let(:language)      { create(:alchemy_language, :english, default: true) }
     let(:klingon)       { create(:alchemy_language, :klingon) }
     let(:language_root) { create(:alchemy_page, :language_root) }
     let(:page)          { mock_model(Page, page_layout: 'foo') }

--- a/spec/models/alchemy/site_spec.rb
+++ b/spec/models/alchemy/site_spec.rb
@@ -14,26 +14,6 @@ module Alchemy
       end
 
       context 'when being saved' do
-        context 'when it has no languages yet' do
-          it 'should automatically create a default language' do
-            subject.save!
-            expect(subject.languages.count).to eq(1)
-            expect(subject.languages.first).to be_default
-          end
-
-          context 'when default language configuration is missing' do
-            before do
-              stub_alchemy_config(:default_language, nil)
-            end
-
-            it 'raises error' do
-              expect {
-                subject.save!
-              }.to raise_error(DefaultLanguageNotFoundError)
-            end
-          end
-        end
-
         context 'when it already has a language' do
           let(:language) { build(:alchemy_language, site: nil) }
           before { subject.languages << language }
@@ -56,21 +36,7 @@ module Alchemy
           Site.delete_all
         end
 
-        it 'creates it' do
-          expect { subject }.to change { Site.count }.by(1)
-        end
-
-        context 'when default site configuration is missing' do
-          before do
-            stub_alchemy_config(:default_site, nil)
-          end
-
-          it 'raises error' do
-            expect {
-              subject.save!
-            }.to raise_error(DefaultSiteNotFoundError)
-          end
-        end
+        it { is_expected.to be nil }
       end
 
       context 'when default site is present' do
@@ -122,7 +88,11 @@ module Alchemy
 
     describe '.current' do
       context 'when set to nil' do
-        before { Site.current = nil }
+        let!(:site) { create(:alchemy_site, host: 'example.com') }
+
+        before do
+          Site.current = nil
+        end
 
         it "should return default site" do
           expect(Site.current).not_to be_nil
@@ -206,11 +176,11 @@ module Alchemy
 
     describe '#default_language' do
       let!(:default_language) do
-        Alchemy::Language.find_by(default: true, site: site)
+        create(:alchemy_language, default: true, site: site)
       end
 
       let!(:other_language) do
-        create(:alchemy_language, default: false, site: site)
+        create(:alchemy_language, :english, default: false, site: site)
       end
 
       subject(:site_default_language) do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -78,6 +78,7 @@ RSpec.configure do |config|
   # All specs are running in transactions, but feature specs not.
   config.before(:each) do
     Alchemy::Site.current = nil
+    Alchemy::Language.current = nil
     ::I18n.locale = :en
   end
 

--- a/spec/requests/alchemy/admin/pages_controller_spec.rb
+++ b/spec/requests/alchemy/admin/pages_controller_spec.rb
@@ -5,6 +5,9 @@ require 'rails_helper'
 
 module Alchemy
   describe Admin::PagesController do
+    let(:site) { create(:alchemy_site, host: "*") }
+    let!(:language) { create(:alchemy_language, site: site) }
+
     context 'a guest' do
       it 'can not access page tree' do
         get admin_pages_path
@@ -27,8 +30,6 @@ module Alchemy
       before { authorize_user(user) }
 
       describe '#index' do
-        let!(:language) { create(:alchemy_language) }
-
         context 'with existing language root page' do
           let!(:language_root) { create(:alchemy_page, :language_root) }
 
@@ -59,7 +60,7 @@ module Alchemy
             end
 
             let(:site_2_language) do
-              site_2.default_language
+              create(:alchemy_language, site: site_2)
             end
 
             before do

--- a/spec/requests/alchemy/site_requests_spec.rb
+++ b/spec/requests/alchemy/site_requests_spec.rb
@@ -5,10 +5,11 @@ require 'rails_helper'
 RSpec.describe 'Site requests' do
   context 'a site with host' do
     let!(:site) { create(:alchemy_site, :public, host: 'alchemy-cms.com') }
+    let(:language) { create(:alchemy_language, site: site) }
 
     let(:page) do
       Alchemy::Site.current = site
-      root = create(:alchemy_page, :language_root, language: site.languages.last)
+      root = create(:alchemy_page, :language_root, language: language)
       create(:alchemy_page, :public, parent: root)
     end
 

--- a/spec/views/pages/meta_data_spec.rb
+++ b/spec/views/pages/meta_data_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 module Alchemy
   describe 'alchemy/pages/_meta_data' do
+    let!(:language) { create(:alchemy_language, code: :en) }
     let(:root_page)       { Page.new }
     let(:page)            { Page.new(language_code: "en", title: "Road Runner", urlname: "roadrunner") }
     let(:title_prefix)    { "" }


### PR DESCRIPTION
## What is this pull request for?

We do not want to implicitly create a site when none or a language when none is there. This
should be in control of the admin user. Instead, an admin user on a new site gets redirected to sites/languages whenever she tries accessing the pages, layoutpages, or menu admin.

This will  make it easier to explicitly do test setup for multi-site and multi-language projects.

### Notable changes (remove if none)

We make no use anymore of the default site configuration in `config/alchemy/config.yml`. 

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have changed and removed specs to cover the removed functionality
