### PR TITLE
Remove url_nesting config

### DIFF
--- a/config/alchemy/config.yml
+++ b/config/alchemy/config.yml
@@ -38,19 +38,6 @@ sitemap:
   show_root: true
   show_flag: false
 
-# === URL nesting
-#
-# Since Alchemy 2.6.0, page urls are nested, respectively to their tree position.
-#
-# Disable +url_nesting+ to get slug only urls.
-#
-# NOTE: After changing the url_nesting, you should run one of these convert rake tasks:
-#
-#   rake alchemy:convert:urlnames:to_nested
-#   rake alchemy:convert:urlnames:to_slug
-#
-url_nesting: true
-
 # === Default items per page in admin views
 #
 # In Alchemy's Admin, change how many items you would get shown per page by Kaminari


### PR DESCRIPTION
## What is this pull request for?

After merging #1844 we should also remove the config

### Notable changes

Remove the deprecated `url_nesting` config

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
