### PR TITLE
Do not use ES6 Syntax in Node Selector

### DIFF
--- a/app/assets/javascripts/alchemy/node_select.js
+++ b/app/assets/javascripts/alchemy/node_select.js
@@ -1,9 +1,9 @@
 $.fn.alchemyNodeSelect = function(options) {
-  var renderNodeTemplate = (node) => HandlebarsTemplates.node({ node: node })
-  var queryParamsFromTerm = (term) => {
+  var renderNodeTemplate = function(node) { return HandlebarsTemplates.node({ node: node }) }
+  var queryParamsFromTerm = function(term) {
     return {filter: Object.assign({ name_or_page_name_cont: term }, options.query_params)}
   }
-  var resultsFromResponse = (response) => {
+  var resultsFromResponse = function(response) {
     var { meta, data } = response
     var more = meta.page * meta.per_page < meta.total_count
     return { results: data, more: more }


### PR DESCRIPTION
## What is this pull request for?

The previous version of this code fails in host apps that do not have
Uglifier in Harmony mode. Let's stick with ES5 instead.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] Not adding specs
