### PR TITLE
Remove active_record_5_1? method

### DIFF
--- a/app/models/alchemy/base_record.rb
+++ b/app/models/alchemy/base_record.rb
@@ -6,9 +6,5 @@ module Alchemy
 
   class BaseRecord < ActiveRecord::Base
     self.abstract_class = true
-
-    def active_record_5_1?
-      ActiveRecord.gem_version >= Gem::Version.new("5.1.0")
-    end
   end
 end

--- a/app/models/alchemy/language.rb
+++ b/app/models/alchemy/language.rb
@@ -164,11 +164,7 @@ module Alchemy
     end
 
     def should_set_pages_language?
-      if active_record_5_1?
-        saved_change_to_language_code? || saved_change_to_country_code?
-      else
-        language_code_changed? || country_code_changed?
-      end
+      saved_change_to_language_code? || saved_change_to_country_code?
     end
 
     def set_pages_language
@@ -176,11 +172,7 @@ module Alchemy
     end
 
     def should_unpublish_pages?
-      if active_record_5_1?
-        saved_changes[:public] == [true, false]
-      else
-        changes[:public] == [true, false]
-      end
+      saved_changes[:public] == [true, false]
     end
 
     def unpublish_pages

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -136,7 +136,7 @@ module Alchemy
       if: -> { fixed_attributes.any? }
 
     after_update :create_legacy_url,
-      if: :should_create_legacy_url?
+      if: :saved_change_to_urlname?
 
     after_update :attach_to_menu!,
       if: :should_attach_to_menu?
@@ -530,22 +530,9 @@ module Alchemy
       self.language_code = language.code
     end
 
-    def should_create_legacy_url?
-      if active_record_5_1?
-        saved_change_to_urlname?
-      else
-        urlname_changed?
-      end
-    end
-
     # Stores the old urlname in a LegacyPageUrl
     def create_legacy_url
-      if active_record_5_1?
-        former_urlname = urlname_before_last_save
-      else
-        former_urlname = urlname_was
-      end
-      legacy_urls.find_or_create_by(urlname: former_urlname)
+      legacy_urls.find_or_create_by(urlname: urlname_before_last_save)
     end
 
     def set_published_at

--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -36,10 +36,10 @@ module Alchemy
         unless: -> { autogenerate_elements == false }
 
       after_update :trash_not_allowed_elements!,
-        if: :has_page_layout_changed?
+        if: :saved_change_to_page_layout?
 
       after_update :generate_elements,
-        if: :has_page_layout_changed?
+        if: :saved_change_to_page_layout?
     end
 
     module ClassMethods
@@ -209,14 +209,6 @@ module Alchemy
         element_definition_names,
       ])
       not_allowed_elements.to_a.map(&:trash!)
-    end
-
-    def has_page_layout_changed?
-      if active_record_5_1?
-        saved_change_to_page_layout?
-      else
-        page_layout_changed?
-      end
     end
 
     # Deletes unique and already present definitions from @_element_definitions.

--- a/app/models/alchemy/page/page_naming.rb
+++ b/app/models/alchemy/page/page_naming.rb
@@ -66,11 +66,7 @@ module Alchemy
     def should_update_descendants_urlnames?
       return false if !Config.get(:url_nesting)
 
-      if active_record_5_1?
-        saved_change_to_urlname? || saved_change_to_visible?
-      else
-        urlname_changed? || visible_changed?
-      end
+      saved_change_to_urlname? || saved_change_to_visible?
     end
 
     def update_descendants_urlnames


### PR DESCRIPTION
## What is this pull request for?

Remove `active_record_5_1?` method

This check is not neessary anymore since we dropped support for Rails 5.0 and 5.1

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
