### PR TITLE
Deprecate auto_logout_time (4.6)

### DIFF
--- a/config/alchemy/config.yml
+++ b/config/alchemy/config.yml
@@ -1,14 +1,6 @@
 # == This is the global Alchemy configuration file
 #
 
-# === Auto Log Out Time
-#
-# The amount of time of inactivity in minutes after which the user is kicked out of his current session.
-#
-# NOTE: This is only active in production environments
-#
-auto_logout_time: 30
-
 # === Redirect Options
 #
 #   redirect_to_public_child  [Boolean]   # Alchemy redirects to the first public child page found, if a page is not visible.

--- a/lib/alchemy/config.rb
+++ b/lib/alchemy/config.rb
@@ -34,6 +34,7 @@ module Alchemy
         {
           url_nesting: true,
           require_ssl: nil,
+          auto_logout_time: nil,
         }
       end
 


### PR DESCRIPTION
## What is this pull request for?

This option has no effect. The only usage is in `alchemy-devise` [to determine the `logged_in?` state of a user](https://github.com/AlchemyCMS/alchemy-devise/blob/master/app/models/alchemy/user.rb#L43-L45).

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
