### PR TITLE
Add element editor loaded event

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.elements_window.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.elements_window.js.coffee
@@ -50,6 +50,7 @@ Alchemy.ElementsWindow =
     $.get @url, (data) =>
       @element_area.html data
       Alchemy.GUI.init(@element_area)
+      @element_area.trigger('LoadedElementEditor.Alchemy');
       if @callback
         @callback.call()
     .fail (xhr, status, error) =>


### PR DESCRIPTION
## What is this pull request for?
Trigger event when the admin content editor is loaded. Eg:

```
$('#element_area').on('LoadedElementEditor.Alchemy', () => {
  console.log('Now the editors exist for querying!');
})
```

## Checklist
- [X] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [ ] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
