### PR TITLE
Deprecate Attachment#urlname

### DIFF
--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -138,7 +138,7 @@ module Alchemy
 
       def link
         @attachments = Attachment.all.collect { |f|
-          [f.name, download_attachment_path(id: f.id, name: f.urlname)]
+          [f.name, download_attachment_path(id: f.id, name: f.slug)]
         }
       end
 

--- a/app/helpers/alchemy/url_helper.rb
+++ b/app/helpers/alchemy/url_helper.rb
@@ -26,12 +26,12 @@ module Alchemy
 
     # Returns the path for downloading an alchemy attachment
     def download_alchemy_attachment_path(attachment)
-      alchemy.download_attachment_path(attachment, attachment.urlname)
+      alchemy.download_attachment_path(attachment, attachment.slug)
     end
 
     # Returns the url for downloading an alchemy attachment
     def download_alchemy_attachment_url(attachment)
-      alchemy.download_attachment_url(attachment, attachment.urlname)
+      alchemy.download_attachment_url(attachment, attachment.slug)
     end
 
     # Returns the full url containing host, page and anchor for the given element

--- a/app/models/alchemy/attachment.rb
+++ b/app/models/alchemy/attachment.rb
@@ -77,9 +77,12 @@ module Alchemy
     end
 
     # An url save filename without format suffix
