### PR TITLE
Remove root page

### DIFF
--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -222,13 +222,11 @@ module Alchemy
       private
 
       def copy_of_language_root
-        page_copy = Page.copy(
+        Page.copy(
           language_root_to_copy_from,
           language_id: params[:languages][:new_lang_id],
           language_code: @current_language.code,
         )
-        page_copy.move_to_child_of Page.root
-        page_copy
       end
 
       def language_root_to_copy_from
@@ -363,7 +361,7 @@ module Alchemy
       def paste_from_clipboard
         if params[:paste_from_clipboard]
           source = Page.find(params[:paste_from_clipboard])
-          parent = Page.find_by(id: params[:page][:parent_id]) || Page.root
+          parent = Page.find_by(id: params[:page][:parent_id])
           Page.copy_and_paste(source, parent, params[:page][:name])
         end
       end

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -117,7 +117,7 @@ module Alchemy
 
     validates_presence_of :page_layout
     validates_format_of :page_layout, with: /\A[a-z0-9_-]+\z/, unless: -> { page_layout.blank? }
-    validates_presence_of :parent_id, if: proc { Page.count > 1 }, unless: -> { layoutpage? }
+    validates_presence_of :parent, unless: -> { layoutpage? || language_root? }
 
     before_save :set_language_code,
       if: -> { language.present? }
@@ -159,18 +159,6 @@ module Alchemy
     # Class methods
     #
     class << self
-      # The root page of the page tree
-      #
-      # Internal use only. You wouldn't use this page ever.
-      #
-      # Automatically created when accessed the first time.
-      #
-      def root
-        super || create!(name: "Root", page_layout: "standard")
-      end
-
-      alias_method :rootpage, :root
-
       # Used to store the current page previewed in the edit page template.
       #
       def current_preview=(page)

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -114,32 +114,28 @@ module Alchemy
     has_many :nodes, class_name: "Alchemy::Node", inverse_of: :page
 
     validates_presence_of :language, on: :create, unless: :root
-    validates_presence_of :page_layout, unless: :systempage?
-    validates_format_of :page_layout, with: /\A[a-z0-9_-]+\z/, unless: -> { systempage? || page_layout.blank? }
+
+    validates_presence_of :page_layout
+    validates_format_of :page_layout, with: /\A[a-z0-9_-]+\z/, unless: -> { page_layout.blank? }
     validates_presence_of :parent_id, if: proc { Page.count > 1 }, unless: -> { layoutpage? }
 
     before_save :set_language_code,
-      if: -> { language.present? },
-      unless: :systempage?
+      if: -> { language.present? }
 
     before_save :set_restrictions_to_child_pages,
-      if: :restricted_changed?,
-      unless: :systempage?
+      if: :restricted_changed?
 
     before_save :inherit_restricted_status,
-      if: -> { parent && parent.restricted? },
-      unless: :systempage?
+      if: -> { parent && parent.restricted? }
 
     before_save :set_published_at,
-      if: -> { public_on.present? && published_at.nil? },
-      unless: :systempage?
+      if: -> { public_on.present? && published_at.nil? }
 
     before_save :set_fixed_attributes,
       if: -> { fixed_attributes.any? }
 
     before_create :set_language,
-      if: -> { language.nil? },
-      unless: :systempage?
+      if: -> { language.nil? }
 
     after_update :create_legacy_url,
       if: :should_create_legacy_url?
@@ -170,7 +166,7 @@ module Alchemy
       # Automatically created when accessed the first time.
       #
       def root
-        super || create!(name: "Root")
+        super || create!(name: "Root", page_layout: "standard")
       end
 
       alias_method :rootpage, :root

--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -33,7 +33,7 @@ module Alchemy
         join_table: ElementToPage.table_name
 
       after_create :generate_elements,
-        unless: -> { systempage? || autogenerate_elements == false }
+        unless: -> { autogenerate_elements == false }
 
       after_update :trash_not_allowed_elements!,
         if: :has_page_layout_changed?
@@ -81,11 +81,11 @@ module Alchemy
     #
     def available_element_definitions(only_element_named = nil)
       @_element_definitions ||= if only_element_named
-        definition = Element.definition_by_name(only_element_named)
-        element_definitions_by_name(definition["nestable_elements"])
-      else
-        element_definitions
-      end
+          definition = Element.definition_by_name(only_element_named)
+          element_definitions_by_name(definition["nestable_elements"])
+        else
+          element_definitions
+        end
 
       return [] if @_element_definitions.blank?
 
@@ -107,13 +107,13 @@ module Alchemy
     #
     def available_elements_within_current_scope(parent)
       @_available_elements = if parent
-        parents_unique_nested_elements = parent.nested_elements.where(unique: true).pluck(:name)
-        available_element_definitions(parent.name).reject do |e|
-          parents_unique_nested_elements.include? e["name"]
+          parents_unique_nested_elements = parent.nested_elements.where(unique: true).pluck(:name)
+          available_element_definitions(parent.name).reject do |e|
+            parents_unique_nested_elements.include? e["name"]
+          end
+        else
+          available_element_definitions
         end
-      else
-        available_element_definitions
-      end
     end
 
     # All element definitions defined for page's page layout
@@ -181,7 +181,7 @@ module Alchemy
     #
     def richtext_contents_ids
       Alchemy::Content.joins(:element)
-        .where(Element.table_name => {page_id: id, folded: false})
+        .where(Element.table_name => { page_id: id, folded: false })
         .select(&:has_tinymce?)
         .collect(&:id)
     end

--- a/app/models/alchemy/page/page_naming.rb
+++ b/app/models/alchemy/page/page_naming.rb
@@ -116,7 +116,7 @@ module Alchemy
     # Returns [], if there is no parent, the parent is
     # the root page itself, or url_nesting is off.
     def ancestor_slugs
-      return [] if !Config.get(:url_nesting) || parent.nil? || parent.root?
+      return [] if !Config.get(:url_nesting) || parent.nil?
 
       visible_ancestors.map(&:slug).compact
     end

--- a/app/models/alchemy/page/page_naming.rb
+++ b/app/models/alchemy/page/page_naming.rb
@@ -9,17 +9,16 @@ module Alchemy
     included do
       before_validation :set_urlname,
         if: :renamed?,
-        unless: -> { systempage? || name.blank? }
+        unless: -> { name.blank? }
 
       validates :name,
         presence: true
       validates :urlname,
-        uniqueness: {scope: [:language_id, :layoutpage], if: -> { urlname.present? }},
-        exclusion:  {in: RESERVED_URLNAMES},
-        length:     {minimum: 3, if: -> { urlname.present? }}
+        uniqueness: { scope: [:language_id, :layoutpage], if: -> { urlname.present? } },
+        exclusion: { in: RESERVED_URLNAMES },
+        length: { minimum: 3, if: -> { urlname.present? } }
 
       before_save :set_title,
-        unless: -> { systempage? },
         if: -> { title.blank? }
 
       after_update :update_descendants_urlnames,

--- a/app/models/alchemy/page/page_natures.rb
+++ b/app/models/alchemy/page/page_natures.rb
@@ -21,12 +21,6 @@ module Alchemy
       !new_record? && parent_id.blank?
     end
 
-    def systempage?
-      return true if Page.count.zero?
-
-      rootpage? || (parent_id == Page.root.id && !language_root?)
-    end
-
     def folded?(user_id)
       return unless Alchemy.user_class < ActiveRecord::Base
 

--- a/app/models/alchemy/page/page_scopes.rb
+++ b/app/models/alchemy/page/page_scopes.rb
@@ -22,10 +22,10 @@ module Alchemy
       # All pages locked by given user
       #
       scope :locked_by, ->(user) {
-        if user.class.respond_to? :primary_key
-          locked.where(locked_by: user.send(user.class.primary_key))
-        end
-      }
+              if user.class.respond_to? :primary_key
+                locked.where(locked_by: user.send(user.class.primary_key))
+              end
+            }
 
       # All not locked pages
       #
