### PR TITLE
Change menus to render correct language

### DIFF
--- a/app/helpers/alchemy/pages_helper.rb
+++ b/app/helpers/alchemy/pages_helper.rb
@@ -83,7 +83,6 @@ module Alchemy
     def render_menu(name, options = {})
       root_node = Alchemy::Node.roots.find_by(
         name: name,
-        site: Alchemy::Site.current,
         language: Alchemy::Language.current
       )
       if root_node.nil?

--- a/app/helpers/alchemy/pages_helper.rb
+++ b/app/helpers/alchemy/pages_helper.rb
@@ -81,7 +81,11 @@ module Alchemy
     # @param [String] - Name of the menu
     # @param [Hash] - A set of options available in your menu partials
     def render_menu(name, options = {})
-      root_node = Alchemy::Node.roots.find_by(name: name, site: Alchemy::Site.current)
+      root_node = Alchemy::Node.roots.find_by(
+        name: name,
+        site: Alchemy::Site.current,
+        language: Alchemy::Language.current
+      )
       if root_node.nil?
         warning("Menu with name #{name} not found!")
         return

--- a/spec/helpers/alchemy/pages_helper_spec.rb
+++ b/spec/helpers/alchemy/pages_helper_spec.rb
@@ -76,6 +76,18 @@ module Alchemy
           is_expected.to have_selector('ul.nav > li.nav-item > a.nav-link[href="/default-site"]')
         end
       end
+
+      context 'with multiple languages' do
+        let!(:menu) { create(:alchemy_node, name: name) }
+        let!(:node) { create(:alchemy_node, parent: menu, url: '/default') }
+        let!(:klingon_menu) { create(:alchemy_node, name: name, language: klingon) }
+        let!(:klingon_node) { create(:alchemy_node, parent: klingon_menu, language: klingon, url: '/klingon') }
+
+        it 'should return the menu for the current language' do
+          is_expected.to have_selector('ul.nav > li.nav-item > a.nav-link[href="/default"]')
+          is_expected.not_to have_selector('ul.nav > li.nav-item > a.nav-link[href="/klingon"]')
+        end
+      end
     end
 
     describe "#render_breadcrumb" do


### PR DESCRIPTION
## What is this pull request for?

Currently, Alchemy Menus will render the first menu item by name, and not the menu item by current language. Now, we can have proper multi-language menus.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
