### PR TITLE
Fix Association between Nodes and EssenceNodes

### DIFF
--- a/app/models/alchemy/node.rb
+++ b/app/models/alchemy/node.rb
@@ -12,7 +12,7 @@ module Alchemy
 
     has_one :site, through: :language
 
-    has_many :essence_nodes, class_name: "Alchemy::Node", inverse_of: :node
+    has_many :essence_nodes, class_name: "Alchemy::EssenceNode", foreign_key: :node_id, inverse_of: :ingredient_association
 
     validates :name, presence: true, if: -> { page.nil? }
     validates :url, format: { with: VALID_URL_REGEX }, unless: -> { url.nil? }

--- a/spec/models/alchemy/node_spec.rb
+++ b/spec/models/alchemy/node_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 
 module Alchemy
   describe Node do
+    it { is_expected.to have_many(:essence_nodes) }
+
     it "is only valid with language and name given" do
       expect(Node.new).to be_invalid
       expect(build(:alchemy_node)).to be_valid


### PR DESCRIPTION
## What is this pull request for?

There was a typo here resulting in Nodes being associated to themselves
in an impossible way.

### Notable changes (remove if none)

Prior to this, accessing `node.essence_nodes` would result in a hard-to-decipher error.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
