### PR TITLE
Always make pages taggable

### DIFF
--- a/app/models/alchemy/page/page_natures.rb
+++ b/app/models/alchemy/page/page_natures.rb
@@ -17,6 +17,8 @@ module Alchemy
       definition["taggable"] == true
     end
 
+    deprecate :taggable?, deprecator: Alchemy::Deprecation
+
     def rootpage?
       !new_record? && parent_id.blank?
     end

--- a/app/views/alchemy/admin/layoutpages/edit.html.erb
+++ b/app/views/alchemy/admin/layoutpages/edit.html.erb
@@ -5,11 +5,9 @@
     include_blank: Alchemy.t('Please choose'),
     input_html: {class: 'alchemy_selectbox'} %>
   <%= f.input :name, autofocus: true %>
-  <% if @page.taggable? %>
-    <div class="input string">
-      <%= f.label :tag_list %>
-      <%= render 'alchemy/admin/partials/autocomplete_tag_list', f: f %>
-    </div>
-  <% end %>
+  <div class="input string">
+    <%= f.label :tag_list %>
+    <%= render 'alchemy/admin/partials/autocomplete_tag_list', f: f %>
+  </div>
   <%= f.submit Alchemy.t(:save) %>
 <% end %>

--- a/app/views/alchemy/admin/pages/_form.html.erb
+++ b/app/views/alchemy/admin/pages/_form.html.erb
@@ -36,12 +36,10 @@
     as: 'text',
     hint: Alchemy.t('pages.update.comma_seperated') %>
 
-  <% if @page.taggable? %>
-    <div class="input string autocomplete_tag_list">
-      <%= f.label :tag_list %>
-      <%= render 'alchemy/admin/partials/autocomplete_tag_list', f: f %>
-    </div>
-  <% end %>
+  <div class="input string autocomplete_tag_list">
+    <%= f.label :tag_list %>
+    <%= render 'alchemy/admin/partials/autocomplete_tag_list', f: f %>
+  </div>
 
   <%= f.submit Alchemy.t(:save) %>
 <% end %>

--- a/spec/features/admin/page_editing_feature_spec.rb
+++ b/spec/features/admin/page_editing_feature_spec.rb
@@ -90,15 +90,9 @@ RSpec.describe "Page editing feature", type: :system do
         end
       end
 
-      context "when page is taggable" do
-        before do
-          expect_any_instance_of(Alchemy::Page).to receive(:taggable?).and_return(true)
-        end
-
-        it "should show the tag_list input field" do
-          visit alchemy.configure_admin_page_path(a_page)
-          expect(page).to have_selector("input#page_tag_list")
-        end
+      it "should show the tag_list input field" do
+        visit alchemy.configure_admin_page_path(a_page)
+        expect(page).to have_selector("input#page_tag_list")
       end
     end
 

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1482,6 +1482,10 @@ module Alchemy
     end
 
     describe "#taggable?" do
+      around do |example|
+        Alchemy::Deprecation.silence { example.run }
+      end
+
       context "definition has 'taggable' key with true value" do
         it "should return true" do
           page = build(:alchemy_page)


### PR DESCRIPTION
## What is this pull request for?

Instead of using the now deprecated `taggable` flag on a page definition we now always show the taggable input field.

### Screenshots

![Screen Shot 2020-07-14 at 22 05 57](https://user-images.githubusercontent.com/42868/87471198-40ff1980-c61e-11ea-95c0-deff9bbcb93b.png)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
