### PR TITLE
fix remove correct image in edit element content picture

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.base.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.base.js.coffee
@@ -62,9 +62,10 @@ $.extend Alchemy,
   removePicture: (selector) ->
     $form_field = $(selector)
     $element = $form_field.closest(".element-editor")
+    $content = $form_field.closest(".content_editor")
     if $form_field[0]
       $form_field.val ""
-      $element.find(".thumbnail_background").html('<i class="icon far fa-image fa-fw"/>')
+      $content.find(".thumbnail_background").html('<i class="icon far fa-image fa-fw"/>')
       Alchemy.setElementDirty $element
     false
 


### PR DESCRIPTION
## What is this pull request for?

Fix delete all EssencePicture images in an element editor when you click on delete button of an image

Closes #1779

Explain any changes (maybe breaking?) that have been made.

I modified the javascript function Alchemy.removePicture in order to delete only the thumbnail of the deleted image

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
