### PR TITLE
Add a quick Node select

### DIFF
--- a/app/assets/javascripts/alchemy/admin.js
+++ b/app/assets/javascripts/alchemy/admin.js
@@ -47,3 +47,4 @@
 //= require alchemy/alchemy.tooltips
 //= require alchemy/alchemy.trash_window
 //= require alchemy/page_select
+//= require alchemy/node_select

--- a/app/assets/javascripts/alchemy/node_select.js
+++ b/app/assets/javascripts/alchemy/node_select.js
@@ -1,0 +1,31 @@
+$.fn.alchemyNodeSelect = function(options) {
+  var renderNodeTemplate = (node) => HandlebarsTemplates.node({ node: node })
+  var queryParamsFromTerm = (term) => {
+    return {filter: Object.assign({ name_or_page_name_cont: term }, options.query_params)}
+  }
+  var resultsFromResponse = (response) => {
+    var { meta, data } = response
+    var more = meta.page * meta.per_page < meta.total_count
+    return { results: data, more: more }
+  }
+
+  return this.select2({
+    placeholder: options.placeholder,
+    allowClear: true,
+    minimumInputLength: 3,
+    initSelection: function (_$el, callback) {
+      if (options.initialSelection) {
+        callback(options.initialSelection)
+      }
+    },
+    ajax: {
+      url: options.url,
+      datatype: 'json',
+      quietMillis: 300,
+      data: queryParamsFromTerm,
+      results: resultsFromResponse
+    },
+    formatSelection: renderNodeTemplate,
+    formatResult: renderNodeTemplate
+  })
+}

--- a/app/assets/javascripts/alchemy/templates/index.js
+++ b/app/assets/javascripts/alchemy/templates/index.js
@@ -1,3 +1,4 @@
 //= require alchemy/templates/spinner
 //= require alchemy/templates/page
 //= require alchemy/templates/node_folder
+//= require alchemy/templates/node

--- a/app/assets/javascripts/alchemy/templates/node.hbs
+++ b/app/assets/javascripts/alchemy/templates/node.hbs
@@ -1,0 +1,16 @@
+<div class="node-select--node">
+  <i class="icon fas fa-list fa-lg"></i>
+  <div class="node-select--node-display_name">
+    <span class="node-select--node-ancestors">
+      {{#each node.ancestors}}
+        {{ this.name }} /&nbsp;
+      {{/each}}
+    </span>
+    <span class="node-select--node-name">
+      {{ node.name }}
+    </span>
+  </div>
+  <div class="node-select--node-url">
+    {{ node.url }}
+  </div>
+</div>

--- a/app/assets/stylesheets/alchemy/admin.scss
+++ b/app/assets/stylesheets/alchemy/admin.scss
@@ -31,6 +31,7 @@
 @import "alchemy/image_library";
 @import "alchemy/labels";
 @import "alchemy/nodes";
+@import "alchemy/node-select";
 @import "alchemy/notices";
 @import "alchemy/page-select";
 @import "alchemy/pagination";

--- a/app/assets/stylesheets/alchemy/node-select.scss
+++ b/app/assets/stylesheets/alchemy/node-select.scss
@@ -32,3 +32,12 @@
     color: $white
   }
 }
+
+// The container of the rendered node is slightly larger than other a line of
+// text, as it would be for the Alchemy::EssencePage. Reducing the padding here from 0.6em
+// to 0.4em centers the content nicely.
+.essence_node {
+  .select2-container.alchemy_selectbox .select2-choice {
+    padding: 0.4em 0.75em;
+  }
+}

