### PR TITLE
Make page language mandatory

### DIFF
--- a/app/models/alchemy/language.rb
+++ b/app/models/alchemy/language.rb
@@ -25,7 +25,7 @@ require_dependency "alchemy/site"
 module Alchemy
   class Language < BaseRecord
     belongs_to :site
-    has_many :pages
+    has_many :pages, inverse_of: :language
     has_many :nodes, inverse_of: :language
 
     before_validation :set_locale, if: -> { locale.blank? }

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -87,7 +87,7 @@ module Alchemy
 
     stampable stamper_class_name: Alchemy.user_class_name
 
-    belongs_to :language, optional: true
+    belongs_to :language
 
     belongs_to :creator,
       primary_key: Alchemy.user_class_primary_key,
@@ -113,7 +113,8 @@ module Alchemy
     has_many :legacy_urls, class_name: "Alchemy::LegacyPageUrl"
     has_many :nodes, class_name: "Alchemy::Node", inverse_of: :page
 
-    validates_presence_of :language, on: :create, unless: :root
+    before_validation :set_language,
+      if: -> { language.nil? }
 
     validates_presence_of :page_layout
     validates_format_of :page_layout, with: /\A[a-z0-9_-]+\z/, unless: -> { page_layout.blank? }
@@ -133,9 +134,6 @@ module Alchemy
 
     before_save :set_fixed_attributes,
       if: -> { fixed_attributes.any? }
-
-    before_create :set_language,
-      if: -> { language.nil? }
 
     after_update :create_legacy_url,
       if: :should_create_legacy_url?

--- a/db/migrate/20200505215518_add_language_id_foreign_key_to_alchemy_pages.rb
+++ b/db/migrate/20200505215518_add_language_id_foreign_key_to_alchemy_pages.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddLanguageIdForeignKeyToAlchemyPages < ActiveRecord::Migration[5.2]
+  def change
+    add_foreign_key :alchemy_pages, :alchemy_languages, column: :language_id
+    change_column_null :alchemy_pages, :language_id, false, Alchemy::Language.default&.id
+  end
+end

--- a/lib/alchemy/seeder.rb
+++ b/lib/alchemy/seeder.rb
@@ -102,7 +102,7 @@ module Alchemy
         page = Alchemy::Page.create!(draft.merge(attributes))
         log "Created page: #{page.name}"
         children.each do |child|
-          create_page(child, parent: page)
+          create_page(child, parent: page, language: page.language)
         end
       end
 

--- a/spec/dummy/db/migrate/20200505215518_add_language_id_foreign_key_to_alchemy_pages.rb
+++ b/spec/dummy/db/migrate/20200505215518_add_language_id_foreign_key_to_alchemy_pages.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20200505215518_add_language_id_foreign_key_to_alchemy_pages.rb

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_04_210159) do
+ActiveRecord::Schema.define(version: 2020_05_05_215518) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string "name"
@@ -226,7 +226,7 @@ ActiveRecord::Schema.define(version: 2020_05_04_210159) do
     t.datetime "updated_at", null: false
     t.integer "creator_id"
     t.integer "updater_id"
-    t.integer "language_id"
+    t.integer "language_id", null: false
     t.datetime "published_at"
     t.datetime "public_on"
     t.datetime "public_until"
@@ -338,4 +338,5 @@ ActiveRecord::Schema.define(version: 2020_05_04_210159) do
   add_foreign_key "alchemy_essence_pages", "alchemy_pages", column: "page_id"
   add_foreign_key "alchemy_nodes", "alchemy_languages", column: "language_id"
   add_foreign_key "alchemy_nodes", "alchemy_pages", column: "page_id", on_delete: :cascade
+  add_foreign_key "alchemy_pages", "alchemy_languages", column: "language_id"
 end

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -534,16 +534,18 @@ module Alchemy
         end
 
         context "with language given" do
+          let!(:page) { Page.create!(name: "A New Page", parent: language_root, language: language, page_layout: "standard") }
+
           it "does not set the language from parent" do
-            expect_any_instance_of(Page).not_to receive(:set_language)
-            Page.create!(name: "A", parent: language_root, page_layout: "standard", language: language)
+            expect(page.language).to eq(language)
           end
         end
 
         context "with no language given" do
+          let!(:page) { Page.create!(name: "A New Page", parent: language_root, language: nil, page_layout: "standard") }
+
           it "sets the language from parent" do
-            expect_any_instance_of(Page).to receive(:set_language)
-            Page.create!(name: "A", parent: language_root, page_layout: "standard")
+            expect(page.language).to eq(language_root.language)
           end
         end
       end


### PR DESCRIPTION
## What is this pull request for?

Now that the hidden root pages have been removed in #1812 and #1817 we can make the language a mandatory belongs to association on the page.

### Notable changes

Adds a foreign key constraint to `language_id` on the pages table.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
