### PR TITLE
Remove stamper from essences

### DIFF
--- a/app/models/alchemy/essence_boolean.rb
+++ b/app/models/alchemy/essence_boolean.rb
@@ -8,8 +8,6 @@
 #  value      :boolean
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  creator_id :integer
-#  updater_id :integer
 #
 
 # Stores boolean values.

--- a/app/models/alchemy/essence_date.rb
+++ b/app/models/alchemy/essence_date.rb
@@ -6,8 +6,6 @@
 #
 #  id         :integer          not null, primary key
 #  date       :datetime
-#  creator_id :integer
-#  updater_id :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #

--- a/app/models/alchemy/essence_file.rb
+++ b/app/models/alchemy/essence_file.rb
@@ -8,8 +8,6 @@
 #  attachment_id :integer
 #  title         :string
 #  css_class     :string
-#  creator_id    :integer
-#  updater_id    :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  link_text     :string

--- a/app/models/alchemy/essence_html.rb
+++ b/app/models/alchemy/essence_html.rb
@@ -6,8 +6,6 @@
 #
 #  id         :integer          not null, primary key
 #  source     :text
-#  creator_id :integer
-#  updater_id :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #

--- a/app/models/alchemy/essence_link.rb
+++ b/app/models/alchemy/essence_link.rb
@@ -11,8 +11,6 @@
 #  link_class_name :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  creator_id      :integer
-#  updater_id      :integer
 #
 
 module Alchemy

--- a/app/models/alchemy/essence_picture.rb
+++ b/app/models/alchemy/essence_picture.rb
@@ -14,8 +14,6 @@
 #  link_title      :string
 #  css_class       :string
 #  link_target     :string
-#  creator_id      :integer
-#  updater_id      :integer
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  crop_from       :string

--- a/app/models/alchemy/essence_richtext.rb
+++ b/app/models/alchemy/essence_richtext.rb
@@ -8,8 +8,6 @@
 #  body          :text
 #  stripped_body :text
 #  public        :boolean
-#  creator_id    :integer
-#  updater_id    :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #

--- a/app/models/alchemy/essence_select.rb
+++ b/app/models/alchemy/essence_select.rb
@@ -8,8 +8,6 @@
 #  value      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  creator_id :integer
-#  updater_id :integer
 #
 
 # Provides a select box that stores string values.

--- a/app/models/alchemy/essence_text.rb
+++ b/app/models/alchemy/essence_text.rb
@@ -11,8 +11,6 @@
 #  link_class_name :string
 #  public          :boolean          default(FALSE)
 #  link_target     :string
-#  creator_id      :integer
-#  updater_id      :integer
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #

--- a/db/migrate/20200226213334_alchemy_four_point_four.rb
+++ b/db/migrate/20200226213334_alchemy_four_point_four.rb
@@ -65,8 +65,6 @@ class AlchemyFourPointFour < ActiveRecord::Migration[5.0]
         t.boolean "value"
         t.datetime "created_at", precision: 6, null: false
         t.datetime "updated_at", precision: 6, null: false
-        t.integer "creator_id"
-        t.integer "updater_id"
         t.index ["value"], name: "index_alchemy_essence_booleans_on_value"
       end
     end
@@ -74,8 +72,6 @@ class AlchemyFourPointFour < ActiveRecord::Migration[5.0]
     unless table_exists?("alchemy_essence_dates")
       create_table "alchemy_essence_dates", force: :cascade do |t|
         t.datetime "date"
-        t.integer "creator_id"
-        t.integer "updater_id"
         t.datetime "created_at", precision: 6, null: false
         t.datetime "updated_at", precision: 6, null: false
       end
@@ -86,8 +82,6 @@ class AlchemyFourPointFour < ActiveRecord::Migration[5.0]
         t.integer "attachment_id"
         t.string "title"
         t.string "css_class"
-        t.integer "creator_id"
-        t.integer "updater_id"
         t.datetime "created_at", precision: 6, null: false
         t.datetime "updated_at", precision: 6, null: false
         t.string "link_text"
@@ -98,8 +92,6 @@ class AlchemyFourPointFour < ActiveRecord::Migration[5.0]
     unless table_exists?("alchemy_essence_htmls")
       create_table "alchemy_essence_htmls", force: :cascade do |t|
         t.text "source"
-        t.integer "creator_id"
-        t.integer "updater_id"
         t.datetime "created_at", precision: 6, null: false
         t.datetime "updated_at", precision: 6, null: false
       end
@@ -113,8 +105,6 @@ class AlchemyFourPointFour < ActiveRecord::Migration[5.0]
         t.string "link_class_name"
         t.datetime "created_at", precision: 6, null: false
         t.datetime "updated_at", precision: 6, null: false
