### PR TITLE
Use apt update instead of apt-get in GH action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,15 +60,15 @@ jobs:
         if: matrix.database == 'postgresql'
         run: |
           mkdir -p /home/runner/apt/cache
-          sudo apt-get update -qq
-          sudo apt-get install -qq --fix-missing libpq-dev -o dir::cache::archives="/home/runner/apt/cache"
+          sudo apt update -qq
+          sudo apt install -qq --fix-missing libpq-dev -o dir::cache::archives="/home/runner/apt/cache"
           sudo chown -R runner /home/runner/apt/cache
       - name: Install MySQL headers
         if: matrix.database == 'mysql'
         run: |
           mkdir -p /home/runner/apt/cache
-          sudo apt-get update -qq
-          sudo apt-get install -qq --fix-missing libmysqlclient-dev -o dir::cache::archives="/home/runner/apt/cache"
+          sudo apt update -qq
+          sudo apt install -qq --fix-missing libmysqlclient-dev -o dir::cache::archives="/home/runner/apt/cache"
           sudo chown -R runner /home/runner/apt/cache
       - name: Install bundler
         run: |


### PR DESCRIPTION
We have some weird connection error on GH actions while installing the database headers. Let's try to use a more modern tool...