--- a/app/assets/stylesheets/alchemy/node-select.scss
+++ b/app/assets/stylesheets/alchemy/node-select.scss
@@ -1,0 +1,34 @@
+.node-select--node,
+.node-select--node-url {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.node-select--node {
+  display: flex;
+  align-items: center;
+
+  .icon {
+    margin: 0 8px 0 4px;
+
+    .select2-highlighted & {
+      color: $white
+    }
+  }
+}
+
+.node-select--node-name {
+  font-weight: bold;
+}
+
+.node-select--node-url {
+  margin-left: auto;
+  padding: $default-padding 2*$default-padding;
+  color: $dark-gray;
+  font-size: $small-font-size;
+
+  .select2-highlighted & {
+    color: $white
+  }
+}

--- a/app/controllers/alchemy/api/nodes_controller.rb
+++ b/app/controllers/alchemy/api/nodes_controller.rb
@@ -2,8 +2,20 @@
 
 module Alchemy
   class Api::NodesController < Api::BaseController
-    before_action :load_node
+    before_action :load_node, except: :index
     before_action :authorize_access, only: [:move, :toggle_folded]
+
+    def index
+      @nodes = Node.all
+      @nodes = @nodes.includes(:parent)
+      @nodes = @nodes.ransack(params[:filter]).result
+
+      if params[:page]
+        @nodes = @nodes.page(params[:page]).per(params[:per_page])
+      end
+
+      render json: @nodes, adapter: :json, root: "data", meta: meta_data, include: params[:include]
+    end
 
     def move
       target_parent_node = Node.find(params[:target_parent_id])
@@ -24,6 +36,30 @@ module Alchemy
 
     def authorize_access
       authorize! :update, @node
+    end
+
+    def meta_data
+      {
+        total_count: total_count_value,
+        per_page: per_page_value,
+        page: page_value,
+      }
+    end
+
+    def total_count_value
+      params[:page] ? @nodes.total_count : @nodes.size
+    end
+
+    def per_page_value
+      if params[:page]
+        (params[:per_page] || Kaminari.config.default_per_page).to_i
+      else
+        @nodes.size
+      end
+    end
+
+    def page_value
+      params[:page] ? params[:page].to_i : 1
     end
   end
 end

--- a/app/models/alchemy/essence_node.rb
+++ b/app/models/alchemy/essence_node.rb
@@ -20,7 +20,7 @@ module Alchemy
     def ingredient=(node)
       case node
       when NODE_ID
-        self.node = Alchemy::Page.new(id: node)
+        self.node = Alchemy::Node.new(id: node)
       when Alchemy::Node
         self.node = node
       else

--- a/app/models/alchemy/essence_node.rb
+++ b/app/models/alchemy/essence_node.rb
@@ -15,7 +15,7 @@ module Alchemy
       },
     )
 
-    delegate :name, to: :node, prefix: true
+    delegate :name, to: :node, prefix: true, allow_nil: true
 
     def ingredient=(node)
       case node

--- a/app/models/alchemy/node.rb
+++ b/app/models/alchemy/node.rb
@@ -22,7 +22,11 @@ module Alchemy
     # Either the value is stored in the database
     # or, if attached, the values comes from a page.
     def name
-      read_attribute(:name).presence || page&.name
+      if root?
+        Alchemy.t(read_attribute(:name), scope: :menu_names)
+      else
+        read_attribute(:name).presence || page&.name
+      end
     end
 
     class << self

--- a/app/serializers/alchemy/node_serializer.rb
+++ b/app/serializers/alchemy/node_serializer.rb
@@ -8,5 +8,7 @@ module Alchemy
       :rgt,
       :url,
       :parent_id
+
+    has_many :ancestors, record_type: :node, serializer: self
   end
 end

--- a/app/views/alchemy/admin/nodes/_node.html.erb
+++ b/app/views/alchemy/admin/nodes/_node.html.erb
@@ -47,11 +47,7 @@
       <% end %>
     </span>
     <div class="node_name">
-      <% if node.root? %>
-        <%= I18n.t(node.name, scope: [:alchemy, :menu_names]) %>
-      <% else %>
-        <%= node.name || '&nbsp;'.html_safe %>
-      <% end %>
+      <%= node.name || '&nbsp;'.html_safe %>
       <span class="node_page">
       <% if node.page %>
         <i class="icon far fa-file"></i>

--- a/app/views/alchemy/essences/_essence_node_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_node_editor.html.erb
@@ -20,10 +20,8 @@
     url: "<%= alchemy.api_nodes_path %>",
     query_params: <%== query_params.to_json %>,
     <% if essence_node_editor.essence.node %>
-    initialSelection: {
-      id: <%= essence_node_editor.essence.node_id %>,
-      text: "<%= essence_node_editor.essence.node.name %>"
-    }
+    <% serialized_node = ActiveModelSerializers::SerializableResource.new(essence_node_editor.essence.node, include: :ancestors) %>
+    initialSelection: <%== serialized_node.to_json %>
     <% end %>
   })
 </script>

