### PR TITLE
4.6 backports for master

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.link_dialog.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.link_dialog.js.coffee
@@ -76,16 +76,16 @@ class window.Alchemy.LinkDialog extends Alchemy.Dialog
           meta = data.meta
           results:
             data.pages.map (page) ->
-              id: "/#{page.urlname}"
+              id: page.url_path
               name: page.name
-              urlname: page.urlname
+              url_path: page.url_path
               page_id: page.id
           more: meta.page * meta.per_page < meta.total_count
       initSelection: ($element, callback) =>
         urlname = $element.val()
         $.get Alchemy.routes.api_pages_path,
           q:
-            urlname_eq: urlname.replace(/^\//, '')
+            urlname_eq: urlname.replace(/^\/([a-z]{2}(-[A-Z]{2})?\/)?/, '')
           page: 1
           per_page: 1,
           (data) =>
@@ -93,9 +93,9 @@ class window.Alchemy.LinkDialog extends Alchemy.Dialog
             if page
               @initElementSelect(page.id)
               callback
-                id: "/#{page.urlname}"
+                id: page.url_path
                 name: page.name
-                urlname: page.name
+                url_path: page.url_path
                 page_id: page.id
       formatSelection: (page) ->
         page.name

--- a/app/assets/javascripts/alchemy/templates/page.hbs
+++ b/app/assets/javascripts/alchemy/templates/page.hbs
@@ -4,6 +4,6 @@
     {{ page.name }}
   </span>
   <span class="page-select--page-urlname">
-    /{{ page.urlname }}
+    {{ page.url_path }}
   </span>
 </div>

--- a/app/assets/stylesheets/alchemy/_mixins.scss
+++ b/app/assets/stylesheets/alchemy/_mixins.scss
@@ -49,9 +49,8 @@
     border-color: $hover-border-color;
   }
 
