### PR TITLE
Remove stamper from contents

### DIFF
--- a/app/models/alchemy/content.rb
+++ b/app/models/alchemy/content.rb
@@ -28,8 +28,6 @@ module Alchemy
     belongs_to :element, touch: true, inverse_of: :contents
     has_one :page, through: :element
 
-    stampable stamper_class_name: Alchemy.user_class_name
-
     # Essence scopes
     scope :essence_booleans, -> { where(essence_type: "Alchemy::EssenceBoolean") }
     scope :essence_dates, -> { where(essence_type: "Alchemy::EssenceDate") }

--- a/db/migrate/20200226213334_alchemy_four_point_four.rb
+++ b/db/migrate/20200226213334_alchemy_four_point_four.rb
@@ -24,8 +24,6 @@ class AlchemyFourPointFour < ActiveRecord::Migration[5.2]
         t.references "element", null: false
         t.datetime "created_at", precision: 6, null: false
         t.datetime "updated_at", precision: 6, null: false
-        t.references "creator"
-        t.references "updater"
       end
     end
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -34,12 +34,8 @@ ActiveRecord::Schema.define(version: 2020_04_23_073425) do
     t.integer "element_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "creator_id"
-    t.integer "updater_id"
-    t.index ["creator_id"], name: "index_alchemy_contents_on_creator_id"
     t.index ["element_id"], name: "index_alchemy_contents_on_element_id"
     t.index ["essence_type", "essence_id"], name: "index_alchemy_contents_on_essence_type_and_essence_id", unique: true
-    t.index ["updater_id"], name: "index_alchemy_contents_on_updater_id"
   end
 
   create_table "alchemy_elements", force: :cascade do |t|


### PR DESCRIPTION
## What is this pull request for?

Remove the Stamper (creator and updater) from Content model.

The content model always ever is created within an element and it does not make sense to have this information twice.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
