### PR TITLE
Fix editing sites

### DIFF
--- a/app/views/alchemy/admin/sites/_form.html.erb
+++ b/app/views/alchemy/admin/sites/_form.html.erb
@@ -1,4 +1,4 @@
-<%= alchemy_form_for site, url: alchemy.admin_sites_path(site, search_filter_params) do |f| %>
+<%= alchemy_form_for site, url: resource_path(site, search_filter_params) do |f| %>
   <%= f.input :host, hint: resource_handler.help_text_for(name: :host)&.html_safe %>
   <%= f.input :name %>
   <%= f.input :public %>

--- a/spec/features/admin/site_editing_spec.rb
+++ b/spec/features/admin/site_editing_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Site editing feature", type: :system do
+  before { authorize_user(:as_admin) }
+
+  it "can create a new page" do
+    visit alchemy.new_admin_site_path
+    fill_in "site_host", with: "api.example.com"
+    fill_in "site_name", with: "API Site"
+    click_button "Save"
+    expect(page).to have_content "You need at least one language to work with. Please create one below."
+    visit alchemy.edit_admin_site_path(Alchemy::Site.first)
+    fill_in "Aliases", with: "api.localhost"
+    click_button "Save"
+    expect(page).to have_content "api.localhost"
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

Prior to this commit, the site's form partial would only reference the
path needed to create a new site, not the one needed to edit an
existing one. This commit changes the partial to use `resource_path`,
which does the right thing: `/admin/sites/` for creating a new site,
`/admin/sites/2/` for editing an existing one.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change (not adding any)