-        t.integer "creator_id"
-        t.integer "updater_id"
       end
     end
 
@@ -138,8 +128,6 @@ class AlchemyFourPointFour < ActiveRecord::Migration[5.0]
         t.string "link_title"
         t.string "css_class"
         t.string "link_target"
-        t.integer "creator_id"
-        t.integer "updater_id"
         t.datetime "created_at", precision: 6, null: false
         t.datetime "updated_at", precision: 6, null: false
         t.string "crop_from"
@@ -154,8 +142,6 @@ class AlchemyFourPointFour < ActiveRecord::Migration[5.0]
         t.text "body"
         t.text "stripped_body"
         t.boolean "public"
-        t.integer "creator_id"
-        t.integer "updater_id"
         t.datetime "created_at", precision: 6, null: false
         t.datetime "updated_at", precision: 6, null: false
       end
@@ -166,8 +152,6 @@ class AlchemyFourPointFour < ActiveRecord::Migration[5.0]
         t.string "value"
         t.datetime "created_at", precision: 6, null: false
         t.datetime "updated_at", precision: 6, null: false
-        t.integer "creator_id"
-        t.integer "updater_id"
         t.index ["value"], name: "index_alchemy_essence_selects_on_value"
       end
     end
@@ -180,8 +164,6 @@ class AlchemyFourPointFour < ActiveRecord::Migration[5.0]
         t.string "link_class_name"
         t.boolean "public", default: false
         t.string "link_target"
-        t.integer "creator_id"
-        t.integer "updater_id"
         t.datetime "created_at", precision: 6, null: false
         t.datetime "updated_at", precision: 6, null: false
       end

--- a/lib/alchemy/essence.rb
+++ b/lib/alchemy/essence.rb
@@ -48,7 +48,7 @@ module Alchemy #:nodoc:
         class_eval <<-RUBY, __FILE__, __LINE__ + 1
           attr_writer :validation_errors
           include Alchemy::Essence::InstanceMethods
-          stampable stamper_class_name: Alchemy.user_class_name
+
           validate :validate_ingredient, on: :update, if: -> { validations.any? }
 
           has_one :content, as: :essence, class_name: "Alchemy::Content", inverse_of: :essence

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -66,15 +66,11 @@ ActiveRecord::Schema.define(version: 2020_04_23_073425) do
     t.boolean "value"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "creator_id"
-    t.integer "updater_id"
     t.index ["value"], name: "index_alchemy_essence_booleans_on_value"
   end
 
   create_table "alchemy_essence_dates", force: :cascade do |t|
     t.datetime "date"
-    t.integer "creator_id"
-    t.integer "updater_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
@@ -83,8 +79,6 @@ ActiveRecord::Schema.define(version: 2020_04_23_073425) do
     t.integer "attachment_id"
     t.string "title"
     t.string "css_class"
-    t.integer "creator_id"
-    t.integer "updater_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "link_text"
@@ -93,8 +87,6 @@ ActiveRecord::Schema.define(version: 2020_04_23_073425) do
 
   create_table "alchemy_essence_htmls", force: :cascade do |t|
     t.text "source"
-    t.integer "creator_id"
-    t.integer "updater_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
@@ -106,8 +98,6 @@ ActiveRecord::Schema.define(version: 2020_04_23_073425) do
     t.string "link_class_name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "creator_id"
-    t.integer "updater_id"
   end
 
   create_table "alchemy_essence_nodes", force: :cascade do |t|
@@ -134,8 +124,6 @@ ActiveRecord::Schema.define(version: 2020_04_23_073425) do
     t.string "link_title"
     t.string "css_class"
     t.string "link_target"
-    t.integer "creator_id"
-    t.integer "updater_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "crop_from"
@@ -148,8 +136,6 @@ ActiveRecord::Schema.define(version: 2020_04_23_073425) do
     t.text "body"
     t.text "stripped_body"
     t.boolean "public"
-    t.integer "creator_id"
-    t.integer "updater_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
@@ -158,8 +144,6 @@ ActiveRecord::Schema.define(version: 2020_04_23_073425) do
     t.string "value"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "creator_id"
-    t.integer "updater_id"
     t.index ["value"], name: "index_alchemy_essence_selects_on_value"
   end
 
@@ -170,8 +154,6 @@ ActiveRecord::Schema.define(version: 2020_04_23_073425) do
     t.string "link_class_name"
     t.boolean "public", default: false
     t.string "link_target"
-    t.integer "creator_id"
-    t.integer "updater_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end


### PR DESCRIPTION
## What is this pull request for?

We do not need the creator and updater information on the essences. We already have them on the elements.

Closes #1800 

### Notable changes (remove if none)

Removes the `creator_id` and `updater_id` from new install and the `stamper` module from all essences.
