### PR TITLE
Remove Page.ancestors_for

### DIFF
--- a/app/helpers/alchemy/pages_helper.rb
+++ b/app/helpers/alchemy/pages_helper.rb
@@ -37,7 +37,7 @@ module Alchemy
         partial: "alchemy/language_links/language",
         collection: languages,
         spacer_template: "alchemy/language_links/spacer",
-        locals: {languages: languages, options: options},
+        locals: { languages: languages, options: options },
       )
     end
 
@@ -127,8 +127,8 @@ module Alchemy
         link_active_page: false,
       }.merge(options)
 
-      pages = Page.
-        ancestors_for(options[:page]).
+      pages = options[:page].
+        self_and_ancestors.contentpages.
         accessible_by(current_ability, :see)
 
       if options.delete(:restricted_only)

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -256,14 +256,6 @@ module Alchemy
         options
       end
 
-      # Returns an array of all pages in the same branch from current.
-      # I.e. used to find the active page in navigation.
-      def ancestors_for(current)
-        return [] if current.nil?
-
-        current.self_and_ancestors.contentpages
-      end
-
       private
 
       # Aggregates the attributes from given source for copy of page.

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -376,26 +376,6 @@ module Alchemy
       end
     end
 
-    describe ".ancestors_for" do
-      let(:lang_root) { Page.language_root_for(Language.default.id) }
-      let(:parent) { create(:alchemy_page, :public) }
-      let(:page) { create(:alchemy_page, :public, parent_id: parent.id) }
-
-      it "returns an array of all parents including self" do
-        expect(Page.ancestors_for(page)).to eq([lang_root, parent, page])
-      end
-
-      it "does not include the root page" do
-        expect(Page.ancestors_for(page)).not_to include(Page.root)
-      end
-
-      context "with current page nil" do
-        it "should return an empty array" do
-          expect(Page.ancestors_for(nil)).to eq([])
-        end
-      end
-    end
-
     describe ".contentpages" do
       let!(:layoutpage) do
         create :alchemy_page, :public, {


### PR DESCRIPTION
## What is this pull request for?

Remove `Page.ancestors_for` class method.

It's only used by the render_breadcrumb helper and that could just use the self_and_ancestors scope.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