@@ -46,28 +46,28 @@ module Alchemy
       # All pages that are a published language root
       #
       scope :public_language_roots, -> {
-        published.language_roots.where(
-          language_code: Language.published.pluck(:language_code),
-        )
-      }
+              published.language_roots.where(
+                language_code: Language.published.pluck(:language_code),
+              )
+            }
 
       # Last 5 pages that where recently edited by given user
       #
       scope :all_last_edited_from, ->(user) {
-        where(updater_id: user.id).order("updated_at DESC").limit(5)
-      }
+              where(updater_id: user.id).order("updated_at DESC").limit(5)
+            }
 
       # Returns all pages that have the given +language_id+
       #
       scope :with_language, ->(language_id) {
-        where(language_id: language_id)
-      }
+              where(language_id: language_id)
+            }
 
       # Returns all content pages.
       #
       scope :contentpages, -> {
-        where(layoutpage: [false, nil]).where.not(parent_id: nil)
-      }
+              where(layoutpage: [false, nil]).where.not(parent_id: nil)
+            }
 
       # Returns all public contentpages that are not locked.
       #
@@ -80,8 +80,8 @@ module Alchemy
       # Used for flushing all pages caches at once.
       #
       scope :flushable_layoutpages, -> {
-        not_locked.layoutpages.where.not(parent_id: Page.unscoped.root.id)
-      }
+              not_locked.layoutpages.where.not(parent_id: Page.unscoped.root.id)
+            }
 
       # All searchable pages
       #
