### PR TITLE
Add error flash to resource controller

### DIFF
--- a/app/controllers/alchemy/admin/resources_controller.rb
+++ b/app/controllers/alchemy/admin/resources_controller.rb
@@ -79,6 +79,9 @@ module Alchemy
 
       def destroy
         resource_instance_variable.destroy
+        if resource_instance_variable.errors.any?
+          flash[:error] = resource_instance_variable.errors.full_messages.join(", ")
+        end
         flash_notice_for_resource_action
         do_redirect_to resource_url_proxy.url_for(search_filter_params.merge(action: "index"))
       end

--- a/spec/controllers/alchemy/admin/resources_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/resources_controller_spec.rb
@@ -137,5 +137,16 @@ describe Admin::EventsController do
       delete :destroy, params: {id: peter.id}.merge(params)
       expect(response.redirect_url).to eq("http://test.host/admin/events?page=6&q%5Bname_or_hidden_name_or_description_or_location_name_cont%5D=some_query")
     end
+
+    context "If the resource is not destroyable" do
+      let!(:undestroyable) { create(:event, name: "Undestructible") }
+
+      it "adds an error flash" do
+        delete :destroy, params: {id: undestroyable.id}.merge(params)
+
+        expect(response.redirect_url).to eq("http://test.host/admin/events?page=6&q%5Bname_or_hidden_name_or_description_or_location_name_cont%5D=some_query")
+        expect(flash[:error]).to eq("This is the undestructible event!")
+      end
+    end
   end
 end

--- a/spec/dummy/app/models/event.rb
+++ b/spec/dummy/app/models/event.rb
@@ -5,6 +5,7 @@ class Event < ActiveRecord::Base
 
   validates_presence_of :name
   belongs_to :location
+  before_destroy :abort_if_name_is_undestructible
 
   scope :starting_today, -> { where(starts_at: Time.current.at_midnight..Date.tomorrow.at_midnight) }
   scope :future, -> { where("starts_at > ?", Date.tomorrow.at_midnight) }
@@ -17,5 +18,14 @@ class Event < ActiveRecord::Base
 
   def self.alchemy_resource_filters
     %w(starting_today future)
+  end
+
+  private
+
+  def abort_if_name_is_undestructible
+    if name == "Undestructible"
+      errors.add(:base, "This is the undestructible event!")
+      throw(:abort)
+    end
   end
 end


### PR DESCRIPTION
## What is this pull request for?

This adds an error flash to the resource controller if some action does
not succeed.

### Notable changes (remove if none)

This adds a flash message to an action if the action does not succeed. There might be a breaking change in here for actions that render a form afterwards.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
