### PR TITLE
Add support for parent and child page restrictions in page_layout definition

### DIFF
--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -57,9 +57,9 @@ module Alchemy
 
       def new
         @page ||= Page.new(layoutpage: params[:layoutpage] == "true", parent_id: params[:parent_id])
-        @page_layouts = PageLayout.layouts_for_select(@current_language.id, @page.layoutpage?)
+        @page_layouts = PageLayout.layouts_for_select(@current_language.id, @page.layoutpage?, @page.parent&.page_layout)
         @clipboard = get_clipboard("pages")
-        @clipboard_items = Page.all_from_clipboard_for_select(@clipboard, @current_language.id, @page.layoutpage?)
+        @clipboard_items = Page.all_from_clipboard_for_select(@clipboard, @current_language.id, @page.layoutpage?, @page.parent&.page_layout)
       end
 
       def create

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -226,11 +226,11 @@ module Alchemy
         where(id: clipboard.collect { |p| p["id"] })
       end
 
-      def all_from_clipboard_for_select(clipboard, language_id, layoutpage = false)
+      def all_from_clipboard_for_select(clipboard, language_id, layoutpage = false, parent_layout_name = nil)
         return [] if clipboard.blank?
 
         clipboard_pages = all_from_clipboard(clipboard)
-        allowed_page_layouts = Alchemy::PageLayout.selectable_layouts(language_id, layoutpage)
+        allowed_page_layouts = Alchemy::PageLayout.selectable_layouts(language_id, layoutpage, parent_layout_name)
         allowed_page_layout_names = allowed_page_layouts.collect { |p| p["name"] }
         clipboard_pages.select { |cp| allowed_page_layout_names.include?(cp.page_layout) }
       end

--- a/app/serializers/alchemy/page_tree_serializer.rb
+++ b/app/serializers/alchemy/page_tree_serializer.rb
@@ -55,6 +55,7 @@ module Alchemy
         public: page.public?,
         restricted: page.restricted?,
         page_layout: page.page_layout,
+        show_create_page_btn: page.definition["child_pages"] != false,
         slug: page.slug,
         urlname: page.urlname,
         url_path: page.url_path,

--- a/app/views/alchemy/admin/pages/_page.html.erb
+++ b/app/views/alchemy/admin/pages/_page.html.erb
@@ -124,17 +124,21 @@
         {{/if}}
         </div>
         {{#if permissions.create}}
-        <div class="button_with_label sitemap_tool">
-          <%= link_to_dialog(
-            render_icon(:plus),
-            alchemy.new_admin_page_path(parent_id: '__ID__').gsub('__ID__', '{{id}}'),
-            {
-              title: Alchemy.t(:create_page),
-              size: '340x165',
-              overflow: true
-            }
-          ) -%>
-          <label class="left"><%= Alchemy.t(:create_page) %></label>
+          {{#if show_create_page_btn}}
+          <div class="button_with_label sitemap_tool">
+            <%= link_to_dialog(
+              render_icon(:plus),
+              alchemy.new_admin_page_path(parent_id: '__ID__').gsub('__ID__', '{{id}}'),
+              {
+                title: Alchemy.t(:create_page),
+                size: '340x165',
+                overflow: true
+              }
+            ) -%>
+            <label class="left"><%= Alchemy.t(:create_page) %></label>
+          {{else}}
+          <div class="sitemap_tool">
+          {{/if}}
         {{else}}
         <div class="sitemap_tool disabled with-hint">
           <%= render_icon(:plus) %>

--- a/spec/controllers/alchemy/admin/pages_controller.rb
+++ b/spec/controllers/alchemy/admin/pages_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Alchemy
+  describe Admin::PagesController do
+    routes { Alchemy::Engine.routes }
+
+    let(:alchemy_page)         { create(:alchemy_page) }
+    let!(:current_language)    { create(:alchemy_language, default: true) }
+
+    before { authorize_user(:as_admin) }
+
+    describe "#new" do
+      it "Calls PageLayout.layout_for_select with correct params" do
+        expect(PageLayout).to receive(:layouts_for_select).with(alchemy_page.parent.id, false, "standard")
+        get :new, params: {layout_page: false, parent_id: alchemy_page.id}
+      end
+
+      it "Calls Page.all_from_clipboard_for_select with correct params" do
+        allow(subject).to receive(:get_clipboard).and_return(["dummy1", "dummy2"])
+
+        expect(Page).to receive(:all_from_clipboard_for_select).with(["dummy1", "dummy2"], current_language.id, false, "standard")
+        get :new, params: {layout_page: false, parent_id: alchemy_page.id}
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Update 8/7

See comment: https://github.com/AlchemyCMS/alchemy_cms/pull/1776#issuecomment-651109428

---

## What is this pull request for?
Add support for restricting parent/child_pages:


### Update 17/5

Renamed `sub_pages` to `child_pages` and added `include`/`exclude` as suggested by @mamhoff.
```YML
# config/alchemy/page_layouts.yml

- name: blog
  child_pages: 
     include: [blog_post] # array of allowed child_pages.

- name: blog_post
  parent_pages: 
     include: [blog] # array of parent pages under which page can be created
  child_pages: false # hides add child_page button from page tree

- name: no_blogs_pages # Excludes example
  child_pages:
    exclude: [blog] 
  parent_pages:
    exclude: [blog]
```

### Note
- `If child_pages = false` it will entirely hide the create child_page button (+) in page_tree. See screenshot 1.
- `if selectable_layouts.length == 1`  i added autoselect and removed blank option in create selection. See screenshot 2 

### Changes in the code
- Passed in the `page_layout` of the parent_page to `PageLayout.selectable_layouts` to be able to check the definitions.
- Added `allowing_child_pages: page.definition['child_pages'] != false` to the `page_tree_serializer` so i could hide the create (+) button.

### Screenshots
1. No (+) button if `child_pages = false`
![image](https://user-images.githubusercontent.com/9784434/78499699-8c1dac80-7752-11ea-8ba0-a20449b95ad8.png)

2. No blank/"Please choose" option when only 1 to choose.
![image](https://user-images.githubusercontent.com/9784434/78499751-be2f0e80-7752-11ea-9803-b426ed7a6c4a.png)

## Tests 
I wanted to check with you if the overall implementation looks good before fixing the tests. Currently 2 fails saying `undefined method page_layout for nil:NilClass`
```
rspec ./spec/features/admin/page_creation_feature_spec.rb:21 # Page creation overlay GUI when having a Page in the clipboard contains tabs for creating a new page and pasting from clipboard
rspec ./spec/requests/alchemy/admin/pages_controller_spec.rb:261 # Alchemy::Admin::PagesController with logged in editor user #new with current language present pages in clipboard should load all pages from clipboard
```

## Checklist
- [X] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [X] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