@@ -90,8 +90,8 @@ module Alchemy
       # All pages from +Alchemy::Site.current+
       #
       scope :from_current_site, -> {
-        where(Language.table_name => {site_id: Site.current || Site.default}).joins(:language)
-      }
+              where(Language.table_name => { site_id: Site.current || Site.default }).joins(:language)
+            }
 
       # All pages for xml sitemap
       #

--- a/app/models/alchemy/page/page_scopes.rb
+++ b/app/models/alchemy/page/page_scopes.rb
@@ -66,7 +66,7 @@ module Alchemy
       # Returns all content pages.
       #
       scope :contentpages, -> {
-              where(layoutpage: [false, nil]).where.not(parent_id: nil)
+              where(layoutpage: [false, nil])
             }
 
       # Returns all public contentpages that are not locked.
@@ -80,7 +80,7 @@ module Alchemy
       # Used for flushing all pages caches at once.
       #
       scope :flushable_layoutpages, -> {
-              not_locked.layoutpages.where.not(parent_id: Page.unscoped.root.id)
+              not_locked.layoutpages
             }
 
       # All searchable pages

--- a/app/models/alchemy/page/page_scopes.rb
+++ b/app/models/alchemy/page/page_scopes.rb
@@ -21,11 +21,12 @@ module Alchemy
 
       # All pages locked by given user
       #
-      scope :locked_by, ->(user) {
-              if user.class.respond_to? :primary_key
-                locked.where(locked_by: user.send(user.class.primary_key))
-              end
-            }
+      scope :locked_by,
+        ->(user) {
+          if user.class.respond_to? :primary_key
+            locked.where(locked_by: user.send(user.class.primary_key))
+          end
+        }
 
       # All not locked pages
       #
@@ -45,29 +46,27 @@ module Alchemy
 
       # All pages that are a published language root
       #
-      scope :public_language_roots, -> {
-              published.language_roots.where(
-                language_code: Language.published.pluck(:language_code),
-              )
-            }
+      scope :public_language_roots,
+        -> {
+          published.language_roots.where(
+            language_code: Language.published.pluck(:language_code),
+          )
+        }
 
       # Last 5 pages that where recently edited by given user
       #
-      scope :all_last_edited_from, ->(user) {
-              where(updater_id: user.id).order("updated_at DESC").limit(5)
-            }
+      scope :all_last_edited_from,
+        ->(user) {
+          where(updater_id: user.id).order("updated_at DESC").limit(5)
+        }
 
       # Returns all pages that have the given +language_id+
       #
-      scope :with_language, ->(language_id) {
-              where(language_id: language_id)
-            }
+      scope :with_language, ->(language_id) { where(language_id: language_id) }
 
       # Returns all content pages.
       #
-      scope :contentpages, -> {
-              where(layoutpage: [false, nil])
-            }
+      scope :contentpages, -> { where(layoutpage: [false, nil]) }
 
       # Returns all public contentpages that are not locked.
       #
@@ -79,9 +78,7 @@ module Alchemy
       #
       # Used for flushing all pages caches at once.
       #
-      scope :flushable_layoutpages, -> {
-              not_locked.layoutpages
-            }
+      scope :flushable_layoutpages, -> { not_locked.layoutpages }
 
       # All searchable pages
       #
