### PR TITLE
Install Webpacker in install generator

### DIFF
--- a/lib/generators/alchemy/install/install_generator.rb
+++ b/lib/generators/alchemy/install/install_generator.rb
@@ -11,6 +11,11 @@ module Alchemy
         default: false,
         desc: "Skip creation of demo element, page and application layout."
 
+      class_option :skip_webpacker_installer,
+        type: :boolean,
+        default: false,
+        desc: "Skip running the webpacker installer."
+
       source_root File.expand_path("files", __dir__)
 
       def copy_config
@@ -53,6 +58,12 @@ module Alchemy
 
       def install_gutentag_migrations
         rake "gutentag:install:migrations"
+      end
+
+      def run_webpacker_installer
+        unless options[:skip_webpacker_installer]
+          rake("webpacker:install", abort_on_failure: true)
+        end
       end
 
       private


### PR DESCRIPTION


## What is this pull request for?

We use this generator in the Alchemy ecosystem, and the dummy apps of
gems like alchemy-devise or alchemy-solidus need webpacker installed to
function.

That generator will run through cleanly if webpacker is not installed, and ask for changes if there are conflicting configurations present.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have NOT added tests to cover this change.
