### PR TITLE
Deprecate require_ssl (4.6)

### DIFF
--- a/config/alchemy/config.yml
+++ b/config/alchemy/config.yml
@@ -1,12 +1,6 @@
 # == This is the global Alchemy configuration file
 #
 
-# === Require SSL for login form and all admin modules
-#
-# NOTE: You have to create a SSL certificate on your server to make this work
-#
-require_ssl: false
-
 # === Auto Log Out Time
 #
 # The amount of time of inactivity in minutes after which the user is kicked out of his current session.

--- a/lib/alchemy/config.rb
+++ b/lib/alchemy/config.rb
@@ -33,6 +33,7 @@ module Alchemy
       def deprecated_configs
         {
           url_nesting: true,
+          require_ssl: nil,
         }
       end
 

--- a/lib/alchemy/ssl_protection.rb
+++ b/lib/alchemy/ssl_protection.rb
@@ -26,7 +26,9 @@ module Alchemy
 
     # Redirects current request to https.
     def enforce_ssl
-      redirect_to url_for(request.params.merge(protocol: 'https'))
+      redirect_to url_for(request.params.merge(protocol: "https"))
     end
+
+    deprecate :enforce_ssl, deprecator: Alchemy::Deprecation
   end
 end

--- a/spec/libraries/config_spec.rb
+++ b/spec/libraries/config_spec.rb
@@ -17,15 +17,10 @@ module Alchemy
 
       context "if config is deprecated" do
         context "without a new default" do
-          before do
-            expect(described_class).to receive(:deprecated_configs).at_least(:once) do
-              { url_nesting: nil }
-            end
-          end
-
           it "warns" do
-            expect(Alchemy::Deprecation).to receive(:warn)
-            Config.get(:url_nesting)
+            expect(Alchemy::Deprecation).to \
+              receive(:warn).with("require_ssl configuration is deprecated and will be removed from Alchemy 5.0")
+            Config.get(:require_ssl)
           end
         end
 


### PR DESCRIPTION
## What is this pull request for?

Deprecate `require_ssl` configuration and the `Alchemy::SslProtection` module.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