@@ -89,9 +86,10 @@ module Alchemy
 
       # All pages from +Alchemy::Site.current+
       #
-      scope :from_current_site, -> {
-              where(Language.table_name => { site_id: Site.current || Site.default }).joins(:language)
-            }
+      scope :from_current_site,
+        -> {
+          where(Language.table_name => { site_id: Site.current || Site.default }).joins(:language)
+        }
 
       # All pages for xml sitemap
       #

--- a/app/views/alchemy/admin/pages/_create_language_form.html.erb
+++ b/app/views/alchemy/admin/pages/_create_language_form.html.erb
@@ -1,4 +1,3 @@
-<% if root = Alchemy::Page.rootpage %>
 <div class="panel">
   <%= render_message do %>
     <p><%= Alchemy.t(:language_does_not_exist) %></p>
@@ -37,7 +36,6 @@
       <%= form.hidden_field :language_id, value: @language.id %>
       <%= form.hidden_field :language_code, value: @language.code %>
       <%= form.hidden_field :language_root, value: true %>
-      <%= form.hidden_field :parent_id, value: root.id %>
       <%= form.hidden_field :public, value: Alchemy::Language.all.size == 1 %>
       <%= form.submit Alchemy.t("create_tree_as_new_language", language: @language.name), autofocus: true %>
     <% end %>
@@ -50,9 +48,3 @@
 <%- end -%>
 
 </div>
-<% else %>
-<%= render_message :error do %>
-  <h2>Root page not found.</h2>
-  <p>Please run <code>bin/rake db:seed</code> task.</p>
-<% end %>
-<% end %>

--- a/lib/alchemy/seeder.rb
+++ b/lib/alchemy/seeder.rb
@@ -45,7 +45,6 @@ module Alchemy
 
         contentpages.each do |page|
           create_page(page, {
-            parent: Alchemy::Page.root,
             language: Alchemy::Language.default,
             language_root: true,
           })

--- a/lib/alchemy/test_support/factories/page_factory.rb
+++ b/lib/alchemy/test_support/factories/page_factory.rb
@@ -38,14 +38,6 @@ FactoryBot.define do
       public_on { Time.current }
     end
 
-    trait :system do
-      name { "Systempage" }
-      parent_id { Alchemy::Page.root.id }
-      language_root { false }
-      page_layout { nil }
-      language { nil }
-    end
-
     trait :layoutpage do
       layoutpage { true }
       page_layout { "footer" }

--- a/lib/alchemy/test_support/factories/page_factory.rb
+++ b/lib/alchemy/test_support/factories/page_factory.rb
@@ -9,28 +9,21 @@ FactoryBot.define do
     sequence(:name) { |n| "A Page #{n}" }
     page_layout { "standard" }
 
-    parent_id do
-      (Alchemy::Page.find_by(language_root: true) ||
-       FactoryBot.create(:alchemy_page, :language_root, language: language)).id
+    parent do
+      Alchemy::Page.find_by(language_root: true, language: language) ||
+        FactoryBot.create(:alchemy_page, :language_root, language: language)
     end
 
     # This speeds up creating of pages dramatically.
     # Pass autogenerate_elements: true to generate elements
     autogenerate_elements { false }
 
-    trait :root do
-      name { "Root" }
-      language { nil }
-      parent_id { nil }
-      page_layout { nil }
-    end
-
     trait :language_root do
-      name { "Startseite" }
+      name { language.frontpage_name }
       page_layout { language.page_layout }
       language_root { true }
       public_on { Time.current }
-      parent_id { Alchemy::Page.root.id }
+      parent { nil }
     end
 
     trait :public do

--- a/lib/alchemy/upgrader/five_point_zero.rb
+++ b/lib/alchemy/upgrader/five_point_zero.rb
@@ -24,6 +24,18 @@ module Alchemy
           log "No layout root pages found.", :skip
         end
       end
+
+      def remove_root_page
+        desc "Remove root page"
+        root_page = Alchemy::Page.find_by(parent_id: nil, name: "Root")
+        if root_page
+          Alchemy::Page.where(parent_id: root_page.id).update_all(parent_id: nil)
+          root_page.delete
+          log "Done.", :success
+        else
+          log "Root page not found.", :skip
+        end
+      end
     end
   end
 end

