### PR TITLE
Use depth for page tree serializer root_or_leaf

### DIFF
--- a/app/serializers/alchemy/page_tree_serializer.rb
+++ b/app/serializers/alchemy/page_tree_serializer.rb
@@ -62,8 +62,8 @@ module Alchemy
         external_urlname: page.definition['redirects_to_external'] ? page.external_urlname : nil,
         url_path: page.url_path,
         level: level,
-        root: level == 1,
-        root_or_leaf: level == 1 || !has_children,
+        root: page.depth == 1,
+        root_or_leaf: page.depth == 1 || !has_children,
         children: []
       }
 


### PR DESCRIPTION
## What is this pull request for?

Depth is a cached attribute on the page that does not need calculation and will always be correct even if the root page has been removed.

This commit helps to migrate to Alchemy 5 without making further changes to the page tree serializer. Without that change page trees that already have been migrated to "root-page-less" Alchemy 5 will have page toggle switches disappear in the first level.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
