### PR TITLE
Backport ContentEditor to 4.6, deprecate removed methods on `Alchemy::Content`

### DIFF
--- a/app/decorators/alchemy/content_editor.rb
+++ b/app/decorators/alchemy/content_editor.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Alchemy
+  class ContentEditor < SimpleDelegator
+    alias_method :content, :__getobj__
+
+    def to_partial_path
+      "alchemy/essences/#{essence_partial_name}_editor"
+    end
+
+    def css_classes
+      [
+        "content_editor",
+        essence_partial_name,
+      ].compact
+    end
+
+    def data_attributes
+      {
+        content_id: id,
+        content_name: name,
+      }
+    end
+
+    # Returns a string to be passed to Rails form field tags to ensure we have same params layout everywhere.
+    #
+    # === Example:
+    #
+    #   <%= text_field_tag content_editor.form_field_name, content_editor.ingredient %>
+    #
+    # === Options:
+    #
+    # You can pass an Essence column_name. Default is 'ingredient'
+    #
+    # ==== Example:
+    #
+    #   <%= text_field_tag content_editor.form_field_name(:link), content_editor.ingredient %>
+    #
+    def form_field_name(essence_column = "ingredient")
+      "contents[#{id}][#{essence_column}]"
+    end
+
+    def form_field_id(essence_column = "ingredient")
+      "contents_#{id}_#{essence_column}"
+    end
+
+    # Fixes Rails partial renderer calling to_model on the object
+    # which reveals the delegated content instead of this decorator.
+    def respond_to?(method_name)
+      return false if method_name == :to_model
+
+      super
+    end
+  end
+end

--- a/app/models/alchemy/content.rb
+++ b/app/models/alchemy/content.rb
@@ -172,28 +172,6 @@ module Alchemy
       definition['validate'].present?
     end
 
-    # Returns a string to be passed to Rails form field tags to ensure we have same params layout everywhere.
-    #
-    # === Example:
-    #
-    #   <%= text_field_tag content.form_field_name, content.ingredient %>
-    #
-    # === Options:
-    #
-    # You can pass an Essence column_name. Default is 'ingredient'
-    #
-    # ==== Example:
-    #
-    #   <%= text_field_tag content.form_field_name(:link), content.ingredient %>
-    #
-    def form_field_name(essence_column = 'ingredient')
-      "contents[#{id}][#{essence_column}]"
-    end
-
-    def form_field_id(essence_column = 'ingredient')
-      "contents_#{id}_#{essence_column}"
-    end
-
     # Returns a string used as dom id on html elements.
     def dom_id
       return '' if essence.nil?
@@ -244,6 +222,14 @@ module Alchemy
     def tinymce_class_name
       "has_tinymce" + (has_custom_tinymce_config? ? " #{element.name}_#{name}" : "")
     end
+
+    def editor
+      @_editor ||= ContentEditor.new(self)
+    end
+    delegate :form_field_name, to: :editor
+    deprecate form_field_name: "use Alchemy::ContentEditor#form_field_name instead", deprecator: Alchemy::Deprecation
+    delegate :form_field_id, to: :editor
+    deprecate form_field_id: "use Alchemy::ContentEditor#form_field_id instead", deprecator: Alchemy::Deprecation
 
     # Returns the default value from content definition
     #

--- a/spec/decorators/alchemy/content_editor_spec.rb
+++ b/spec/decorators/alchemy/content_editor_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::ContentEditor do
+  let(:essence) { Alchemy::EssenceText.new }
+  let(:content) { Alchemy::Content.new(id: 1, essence: essence) }
+  let(:content_editor) { described_class.new(content) }
+
+  describe "#content" do
+    it "returns content object" do
+      expect(content_editor.content).to eq(content)
+    end
+  end
+
+  describe "#css_classes" do
+    it "includes content_editor class" do
+      expect(content_editor.css_classes).to include("content_editor")
+    end
+
+    it "includes essence partial class" do
+      expect(content_editor.css_classes).to include(content_editor.essence_partial_name)
+    end
+  end
+
+  describe "#data_attributes" do
+    it "includes content_id" do
+      expect(content_editor.data_attributes[:content_id]).to eq(content_editor.id)
+    end
+
+    it "includes content_name" do
+      expect(content_editor.data_attributes[:content_name]).to eq(content_editor.name)
+    end
+  end
+
+  describe "#to_partial_path" do
+    subject { content_editor.to_partial_path }
+
+    it "returns the editor partial path" do
+      is_expected.to eq("alchemy/essences/essence_text_editor")
+    end
+  end
+
+  describe "#form_field_name" do
+    it "returns a name value for form fields with ingredient as default" do
+      expect(content_editor.form_field_name).to eq("contents[1][ingredient]")
+    end
+
+    context "with a essence column given" do
+      it "returns a name value for form fields for that column" do
+        expect(content_editor.form_field_name(:link_title)).to eq("contents[1][link_title]")
+      end
+    end
+  end
+
+  describe "#form_field_id" do
+    it "returns a id value for form fields with ingredient as default" do
+      expect(content_editor.form_field_id).to eq("contents_1_ingredient")
+    end
+
+    context "with a essence column given" do
+      it "returns a id value for form fields for that column" do
+        expect(content_editor.form_field_id(:link_title)).to eq("contents_1_link_title")
+      end
+    end
+  end
+
+  describe "#respond_to?(:to_model)" do
+    subject { content_editor.respond_to?(:to_model) }
+
+    it { is_expected.to be(false) }
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

This backports the ContentEditor class from the `master` branch, and deprecated the removed methods. This should provide a doable upgrade path for users.

## Checklist

- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
