### PR TITLE
Scope has one site

### DIFF
--- a/app/models/alchemy/language.rb
+++ b/app/models/alchemy/language.rb
@@ -30,7 +30,7 @@ module Alchemy
 
     before_validation :set_locale, if: -> { locale.blank? }
 
-    has_one :root_page, -> { where(parent: nil) }, class_name: "Alchemy::Page"
+    has_one :root_page, -> { where(parent: nil, layoutpage: false) }, class_name: "Alchemy::Page"
 
     validates :name, presence: true
     validates :page_layout, presence: true

--- a/db/migrate/20200514091507_make_page_layoutpage_null_false.rb
+++ b/db/migrate/20200514091507_make_page_layoutpage_null_false.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class MakePageLayoutpageNullFalse < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :alchemy_pages, :layoutpage, false, false
+  end
+end

--- a/spec/dummy/db/migrate/20200514091507_make_page_layoutpage_null_false.rb
+++ b/spec/dummy/db/migrate/20200514091507_make_page_layoutpage_null_false.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20200514091507_make_page_layoutpage_null_false.rb

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_05_215518) do
+ActiveRecord::Schema.define(version: 2020_05_14_091507) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string "name"
@@ -221,7 +221,7 @@ ActiveRecord::Schema.define(version: 2020_05_05_215518) do
     t.boolean "robot_index", default: true
     t.boolean "robot_follow", default: true
     t.boolean "sitemap", default: true
-    t.boolean "layoutpage", default: false
+    t.boolean "layoutpage", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "creator_id"

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -61,7 +61,7 @@ module Alchemy
       end
 
       context "a page not being a language_root and without parent" do
-        let(:page) { build(:alchemy_page, parent: nil, layoutpage: nil) }
+        let(:page) { build(:alchemy_page, parent: nil, layoutpage: false) }
 
         it { expect(page).to_not be_valid }
       end
@@ -360,7 +360,7 @@ module Alchemy
       let!(:klingon_lang_root) do
         create :alchemy_page, :language_root, {
           name: "klingon_lang_root",
-          layoutpage: nil,
+          layoutpage: false,
           language: klingon,
         }
       end
@@ -385,10 +385,8 @@ module Alchemy
         expect(Page.contentpages.to_a.select { |p| p.layoutpage == true }).to be_empty
       end
 
-      it "contains pages with attribute :layoutpage set to nil" do
-        expect(Page.contentpages.to_a.select do |page|
-          page.layoutpage.nil?
-        end).to include(klingon_lang_root)
+      it "contains pages with attribute :layoutpage set to false" do
+        expect(Page.contentpages.to_a.select { |p| p.layoutpage == false }).to include(klingon_lang_root)
       end
     end
 


### PR DESCRIPTION
## What is this pull request for?

Make sure that layoutpages don't show up as root pages when calling `language.root_page`.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] This is just using ActiveRecord properly, I don't see a need to add specs for this.