--- a/lib/tasks/alchemy/upgrade.rake
+++ b/lib/tasks/alchemy/upgrade.rake
@@ -21,6 +21,7 @@ namespace :alchemy do
     task database: [
       "alchemy:upgrade:5.0:install_gutentag_migrations",
       "alchemy:upgrade:5.0:remove_layout_roots",
+      "alchemy:upgrade:5.0:remove_root_page",
       "alchemy:install:migrations",
       "db:migrate",
       "alchemy:db:seed",
@@ -47,6 +48,11 @@ namespace :alchemy do
       desc "Remove layout root pages"
       task remove_layout_roots: [:environment] do
         Alchemy::Upgrader::FivePointZero.remove_layout_roots
+      end
+
+      desc "Remove root page"
+      task remove_root_page: [:environment] do
+        Alchemy::Upgrader::FivePointZero.remove_root_page
       end
     end
   end

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 require "rails_helper"

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 # frozen_string_literal: true
 
 require "rails_helper"
@@ -84,14 +85,6 @@ module Alchemy
 
         it "should be valid" do
           expect(rootpage).to be_valid
-        end
-      end
-
-      context "saving a systempage" do
-        let(:systempage) { build(:alchemy_page, :system) }
-
-        it "should not validate the page_layout" do
-          expect(systempage).to be_valid
         end
       end
     end
@@ -261,18 +254,6 @@ module Alchemy
             page.save
             expect(page.elements).to be_empty
           end
-        end
-      end
-
-      context "Creating a systempage" do
-        let!(:page) { create(:alchemy_page, :system) }
-
-        it "does not get the language code from language" do
-          expect(page.language_code).to be_nil
-        end
-
-        it "does not autogenerate the elements" do
-          expect(page.elements).to be_empty
         end
       end
 

--- a/spec/requests/alchemy/admin/pages_controller_spec.rb
+++ b/spec/requests/alchemy/admin/pages_controller_spec.rb
@@ -492,7 +492,7 @@ module Alchemy
             expect(Page).to receive(:copy_and_paste).with(
               page_in_clipboard,
               parent,
-              page_params[:name]
+              page_params[:name],
             )
             post admin_pages_path(
               page: page_params,

--- a/spec/requests/alchemy/admin/pages_controller_spec.rb
+++ b/spec/requests/alchemy/admin/pages_controller_spec.rb
@@ -87,7 +87,7 @@ module Alchemy
       end
 
       describe "#tree" do
-        let(:user)   { create(:alchemy_dummy_user, :as_editor) }
+        let(:user) { create(:alchemy_dummy_user, :as_editor) }
         let(:page_1) { create(:alchemy_page, visible: true, name: "one") }
         let(:page_2) { create(:alchemy_page, visible: true, name: "two", parent_id: page_1.id) }
         let(:page_3) { create(:alchemy_page, visible: true, name: "three", parent_id: page_2.id) }
@@ -254,7 +254,7 @@ module Alchemy
 
             before do
               allow_any_instance_of(described_class).to receive(:get_clipboard).with("pages") do
-                [{"id" => page.id.to_s, "action" => "copy"}]
+                [{ "id" => page.id.to_s, "action" => "copy" }]
               end
             end
 
@@ -305,12 +305,12 @@ module Alchemy
       end
 
       describe "#order" do
-        let(:page_1)       { create(:alchemy_page, visible: true) }
-        let(:page_2)       { create(:alchemy_page, visible: true) }
-        let(:page_3)       { create(:alchemy_page, visible: true) }
-        let(:page_item_1)  { {id: page_1.id, slug: page_1.slug, restricted: false, visible: page_1.visible?, children: [page_item_2]} }
-        let(:page_item_2)  { {id: page_2.id, slug: page_2.slug, restricted: false, visible: page_2.visible?, children: [page_item_3]} }
-        let(:page_item_3)  { {id: page_3.id, slug: page_3.slug, restricted: false, visible: page_3.visible? } }
+        let(:page_1) { create(:alchemy_page, visible: true) }
+        let(:page_2) { create(:alchemy_page, visible: true) }
+        let(:page_3) { create(:alchemy_page, visible: true) }
+        let(:page_item_1) { { id: page_1.id, slug: page_1.slug, restricted: false, visible: page_1.visible?, children: [page_item_2] } }
+        let(:page_item_2) { { id: page_2.id, slug: page_2.slug, restricted: false, visible: page_2.visible?, children: [page_item_3] } }
+        let(:page_item_3) { { id: page_3.id, slug: page_3.slug, restricted: false, visible: page_3.visible? } }
         let(:set_of_pages) { [page_item_1] }
 
         it "stores the new order" do
@@ -488,8 +488,11 @@ module Alchemy
           let(:page_in_clipboard) { create(:alchemy_page) }
 
           it "should call Page#copy_and_paste" do
-            expect(Page).to receive(:copy_and_paste).
-              with(page_in_clipboard, parent, page_params[:name])
+            expect(Page).to receive(:copy_and_paste).with(
+              page_in_clipboard,
+              parent,
+              page_params[:name]
+            )
             post admin_pages_path(
               page: page_params,
               paste_from_clipboard: page_in_clipboard.id,
@@ -499,10 +502,10 @@ module Alchemy
       end
 
       describe "#copy_language_tree" do
-        let(:params)                     { {languages: {new_lang_id: "2", old_lang_id: "1"}} }
+        let(:params) { { languages: { new_lang_id: "2", old_lang_id: "1" } } }
         let(:language_root_to_copy_from) { build_stubbed(:alchemy_page, :language_root) }
-        let(:copy_of_language_root)      { build_stubbed(:alchemy_page, :language_root) }
-        let(:root_page)                  { mock_model("Page") }
+        let(:copy_of_language_root) { build_stubbed(:alchemy_page, :language_root) }
+        let(:root_page) { mock_model("Page") }
 
         before do
           allow(Page).to receive(:copy).and_return(copy_of_language_root)
@@ -514,7 +517,7 @@ module Alchemy
         end
 
         it "should copy the language root page over to the other language" do
-          expect(Page).to receive(:copy).with(language_root_to_copy_from, {language_id: "2", language_code: "de"})
+          expect(Page).to receive(:copy).with(language_root_to_copy_from, { language_id: "2", language_code: "de" })
           post copy_language_tree_admin_pages_path(params)
         end
 
@@ -541,7 +544,7 @@ module Alchemy
       end
 
       describe "#edit" do
-        let!(:page)       { create(:alchemy_page) }
+        let!(:page) { create(:alchemy_page) }
         let!(:other_user) { create(:alchemy_dummy_user, :as_author) }
 
         context "if page is locked by another user" do
@@ -631,7 +634,7 @@ module Alchemy
       end
 
       describe "#destroy" do
-        let(:clipboard) { [{"id" => page.id.to_s}] }
+        let(:clipboard) { [{ "id" => page.id.to_s }] }
         let(:page) { create(:alchemy_page, :public) }
 
         before do

--- a/spec/requests/alchemy/admin/pages_controller_spec.rb
+++ b/spec/requests/alchemy/admin/pages_controller_spec.rb
@@ -421,6 +421,7 @@ module Alchemy
             parent_id: parent.id,
             name: "new Page",
             page_layout: "standard",
+            language_id: parent.language_id,
           }
         end
 
@@ -509,7 +510,6 @@ module Alchemy
 
         before do
           allow(Page).to receive(:copy).and_return(copy_of_language_root)
-          allow(Page).to receive(:root).and_return(root_page)
           allow(Page).to receive(:language_root_for).and_return(language_root_to_copy_from)
           allow_any_instance_of(Page).to receive(:move_to_child_of)
           allow_any_instance_of(Page).to receive(:copy_children_to)
@@ -518,11 +518,6 @@ module Alchemy
 
         it "should copy the language root page over to the other language" do
           expect(Page).to receive(:copy).with(language_root_to_copy_from, { language_id: "2", language_code: "de" })
-          post copy_language_tree_admin_pages_path(params)
-        end
-
-        it "should move the newly created language-root-page below the absolute root page" do
-          expect(copy_of_language_root).to receive(:move_to_child_of).with(root_page)
           post copy_language_tree_admin_pages_path(params)
         end
 


### PR DESCRIPTION
Builds on top of #1813 

## What is this pull request for?

We have a hidden page called "Root" that is the top most parent page of all other pages. This is not necessary since all pages that share the same language and are not a layoutpage ("Global Page") are a nested set already.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
