### PR TITLE
Fix bug in language from session w/o site

### DIFF
--- a/lib/alchemy/controller_actions.rb
+++ b/lib/alchemy/controller_actions.rb
@@ -82,7 +82,7 @@ module Alchemy
     # Load language from session if it's present on current site.
     # Otherwise return nil so we can load the default language from current site.
     def load_alchemy_language_from_session
-      if session[:alchemy_language_id].present?
+      if session[:alchemy_language_id].present? && Site.current
         Site.current.languages.find_by(id: session[:alchemy_language_id])
       end
     end

--- a/spec/libraries/controller_actions_spec.rb
+++ b/spec/libraries/controller_actions_spec.rb
@@ -109,6 +109,19 @@ describe 'Alchemy::ControllerActions', type: 'controller' do
         expect(Alchemy::Language.current).to eq(klingon)
       end
 
+      context "if no current site exists" do
+        before do
+          expect(Alchemy::Site).to receive(:current).exactly(:twice) { nil }
+        end
+
+        it "should set the default language" do
+          controller.send :set_alchemy_language
+
+          expect(assigns(:language)).to eq(default_language)
+          expect(Alchemy::Language.current).to eq(default_language)
+        end
+      end
+
       context "if the language is not on the current site" do
         let(:french_site) do
           create(:alchemy_site, host: 'french.fr')


### PR DESCRIPTION
If there is no Site yet the language can not be loaded from the users session. We must fall back to the default language.
