### PR TITLE
Allow page visible toggle (4.6)

### DIFF
--- a/app/assets/stylesheets/alchemy/_mixins.scss
+++ b/app/assets/stylesheets/alchemy/_mixins.scss
@@ -49,9 +49,8 @@
     border-color: $hover-border-color;
   }
 
-  &:active, &:active:focus {
-    border-color: $hover-border-color;
-    box-shadow: none;
+  &:active, &.active {
+    box-shadow: inset $button-box-shadow;
   }
 
   &:focus {

--- a/app/assets/stylesheets/alchemy/_variables.scss
+++ b/app/assets/stylesheets/alchemy/_variables.scss
@@ -76,7 +76,7 @@ $button-text-shadow: none !default;
 $button-box-shadow: 0px 1px 1px -1px #333 !default;
 $button-focus-box-shadow: 0px 1px 1px 0px $button-focus-border-color !default;
 $button-padding: 0.55em 2em !default;
-$small-button-padding: 0.4em 1.25em !default;
+$small-button-padding: 0.4em 0.8em !default;
 $button-margin: $form-field-margin !default;
 
 $secondary-button-bg-color: transparent !default;

--- a/app/helpers/alchemy/admin/pages_helper.rb
+++ b/app/helpers/alchemy/admin/pages_helper.rb
@@ -9,13 +9,13 @@ module Alchemy
       #
       def preview_sizes_for_select
         options_for_select([
-          'auto',
-          [Alchemy.t('240', scope: 'preview_sizes'), 240],
-          [Alchemy.t('320', scope: 'preview_sizes'), 320],
-          [Alchemy.t('480', scope: 'preview_sizes'), 480],
-          [Alchemy.t('768', scope: 'preview_sizes'), 768],
-          [Alchemy.t('1024', scope: 'preview_sizes'), 1024],
-          [Alchemy.t('1280', scope: 'preview_sizes'), 1280]
+          "auto",
+          [Alchemy.t("240", scope: "preview_sizes"), 240],
+          [Alchemy.t("320", scope: "preview_sizes"), 320],
+          [Alchemy.t("480", scope: "preview_sizes"), 480],
+          [Alchemy.t("768", scope: "preview_sizes"), 768],
+          [Alchemy.t("1024", scope: "preview_sizes"), 1024],
+          [Alchemy.t("1280", scope: "preview_sizes"), 1280],
         ])
       end
 
@@ -27,8 +27,8 @@ module Alchemy
         if page.persisted? && page.definition.blank?
           [
             page_layout_missing_warning,
-            Alchemy.t(:page_type)
-          ].join('&nbsp;').html_safe
+            Alchemy.t(:page_type),
+          ].join("&nbsp;").html_safe
         else
           Alchemy.t(:page_type)
         end
@@ -39,10 +39,10 @@ module Alchemy
 
         if page.attribute_fixed?(attribute)
           checkbox = check_box(:page, attribute, disabled: true)
-          hint = content_tag(:span, class: 'hint-bubble') do
+          hint = content_tag(:span, class: "hint-bubble") do
             Alchemy.t(:attribute_fixed, attribute: attribute)
           end
-          content = content_tag(:span, class: 'with-hint') do
+          content = content_tag(:span, class: "with-hint") do
             "#{checkbox}\n#{label}\n#{hint}".html_safe
           end
         else
@@ -50,7 +50,7 @@ module Alchemy
           content = "#{checkbox}\n#{label}".html_safe
         end
 
-        content_tag(:label, class: 'checkbox') { content }
+        content_tag(:label, class: "checkbox") { content }
       end
     end
   end

--- a/app/helpers/alchemy/admin/pages_helper.rb
+++ b/app/helpers/alchemy/admin/pages_helper.rb
@@ -34,8 +34,8 @@ module Alchemy
         end
       end
 
-      def page_status_checkbox(page, attribute)
-        label = page.class.human_attribute_name(attribute)
+      def page_status_checkbox(page, attribute, label: nil)
+        label_text = label || page.class.human_attribute_name(attribute)
 
         if page.attribute_fixed?(attribute)
           checkbox = check_box(:page, attribute, disabled: true)
@@ -43,11 +43,11 @@ module Alchemy
             Alchemy.t(:attribute_fixed, attribute: attribute)
           end
           content = content_tag(:span, class: "with-hint") do
-            "#{checkbox}\n#{label}\n#{hint}".html_safe
+            "#{checkbox}\n#{label_text}\n#{hint}".html_safe
           end
         else
           checkbox = check_box(:page, attribute)
-          content = "#{checkbox}\n#{label}".html_safe
+          content = "#{checkbox}\n#{label_text}".html_safe
         end
 
         content_tag(:label, class: "checkbox") { content }

--- a/app/views/alchemy/admin/pages/_menu_fields.html.erb
+++ b/app/views/alchemy/admin/pages/_menu_fields.html.erb
@@ -5,12 +5,14 @@
   </label>
   <% @page.menus.each do |menu| %>
     <span class="page-menu-name label">
-      <%= menu.name %>
+      <%= I18n.t(menu.name, scope: [:alchemy, :menu_names]) %>
     </span>
   <% end %>
 <% elsif Alchemy::Node.roots.any? %>
   <%= page_status_checkbox(@page, :visible) %>
-  <%= f.input :menu_id, collection: Alchemy::Node.roots.map { |n| [n.name, n.id] },
+  <%= f.input :menu_id, collection: Alchemy::Node.roots.map { |n|
+      [I18n.t(n.name, scope: [:alchemy, :menu_names]), n.id]
+    },
     prompt: Alchemy.t('Please choose a menu'),
     input_html: { class: 'alchemy_selectbox' },
     wrapper_html: { style: @page.visible? ? 'display: block' : 'display: none' },

--- a/app/views/alchemy/admin/pages/_menu_fields.html.erb
+++ b/app/views/alchemy/admin/pages/_menu_fields.html.erb
@@ -8,7 +8,7 @@
       <%= I18n.t(menu.name, scope: [:alchemy, :menu_names]) %>
     </span>
   <% end %>
-<% elsif Alchemy::Node.roots.any? %>
+<% elsif Alchemy::Node.roots.where(language: @page.language).any? %>
   <%= page_status_checkbox(@page, :visible) %>
   <%= f.input :menu_id, collection: Alchemy::Node.roots.map { |n|
       [I18n.t(n.name, scope: [:alchemy, :menu_names]), n.id]

--- a/app/views/alchemy/admin/pages/_menu_fields.html.erb
+++ b/app/views/alchemy/admin/pages/_menu_fields.html.erb
@@ -1,35 +1,37 @@
-<% if @page.menus.any? %>
-  <label class="checkbox">
-    <input type="checkbox" disabled checked>
-    <%= Alchemy.t(:attached_to) %>
-  </label>
-  <% @page.menus.each do |menu| %>
-    <span class="page-menu-name label">
-      <%= I18n.t(menu.name, scope: [:alchemy, :menu_names]) %>
-    </span>
+<% if Alchemy::Node.roots.where(language: @page.language).any? %>
+  <% unless @page.language_root %>
+    <%= page_status_checkbox(@page, :visible, label: Alchemy.t("show in url of child pages")) %>
   <% end %>
-<% elsif Alchemy::Node.roots.where(language: @page.language).any? %>
-  <%= page_status_checkbox(@page, :visible) %>
-  <%= f.input :menu_id, collection: Alchemy::Node.roots.map { |n|
-      [I18n.t(n.name, scope: [:alchemy, :menu_names]), n.id]
-    },
-    prompt: Alchemy.t('Please choose a menu'),
-    input_html: { class: 'alchemy_selectbox' },
-    wrapper_html: { style: @page.visible? ? 'display: block' : 'display: none' },
-    label: false %>
-  <script>
-    (function() {
-      var $wrapper = $('.input.page_menu_id')
-      $('#page_visible').click(function() {
-        if ($(this).is(':checked')) {
-          $wrapper.show()
-        } else {
-          $wrapper.find('select').val('')
-          $wrapper.hide()
-        }
-      })
-    })()
-  </script>
+  <% if @page.menus.any? %>
+    <label style="vertical-align: middle">
+      <%= Alchemy.t(:attached_to) %>
+    </label>
+    <% @page.menus.each do |menu| %>
+      <span class="page-menu-name label">
+        <%= I18n.t(menu.name, scope: [:alchemy, :menu_names]) %>
+      </span>
+    <% end %>
+  <% else %>
+    <a class="button small" id="attach-page"><%= Alchemy.t("attach to a menu") %></a>
+    <%= f.input :menu_id, collection: Alchemy::Node.roots.map { |n|
+        [I18n.t(n.name, scope: [:alchemy, :menu_names]), n.id]
+      },
+      prompt: Alchemy.t("Please choose a menu"),
+      input_html: { class: "alchemy_selectbox" },
+      wrapper_html: { class: "hidden" },
+      label: false %>
+    <script>
+      (function() {
+        var wrapper = document.querySelector(".input.page_menu_id")
+        document.querySelector("#attach-page").addEventListener("click", function() {
+          var select = wrapper.querySelector("select")
+          this.classList.toggle("active")
+          wrapper.classList.toggle("hidden")
+          $(select).select2("val", "")
+        })
+      })()
+    </script>
+  <% end %>
 <% else %>
   <%= page_status_checkbox(@page, :visible) %>
 <% end %>


### PR DESCRIPTION
## What is this pull request for?

_For **4.6-stable** branch_

Put back the "visible navigation" checkbox into the form of pages that are attached to a menu (node). This is necessary because Alchemy uses this flag on parent pages to build the urlname of a page. This might change in the future, but in 4.x it is still the case.

This changes the current checkbox "visible in navigation" into a button "attach to a menu" for sites having languages with menus available. The checkbox for the `visible` status changes from "visible in navigation" to "show in url of child pages".

For sites not having any languages with menus this does not change at all. Think of the availability of menus toggle this feature. This is necessary because we still support the deprecated `render_navigation` helper in 4.x

### Screenshots

![Alchemy CMS - Pages 2020-05-19 00-09-06](https://user-images.githubusercontent.com/42868/82294117-e9da2100-99ad-11ea-9608-b659a4db48e7.png)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
