### PR TITLE
Fix sitemap wrapper height

### DIFF
--- a/app/assets/stylesheets/alchemy/sitemap.scss
+++ b/app/assets/stylesheets/alchemy/sitemap.scss
@@ -20,7 +20,7 @@
 
 #sitemap-wrapper {
   position: relative;
-  min-height: 100%;
+  min-height: calc(100vh - 96px);
 }
 
 .sitemap_pagename_link {


### PR DESCRIPTION
## What is this pull request for?

Center the sitemap loading spinner.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
