### PR TITLE
Invoke rake task in upgrader instead of system call

### DIFF
--- a/lib/alchemy/upgrader/five_point_zero.rb
+++ b/lib/alchemy/upgrader/five_point_zero.rb
@@ -7,9 +7,9 @@ module Alchemy
     class << self
       def install_gutentag_migrations
         desc "Install Gutentag migrations"
-        `bundle exec rake gutentag:install:migrations`
+        Rake::Task["gutentag:install:migrations"].invoke
         Alchemy::Upgrader::Tasks::HardenGutentagMigrations.new.patch_migrations
-        `bundle exec rake db:migrate`
+        Rake::Task["db:migrate"].invoke
       end
 
       def remove_layout_roots


### PR DESCRIPTION
## What is this pull request for?

Invokes the rake task in the 5.0 upgrader instead of making a system call. This helps to keep logging to stdout in sync with the current thread.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
