### PR TITLE
Deprecate Page#visible attribute

### DIFF
--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -161,6 +161,10 @@ module Alchemy
 
     attr_accessor :menu_id
 
+    deprecate visible: "Page slugs will be visible in URLs of child pages all the time. " \
+      "Please use Menus and Tags instead to re-organize your pages if your page tree does not reflect the URL hierarchy.",
+      deprecator: Alchemy::Deprecation
+
     # Class methods
     #
     class << self

--- a/lib/alchemy/upgrader/four_point_six.rb
+++ b/lib/alchemy/upgrader/four_point_six.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Alchemy
+  class Upgrader::FourPointSix < Upgrader
+    class << self
+      def restructure_page_tree
+        desc "Move child pages of invisible pages to visible parent."
+        pages = Alchemy::Page.contentpages.where(visible: [false, nil]).order(depth: :desc)
+        if pages.size > 0
+          log "Moving #{pages.size} page(s). Please wait..."
+          pages.find_each do |page|
+            parent = visible_parent(page.parent)
+            Alchemy::Page.transaction do
+              if parent
+                page.children.find_each { |child| child.move_to_child_of(parent) }
+              end
+              page.update!(visible: true)
+            end
+            print "."
+          end
+          puts "\n"
+          log "Done!"
+        else
+          log "No invisible pages found!", :skip
+        end
+      end
+
+      private
+
+      def visible_parent(page)
+        return unless page
+        return page if page.visible? || page.language_root?
+
+        visible_parent(page.parent)
+      end
+    end
+  end
+end

--- a/lib/alchemy/upgrader/four_point_six.rb
+++ b/lib/alchemy/upgrader/four_point_six.rb
@@ -27,9 +27,10 @@ module Alchemy
           Alchemy::Page.leaves.update_all(visible: true)
           Alchemy::Page.language_roots.each do |root_page|
             # Root pages are always visible
-            root_page.update(visible: true)
+            root_page.update!(visible: true)
             remove_invisible_children(root_page)
           end
+          Alchemy::Page.update_all(visible: true)
         end
       end
 

--- a/lib/alchemy/upgrader/four_point_six.rb
+++ b/lib/alchemy/upgrader/four_point_six.rb
@@ -3,6 +3,23 @@
 module Alchemy
   class Upgrader::FourPointSix < Upgrader
     class << self
+      def todos
+        notice = <<-NOTE.strip_heredoc
+
+          ℹ️  Page visible attribute is deprecated
+          ----------------------------------------
+
+          Page slugs will be visible in URLs of child pages all the time in the future.
+          Please use Menus and Tags instead to re-organize your pages if your page tree does not reflect the URL hierarchy.
+
+          A rake task to help with the migration is available.
+
+              bin/rake alchemy:upgrade:4.6:restructure_page_tree
+
+        NOTE
+        todo notice, "Alchemy v4.6 TODO"
+      end
+
       def restructure_page_tree
         desc "Move child pages of invisible pages to visible parent."
         pages = Alchemy::Page.contentpages.where(visible: [false, nil]).order(depth: :desc)

--- a/lib/tasks/alchemy/upgrade.rake
+++ b/lib/tasks/alchemy/upgrade.rake
@@ -1,29 +1,31 @@
-require 'alchemy/upgrader'
-require 'alchemy/version'
+# frozen_string_literal: true
+
+require "alchemy/upgrader"
+require "alchemy/version"
 
 namespace :alchemy do
   desc "Upgrades your app to AlchemyCMS v#{Alchemy::VERSION}."
   task upgrade: [
-    'alchemy:upgrade:prepare',
-    'alchemy:upgrade:4.1:run', 'alchemy:upgrade:4.1:todo',
-    'alchemy:upgrade:4.2:run', 'alchemy:upgrade:4.2:todo',
-    'alchemy:upgrade:4.4:run', 'alchemy:upgrade:4.4:todo'
+    "alchemy:upgrade:prepare",
+    "alchemy:upgrade:4.1:run", "alchemy:upgrade:4.1:todo",
+    "alchemy:upgrade:4.2:run", "alchemy:upgrade:4.2:todo",
+    "alchemy:upgrade:4.4:run", "alchemy:upgrade:4.4:todo",
   ] do
     Alchemy::Upgrader.display_todos
   end
 
   namespace :upgrade do