-  &:active, &:active:focus {
-    border-color: $hover-border-color;
-    box-shadow: none;
+  &:active, &.active {
+    box-shadow: inset $button-box-shadow;
   }
 
   &:focus {

--- a/app/assets/stylesheets/alchemy/_variables.scss
+++ b/app/assets/stylesheets/alchemy/_variables.scss
@@ -76,7 +76,7 @@ $button-text-shadow: none !default;
 $button-box-shadow: 0px 1px 1px -1px #333 !default;
 $button-focus-box-shadow: 0px 1px 1px 0px $button-focus-border-color !default;
 $button-padding: 0.55em 2em !default;
-$small-button-padding: 0.4em 1.25em !default;
+$small-button-padding: 0.4em 0.8em !default;
 $button-margin: $form-field-margin !default;
 
 $secondary-button-bg-color: transparent !default;

--- a/app/assets/stylesheets/alchemy/_variables.scss
+++ b/app/assets/stylesheets/alchemy/_variables.scss
@@ -108,7 +108,7 @@ $form-right-width: 65% !default;
 $sitemap-line-height: 32px !default;
 $sitemap-page-background-color: rgba($white, 0.75) !default;
 $sitemap-page-hover-color: rgba($light_yellow, 0.5) !default;
-$sitemap-info-background-color: rgba($linked-color, 0.5) !default;
+$sitemap-info-background-color: rgba($white, 0.5) !default;
 $sitemap-highlight-color: rgba(#fffba5, 0.5) !default;
 
 $main-menu-width: 150px !default;

--- a/app/assets/stylesheets/alchemy/lists.scss
+++ b/app/assets/stylesheets/alchemy/lists.scss
@@ -13,14 +13,6 @@ ul.list {
   padding: 0;
   list-style-type: none;
 
-  &#layoutpages {
-    margin-top: 16px;
-
-    li {
-      margin-left: 8px;
-    }
-  }
-
   li {
     list-style-type: none;
     display: block;

--- a/app/assets/stylesheets/alchemy/nodes.scss
+++ b/app/assets/stylesheets/alchemy/nodes.scss
@@ -18,7 +18,7 @@
 
   .node_page,
   .node_url {
-    width: 200px;
+    width: 250px;
     max-width: 45%;
     white-space: nowrap;
     text-overflow: ellipsis;

--- a/app/assets/stylesheets/alchemy/sitemap.scss
+++ b/app/assets/stylesheets/alchemy/sitemap.scss
@@ -1,3 +1,6 @@
+$sitemap-url-large-width: 250px;
+$sitemap-url-xlarge-width: 350px;
+
 #sort_panel {
   background: $light-gray;
   padding: 47px 0 8px 0;
@@ -28,23 +31,35 @@
   padding: 0 10px;
   margin: 2px;
   text-decoration: none;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 
   &.inactive {
     color: #656565;
   }
 }
 
-.redirect_url {
+.sitemap_url {
+  display: none;
   float: right;
-  text-align: right;
   background-color: $sitemap-info-background-color;
-  line-height: $sitemap-line-height;
+  line-height: $sitemap-line-height - 2px;
   font-size: $small-font-size;
-  padding: 0 2*$default-padding;
-  max-width: 45%;
+  padding: 0 2 * $default-padding;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  border: 1px solid $sitemap-page-background-color;
+
+  @media screen and (min-width: $large-screen-break-point) {
+    display: block;
+    width: $sitemap-url-large-width;
+  }
+
+  @media screen and (min-width: 1440px) {
+    width: $sitemap-url-xlarge-width;
+  }
 }
 
 .sitemap_line_spacer {
@@ -55,7 +70,7 @@
 
 .sitemap_page {
   height: $sitemap-line-height;
-  margin: 3*$default-margin 0;
+  margin: 3 * $default-margin 0;
   position: relative;
   transition: background-color $transition-duration;
 
@@ -89,13 +104,13 @@
   width: 32px;
   line-height: $sitemap-line-height;
   float: left;
-  padding: 0 2*$default-padding;
+  padding: 0 2 * $default-padding;
   text-align: center;
 }
 
 .sitemap_right_tools {
   height: $sitemap-line-height;
-  padding: 0 2*$default-padding;
+  padding: 0 2 * $default-padding;
   float: right;
 
   .sitemap_tool {
@@ -130,7 +145,9 @@
   &.sorting {
     padding-top: 100px;
 
-    .page_icon { cursor: move }
+    .page_icon {
+      cursor: move;
+    }
   }
 
   .page_folder {
@@ -183,25 +200,44 @@
 }
 
 #sitemap_heading {
+  display: flex;
   padding: 0;
-
-  .page_infos {
-    margin-right: 210px;
-    text-align: left;
-    float: right;
-    line-height: 28px;
-    background: transparent;
-  }
+  line-height: 28px;
 
   .page_name {
-    line-height: 28px;
     margin-left: 43px;
+  }
+
+  .page_urlname {
+    display: none;
+    margin-left: auto;
+    padding-left: 2 * $default-padding;
+    padding-right: 2 * $default-padding;
+
+    @media screen and (min-width: $large-screen-break-point) {
+      display: block;
+      width: $sitemap-url-large-width;
+    }
+
+    @media screen and (min-width: 1440px) {
+      width: $sitemap-url-xlarge-width;
+    }
+  }
+
+  .page_status {
+    padding-left: 2 * $default-padding;
+    margin-right: 214px;
+    margin-left: auto;
+
+    @media screen and (min-width: $large-screen-break-point) {
+      margin-left: initial;
+    }
   }
 }
 
 #page_filter_result {
   display: none;
-  margin-left: 2*$default-margin;
+  margin-left: 2 * $default-margin;
 }
 
 .alchemy-dialog {
@@ -213,6 +249,8 @@
     margin: 0;
     padding: 0 24px 8px 8px;
 
-    .page_icon { cursor: default }
+    .page_icon {
+      cursor: default;
+    }
   }
 }

--- a/app/assets/stylesheets/alchemy/sitemap.scss
+++ b/app/assets/stylesheets/alchemy/sitemap.scss
@@ -20,7 +20,7 @@
 
 #sitemap-wrapper {
   position: relative;
-  min-height: 100%;
+  min-height: calc(100vh - 96px);
 }
 
 .sitemap_pagename_link {

--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -140,7 +140,6 @@ module Alchemy
         @attachments = Attachment.all.collect { |f|
           [f.name, download_attachment_path(id: f.id, name: f.urlname)]
         }
-        @url_prefix = prefix_locale? ? "#{@current_language.code}/" : ""
       end
 
       def fold

--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -96,6 +96,7 @@ module Alchemy
       [
         :tags,
         {
+          language: :site,
           elements: [
             {
               nested_elements: [

--- a/app/models/alchemy/node.rb
+++ b/app/models/alchemy/node.rb
@@ -67,7 +67,7 @@ module Alchemy
     # Either the value is stored in the database, aka. an external url.
     # Or, if attached, the values comes from a page.
     def url
-      page && "/#{page.urlname}" || read_attribute(:url).presence
+      page&.url_path || read_attribute(:url).presence
     end
 
     def to_partial_path

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -302,6 +302,13 @@ module Alchemy
       finder.elements(page: self)
     end
 
+    # = The url_path for this page
+    #
+    # @see Alchemy::Page::UrlPath#call
+    def url_path
+      Alchemy::Page::UrlPath.new(self).call
+    end
+
     # The page's view partial is dependent from its page layout
     #
     # == Define page layouts

--- a/app/models/alchemy/page/url_path.rb
+++ b/app/models/alchemy/page/url_path.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Alchemy
+  class Page
+    # = The url_path for this page
+    #
+    # Use this to build relative links to this page
+    #
+    # It takes several circumstances into account:
+    #
+    # 1. It returns just a slash for language root pages of the default langauge
+    # 2. It returns a url path with a leading slash for regular pages
+    # 3. It returns a url path with a leading slash and language code prefix for pages not having the default language
+    # 4. It returns a url path with a leading slash and the language code for language root pages of a non-default language
+    #
+    # == Examples
+    #
+    # Using Rails' link_to helper
+    #
+    #     link_to page.url
+    #
+    class UrlPath
+      ROOT_PATH = "/"
+
+      def initialize(page)
+        @page = page
+        @language = @page.language
+        @site = @language.site
+      end
+
+      def call
+        if @page.language_root?
+          language_root_path
+        elsif @site.languages.select(&:public?).length > 1
+          page_path_with_language_prefix
+        else
+          page_path_with_leading_slash
+        end
+      end
+
+      private
+
+      def language_root_path
+        @language.default? ? ROOT_PATH : language_path
+      end
+
+      def page_path_with_language_prefix
+        @language.default? ? page_path : language_path + page_path
+      end
+
+      def page_path_with_leading_slash
+        @page.language_root? ? ROOT_PATH : page_path
+      end
+
+      def language_path
+        "/#{@page.language_code}"
+      end
+
+      def page_path
+        "/#{@page.urlname}"
+      end
+    end
+  end
+end

--- a/app/serializers/alchemy/page_serializer.rb
+++ b/app/serializers/alchemy/page_serializer.rb
@@ -13,7 +13,8 @@ module Alchemy
       :tag_list,
       :created_at,
       :updated_at,
-      :status
+      :status,
+      :url_path
 
     has_many :elements
   end

--- a/app/serializers/alchemy/page_tree_serializer.rb
+++ b/app/serializers/alchemy/page_tree_serializer.rb
@@ -60,8 +60,8 @@ module Alchemy
         urlname: page.urlname,
         url_path: page.url_path,
         level: level,
-        root: level == 1,
-        root_or_leaf: level == 1 || !has_children,
+        root: page.depth == 1,
+        root_or_leaf: page.depth == 1 || !has_children,
         children: [],
       }
 

--- a/app/serializers/alchemy/page_tree_serializer.rb
+++ b/app/serializers/alchemy/page_tree_serializer.rb
@@ -58,6 +58,7 @@ module Alchemy
         page_layout: page.page_layout,
         slug: page.slug,
         urlname: page.urlname,
+        url_path: page.url_path,
         level: level,
         root: level == 1,
         root_or_leaf: level == 1 || !has_children,

--- a/app/views/alchemy/admin/layoutpages/index.html.erb
+++ b/app/views/alchemy/admin/layoutpages/index.html.erb
@@ -30,6 +30,10 @@
 </div>
 <% end %>
 
+<h4 id="sitemap_heading">
+  <span class="page_name"><%= Alchemy::Page.human_attribute_name(:name) %></span>
+</h4>
+
 <ul class="list" id="layoutpages">
   <%= render partial: "layoutpage", collection: @layout_pages %>
 </ul>

--- a/app/views/alchemy/admin/nodes/_form.html.erb
+++ b/app/views/alchemy/admin/nodes/_form.html.erb
@@ -33,7 +33,7 @@
     initialSelection: {
       id: <%= node.page_id %>,
       text: "<%= node.page.name %>",
-      url: "/<%= node.page.urlname %>"
+      url_path: "<%= node.page.url_path %>"
     }
     <% end %>
   }).on('change', function(e) {
@@ -42,7 +42,7 @@
       $('#node_url').val('').prop('disabled', false)
     } else {
       $('#node_name').attr('placeholder', e.added.name)
-      $('#node_url').val('/' + e.added.urlname).prop('disabled', true)
+      $('#node_url').val(e.added.url_path).prop('disabled', true)
     }
   })
 </script>

--- a/app/views/alchemy/admin/pages/_form.html.erb
+++ b/app/views/alchemy/admin/pages/_form.html.erb
@@ -18,7 +18,7 @@
   </div>
 
   <%= f.input :name, autofocus: true %>
-  <%= f.input :urlname, as: 'string', input_html: {value: @page.slug} %>
+  <%= f.input :urlname, as: 'string', input_html: {value: @page.slug}, label: Alchemy::Page.human_attribute_name(:slug) %>
   <%= f.input :title,
     input_html: {'data-alchemy-char-counter' => 60} %>
 

--- a/app/views/alchemy/admin/pages/_page.html.erb
+++ b/app/views/alchemy/admin/pages/_page.html.erb
@@ -159,6 +159,9 @@
         <span class="hint-bubble">{{status_titles.restricted}}</span>
       </span>
     </div>
+    <div class="sitemap_url" title="{{url_path}}">
+      {{ url_path }}
+    </div>
     <div class="sitemap_sitename">
       {{#if permissions.edit_content}}
         <%= link_to_unless(

--- a/app/views/alchemy/admin/pages/_sitemap.html.erb
+++ b/app/views/alchemy/admin/pages/_sitemap.html.erb
@@ -1,4 +1,10 @@
 <div id="sitemap-wrapper">
+  <h4 id="sitemap_heading">
+    <span class="page_name"><%= Alchemy::Page.human_attribute_name(:name) %></span>
+    <span class="page_urlname"><%= Alchemy::Page.human_attribute_name(:urlname) %></span>
+    <span class="page_status"><%= Alchemy.t(:page_status) %></span>
+  </h4>
+
   <p class="loading"></p>
 </div>
 

--- a/app/views/alchemy/admin/pages/info.html.erb
+++ b/app/views/alchemy/admin/pages/info.html.erb
@@ -14,7 +14,7 @@
     <p><%= @page.layout_display_name %></p>
   </div>
   <div class="value">
-    <label><%= Alchemy::LegacyPageUrl.human_attribute_name(:urlname) %></label>
+    <label><%= Alchemy::Page.human_attribute_name(:urlname) %></label>
     <p><%= "/#{@page.urlname}" %></p>
   </div>
   <div class="value">

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -578,7 +578,6 @@ en:
         button_label: Upload image(s)
         upload_success: "Picture %{name} uploaded successfully"
         upload_failure: "Error while uploading %{name}: %{error}"
-    url_name: "URL-Name"
     visible: "visible"
     want_to_create_new_language: "Do you want to create a new empty language tree?"
     want_to_make_copy_of_existing_language: "Do you want to copy an existing language tree?"
@@ -675,9 +674,9 @@ en:
           page_layout:
             blank: "^Please choose a page layout."
           urlname:
-            too_short: "^The pages urlname is too short (minimum of 3 characters)."
-            taken: "^URL-Name already taken."
-            exclusion: "^URL-Name reserved."
+            too_short: "^URL-Path is too short (minimum of 3 characters)."
+            taken: "^URL-Path already taken."
+            exclusion: "^URL-Path reserved."
       alchemy/picture:
         attributes:
           image_file:
@@ -799,7 +798,7 @@ en:
         locale: Localization
         code: ISO Code
       alchemy/legacy_page_url:
-        urlname: "URL path"
+        urlname: "URL-Path"
       alchemy/node:
         menu_type: Menu Type
         name: "Name"
@@ -825,7 +824,7 @@ en:
         tag_list: Tags
         title: "Title"
         updated_at: "Updated at"
-        urlname: "Urlname"
+        urlname: "URL-Path"
         slug: "Slug"
         visible: "visible in navigation"
       alchemy/picture:

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -826,6 +826,7 @@ en:
         title: "Title"
         updated_at: "Updated at"
         urlname: "Urlname"
+        slug: "Slug"
         visible: "visible in navigation"
       alchemy/picture:
         image_file_name: "Filename"

--- a/spec/controllers/alchemy/api/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/api/pages_controller_spec.rb
@@ -11,7 +11,7 @@ module Alchemy
         let(:result) { JSON.parse(response.body) }
 
         it "returns JSON" do
-          get :index, params: {format: :json}
+          get :index, params: { format: :json }
           expect(result["pages"]).to eq([])
         end
       end
@@ -21,7 +21,7 @@ module Alchemy
         let(:result) { JSON.parse(response.body) }
 
         it "returns JSON" do
-          get :index, params: {format: :json}
+          get :index, params: { format: :json }
 
           expect(response.status).to eq(200)
           expect(response.media_type).to eq("application/json")
@@ -29,7 +29,7 @@ module Alchemy
         end
 
         it "returns all public pages" do
-          get :index, params: {format: :json}
+          get :index, params: { format: :json }
 
           expect(result["pages"].size).to eq(2)
         end
@@ -40,7 +40,7 @@ module Alchemy
           end
 
           it "returns all pages" do
-            get :index, params: {format: :json}
+            get :index, params: { format: :json }
 
             expect(result["pages"].size).to eq(Alchemy::Page.count)
           end
@@ -86,7 +86,7 @@ module Alchemy
         let!(:page) { create(:alchemy_page, :public, page_layout: "contact") }
 
         it "returns all pages as nested json tree without admin related infos", :aggregate_failures do
-          get :nested, params: {format: :json}
+          get :nested, params: { format: :json }
 
           expect(response.status).to eq(200)
           expect(response.media_type).to eq("application/json")
@@ -114,7 +114,7 @@ module Alchemy
           end
 
           it "returns all pages as nested json tree with admin related infos", :aggregate_failures do
-            get :nested, params: {format: :json}
+            get :nested, params: { format: :json }
 
             expect(response.status).to eq(200)
             expect(response.media_type).to eq("application/json")
@@ -139,7 +139,7 @@ module Alchemy
 
         context "when a page_id is passed" do
           it "returns all pages as nested json from this page only" do
-            get :nested, params: {page_id: page.id, format: :json}
+            get :nested, params: { page_id: page.id, format: :json }
 
             expect(response.status).to eq(200)
             expect(response.media_type).to eq("application/json")
@@ -153,7 +153,7 @@ module Alchemy
 
         context "when `elements=true` is passed" do
           it "returns all pages as nested json tree with elements included" do
-            get :nested, params: {elements: "true", format: :json}
+            get :nested, params: { elements: "true", format: :json }
 
             expect(response.status).to eq(200)
             expect(response.media_type).to eq("application/json")
@@ -170,7 +170,7 @@ module Alchemy
             end
 
             it "returns all pages as nested json tree with only these elements included" do
-              get :nested, params: {elements: "headline,text", format: :json}
+              get :nested, params: { elements: "headline,text", format: :json }
 
               result = JSON.parse(response.body)
 
@@ -189,7 +189,7 @@ module Alchemy
         let(:page) { create(:alchemy_page, :public, urlname: "a-page") }
 
         it "returns page as json" do
-          get :show, params: {urlname: page.urlname, format: :json}
+          get :show, params: { urlname: page.urlname, format: :json }
 
           expect(response.status).to eq(200)
           expect(response.media_type).to eq("application/json")
@@ -197,13 +197,14 @@ module Alchemy
           result = JSON.parse(response.body)
 
           expect(result["id"]).to eq(page.id)
+          expect(result["url_path"]).to eq("/a-page")
         end
 
         context "requesting an restricted page" do
           let(:page) { create(:alchemy_page, restricted: true, urlname: "a-page") }
 
           it "responds with 403" do
-            get :show, params: {urlname: page.urlname, format: :json}
+            get :show, params: { urlname: page.urlname, format: :json }
 
             expect(response.status).to eq(403)
             expect(response.media_type).to eq("application/json")
@@ -219,7 +220,7 @@ module Alchemy
           let(:page) { create(:alchemy_page, urlname: "a-page") }
 
           it "responds with 403" do
-            get :show, params: {urlname: page.urlname, format: :json}
+            get :show, params: { urlname: page.urlname, format: :json }
 
             expect(response.status).to eq(403)
             expect(response.media_type).to eq("application/json")
@@ -234,7 +235,7 @@ module Alchemy
 
       context "requesting an unknown page" do
         it "responds with 404" do
-          get :show, params: {urlname: "not-existing", format: :json}
+          get :show, params: { urlname: "not-existing", format: :json }
 
           expect(response.status).to eq(404)
           expect(response.media_type).to eq("application/json")
@@ -249,7 +250,7 @@ module Alchemy
           let(:page) { create(:alchemy_page, :public) }
 
           it "responds with 404" do
-            get :show, params: {urlname: page.urlname, locale: "na", format: :json}
+            get :show, params: { urlname: page.urlname, locale: "na", format: :json }
             expect(response.status).to eq(404)
           end
         end
@@ -259,7 +260,7 @@ module Alchemy
         let(:page) { create(:alchemy_page, :public) }
 
         it "responds with json" do
-          get :show, params: {urlname: page.id, format: :json}
+          get :show, params: { urlname: page.id, format: :json }
 
           expect(response.status).to eq(200)
           expect(response.media_type).to eq("application/json")
@@ -280,7 +281,7 @@ module Alchemy
 
           context "when a locale is given" do
             it "renders the page related to its language" do
-              get :show, params: {urlname: "same-name", locale: klingon_page.language_code, format: :json}
+              get :show, params: { urlname: "same-name", locale: klingon_page.language_code, format: :json }
               result = JSON.parse(response.body)
               expect(result["id"]).to eq(klingon_page.id)
             end
@@ -288,7 +289,7 @@ module Alchemy
 
           context "when no locale is given" do
             it "renders the page of the default language" do
-              get :show, params: {urlname: "same-name", format: :json}
+              get :show, params: { urlname: "same-name", format: :json }
               result = JSON.parse(response.body)
               expect(result["id"]).to eq(english_page.id)
             end

--- a/spec/features/admin/legacy_page_url_management_spec.rb
+++ b/spec/features/admin/legacy_page_url_management_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Legacy page url management", type: :system, js: true do
       fill_in "legacy_page_url_urlname", with: "invalid url name"
       click_button "Add"
       within "#new_legacy_page_url" do
-        expect(page).to have_content("URL path is invalid")
+        expect(page).to have_content("URL-Path is invalid")
       end
     end
   end

--- a/spec/models/alchemy/page/url_path_spec.rb
+++ b/spec/models/alchemy/page/url_path_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::Page::UrlPath do
+  subject(:url) { described_class.new(page).call }
+
+  let(:site) { create(:alchemy_site) }
+
+  context "on a single language site" do
+    context "for the language root page" do
+      let(:page) { create(:alchemy_page, :language_root) }
+
+      it { is_expected.to eq("/") }
+    end
+
+    context "for a regular page" do
+      let(:page) { create(:alchemy_page) }
+
+      it { is_expected.to eq("/#{page.urlname}") }
+    end
+  end
+
+  context "on a multi language site" do
+    let!(:default_language) { create(:alchemy_language, site: site) }
+    let!(:language) { create(:alchemy_language, :klingon, site: site) }
+
+    context "for the language root page" do
+      context "and page having the default language" do
+        let(:page) do
+          create(:alchemy_page, :language_root, language: default_language)
+        end
+
+        it { is_expected.to eq("/") }
+      end
+
+      context "and page having a non-default language" do
+        let(:page) do
+          create(:alchemy_page, :language_root, language: language)
+        end
+
+        it do
+          is_expected.to eq("/#{page.language_code}")
+        end
+      end
+    end
+
+    context "for a regular page" do
+      context "and page having the default language" do
+        let(:page) do
+          create(:alchemy_page, language: default_language)
+        end
+
+        it { is_expected.to eq("/#{page.urlname}") }
+      end
+
+      context "and page having a non-default language" do
+        let(:page) do
+          create(:alchemy_page, language: language)
+        end
+
+        it do
+          is_expected.to eq("/#{page.language_code}/#{page.urlname}")
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/alchemy/admin/pages_controller_spec.rb
+++ b/spec/requests/alchemy/admin/pages_controller_spec.rb
@@ -116,6 +116,8 @@ module Alchemy
           expect(page["name"]).to eq(page_1.name)
           expect(page).to have_key("children")
           expect(page["children"].count).to eq(1)
+          expect(page).to have_key("url_path")
+          expect(page["url_path"]).to eq(page_1.url_path)
 
           page = page["children"].first
 
@@ -125,6 +127,8 @@ module Alchemy
           expect(page["name"]).to eq(page_2.name)
           expect(page).to have_key("children")
           expect(page["children"].count).to eq(1)
+          expect(page).to have_key("url_path")
+          expect(page["url_path"]).to eq(page_2.url_path)
 
           page = page["children"].first
 
@@ -134,6 +138,8 @@ module Alchemy
           expect(page["name"]).to eq(page_3.name)
           expect(page).to have_key("children")
           expect(page["children"].count).to eq(0)
+          expect(page).to have_key("url_path")
+          expect(page["url_path"]).to eq(page_3.url_path)
         end
 
         context "when branch is folded" do


### PR DESCRIPTION
## What is this pull request for?

Cherry picks changes from 4.6-stable that needs to be ported over to master

- Fix the sitemap wrapper height (#1861)
- Update Urlname translation (#1857)
- Introduce Page#url_path (#1859)
- Show url_path in page tree (#1856)
- Use depth for page tree serializer root_or_leaf (#1864)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
