### PR TITLE
Only load published sites as default or current

### DIFF
--- a/app/models/alchemy/site.rb
+++ b/app/models/alchemy/site.rb
@@ -66,7 +66,7 @@ module Alchemy
       end
 
       def default
-        Site.first
+        Site.published.first
       end
 
       def find_for_host(host)

--- a/lib/alchemy/controller_actions.rb
+++ b/lib/alchemy/controller_actions.rb
@@ -49,7 +49,7 @@ module Alchemy
     # Returns the current site.
     #
     def current_alchemy_site
-      @current_alchemy_site ||= Site.find_for_host(request.host)
+      @current_alchemy_site ||= Site.published.find_for_host(request.host)
     end
 
     # Sets the current site in a cvar so the Language model


### PR DESCRIPTION
## What is this pull request for?

When a site is not marked as public, it should not be set as the current
site, and it should not load even if the host matches.

### Notable changes (remove if none)

Sites that should show publicly need to have the `public` flag set to `true`. 

## Checklist
- [ ] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [ ] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
