### PR TITLE
Configurable Image Preprocessor

### DIFF
--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -53,9 +53,8 @@ module Alchemy
     # Enables Dragonfly image processing
     dragonfly_accessor :image_file, app: :alchemy_pictures do
       # Preprocess after uploading the picture
-      after_assign do |p|
-        resize = Config.get(:preprocess_image_resize)
-        p.thumb!(resize) if resize.present?
+      after_assign do |image|
+        Preprocessor.new(image).call
       end
     end
 

--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -50,11 +50,25 @@ module Alchemy
       raise PictureInUseError, Alchemy.t(:cannot_delete_picture_notice) % { name: name }
     end
 
+    # Image preprocessing class
+    def self.preprocessor_class
+      @_preprocessor_class ||= Preprocessor
+    end
+
+    # Set a image preprocessing class
+    #
+    #     # config/initializers/alchemy.rb
+    #     Alchemy::Picture.preprocessor_class = My::ImagePreprocessor
+    #
+    def self.preprocessor_class=(klass)
+      @_preprocessor_class = klass
+    end
+
     # Enables Dragonfly image processing
     dragonfly_accessor :image_file, app: :alchemy_pictures do
       # Preprocess after uploading the picture
       after_assign do |image|
-        Preprocessor.new(image).call
+        self.class.preprocessor_class.new(image).call
       end
     end
 

--- a/app/models/alchemy/picture/preprocessor.rb
+++ b/app/models/alchemy/picture/preprocessor.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Alchemy
+  class Picture < BaseRecord
+    class Preprocessor
+      def initialize(image_file)
+        @image_file = image_file
+      end
+
+      # Preprocess images after upload
+      #
+      # Define preprocessing options in the Alchemy::Config
+      #
+      #   preprocess_image_resize [String] - Downsizing example: '1000x1000>'
+      #
+      def call
+        max_image_size = Alchemy::Config.get(:preprocess_image_resize)
+        image_file.thumb!(max_image_size) if max_image_size.present?
+      end
+
+      private
+
+      attr_reader :image_file
+    end
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

Extracts the image preprocessing into a class.

This does not do much besides the default preprocessing we currently already allow in the config. But for remote image extensions it might be useful to create and store image thumbnails after upload.

You can define your own preprocessor class:

    # config/initializers/alchemy.rb
    Alchemy::Picture.preprocessor_class = My::ImagePreprocessor

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
