### PR TITLE
Re-add form_field_[name,id] to Alchemy::Content

### DIFF
--- a/app/models/alchemy/content.rb
+++ b/app/models/alchemy/content.rb
@@ -226,6 +226,14 @@ module Alchemy
       "has_tinymce" + (has_custom_tinymce_config? ? " #{element.name}_#{name}" : "")
     end
 
+    def editor
+      @_editor ||= ContentEditor.new(self)
+    end
+    delegate :form_field_name, to: :editor
+    deprecate form_field_name: "use Alchemy::ContentEditor#form_field_name instead", deprecator: Alchemy::Deprecation
+    delegate :form_field_id, to: :editor
+    deprecate form_field_id: "use Alchemy::ContentEditor#form_field_id instead", deprecator: Alchemy::Deprecation
+
     # Returns the default value from content definition
     #
     # If the value is a symbol it gets passed through i18n


### PR DESCRIPTION
These were removed with the introduction of the ContentEditor, but gems
in the ecosystem still use them. In order to provide a good upgrade path
to 5.0, we should reintroduce and deprecate these methods.