-    def urlname
+    def slug
       CGI.escape(file_name.gsub(/\.#{extension}$/, "").tr(".", " "))
     end
+
+    alias_method :urlname, :slug
+    deprecate urlname: :slug, deprecator: Alchemy::Deprecation
 
     # Checks if the attachment is restricted, because it is attached on restricted pages only
     def restricted?

--- a/app/models/alchemy/essence_file.rb
+++ b/app/models/alchemy/essence_file.rb
@@ -23,7 +23,7 @@ module Alchemy
 
       routes.download_attachment_path(
         id: attachment.id,
-        name: attachment.urlname,
+        name: attachment.slug,
         format: attachment.suffix,
       )
     end

--- a/app/views/alchemy/essences/_essence_file_view.html.erb
+++ b/app/views/alchemy/essences/_essence_file_view.html.erb
@@ -7,7 +7,7 @@
     attachment.name,
   alchemy.download_attachment_path(
     attachment,
-    name: attachment.urlname,
+    name: attachment.slug,
     format: attachment.suffix
   ),
   {

--- a/spec/helpers/alchemy/url_helper_spec.rb
+++ b/spec/helpers/alchemy/url_helper_spec.rb
@@ -28,7 +28,7 @@ module Alchemy
 
           context "with addiitonal parameters" do
             subject(:show_page_path_params) do
-              helper.show_page_path_params(page, {query: "test"})
+              helper.show_page_path_params(page, { query: "test" })
             end
 
             it "returns a Hash with urlname, no locale and query parameter" do
@@ -52,7 +52,7 @@ module Alchemy
 
           context "with additional parameters" do
             subject(:show_page_path_params) do
-              helper.show_page_path_params(page, {query: "test"})
+              helper.show_page_path_params(page, { query: "test" })
             end
 
             it "returns a Hash with urlname, locale and query parameter" do
@@ -74,7 +74,7 @@ module Alchemy
           end
 
           it "should return the correct relative path string with additional parameters" do
-            expect(helper.show_alchemy_page_path(page, {query: "test"})).to \
+            expect(helper.show_alchemy_page_path(page, { query: "test" })).to \
               eq("/#{page.language_code}/testpage?query=test")
           end
         end
@@ -89,7 +89,7 @@ module Alchemy
           end
 
           it "should return the correct relative path string with additional parameter" do
-            expect(helper.show_alchemy_page_path(page, {query: "test"})).to \
+            expect(helper.show_alchemy_page_path(page, { query: "test" })).to \
               eq("/testpage?query=test")
           end
         end
@@ -107,7 +107,7 @@ module Alchemy
           end
 
           it "should return the correct url string with additional parameters" do
-            expect(helper.show_alchemy_page_url(page, {query: "test"})).to \
+            expect(helper.show_alchemy_page_url(page, { query: "test" })).to \
               eq("http://#{helper.request.host}/#{page.language_code}/testpage?query=test")
           end
         end
@@ -123,7 +123,7 @@ module Alchemy
           end
 
           it "should return the correct url string with additional parameter" do
-            expect(helper.show_alchemy_page_url(page, {query: "test"})).to \
+            expect(helper.show_alchemy_page_url(page, { query: "test" })).to \
               eq("http://#{helper.request.host}/testpage?query=test")
           end
         end
@@ -131,16 +131,16 @@ module Alchemy
     end
 
     context "attachment path helpers" do
-      let(:attachment) { mock_model(Attachment, urlname: "test-attachment.pdf") }
+      let(:attachment) { mock_model(Attachment, slug: "test-attachment.pdf") }
 
       it "should return the correct relative path to download an attachment" do
         expect(helper.download_alchemy_attachment_path(attachment)).to \
-          eq("/attachment/#{attachment.id}/download/#{attachment.urlname}")
+          eq("/attachment/#{attachment.id}/download/#{attachment.slug}")
       end
 
       it "should return the correct url to download an attachment" do
         expect(helper.download_alchemy_attachment_url(attachment)).to \
-          eq("http://#{helper.request.host}/attachment/#{attachment.id}/download/#{attachment.urlname}")
+          eq("http://#{helper.request.host}/attachment/#{attachment.id}/download/#{attachment.slug}")
       end
     end
 

--- a/spec/models/alchemy/attachment_spec.rb
+++ b/spec/models/alchemy/attachment_spec.rb
@@ -54,22 +54,22 @@ module Alchemy
     describe "urlname sanitizing" do
       it "escapes unsafe url characters" do
         attachment.file_name = "f#%&cking cute kitten pic.png"
-        expect(attachment.urlname).to eq("f%23%25%26cking+cute+kitten+pic")
+        expect(attachment.slug).to eq("f%23%25%26cking+cute+kitten+pic")
       end
 
       it "removes format suffix from end of file name" do
         attachment.file_name = "pic.png.png"
-        expect(attachment.urlname).to eq("pic+png")
+        expect(attachment.slug).to eq("pic+png")
       end
 
       it "converts dots into escaped spaces" do
         attachment.file_name = "cute.kitten.pic.png"
-        expect(attachment.urlname).to eq("cute+kitten+pic")
+        expect(attachment.slug).to eq("cute+kitten+pic")
       end
 
       it "escapes umlauts in the name" do
         attachment.file_name = "süßes katzenbild.png"
-        expect(attachment.urlname).to eq("s%C3%BC%C3%9Fes+katzenbild")
+        expect(attachment.slug).to eq("s%C3%BC%C3%9Fes+katzenbild")
       end
     end
 

--- a/spec/models/alchemy/essence_file_spec.rb
+++ b/spec/models/alchemy/essence_file_spec.rb
@@ -16,7 +16,7 @@ module Alchemy
       subject { essence.attachment_url }
 
       it "returns the download attachment url." do
-        is_expected.to match(/\/attachment\/#{attachment.id}\/download\/#{attachment.urlname}\.#{attachment.suffix}/)
+        is_expected.to match(/\/attachment\/#{attachment.id}\/download\/#{attachment.slug}\.#{attachment.suffix}/)
       end
 
       context "without attachment assigned" do

--- a/spec/views/essences/essence_file_view_spec.rb
+++ b/spec/views/essences/essence_file_view_spec.rb
@@ -11,8 +11,8 @@ describe "alchemy/essences/_essence_file_view" do
     build_stubbed(:alchemy_attachment, file: file, name: "an image", file_name: "image with spaces.png")
   end
 
-  let(:essence)    { Alchemy::EssenceFile.new(attachment: attachment) }
-  let(:content)    { Alchemy::Content.new(essence: essence) }
+  let(:essence) { Alchemy::EssenceFile.new(attachment: attachment) }
+  let(:content) { Alchemy::Content.new(essence: essence) }
 
   context "without attachment" do
     let(:essence) { Alchemy::EssenceFile.new(attachment: nil) }
@@ -27,7 +27,7 @@ describe "alchemy/essences/_essence_file_view" do
     it "renders a link to download the attachment" do
       render content, content: content
       expect(rendered).to have_selector(
-        "a[href='/attachment/#{attachment.id}/download/#{attachment.urlname}.#{attachment.suffix}']",
+        "a[href='/attachment/#{attachment.id}/download/#{attachment.slug}.#{attachment.suffix}']"
       )
     end
 
@@ -40,14 +40,14 @@ describe "alchemy/essences/_essence_file_view" do
 
     context "with link_text set in the local options" do
       it "has this value as link text" do
-        render content, content: content, options: {link_text: "Download this file"}
+        render content, content: content, options: { link_text: "Download this file" }
         expect(rendered).to have_selector("a:contains('Download this file')")
       end
     end
 
     context "with link_text set in the content settings" do
       before do
-        allow(content).to receive(:settings) { {link_text: "Download this file"} }
+        allow(content).to receive(:settings) { { link_text: "Download this file" } }
       end
 
       it "has this value as link text" do
@@ -69,7 +69,7 @@ describe "alchemy/essences/_essence_file_view" do
 
     context "with html_options given" do
       it "renders the linked ingredient with these options" do
-        render content, content: content, html_options: {title: "Bar", class: "blue"}
+        render content, content: content, html_options: { title: "Bar", class: "blue" }
         expect(rendered).to have_selector('a.blue[title="Bar"]')
       end
     end


### PR DESCRIPTION
###  What is this pull request for?

Deprecate `Attachment#urlname` and use slug instead.

`urlname` is a strange term. We should use the common name.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