--- a/app/views/alchemy/essences/_essence_node_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_node_editor.html.erb
@@ -1,21 +1,29 @@
-<%#
-  Available locals:
-  * content (The object the essence is linked to the element)
-  * html_options
-
-  Please consult Alchemy::Content.rb docs for further methods on the content object
-%>
-<div class="content_editor essence_node" id="<%= content.dom_id %>" data-content-id="<%= content.id %>">
-  <%= content_label(content) %>
-   <%= select_tag(
-    content.form_field_name,
-    options_from_collection_for_select(
-      local_assigns.fetch(:options, {})[:nodes] || Alchemy::Node.where(site: Alchemy::Site.current),
-      :id,
-      :name,
-      content.essence.node_id
-    ),
-    include_blank: t(".none"),
-    class: "alchemy_selectbox essence_editor_select full_width"
+<%= content_tag :div,
+  id: essence_node_editor.dom_id,
+  class: essence_node_editor.css_classes,
+  data: essence_node_editor.data_attributes do %>
+  <%= content_label(essence_node_editor) %>
+  <%= text_field_tag(
+    essence_node_editor.form_field_name,
+    essence_node_editor.essence.node_id,
+    id: essence_node_editor.form_field_id,
+    class: 'alchemy_selectbox full_width'
   ) %>
-</div>
+<% end %>
+
+<script>
+  <% query_params = essence_node_editor.settings.fetch(:query_params, {}).merge({
+    include: :ancestors
+  }) %>
+  $('#<%= essence_node_editor.form_field_id %>').alchemyNodeSelect({
+    placeholder: "<%= Alchemy.t(:search_node) %>",
+    url: "<%= alchemy.api_nodes_path %>",
+    query_params: <%== query_params.to_json %>,
+    <% if essence_node_editor.essence.node %>
+    initialSelection: {
+      id: <%= essence_node_editor.essence.node_id %>,
+      text: "<%= essence_node_editor.essence.node.name %>"
+    }
+    <% end %>
+  })
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -150,7 +150,7 @@ Alchemy::Engine.routes.draw do
     get "/pages/*urlname(.:format)" => "pages#show", as: "page"
     get "/admin/pages/:id(.:format)" => "pages#show", as: "preview_page"
 
-    resources :nodes, only: [] do
+    resources :nodes, only: [:index] do
       member do
         patch :move
         patch :toggle_folded

--- a/spec/dummy/config/alchemy/elements.yml
+++ b/spec/dummy/config/alchemy/elements.yml
@@ -160,3 +160,8 @@
   fixed: true
   unique: true
   nestable_elements: [text]
+
+- name: menu
+  contents:
+  - name: Menu
+    type: EssenceNode

--- a/spec/dummy/config/alchemy/page_layouts.yml
+++ b/spec/dummy/config/alchemy/page_layouts.yml
@@ -39,6 +39,8 @@
   autogenerate: [headline, text, contactform]
 
 - name: footer
+  elements:
+  - menu
   layoutpage: true
 
 - name: <%= 'erb_' + 'layout' %>

--- a/spec/models/alchemy/node_spec.rb
+++ b/spec/models/alchemy/node_spec.rb
@@ -82,18 +82,28 @@ module Alchemy
     end
 
     describe "#name" do
-      context "with page attached" do
-        let(:node) { build_stubbed(:alchemy_node, :with_page) }
+      subject { node.name }
+      context "root node" do
+        let(:node) { build_stubbed(:alchemy_node, name: "main_menu") }
 
-        it "returns the name from page" do
-          expect(node.name).to eq(node.page.name)
-        end
+        it { is_expected.to eq("Main Menu") }
+      end
 
-        context "but with name set" do
-          let(:node) { build_stubbed(:alchemy_node, :with_page, name: "Google") }
+      context "child node" do
+        let(:parent) { build_stubbed(:alchemy_node) }
+        context "with page attached" do
+          let(:node) { build_stubbed(:alchemy_node, :with_page, parent: parent) }
 
-          it "still returns the name from name attribute" do
-            expect(node.name).to eq("Google")
+          it "returns the name from page" do
+            expect(node.name).to eq(node.page.name)
+          end
+
+          context "but with name set" do
+            let(:node) { build_stubbed(:alchemy_node, :with_page, name: "Google", parent: parent) }
+
+            it "still returns the name from name attribute" do
+              expect(node.name).to eq("Google")
+            end
           end
         end
       end

--- a/spec/serializers/alchemy/node_serializer_spec.rb
+++ b/spec/serializers/alchemy/node_serializer_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Alchemy::NodeSerializer do
       "parent_id" => node.parent_id,
       "name" => node.name,
       "url" => node.url,
+      "ancestors" => [],
     )
   end
 end


### PR DESCRIPTION
## What is this pull request for?

This faster select also shows the ancestors of each node, such that one
is not confused between nodes that have similar names.

This adds an index action to the included Nodes API, and it fixes a bug with the EssenceNode class.

### Screenshots

![grafik](https://user-images.githubusercontent.com/703401/81405043-2ba9d280-9137-11ea-82ea-dd7d16c21bf6.png)

Closes #1797 

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
