### PR TITLE
Remove acts_as_list from Content

### DIFF
--- a/app/models/alchemy/content.rb
+++ b/app/models/alchemy/content.rb
@@ -30,27 +30,25 @@ module Alchemy
 
     stampable stamper_class_name: Alchemy.user_class_name
 
-    acts_as_list scope: [:element_id]
-
     # Essence scopes
-    scope :essence_booleans,  -> { where(essence_type: "Alchemy::EssenceBoolean") }
-    scope :essence_dates,     -> { where(essence_type: "Alchemy::EssenceDate") }
-    scope :essence_files,     -> { where(essence_type: "Alchemy::EssenceFile") }
-    scope :essence_htmls,     -> { where(essence_type: "Alchemy::EssenceHtml") }
-    scope :essence_links,     -> { where(essence_type: "Alchemy::EssenceLink") }
-    scope :essence_pictures,  -> { where(essence_type: "Alchemy::EssencePicture") }
+    scope :essence_booleans, -> { where(essence_type: "Alchemy::EssenceBoolean") }
+    scope :essence_dates, -> { where(essence_type: "Alchemy::EssenceDate") }
+    scope :essence_files, -> { where(essence_type: "Alchemy::EssenceFile") }
+    scope :essence_htmls, -> { where(essence_type: "Alchemy::EssenceHtml") }
+    scope :essence_links, -> { where(essence_type: "Alchemy::EssenceLink") }
+    scope :essence_pictures, -> { where(essence_type: "Alchemy::EssencePicture") }
     scope :essence_richtexts, -> { where(essence_type: "Alchemy::EssenceRichtext") }
-    scope :essence_selects,   -> { where(essence_type: "Alchemy::EssenceSelect") }
-    scope :essence_texts,     -> { where(essence_type: "Alchemy::EssenceText") }
-    scope :named,             ->(name) { where(name: name) }
-    scope :available,         -> { published.not_trashed }
-    scope :published,         -> { joins(:element).merge(Element.published) }
-    scope :not_trashed,       -> { joins(:element).merge(Element.not_trashed) }
-    scope :not_restricted,    -> { joins(:element).merge(Element.not_restricted) }
+    scope :essence_selects, -> { where(essence_type: "Alchemy::EssenceSelect") }
+    scope :essence_texts, -> { where(essence_type: "Alchemy::EssenceText") }
+    scope :named, ->(name) { where(name: name) }
+    scope :available, -> { published.not_trashed }
+    scope :published, -> { joins(:element).merge(Element.published) }
+    scope :not_trashed, -> { joins(:element).merge(Element.not_trashed) }
+    scope :not_restricted, -> { joins(:element).merge(Element.not_restricted) }
 
-    delegate :restricted?, to: :page,    allow_nil: true
-    delegate :trashed?,    to: :element, allow_nil: true
-    delegate :public?,     to: :element, allow_nil: true
+    delegate :restricted?, to: :page, allow_nil: true
+    delegate :trashed?, to: :element, allow_nil: true
+    delegate :public?, to: :element, allow_nil: true
 
     class << self
       # Returns the translated label for a content name.

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -60,7 +60,7 @@ module Alchemy
 
     stampable stamper_class_name: Alchemy.user_class_name
 
-    has_many :contents, -> { order(:position) }, dependent: :destroy, inverse_of: :element
+    has_many :contents, dependent: :destroy, inverse_of: :element
 
     has_many :all_nested_elements,
       -> { order(:position).not_trashed },

--- a/app/serializers/alchemy/content_serializer.rb
+++ b/app/serializers/alchemy/content_serializer.rb
@@ -6,7 +6,6 @@ module Alchemy
       :name,
       :ingredient,
       :element_id,
-      :position,
       :created_at,
       :updated_at,
       :settings

--- a/db/migrate/20200226213334_alchemy_four_point_four.rb
+++ b/db/migrate/20200226213334_alchemy_four_point_four.rb
@@ -23,12 +23,11 @@ class AlchemyFourPointFour < ActiveRecord::Migration[5.0]
         t.string "essence_type", null: false
         t.integer "essence_id", null: false
         t.integer "element_id", null: false
-        t.integer "position"
         t.datetime "created_at", precision: 6, null: false
         t.datetime "updated_at", precision: 6, null: false
         t.integer "creator_id"
         t.integer "updater_id"
-        t.index ["element_id", "position"], name: "index_contents_on_element_id_and_position"
+        t.index ["element_id"], name: "index_contents_on_element_id"
         t.index ["essence_id", "essence_type"], name: "index_alchemy_contents_on_essence_id_and_essence_type", unique: true
       end
     end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -30,12 +30,11 @@ ActiveRecord::Schema.define(version: 2020_04_23_073425) do
     t.string "essence_type", null: false
     t.integer "essence_id", null: false
     t.integer "element_id", null: false
-    t.integer "position"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "creator_id"
     t.integer "updater_id"
-    t.index ["element_id", "position"], name: "index_contents_on_element_id_and_position"
+    t.index ["element_id"], name: "index_contents_on_element_id"
     t.index ["essence_id", "essence_type"], name: "index_alchemy_contents_on_essence_id_and_essence_type", unique: true
   end
 

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -398,23 +398,6 @@ module Alchemy
       end
     end
 
-    describe "#contents" do
-      let(:element) { create(:alchemy_element) }
-      let!(:content1) { create(:alchemy_content, element: element) }
-      let!(:content2) { create(:alchemy_content, element: element) }
-
-      subject { element.contents }
-
-      before do
-        content1.update_column(:position, 2)
-        content2.update_column(:position, 1)
-      end
-
-      it "are ordered by position" do
-        is_expected.to eq([content2, content1])
-      end
-    end
-
     describe "#content_by_type" do
       before(:each) do
         @element = create(:alchemy_element, name: "headline")


### PR DESCRIPTION
Removes the `position` column from new installs and removes `acts_as_list` from the Content model. We do not use the sortable contents feature for anything anymore. The have been superseded by nestable elements.

This does not remove the `position` column from existing installs, since we do not want to delete data. If you do not like unused columns you can add a migration that removes it.

Closes #1793
