### PR TITLE
Drop Rails 5.0 and 5.1 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ rails_version = ENV.fetch("RAILS_VERSION", 6.0).to_f
 gem "rails", "~> #{rails_version}.0"
 
 if ENV["DB"].nil? || ENV["DB"] == "sqlite"
-  gem "sqlite3", rails_version > 5.0 ? "~> 1.4.1" : "~> 1.3.6"
+  gem "sqlite3", "~> 1.4.1"
 end
 gem "mysql2", "~> 0.5.1" if ENV["DB"] == "mysql"
 gem "pg",     "~> 1.0"   if ENV["DB"] == "postgresql"

--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ or visit the existing demo at https://alchemy-demo.herokuapp.com
 
 ## 🚂 Rails Version
 
-**This version of AlchemyCMS runs with all versions of Rails 5 and Rails 6**
+**This version of AlchemyCMS runs with Rails 5.2 and Rails 6.0**
 
+* For a Rails 5.0 or 5.1 compatible version use the [`4.5-stable` branch](https://github.com/AlchemyCMS/alchemy_cms/tree/4.5-stable).
 * For a Rails 4.2 compatible version use the [`3.6-stable` branch](https://github.com/AlchemyCMS/alchemy_cms/tree/3.6-stable).
 * For a Rails 4.0/4.1 compatible version use the [`3.1-stable` branch](https://github.com/AlchemyCMS/alchemy_cms/tree/3.1-stable).
 * For a Rails 3.2 compatible version use the [`2.8-stable` branch](https://github.com/AlchemyCMS/alchemy_cms/tree/2.8-stable).

--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |gem|
   gem.authors               = ['Thomas von Deyen', 'Robin Boening', 'Marc Schettke', 'Hendrik Mans', 'Carsten Fregin', 'Martin Meyerhoff']
   gem.email                 = ['hello@alchemy-cms.com']
   gem.homepage              = 'https://alchemy-cms.com'
-  gem.summary               = 'A powerful, userfriendly and flexible CMS for Rails 5'
-  gem.description           = 'Alchemy is a powerful, userfriendly and flexible Rails 5 CMS.'
+  gem.summary               = 'A powerful, userfriendly and flexible CMS for Rails'
+  gem.description           = 'Alchemy is a powerful, userfriendly and flexible Rails CMS.'
   gem.requirements << 'ImageMagick (libmagick), v6.6 or greater.'
   gem.required_ruby_version = '>= 2.3.0'
   gem.license               = 'BSD New'
@@ -32,7 +32,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'kaminari',                         ['~> 1.1']
   gem.add_runtime_dependency 'originator',                       ['~> 3.1']
   gem.add_runtime_dependency 'non-stupid-digest-assets',         ['~> 1.0.8']
-  gem.add_runtime_dependency 'rails',                            ['>= 5.0.0', '< 6.1']
+  gem.add_runtime_dependency 'rails',                            ['>= 5.2.0', '< 6.1']
   gem.add_runtime_dependency 'ransack',                          ['>= 1.8', '< 3.0']
   gem.add_runtime_dependency 'request_store',                    ['~> 1.2']
   gem.add_runtime_dependency 'responders',                       ['>= 2.0', '< 4.0']

--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -179,12 +179,7 @@ module Alchemy
 
     # Renders the HTML tag attributes required for preview mode.
     def element_preview_code(element)
-      if respond_to?(:tag_options)
-        tag_options(element_preview_code_attributes(element))
-      else
-        # Rails 5.1 uses TagBuilder
-        tag_builder.tag_options(element_preview_code_attributes(element))
-      end
+      tag_builder.tag_options(element_preview_code_attributes(element))
     end
 
     # Returns a hash containing the HTML tag attributes required for preview mode.
@@ -203,12 +198,7 @@ module Alchemy
     #   HTML tag attributes containing the element's tag information.
     #
     def element_tags(element, options = {})
-      if respond_to?(:tag_options)
-        tag_options(element_tags_attributes(element, options))
-      else
-        # Rails 5.1 uses TagBuilder
-        tag_builder.tag_options(element_tags_attributes(element, options))
-      end
+      tag_builder.tag_options(element_tags_attributes(element, options))
     end
 
     # Returns the element's tags information as an attribute hash.

--- a/db/migrate/20200226213334_alchemy_four_point_four.rb
+++ b/db/migrate/20200226213334_alchemy_four_point_four.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlchemyFourPointFour < ActiveRecord::Migration[5.0]
+class AlchemyFourPointFour < ActiveRecord::Migration[5.2]
   def up
     unless table_exists?("alchemy_attachments")
       create_table "alchemy_attachments", force: :cascade do |t|

--- a/db/migrate/20200226213334_alchemy_four_point_four.rb
+++ b/db/migrate/20200226213334_alchemy_four_point_four.rb
@@ -8,8 +8,8 @@ class AlchemyFourPointFour < ActiveRecord::Migration[5.2]
         t.string "file_name"
         t.string "file_mime_type"
         t.integer "file_size"
-        t.integer "creator_id"
-        t.integer "updater_id"
+        t.references "creator"
+        t.references "updater"
         t.datetime "created_at", precision: 6, null: false
         t.datetime "updated_at", precision: 6, null: false
         t.string "file_uid"
@@ -20,15 +20,12 @@ class AlchemyFourPointFour < ActiveRecord::Migration[5.2]
     unless table_exists?("alchemy_contents")
       create_table "alchemy_contents", force: :cascade do |t|
         t.string "name"
-        t.string "essence_type", null: false
-        t.integer "essence_id", null: false
-        t.integer "element_id", null: false
+        t.references "essence", null: false, polymorphic: true, index: { unique: true }
+        t.references "element", null: false
         t.datetime "created_at", precision: 6, null: false
         t.datetime "updated_at", precision: 6, null: false
-        t.integer "creator_id"
-        t.integer "updater_id"
-        t.index ["element_id"], name: "index_contents_on_element_id"
-        t.index ["essence_id", "essence_type"], name: "index_alchemy_contents_on_essence_id_and_essence_type", unique: true
+        t.references "creator"
+        t.references "updater"
       end
     end
 
@@ -36,15 +33,15 @@ class AlchemyFourPointFour < ActiveRecord::Migration[5.2]
       create_table "alchemy_elements", force: :cascade do |t|
         t.string "name"
         t.integer "position"
-        t.integer "page_id", null: false
+        t.references "page", null: false, index: false
         t.boolean "public", default: true
         t.boolean "folded", default: false
         t.boolean "unique", default: false
         t.datetime "created_at", precision: 6, null: false
         t.datetime "updated_at", precision: 6, null: false
-        t.integer "creator_id"
-        t.integer "updater_id"
-        t.integer "parent_element_id"
+        t.references "creator"
+        t.references "updater"
+        t.references "parent_element", index: false
         t.boolean "fixed", default: false, null: false
         t.index ["fixed"], name: "index_alchemy_elements_on_fixed"
         t.index ["page_id", "parent_element_id"], name: "index_alchemy_elements_on_page_id_and_parent_element_id"
@@ -54,8 +51,8 @@ class AlchemyFourPointFour < ActiveRecord::Migration[5.2]
 
     unless table_exists?("alchemy_elements_alchemy_pages")
       create_table "alchemy_elements_alchemy_pages", id: false, force: :cascade do |t|
-        t.integer "element_id"
-        t.integer "page_id"
+        t.references "element"
+        t.references "page"
       end
     end
 
@@ -78,13 +75,12 @@ class AlchemyFourPointFour < ActiveRecord::Migration[5.2]
 
     unless table_exists?("alchemy_essence_files")
       create_table "alchemy_essence_files", force: :cascade do |t|
-        t.integer "attachment_id"
+        t.references "attachment"
         t.string "title"
         t.string "css_class"
         t.datetime "created_at", precision: 6, null: false
         t.datetime "updated_at", precision: 6, null: false
         t.string "link_text"
-        t.index ["attachment_id"], name: "index_alchemy_essence_files_on_attachment_id"
       end
     end
 
@@ -109,16 +105,15 @@ class AlchemyFourPointFour < ActiveRecord::Migration[5.2]
 
     unless table_exists?("alchemy_essence_pages")
       create_table "alchemy_essence_pages", force: :cascade do |t|
-        t.integer "page_id"
+        t.references "page"
         t.datetime "created_at", null: false
         t.datetime "updated_at", null: false
-        t.index ["page_id"], name: "index_alchemy_essence_pages_on_page_id"
       end
     end
 
     unless table_exists?("alchemy_essence_pictures")
       create_table "alchemy_essence_pictures", force: :cascade do |t|
-        t.integer "picture_id"
+        t.references "picture"
         t.string "caption"
         t.string "title"
         t.string "alt_tag"
@@ -132,7 +127,6 @@ class AlchemyFourPointFour < ActiveRecord::Migration[5.2]
         t.string "crop_from"
         t.string "crop_size"
         t.string "render_size"
-        t.index ["picture_id"], name: "index_alchemy_essence_pictures_on_picture_id"
       end
     end
 
@@ -170,8 +164,8 @@ class AlchemyFourPointFour < ActiveRecord::Migration[5.2]
 
     unless table_exists?("alchemy_folded_pages")
       create_table "alchemy_folded_pages", force: :cascade do |t|
-        t.integer "page_id", null: false
-        t.integer "user_id", null: false
+        t.references "page", null: false, index: false
+        t.references "user", null: false, index: false
         t.boolean "folded", default: false
         t.index ["page_id", "user_id"], name: "index_alchemy_folded_pages_on_page_id_and_user_id", unique: true
       end
@@ -186,25 +180,23 @@ class AlchemyFourPointFour < ActiveRecord::Migration[5.2]
         t.boolean "public", default: false
         t.datetime "created_at", precision: 6, null: false
         t.datetime "updated_at", precision: 6, null: false
-        t.integer "creator_id"
-        t.integer "updater_id"
+        t.references "creator"
+        t.references "updater"
         t.boolean "default", default: false
         t.string "country_code", default: "", null: false
-        t.integer "site_id", null: false
+        t.references "site", null: false
         t.string "locale"
         t.index ["language_code", "country_code"], name: "index_alchemy_languages_on_language_code_and_country_code"
         t.index ["language_code"], name: "index_alchemy_languages_on_language_code"
-        t.index ["site_id"], name: "index_alchemy_languages_on_site_id"
       end
     end
 
     unless table_exists?("alchemy_legacy_page_urls")
       create_table "alchemy_legacy_page_urls", force: :cascade do |t|
         t.string "urlname", null: false
-        t.integer "page_id", null: false
+        t.references "page", null: false
         t.datetime "created_at", precision: 6, null: false
         t.datetime "updated_at", precision: 6, null: false
-        t.index ["page_id"], name: "index_alchemy_legacy_page_urls_on_page_id"
         t.index ["urlname"], name: "index_alchemy_legacy_page_urls_on_urlname"
       end
     end
@@ -217,25 +209,19 @@ class AlchemyFourPointFour < ActiveRecord::Migration[5.2]
         t.boolean "nofollow", default: false, null: false
         t.boolean "external", default: false, null: false
         t.boolean "folded", default: false, null: false
-        t.integer "parent_id"
+        t.references "parent"
         t.integer "lft", null: false
         t.integer "rgt", null: false
         t.integer "depth", default: 0, null: false
-        t.integer "page_id"
-        t.integer "language_id", null: false
-        t.integer "creator_id"
-        t.integer "updater_id"
+        t.references "page"
+        t.references "language", null: false
+        t.references "creator"
+        t.references "updater"
         t.datetime "created_at", null: false
         t.datetime "updated_at", null: false
-        t.integer "site_id", null: false
-        t.index ["creator_id"], name: "index_alchemy_nodes_on_creator_id"
-        t.index ["language_id"], name: "index_alchemy_nodes_on_language_id"
+        t.references "site", null: false
         t.index ["lft"], name: "index_alchemy_nodes_on_lft"
-        t.index ["page_id"], name: "index_alchemy_nodes_on_page_id"
-        t.index ["parent_id"], name: "index_alchemy_nodes_on_parent_id"
         t.index ["rgt"], name: "index_alchemy_nodes_on_rgt"
-        t.index ["site_id"], name: "index_alchemy_nodes_on_site_id"
-        t.index ["updater_id"], name: "index_alchemy_nodes_on_updater_id"
       end
     end
 
@@ -251,7 +237,7 @@ class AlchemyFourPointFour < ActiveRecord::Migration[5.2]
         t.text "meta_description"
         t.integer "lft"
         t.integer "rgt"
-        t.integer "parent_id"
+        t.references "parent", index: false
         t.integer "depth"
         t.boolean "visible", default: false
         t.integer "locked_by"
@@ -262,14 +248,13 @@ class AlchemyFourPointFour < ActiveRecord::Migration[5.2]
         t.boolean "layoutpage", default: false
         t.datetime "created_at", precision: 6, null: false
         t.datetime "updated_at", precision: 6, null: false
-        t.integer "creator_id"
-        t.integer "updater_id"
-        t.integer "language_id"
+        t.references "creator"
+        t.references "updater"
+        t.references "language"
         t.datetime "published_at"
         t.datetime "public_on"
         t.datetime "public_until"
         t.datetime "locked_at"
-        t.index ["language_id"], name: "index_pages_on_language_id"
         t.index ["locked_at", "locked_by"], name: "index_alchemy_pages_on_locked_at_and_locked_by"
         t.index ["parent_id", "lft"], name: "index_pages_on_parent_id_and_lft"
         t.index ["public_on", "public_until"], name: "index_alchemy_pages_on_public_on_and_public_until"
@@ -286,8 +271,8 @@ class AlchemyFourPointFour < ActiveRecord::Migration[5.2]
         t.integer "image_file_height"
         t.datetime "created_at", precision: 6, null: false
         t.datetime "updated_at", precision: 6, null: false
-        t.integer "creator_id"
-        t.integer "updater_id"
+        t.references "creator"
+        t.references "updater"
         t.string "upload_hash"
         t.string "image_file_uid"
         t.integer "image_file_size"

--- a/db/migrate/20200423073425_create_alchemy_essence_nodes.rb
+++ b/db/migrate/20200423073425_create_alchemy_essence_nodes.rb
@@ -3,8 +3,7 @@
 class CreateAlchemyEssenceNodes < ActiveRecord::Migration[5.2]
   def change
     create_table :alchemy_essence_nodes do |t|
-      t.integer "node_id"
-      t.index ["node_id"], name: "index_alchemy_essence_nodes_on_node_id"
+      t.references "node"
       t.timestamps
     end
     add_foreign_key "alchemy_essence_nodes", "alchemy_nodes", column: "node_id"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -22,7 +22,9 @@ ActiveRecord::Schema.define(version: 2020_04_23_073425) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "file_uid"
+    t.index ["creator_id"], name: "index_alchemy_attachments_on_creator_id"
     t.index ["file_uid"], name: "index_alchemy_attachments_on_file_uid"
+    t.index ["updater_id"], name: "index_alchemy_attachments_on_updater_id"
   end
 
   create_table "alchemy_contents", force: :cascade do |t|
@@ -34,8 +36,10 @@ ActiveRecord::Schema.define(version: 2020_04_23_073425) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "creator_id"
     t.integer "updater_id"
-    t.index ["element_id"], name: "index_contents_on_element_id"
-    t.index ["essence_id", "essence_type"], name: "index_alchemy_contents_on_essence_id_and_essence_type", unique: true
+    t.index ["creator_id"], name: "index_alchemy_contents_on_creator_id"
+    t.index ["element_id"], name: "index_alchemy_contents_on_element_id"
+    t.index ["essence_type", "essence_id"], name: "index_alchemy_contents_on_essence_type_and_essence_id", unique: true
+    t.index ["updater_id"], name: "index_alchemy_contents_on_updater_id"
   end
 
   create_table "alchemy_elements", force: :cascade do |t|
@@ -51,14 +55,18 @@ ActiveRecord::Schema.define(version: 2020_04_23_073425) do
     t.integer "updater_id"
     t.integer "parent_element_id"
     t.boolean "fixed", default: false, null: false
+    t.index ["creator_id"], name: "index_alchemy_elements_on_creator_id"
     t.index ["fixed"], name: "index_alchemy_elements_on_fixed"
     t.index ["page_id", "parent_element_id"], name: "index_alchemy_elements_on_page_id_and_parent_element_id"
     t.index ["page_id", "position"], name: "index_elements_on_page_id_and_position"
+    t.index ["updater_id"], name: "index_alchemy_elements_on_updater_id"
   end
 
   create_table "alchemy_elements_alchemy_pages", id: false, force: :cascade do |t|
     t.integer "element_id"
     t.integer "page_id"
+    t.index ["element_id"], name: "index_alchemy_elements_alchemy_pages_on_element_id"
+    t.index ["page_id"], name: "index_alchemy_elements_alchemy_pages_on_page_id"
   end
 
   create_table "alchemy_essence_booleans", force: :cascade do |t|
@@ -178,9 +186,11 @@ ActiveRecord::Schema.define(version: 2020_04_23_073425) do
     t.string "country_code", default: "", null: false
     t.integer "site_id", null: false
     t.string "locale"
+    t.index ["creator_id"], name: "index_alchemy_languages_on_creator_id"
     t.index ["language_code", "country_code"], name: "index_alchemy_languages_on_language_code_and_country_code"
     t.index ["language_code"], name: "index_alchemy_languages_on_language_code"
     t.index ["site_id"], name: "index_alchemy_languages_on_site_id"
+    t.index ["updater_id"], name: "index_alchemy_languages_on_updater_id"
   end
 
   create_table "alchemy_legacy_page_urls", force: :cascade do |t|
@@ -249,11 +259,13 @@ ActiveRecord::Schema.define(version: 2020_04_23_073425) do
     t.datetime "public_on"
     t.datetime "public_until"
     t.datetime "locked_at"
-    t.index ["language_id"], name: "index_pages_on_language_id"
+    t.index ["creator_id"], name: "index_alchemy_pages_on_creator_id"
+    t.index ["language_id"], name: "index_alchemy_pages_on_language_id"
     t.index ["locked_at", "locked_by"], name: "index_alchemy_pages_on_locked_at_and_locked_by"
     t.index ["parent_id", "lft"], name: "index_pages_on_parent_id_and_lft"
     t.index ["public_on", "public_until"], name: "index_alchemy_pages_on_public_on_and_public_until"
     t.index ["rgt"], name: "index_alchemy_pages_on_rgt"
+    t.index ["updater_id"], name: "index_alchemy_pages_on_updater_id"
     t.index ["urlname"], name: "index_pages_on_urlname"
   end
 
@@ -270,6 +282,8 @@ ActiveRecord::Schema.define(version: 2020_04_23_073425) do
     t.string "image_file_uid"
     t.integer "image_file_size"
     t.string "image_file_format"
+    t.index ["creator_id"], name: "index_alchemy_pictures_on_creator_id"
+    t.index ["updater_id"], name: "index_alchemy_pictures_on_updater_id"
   end
 
   create_table "alchemy_sites", force: :cascade do |t|


### PR DESCRIPTION
## What is this pull request for?

These Rails versions are not officially supported anymore and we want to be able to better support MySQL with bigint foreign keys.

Closes #1796

### Notable changes (remove if none)

Drops support for Rails 5.0 and Rails 5.1 and changes all migrations to use `t.references` instead of `t.integer` for foreign keys.
