### PR TITLE
Language Factory: Create default language in host app's locale

### DIFF
--- a/lib/alchemy/test_support/factories/language_factory.rb
+++ b/lib/alchemy/test_support/factories/language_factory.rb
@@ -5,8 +5,8 @@ require "alchemy/test_support/factories/site_factory"
 
 FactoryBot.define do
   factory :alchemy_language, class: "Alchemy::Language" do
-    name { "Deutsch" }
-    code { "de" }
+    name { "Your Language" }
+    code { ::I18n.available_locales.first.to_s }
     default { true }
     frontpage_name { "Intro" }
     page_layout { Alchemy::Config.get(:default_language)["page_layout"] }
@@ -25,7 +25,12 @@ FactoryBot.define do
     trait :english do
       name { "English" }
       code { "en" }
-      frontpage_name { "Intro" }
+      default { false }
+    end
+
+    trait :german do
+      name { "Deutsch" }
+      code { "de" }
       default { false }
     end
   end

--- a/spec/controllers/alchemy/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/pages_controller_spec.rb
@@ -138,13 +138,13 @@ module Alchemy
         end
 
         context "requesting non default locale" do
-          let!(:english) do
-            create(:alchemy_language, :english, default: false)
+          let!(:klingon) do
+            create(:alchemy_language, :klingon, default: false)
           end
 
           let!(:start_page) do
             create :alchemy_page, :language_root,
-              language: english,
+              language: klingon,
               name: "Start Page"
           end
 
@@ -153,12 +153,12 @@ module Alchemy
           end
 
           it "loads the root page of that language" do
-            get :index, params: { locale: "en" }
+            get :index, params: { locale: "kl" }
             expect(assigns(:page)).to eq(start_page)
           end
 
           it "sets @root_page to root page of that language" do
-            get :index, params: { locale: "en" }
+            get :index, params: { locale: "kl" }
             expect(assigns(:root_page)).to eq(start_page)
           end
         end

--- a/spec/features/admin/languages_features_spec.rb
+++ b/spec/features/admin/languages_features_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Admin Languages Features", type: :system do
   end
 
   describe "editing an language" do
-    let!(:language) { create(:alchemy_language) }
+    let!(:language) { create(:alchemy_language, :german) }
 
     context "when selected locale has multiple matching locale files" do
       before do

--- a/spec/helpers/alchemy/pages_helper_spec.rb
+++ b/spec/helpers/alchemy/pages_helper_spec.rb
@@ -207,13 +207,13 @@ module Alchemy
           context "with options[:reverse]" do
             context "set to false" do
               it "should render the language links in an ascending order" do
-                expect(helper.language_links(reverse: false)).to have_selector("a.de + a.kl")
+                expect(helper.language_links(reverse: false)).to have_selector("a.kl + a.en")
               end
             end
 
             context "set to true" do
               it "should render the language links in a descending order" do
-                expect(helper.language_links(reverse: true)).to have_selector("a.kl + a.de")
+                expect(helper.language_links(reverse: true)).to have_selector("a.en + a.kl")
               end
             end
           end

--- a/spec/libraries/configuration_methods_spec.rb
+++ b/spec/libraries/configuration_methods_spec.rb
@@ -25,7 +25,7 @@ describe Alchemy::ConfigurationMethods do
     end
 
     context "if more than one language is present" do
-      let!(:german) { create(:alchemy_language) }
+      let!(:german) { create(:alchemy_language, :german, default: true) }
       let!(:english) { create(:alchemy_language, :english) }
 
       subject { controller.prefix_locale?(args) }

--- a/spec/models/alchemy/language_spec.rb
+++ b/spec/models/alchemy/language_spec.rb
@@ -280,7 +280,7 @@ module Alchemy
       end
 
       before do
-        expect(::I18n).to receive(:available_locales) do
+        expect(::I18n).to receive(:available_locales).twice do
           [:de, :'de-at', :'en-uk']
         end
       end

--- a/spec/models/alchemy/node_spec.rb
+++ b/spec/models/alchemy/node_spec.rb
@@ -143,7 +143,7 @@ module Alchemy
         let!(:parent_node) { create(:alchemy_node, children: [node]) }
 
         it "does not destroy the node and children either but adds an error" do
-          parent_node.destroy
+          parent_node.reload.destroy
           expect(parent_node).not_to be_destroyed
           expect(parent_node.errors.full_messages).to eq(["This menu item is in use inside an Alchemy element on the following pages: #{page.name}."])
         end

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 module Alchemy
   describe Page do
-    let(:language) { create(:alchemy_language, :english, default: true) }
+    let(:language) { create(:alchemy_language, :german, default: true) }
     let(:klingon) { create(:alchemy_language, :klingon) }
     let(:language_root) { create(:alchemy_page, :language_root) }
     let(:page) { mock_model(Page, page_layout: "foo") }

--- a/spec/models/alchemy/site_spec.rb
+++ b/spec/models/alchemy/site_spec.rb
@@ -180,7 +180,7 @@ module Alchemy
       end
 
       let!(:other_language) do
-        create(:alchemy_language, :english, default: false, site: site)
+        create(:alchemy_language, :german, default: false, site: site)
       end
 
       subject(:site_default_language) do


### PR DESCRIPTION
## What is this pull request for?

Our default language factory will create a page in German. That's not
great for apps that do not have German as an `available_locale`, as
Alchemy now validates the language_code of the language. This change
adds a new trait "german" to satisfy our existing test suite, but
creates by default a language in the host apps first available locale.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
