### PR TITLE
Configure edit page preview per site

### DIFF
--- a/config/alchemy/config.yml
+++ b/config/alchemy/config.yml
@@ -55,6 +55,16 @@ items_per_page: 15
 #   auth:
 #     username: <%= ENV["BASIC_AUTH_USERNAME"] %>
 #     password: <%= ENV["BASIC_AUTH_PASSWORD"] %>
+#
+# Preview config per site is supported as well.
+#
+# preview:
+#   My site name:
+#     host: https://www.my-static-site.com
+#     auth:
+#       username: <%= ENV["BASIC_AUTH_USERNAME"] %>
+#       password: <%= ENV["BASIC_AUTH_PASSWORD"] %>
+#
 
 # === Picture rendering settings
 #

--- a/lib/alchemy/admin/preview_url.rb
+++ b/lib/alchemy/admin/preview_url.rb
@@ -43,7 +43,7 @@ module Alchemy
         if @preview_config && uri
           uri_class.build(
             host: uri.host,
-            path: "/#{page.urlname}",
+            path: page.url_path,
             userinfo: userinfo,
           ).to_s
         else

--- a/spec/libraries/admin/preview_url_spec.rb
+++ b/spec/libraries/admin/preview_url_spec.rb
@@ -70,6 +70,57 @@ RSpec.describe Alchemy::Admin::PreviewUrl do
           is_expected.to eq "https://foo:baz@www.example.com/#{page.urlname}"
         end
       end
+
+      context "for a site" do
+        before do
+          stub_alchemy_config(:preview, config)
+        end
+
+        context "that matches the pages site name" do
+          let(:config) do
+            {
+              page.site.name => {
+                "host" => "http://new.example.com",
+              },
+            }
+          end
+
+          it "returns the configured preview url for that site" do
+            is_expected.to eq "http://new.example.com/#{page.urlname}"
+          end
+        end
+
+        context "that does not match the pages site name" do
+          context "with a default configured" do
+            let(:config) do
+              {
+                "Not matching site name" => {
+                  "host" => "http://new.example.com",
+                },
+                "host" => "http://www.example.com",
+              }
+            end
+
+            it "returns the default configured preview url" do
+              is_expected.to eq "http://www.example.com/#{page.urlname}"
+            end
+          end
+
+          context "without a default configured" do
+            let(:config) do
+              {
+                "Not matching site name" => {
+                  "host" => "http://new.example.com",
+                },
+              }
+            end
+
+            it "returns the internal preview url" do
+              is_expected.to eq "/admin/pages/#{page.id}"
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/libraries/admin/preview_url_spec.rb
+++ b/spec/libraries/admin/preview_url_spec.rb
@@ -121,6 +121,20 @@ RSpec.describe Alchemy::Admin::PreviewUrl do
           end
         end
       end
+
+      context "with page being the language root page" do
+        let(:page) { create(:alchemy_page, :language_root) }
+
+        before do
+          stub_alchemy_config(:preview, {
+            "host" => "https://www.example.com",
+          })
+        end
+
+        it "returns the preview url without urlname" do
+          is_expected.to eq "https://www.example.com/"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
You can now configure the preview url per site.

```yml
# config/alchemy/config.yml
preview:
  My site name:
    host: https://www.my-static-site.com
    auth:
      username: <%= ENV["BASIC_AUTH_USERNAME"] %>
      password: <%= ENV["BASIC_AUTH_PASSWORD"] %>
```

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
