### PR TITLE
Show url name in Page tree

### DIFF
--- a/app/assets/stylesheets/alchemy/_variables.scss
+++ b/app/assets/stylesheets/alchemy/_variables.scss
@@ -108,7 +108,7 @@ $form-right-width: 65% !default;
 $sitemap-line-height: 32px !default;
 $sitemap-page-background-color: rgba($white, 0.75) !default;
 $sitemap-page-hover-color: rgba($light_yellow, 0.5) !default;
-$sitemap-info-background-color: rgba($linked-color, 0.5) !default;
+$sitemap-info-background-color: rgba($white, 0.5) !default;
 $sitemap-highlight-color: rgba(#fffba5, 0.5) !default;
 
 $main-menu-width: 150px !default;

--- a/app/assets/stylesheets/alchemy/lists.scss
+++ b/app/assets/stylesheets/alchemy/lists.scss
@@ -13,14 +13,6 @@ ul.list {
   padding: 0;
   list-style-type: none;
 
-  &#layoutpages {
-    margin-top: 16px;
-
-    li {
-      margin-left: 8px;
-    }
-  }
-
   li {
     list-style-type: none;
     display: block;

--- a/app/assets/stylesheets/alchemy/nodes.scss
+++ b/app/assets/stylesheets/alchemy/nodes.scss
@@ -18,7 +18,7 @@
 
   .node_page,
   .node_url {
-    width: 200px;
+    width: 250px;
     max-width: 45%;
     white-space: nowrap;
     text-overflow: ellipsis;

--- a/app/assets/stylesheets/alchemy/sitemap.scss
+++ b/app/assets/stylesheets/alchemy/sitemap.scss
@@ -40,7 +40,7 @@
   background-color: $sitemap-info-background-color;
   line-height: $sitemap-line-height;
   font-size: $small-font-size;
-  padding: 0 2*$default-padding;
+  padding: 0 2 * $default-padding;
   max-width: 45%;
   white-space: nowrap;
   overflow: hidden;
@@ -55,7 +55,7 @@
 
 .sitemap_page {
   height: $sitemap-line-height;
-  margin: 3*$default-margin 0;
+  margin: 3 * $default-margin 0;
   position: relative;
   transition: background-color $transition-duration;
 
@@ -89,13 +89,13 @@
   width: 32px;
   line-height: $sitemap-line-height;
   float: left;
-  padding: 0 2*$default-padding;
+  padding: 0 2 * $default-padding;
   text-align: center;
 }
 
 .sitemap_right_tools {
   height: $sitemap-line-height;
-  padding: 0 2*$default-padding;
+  padding: 0 2 * $default-padding;
   float: right;
 
   .sitemap_tool {
@@ -130,7 +130,9 @@
   &.sorting {
     padding-top: 100px;
 
-    .page_icon { cursor: move }
+    .page_icon {
+      cursor: move;
+    }
   }
 
   .page_folder {
@@ -201,7 +203,7 @@
 
 #page_filter_result {
   display: none;
-  margin-left: 2*$default-margin;
+  margin-left: 2 * $default-margin;
 }
 
 .alchemy-dialog {
@@ -213,6 +215,8 @@
     margin: 0;
     padding: 0 24px 8px 8px;
 
-    .page_icon { cursor: default }
+    .page_icon {
+      cursor: default;
+    }
   }
 }

--- a/app/assets/stylesheets/alchemy/sitemap.scss
+++ b/app/assets/stylesheets/alchemy/sitemap.scss
@@ -1,3 +1,6 @@
+$sitemap-url-large-width: 250px;
+$sitemap-url-xlarge-width: 350px;
+
 #sort_panel {
   background: $light-gray;
   padding: 47px 0 8px 0;
@@ -38,17 +41,25 @@
 }
 
 .sitemap_url {
+  display: none;
   float: right;
-  text-align: right;
   background-color: $sitemap-info-background-color;
   line-height: $sitemap-line-height - 2px;
   font-size: $small-font-size;
   padding: 0 2 * $default-padding;
-  max-width: 35%;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   border: 1px solid $sitemap-page-background-color;
+
+  @media screen and (min-width: $large-screen-break-point) {
+    display: block;
+    width: $sitemap-url-large-width;
+  }
+
+  @media screen and (min-width: 1440px) {
+    width: $sitemap-url-xlarge-width;
+  }
 }
 
 .sitemap_line_spacer {
@@ -192,21 +203,35 @@
   display: flex;
   padding: 0;
   line-height: 28px;
-  justify-content: space-between;
 
   .page_name {
     margin-left: 43px;
   }
 
   .page_urlname {
-    flex-grow: 1;
-    text-align: right;
+    display: none;
+    margin-left: auto;
+    padding-left: 2 * $default-padding;
     padding-right: 2 * $default-padding;
+
+    @media screen and (min-width: $large-screen-break-point) {
+      display: block;
+      width: $sitemap-url-large-width;
+    }
+
+    @media screen and (min-width: 1440px) {
+      width: $sitemap-url-xlarge-width;
+    }
   }
 
   .page_status {
     padding-left: 2 * $default-padding;
-    margin-right: 210px;
+    margin-right: 214px;
+    margin-left: auto;
+
+    @media screen and (min-width: $large-screen-break-point) {
+      margin-left: initial;
+    }
   }
 }
 

--- a/app/assets/stylesheets/alchemy/sitemap.scss
+++ b/app/assets/stylesheets/alchemy/sitemap.scss
@@ -34,7 +34,7 @@
   }
 }
 
-.redirect_url {
+.sitemap_url {
   float: right;
   text-align: right;
   background-color: $sitemap-info-background-color;

--- a/app/assets/stylesheets/alchemy/sitemap.scss
+++ b/app/assets/stylesheets/alchemy/sitemap.scss
@@ -189,19 +189,24 @@
 }
 
 #sitemap_heading {
+  display: flex;
   padding: 0;
-
-  .page_infos {
-    margin-right: 210px;
-    text-align: left;
-    float: right;
-    line-height: 28px;
-    background: transparent;
-  }
+  line-height: 28px;
+  justify-content: space-between;
 
   .page_name {
-    line-height: 28px;
     margin-left: 43px;
+  }
+
+  .page_urlname {
+    flex-grow: 1;
+    text-align: right;
+    padding-right: 2 * $default-padding;
+  }
+
+  .page_status {
+    padding-left: 2 * $default-padding;
+    margin-right: 210px;
   }
 }
 

--- a/app/assets/stylesheets/alchemy/sitemap.scss
+++ b/app/assets/stylesheets/alchemy/sitemap.scss
@@ -28,6 +28,9 @@
   padding: 0 10px;
   margin: 2px;
   text-decoration: none;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 
   &.inactive {
     color: #656565;
@@ -38,13 +41,14 @@
   float: right;
   text-align: right;
   background-color: $sitemap-info-background-color;
-  line-height: $sitemap-line-height;
+  line-height: $sitemap-line-height - 2px;
   font-size: $small-font-size;
   padding: 0 2 * $default-padding;
-  max-width: 45%;
+  max-width: 35%;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  border: 1px solid $sitemap-page-background-color;
 }
 
 .sitemap_line_spacer {

--- a/app/serializers/alchemy/page_tree_serializer.rb
+++ b/app/serializers/alchemy/page_tree_serializer.rb
@@ -9,7 +9,7 @@ module Alchemy
     def pages
       tree = []
       path = [{id: object.parent_id, children: tree}]
-      page_list = object.self_and_descendants
+      page_list = object.self_and_descendants.includes({ language: :site }, :locker)
       base_level = object.level - 1
       # Load folded pages in advance
       folded_user_pages = FoldedPage.folded_for_user(opts[:user]).pluck(:page_id)

--- a/app/serializers/alchemy/page_tree_serializer.rb
+++ b/app/serializers/alchemy/page_tree_serializer.rb
@@ -60,6 +60,7 @@ module Alchemy
         redirects_to_external: page.definition['redirects_to_external'],
         urlname: page.urlname,
         external_urlname: page.definition['redirects_to_external'] ? page.external_urlname : nil,
+        url_path: page.url_path,
         level: level,
         root: level == 1,
         root_or_leaf: level == 1 || !has_children,

--- a/app/views/alchemy/admin/layoutpages/index.html.erb
+++ b/app/views/alchemy/admin/layoutpages/index.html.erb
@@ -30,6 +30,10 @@
 </div>
 <% end %>
 
-<ul class="list" id="layoutpages">
+<h4 id="sitemap_heading">
+  <span class="page_name"><%= Alchemy::Page.human_attribute_name(:name) %></span>
+</h4>
+
+<ul class="list" id="sitemap">
   <%= render partial: "layoutpage", collection: @layout_root.children %>
 </ul>

--- a/app/views/alchemy/admin/pages/_page.html.erb
+++ b/app/views/alchemy/admin/pages/_page.html.erb
@@ -159,12 +159,9 @@
         <span class="hint-bubble">{{status_titles.restricted}}</span>
       </span>
     </div>
-    {{#if redirects_to_external}}
-      <div class="redirect_url" title="{{urlname}}">
-        &raquo; <%= Alchemy.t('Redirects to') %>:
-        {{ external_urlname }}
-      </div>
-    {{/if}}
+    <div class="sitemap_url" title="{{url_path}}">
+      {{ url_path }}
+    </div>
     <div class="sitemap_sitename">
       {{#if redirects_to_external}}
         <span class="sitemap_pagename_link inactive">{{ name }}</span>

--- a/app/views/alchemy/admin/pages/_sitemap.html.erb
+++ b/app/views/alchemy/admin/pages/_sitemap.html.erb
@@ -1,4 +1,10 @@
 <div id="sitemap-wrapper">
+  <h4 id="sitemap_heading">
+    <span class="page_name"><%= Alchemy::Page.human_attribute_name(:name) %></span>
+    <span class="page_urlname"><%= Alchemy::Page.human_attribute_name(:urlname) %></span>
+    <span class="page_status"><%= Alchemy.t(:page_status) %></span>
+  </h4>
+
   <p class="loading"></p>
 </div>
 

--- a/spec/requests/alchemy/admin/pages_controller_spec.rb
+++ b/spec/requests/alchemy/admin/pages_controller_spec.rb
@@ -106,6 +106,8 @@ module Alchemy
           expect(page['name']).to eq(page_1.name)
           expect(page).to have_key('children')
           expect(page['children'].count).to eq(1)
+          expect(page).to have_key("url_path")
+          expect(page["url_path"]).to eq(page_1.url_path)
 
           page = page['children'].first
 
@@ -115,6 +117,8 @@ module Alchemy
           expect(page['name']).to eq(page_2.name)
           expect(page).to have_key('children')
           expect(page['children'].count).to eq(1)
+          expect(page).to have_key("url_path")
+          expect(page["url_path"]).to eq(page_2.url_path)
 
           page = page['children'].first
 
@@ -124,6 +128,8 @@ module Alchemy
           expect(page['name']).to eq(page_3.name)
           expect(page).to have_key('children')
           expect(page['children'].count).to eq(0)
+          expect(page).to have_key("url_path")
+          expect(page["url_path"]).to eq(page_3.url_path)
         end
 
         context "when branch is folded" do


### PR DESCRIPTION
## What is this pull request for?

On top of #1859 

Always show the pages url name in the page tree. This is useful information that should be prominent all the time.

### Screenshots

![localhost_3000_admin_pages(Laptop with HiDPI screen)](https://user-images.githubusercontent.com/42868/83272341-4ff34f00-a1cb-11ea-9c43-c19274204ee7.png)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
