### PR TITLE
Fix missing help_text_text translations

### DIFF
--- a/app/helpers/alchemy/admin/base_helper.rb
+++ b/app/helpers/alchemy/admin/base_helper.rb
@@ -376,7 +376,7 @@ module Alchemy
 
         content_tag :span, class: "hint-with-icon" do
           render_icon("question-circle") +
-            content_tag(:span, element.hint.try(:html_safe), class: "hint-bubble")
+            content_tag(:span, element.hint.html_safe, class: "hint-bubble")
         end
       end
 

--- a/app/helpers/alchemy/admin/base_helper.rb
+++ b/app/helpers/alchemy/admin/base_helper.rb
@@ -376,7 +376,7 @@ module Alchemy
 
         content_tag :span, class: "hint-with-icon" do
           render_icon("question-circle") +
-            content_tag(:span, element.hint.html_safe, class: "hint-bubble")
+            content_tag(:span, element.hint.try(:html_safe), class: "hint-bubble")
         end
       end
 

--- a/app/views/alchemy/admin/sites/_form.html.erb
+++ b/app/views/alchemy/admin/sites/_form.html.erb
@@ -1,5 +1,5 @@
 <%= alchemy_form_for site, url: alchemy.admin_sites_path(site, search_filter_params) do |f| %>
-  <%= f.input :host, hint: resource_handler.help_text_for(name: :host).try(:html_safe) %>
+  <%= f.input :host, hint: resource_handler.help_text_for(name: :host)&.html_safe %>
   <%= f.input :name %>
   <%= f.input :public %>
   <%= f.input :aliases, hint: resource_handler.help_text_for(name: :aliases), input_html: {rows: 4} %>

--- a/app/views/alchemy/admin/sites/_form.html.erb
+++ b/app/views/alchemy/admin/sites/_form.html.erb
@@ -1,5 +1,5 @@
 <%= alchemy_form_for site, url: alchemy.admin_sites_path(site, search_filter_params) do |f| %>
-  <%= f.input :host, hint: resource_handler.help_text_for(name: :host).html_safe %>
+  <%= f.input :host, hint: resource_handler.help_text_for(name: :host).try(:html_safe) %>
   <%= f.input :name %>
   <%= f.input :public %>
   <%= f.input :aliases, hint: resource_handler.help_text_for(name: :aliases), input_html: {rows: 4} %>

--- a/lib/alchemy/resource.rb
+++ b/lib/alchemy/resource.rb
@@ -210,7 +210,7 @@ module Alchemy
       @module_definition && @module_definition["engine_name"]
     end
 
-    # Returns a help text for resource's form
+    # Returns a help text for resource's form or nil if no help text is available
     #
     # === Example:
     #
@@ -223,7 +223,7 @@ module Alchemy
     def help_text_for(attribute)
       ::I18n.translate!(attribute[:name], scope: [:alchemy, :resource_help_texts, resource_name])
     rescue ::I18n::MissingTranslationData
-      false
+      nil
     end
 
     # Return attributes that should be viewable but not editable.

--- a/spec/dummy/config/locales/alchemy.en.yml
+++ b/spec/dummy/config/locales/alchemy.en.yml
@@ -26,3 +26,6 @@ en:
       essence_text: This content type (Essence) represents a simple line of text
     default_content_texts:
       welcome: Welcome to my site
+    resource_help_texts:
+      party:
+        name: Party

--- a/spec/libraries/resource_spec.rb
+++ b/spec/libraries/resource_spec.rb
@@ -395,5 +395,14 @@ module Alchemy
         expect(resource.in_engine?).to eq(true)
       end
     end
+
+    describe "#help_text_for" do
+      it "should return a text as string for an attribute" do
+        expect(resource.help_text_for(name: :name)).to eq("Party")
+      end
+      it "should return nil for a nonexistent attribute" do
+        expect(resource.help_text_for(name: :nonexistent_attribute_dummy)).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes missing method exception for html_safe on missing hint translations. Also allows setting `hint: false` in `elements.yml` (e.g. while development).

## Checklist
- [X] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
