### PR TITLE
Set proper nested set scope on page

### DIFF
--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -83,7 +83,7 @@ module Alchemy
       :menu_id,
     ]
 
-    acts_as_nested_set(dependent: :destroy)
+    acts_as_nested_set(dependent: :destroy, scope: [:layoutpage, :language_id])
 
     stampable stamper_class_name: Alchemy.user_class_name
 

--- a/lib/alchemy/test_support/factories/page_factory.rb
+++ b/lib/alchemy/test_support/factories/page_factory.rb
@@ -23,8 +23,8 @@ FactoryBot.define do
     autogenerate_elements { false }
 
     trait :language_root do
-      name { language.frontpage_name }
-      page_layout { language.page_layout }
+      name { language&.frontpage_name || "Intro" }
+      page_layout { language&.page_layout || "index" }
       language_root { true }
       public_on { Time.current }
       parent { nil }

--- a/lib/alchemy/test_support/factories/page_factory.rb
+++ b/lib/alchemy/test_support/factories/page_factory.rb
@@ -5,7 +5,11 @@ require "alchemy/test_support/factories/language_factory"
 
 FactoryBot.define do
   factory :alchemy_page, class: "Alchemy::Page" do
-    language { Alchemy::Language.default || FactoryBot.create(:alchemy_language) }
+    language do
+      @cached_attributes[:parent]&.language ||
+        Alchemy::Language.default ||
+        FactoryBot.create(:alchemy_language)
+    end
     sequence(:name) { |n| "A Page #{n}" }
     page_layout { "standard" }
 

--- a/lib/alchemy/test_support/factories/page_factory.rb
+++ b/lib/alchemy/test_support/factories/page_factory.rb
@@ -32,6 +32,7 @@ FactoryBot.define do
     end
 
     trait :layoutpage do
+      parent { nil }
       layoutpage { true }
       page_layout { "footer" }
     end

--- a/spec/features/admin/page_editing_feature_spec.rb
+++ b/spec/features/admin/page_editing_feature_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Page editing feature", type: :system do
     end
 
     context "while editing a global page" do
-      let(:a_page) { create(:alchemy_page, layoutpage: true) }
+      let(:a_page) { create(:alchemy_page, :layoutpage) }
 
       it "can publish page." do
         visit alchemy.edit_admin_page_path(a_page)
@@ -57,7 +57,7 @@ RSpec.describe "Page editing feature", type: :system do
 
         context "with sitemaps show_flag config option set to true" do
           before do
-            stub_alchemy_config(:sitemap, {"show_flag" => true})
+            stub_alchemy_config(:sitemap, { "show_flag" => true })
           end
 
           it "should show sitemap checkbox" do
@@ -68,7 +68,7 @@ RSpec.describe "Page editing feature", type: :system do
 
         context "with sitemaps show_flag config option set to false" do
           before do
-            stub_alchemy_config(:sitemap, {"show_flag" => false})
+            stub_alchemy_config(:sitemap, { "show_flag" => false })
           end
 
           it "should not show sitemap checkbox" do
@@ -79,7 +79,7 @@ RSpec.describe "Page editing feature", type: :system do
       end
 
       context "when editing a global page" do
-        let(:layout_page) { create(:alchemy_page, layoutpage: true) }
+        let(:layout_page) { create(:alchemy_page, :layoutpage) }
 
         it "should not show the input fields for normal pages" do
           visit alchemy.edit_admin_layoutpage_path(layout_page)
@@ -92,8 +92,7 @@ RSpec.describe "Page editing feature", type: :system do
 
       context "when page is taggable" do
         before do
-          expect_any_instance_of(Alchemy::Page)
-            .to receive(:taggable?).and_return(true)
+          expect_any_instance_of(Alchemy::Page).to receive(:taggable?).and_return(true)
         end
 
         it "should show the tag_list input field" do

--- a/spec/requests/alchemy/admin/pages_controller_spec.rb
+++ b/spec/requests/alchemy/admin/pages_controller_spec.rb
@@ -195,15 +195,13 @@ module Alchemy
         end
 
         let(:layout_page_1) do
-          create :alchemy_page,
-            layoutpage: true,
+          create :alchemy_page, :layoutpage,
             name: "layout_page 1",
             published_at: Time.current - 5.days
         end
 
         let(:layout_page_2) do
-          create :alchemy_page,
-            layoutpage: true,
+          create :alchemy_page, :layoutpage,
             name: "layout_page 2",
             published_at: Time.current - 8.days
         end


### PR DESCRIPTION
## What is this pull request for?

Set the correct `scope` on `awesome_nested_set` for pages.

This change is necessary for `@page.root` to find the correct parent node now that we do not have a single root node anymore.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
