### PR TITLE
Add Alchemy::Language.has_many :nodes

### DIFF
--- a/app/models/alchemy/language.rb
+++ b/app/models/alchemy/language.rb
@@ -26,6 +26,7 @@ module Alchemy
   class Language < BaseRecord
     belongs_to :site
     has_many :pages
+    has_many :nodes, inverse_of: :language
 
     before_validation :set_locale, if: -> { locale.blank? }
 

--- a/spec/models/alchemy/language_spec.rb
+++ b/spec/models/alchemy/language_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 module Alchemy
   describe Language do
+    it { is_expected.to have_many(:nodes) }
+
     let(:default_language) { create(:alchemy_language) }
     let(:language)         { create(:alchemy_language, :klingon) }
     let(:page)             { create(:alchemy_page, language: language) }


### PR DESCRIPTION
We need those association declarations for better preloading.

## What is this pull request for?

Adds an association between the Alchemy::Language and its nodes.

I think we might want to get rid of the association between sites and nodes, as sites and nodes are already connected via the language?

- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