-    desc 'Alchemy Upgrader: Prepares the database and updates Alchemys configuration file.'
+    desc "Alchemy Upgrader: Prepares the database and updates Alchemys configuration file."
     task prepare: [
-      'alchemy:upgrade:database',
-      'alchemy:upgrade:config'
+      "alchemy:upgrade:database",
+      "alchemy:upgrade:config",
     ]
 
     desc "Alchemy Upgrader: Prepares the database."
     task database: [
-      'alchemy:install:migrations',
-      'db:migrate',
-      'alchemy:db:seed'
+      "alchemy:install:migrations",
+      "db:migrate",
+      "alchemy:db:seed",
     ]
 
     desc "Alchemy Upgrader: Copy configuration file."
@@ -37,19 +39,19 @@ namespace :alchemy do
       end
     end
 
-    desc 'Upgrade Alchemy to v4.1'
-    task '4.1' => [
-      'alchemy:upgrade:prepare',
-      'alchemy:upgrade:4.1:run',
-      'alchemy:upgrade:4.1:todo'
+    desc "Upgrade Alchemy to v4.1"
+    task "4.1" => [
+      "alchemy:upgrade:prepare",
+      "alchemy:upgrade:4.1:run",
+      "alchemy:upgrade:4.1:todo",
     ] do
       Alchemy::Upgrader.display_todos
     end
 
-    namespace '4.1' do
-      task run: ['alchemy:upgrade:4.1:harden_acts_as_taggable_on_migrations']
+    namespace "4.1" do
+      task run: ["alchemy:upgrade:4.1:harden_acts_as_taggable_on_migrations"]
 
-      desc 'Harden acts_as_taggable_on migrations'
+      desc "Harden acts_as_taggable_on migrations"
       task harden_acts_as_taggable_on_migrations: [:environment] do
         Alchemy::Upgrader::FourPointOne.harden_acts_as_taggable_on_migrations
       end
@@ -59,45 +61,45 @@ namespace :alchemy do
       end
     end
 
-    desc 'Upgrade Alchemy to v4.2'
-    task '4.2' => [
-      'alchemy:upgrade:prepare',
-      'alchemy:upgrade:4.2:run',
-      'alchemy:upgrade:4.2:todo'
+    desc "Upgrade Alchemy to v4.2"
+    task "4.2" => [
+      "alchemy:upgrade:prepare",
+      "alchemy:upgrade:4.2:run",
+      "alchemy:upgrade:4.2:todo",
     ] do
       Alchemy::Upgrader.display_todos
     end
 
-    namespace '4.2' do
+    namespace "4.2" do
       task run: [
-        'alchemy:upgrade:4.2:convert_picture_galleries',
-        'alchemy:upgrade:4.2:migrate_picture_galleries',
-        'alchemy:upgrade:4.2:convert_cells',
-        'alchemy:upgrade:4.2:migrate_cells',
-        'alchemy:upgrade:4.2:update_element_partial_name_variable'
+        "alchemy:upgrade:4.2:convert_picture_galleries",
+        "alchemy:upgrade:4.2:migrate_picture_galleries",
+        "alchemy:upgrade:4.2:convert_cells",
+        "alchemy:upgrade:4.2:migrate_cells",
+        "alchemy:upgrade:4.2:update_element_partial_name_variable",
       ]
 
-      desc 'Convert `picture_gallery` element definitions to `nestable_elements`.'
+      desc "Convert `picture_gallery` element definitions to `nestable_elements`."
       task convert_picture_galleries: [:environment] do
         Alchemy::Upgrader::FourPointTwo.convert_picture_galleries
       end
 
-      desc 'Migrate `picture_gallery` elements to `nestable_elements`.'
+      desc "Migrate `picture_gallery` elements to `nestable_elements`."
       task migrate_picture_galleries: [:environment] do
         Alchemy::Upgrader::FourPointTwo.migrate_picture_galleries
       end
 
-      desc 'Convert cells config to fixed nestable elements.'
+      desc "Convert cells config to fixed nestable elements."
       task convert_cells: [:environment] do
         Alchemy::Upgrader::FourPointTwo.convert_cells
       end
 
-      desc 'Migrate existing cells to fixed nestable elements.'
-      task migrate_cells: ['alchemy:install:migrations', 'db:migrate'] do
+      desc "Migrate existing cells to fixed nestable elements."
+      task migrate_cells: ["alchemy:install:migrations", "db:migrate"] do
         Alchemy::Upgrader::FourPointTwo.migrate_cells
       end
 
-      desc 'Update element views to use element partial name variable.'
+      desc "Update element views to use element partial name variable."
       task :update_element_partial_name_variable do
         Alchemy::Upgrader::FourPointTwo.update_element_views_variable_name
       end
@@ -107,19 +109,19 @@ namespace :alchemy do
       end
     end
 
-    desc 'Upgrade Alchemy to v4.4'
-    task '4.4' => [
-      'alchemy:upgrade:prepare',
-      'alchemy:upgrade:4.4:run',
-      'alchemy:upgrade:4.4:todo'
+    desc "Upgrade Alchemy to v4.4"
+    task "4.4" => [
+      "alchemy:upgrade:prepare",
+      "alchemy:upgrade:4.4:run",
+      "alchemy:upgrade:4.4:todo",
     ] do
       Alchemy::Upgrader.display_todos
     end
 
-    namespace '4.4' do
+    namespace "4.4" do
       task run: [
-        'alchemy:upgrade:4.4:rename_element_views',
-        'alchemy:upgrade:4.4:update_local_variable'
+        "alchemy:upgrade:4.4:rename_element_views",
+        "alchemy:upgrade:4.4:update_local_variable",
       ]
 
       desc "Remove '_view' suffix from element views."
@@ -127,7 +129,7 @@ namespace :alchemy do
         Alchemy::Upgrader::FourPointFour.rename_element_views
       end
 
-      desc 'Update element views local variable to element name.'
+      desc "Update element views local variable to element name."
       task update_local_variable: [:environment] do
         Alchemy::Upgrader::FourPointFour.update_local_variable
       end

--- a/lib/tasks/alchemy/upgrade.rake
+++ b/lib/tasks/alchemy/upgrade.rake
@@ -10,6 +10,7 @@ namespace :alchemy do
     "alchemy:upgrade:4.1:run", "alchemy:upgrade:4.1:todo",
     "alchemy:upgrade:4.2:run", "alchemy:upgrade:4.2:todo",
     "alchemy:upgrade:4.4:run", "alchemy:upgrade:4.4:todo",
+    "alchemy:upgrade:4.6:run",
   ] do
     Alchemy::Upgrader.display_todos
   end
@@ -136,6 +137,20 @@ namespace :alchemy do
 
       task :todo do
         Alchemy::Upgrader::FourPointFour.alchemy_4_4_todos
+      end
+    end
+
+    desc "Upgrade Alchemy to v4.6"
+    task "4.6" => [
+      "alchemy:upgrade:prepare",
+    ]
+
+    namespace "4.6" do
+      task run: []
+
+      desc "Move child pages of invisible pages to visible parent."
+      task restructure_page_tree: [:environment] do
+        Alchemy::Upgrader::FourPointSix.restructure_page_tree
       end
     end
   end

--- a/lib/tasks/alchemy/upgrade.rake
+++ b/lib/tasks/alchemy/upgrade.rake
@@ -10,7 +10,7 @@ namespace :alchemy do
     "alchemy:upgrade:4.1:run", "alchemy:upgrade:4.1:todo",
     "alchemy:upgrade:4.2:run", "alchemy:upgrade:4.2:todo",
     "alchemy:upgrade:4.4:run", "alchemy:upgrade:4.4:todo",
-    "alchemy:upgrade:4.6:run",
+    "alchemy:upgrade:4.6:run", "alchemy:upgrade:4.6:todo",
   ] do
     Alchemy::Upgrader.display_todos
   end
@@ -151,6 +151,10 @@ namespace :alchemy do
       desc "Move child pages of invisible pages to visible parent."
       task restructure_page_tree: [:environment] do
         Alchemy::Upgrader::FourPointSix.restructure_page_tree
+      end
+
+      task :todo do
+        Alchemy::Upgrader::FourPointSix.todos
       end
     end
   end


### PR DESCRIPTION
## What is this pull request for?

Deprecate `Page#visible`

Page slugs will be visible in URLs of child pages all the time in the future.
Please use Menus and Tags instead to re-organize your pages if your page tree does not reflect the URL hierarchy.

A rake task to help with the migration is available.

    bin/rake alchemy:upgrade:4.6:restructure_page_tree

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
