### PR TITLE
Support nested controllers in modules

### DIFF
--- a/app/helpers/alchemy/admin/navigation_helper.rb
+++ b/app/helpers/alchemy/admin/navigation_helper.rb
@@ -175,7 +175,8 @@ module Alchemy
       # Returns true if the given entry's controller is current controller
       #
       def is_entry_controller_active?(entry)
-        entry["controller"].gsub(/\A\//, "") == params[:controller]
+        entry["controller"].gsub(/\A\//, "") == params[:controller] ||
+          entry.fetch("nested_controllers", []).include?(params[:controller])
       end
 
       # Returns true if the given entry's action is current controllers action

--- a/config/alchemy/modules.yml
+++ b/config/alchemy/modules.yml
@@ -5,7 +5,7 @@
   position: 1
   navigation:
     name: 'modules.dashboard'
-    controller: 'alchemy/admin/dashboard'
+    controller: '/alchemy/admin/dashboard'
     action: index
     inline_image: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="-4 -6 32 32" class="svg-inline--fa fa-lg fa-fw"><path fill="currentColor" d="M15.7 7.9L9.9 2.2 2.1 4.3 0 12.1l5.7 5.8 7.8-2.1 2.2-7.9zm-5.3 10.3l-1.2 4.4 3.2 3.2 4.4-1.2 1.2-4.4-3.2-3.2-4.4 1.2zM23.5 7.3L17.2 9l-1.7 6.2 4.5 4.6 6.2-1.7 1.7-6.2-4.4-4.6z"/></svg>'
 
@@ -14,18 +14,18 @@
   position: 2
   navigation:
     name: 'modules.pages'
-    controller: 'alchemy/admin/pages'
+    controller: '/alchemy/admin/pages'
     action: index
     icon: file-alt
     sub_navigation:
       - name: 'modules.pages'
-        controller: 'alchemy/admin/pages'
+        controller: '/alchemy/admin/pages'
         action: index
       - name: 'modules.layoutpages'
-        controller: 'alchemy/admin/layoutpages'
+        controller: '/alchemy/admin/layoutpages'
         action: index
     nested:
-      - controller: 'alchemy/admin/pages'
+      - controller: '/alchemy/admin/pages'
         action: edit
 
 - name: menus
@@ -33,7 +33,7 @@
   position: 3
   navigation:
     name: 'modules.menus'
-    controller: 'alchemy/admin/nodes'
+    controller: '/alchemy/admin/nodes'
     action: index
     icon: list-ul
 
@@ -42,7 +42,7 @@
   position: 4
   navigation:
     name: 'modules.languages'
-    controller: 'alchemy/admin/languages'
+    controller: '/alchemy/admin/languages'
     action: index
     icon: flag
 
@@ -51,7 +51,7 @@
   position: 5
   navigation:
     name: 'modules.sites'
-    controller: 'alchemy/admin/sites'
+    controller: '/alchemy/admin/sites'
     action: index
     icon: bullseye
 
@@ -60,7 +60,7 @@
   position: 6
   navigation:
     name: 'modules.tags'
-    controller: 'alchemy/admin/tags'
+    controller: '/alchemy/admin/tags'
     action: index
     icon: tags
 
@@ -68,14 +68,14 @@
   engine_name: alchemy
   position: 7
   navigation:
-    controller: 'alchemy/admin/pictures'
+    controller: '/alchemy/admin/pictures'
     action: index
     name: 'modules.library'
     icon: archive
     sub_navigation:
       - name: 'modules.pictures'
-        controller: 'alchemy/admin/pictures'
+        controller: '/alchemy/admin/pictures'
         action: index
       - name: 'modules.attachments'
-        controller: 'alchemy/admin/attachments'
+        controller: '/alchemy/admin/attachments'
         action: index

--- a/lib/alchemy/modules.rb
+++ b/lib/alchemy/modules.rb
@@ -72,7 +72,8 @@ module Alchemy
         alchemy_modules.detect do |alchemy_module|
           module_navi = alchemy_module.fetch("navigation", {})
           definition_from_mainnavi(module_navi, name_or_params) ||
-            definition_from_subnavi(module_navi, name_or_params)
+            definition_from_subnavi(module_navi, name_or_params) ||
+            definition_from_nested(module_navi, name_or_params)
         end
       else
         raise ArgumentError, "Could not find module definition for #{name_or_params}"
@@ -90,6 +91,15 @@ module Alchemy
       return if subnavi.nil?
 
       subnavi.any? do |navi|
+        controller_matches?(navi, params) && action_matches?(navi, params)
+      end
+    end
+
+    def definition_from_nested(module_navi, params)
+      nested = module_navi["nested"]
+      return if nested.nil?
+
+      nested.any? do |navi|
         controller_matches?(navi, params) && action_matches?(navi, params)
       end
     end

--- a/spec/helpers/alchemy/admin/navigation_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/navigation_helper_spec.rb
@@ -156,8 +156,13 @@ describe Alchemy::Admin::NavigationHelper do
   end
 
   describe "#entry_active?" do
+    subject { helper.entry_active?(entry) }
+
     let(:entry) do
-      { "controller" => "alchemy/admin/dashboard", "action" => "index" }
+      {
+        "controller" => "alchemy/admin/dashboard",
+        "action" => "index",
+      }
     end
 
     context "with active entry" do
@@ -170,33 +175,69 @@ describe Alchemy::Admin::NavigationHelper do
         end
       end
 
-      it "returns true" do
-        expect(helper.entry_active?(entry)).to be_truthy
-      end
+      it { is_expected.to be_truthy }
 
       context "and with leading slash in controller name" do
-        before { entry["controller"] = "/alchemy/admin/dashboard" }
+        let(:entry) do
+          {
+            "controller" => "/alchemy/admin/dashboard",
+            "action" => "index",
+          }
+        end
 
-        it "returns true" do
-          expect(helper.entry_active?(entry)).to be_truthy
+        it { is_expected.to be_truthy }
+      end
+
+      context "with non matching action" do
+        let(:entry) do
+          {
+            "controller" => "alchemy/admin/dashboard",
+            "action" => "some",
+          }
+        end
+
+        it { is_expected.to be_falsey }
+
+        context "but with action listed in nested_actions key" do
+          let(:entry) do
+            {
+              "controller" => "alchemy/admin/dashboard",
+              "action" => "some",
+              "nested_actions" => %w(index),
+            }
+          end
+
+          it { is_expected.to be_truthy }
         end
       end
 
-      context "but with action listed in nested_actions key" do
-        before do
-          entry["action"] = nil
-          entry["nested_actions"] = %w(index)
+      context "with non matching controller" do
+        let(:entry) do
+          {
+            "controller" => "some/one",
+            "action" => "index",
+          }
         end
 
-        it "returns true" do
-          expect(helper.entry_active?(entry)).to be_truthy
+        it { is_expected.to be_falsey }
+
+        context "but controller listed in nested_controllers" do
+          let(:entry) do
+            {
+              "controller" => "some/one",
+              "action" => "index",
+              "nested_controllers" => %w(alchemy/admin/dashboard),
+            }
+          end
+
+          it { is_expected.to be_truthy }
         end
       end
     end
 
     context "with inactive entry" do
       before do
-        expect(helper).to receive(:params) do
+        expect(helper).to receive(:params).twice do
           {
             controller: "alchemy/admin/users",
             action: "index",
@@ -204,9 +245,7 @@ describe Alchemy::Admin::NavigationHelper do
         end
       end
 
-      it "returns false" do
-        expect(helper.entry_active?(entry)).to be_falsey
-      end
+      it { is_expected.to be_falsey }
     end
   end
 

--- a/spec/libraries/modules_spec.rb
+++ b/spec/libraries/modules_spec.rb
@@ -10,17 +10,26 @@ module Alchemy
   describe Modules do
     let(:controller) { ModulesTestController.new }
 
-    let(:alchemy_modules) do
-      YAML.load_file(File.expand_path("../../config/alchemy/modules.yml", __dir__))
-    end
-
     describe "#module_definition_for" do
-      subject { controller.module_definition_for(name) }
+      subject { controller.module_definition_for(params_or_name) }
 
-      let(:dashboard_module) { alchemy_modules.first }
+      before do
+        allow(controller).to receive(:alchemy_modules) { [dashboard_module] }
+      end
+
+      let(:dashboard_module) do
+        {
+          "engine_name" => "alchemy",
+          "name" => "dashboard",
+          "navigation" => {
+            "controller" => "alchemy/admin/dashboard",
+            "action" => "index",
+          },
+        }
+      end
 
       context "with a string given as name" do
-        let(:name) { "dashboard" }
+        let(:params_or_name) { "dashboard" }
 
         it "returns the module definition" do
           is_expected.to eq(dashboard_module)
@@ -28,15 +37,70 @@ module Alchemy
       end
 
       context "with a hash given as name" do
-        let(:controller_name) { "alchemy/admin/dashboard" }
-        let(:name)            { {controller: controller_name, action: "index"} }
+        let(:params_or_name) do
+          {
+            controller: "alchemy/admin/dashboard",
+            action: "index",
+          }
+        end
 
         it "returns the module definition" do
           is_expected.to eq(dashboard_module)
         end
 
         context "with leading slash in controller name" do
-          let(:controller_name) { "/alchemy/admin/dashboard" }
+          let(:params_or_name) do
+            {
+              controller: "/alchemy/admin/dashboard",
+              action: "index",
+            }
+          end
+
+          it "returns the module definition" do
+            is_expected.to eq(dashboard_module)
+          end
+        end
+
+        context "with controller name in subnavigation" do
+          let(:dashboard_module) do
+            {
+              "engine_name" => "alchemy",
+              "name" => "dashboard",
+              "navigation" => {
+                "controller" => "some/thing",
+                "action" => "foo",
+                "sub_navigation" => [
+                  {
+                    "controller" => "alchemy/admin/dashboard",
+                    "action" => "index",
+                  },
+                ],
+              },
+            }
+          end
+
+          it "returns the module definition" do
+            is_expected.to eq(dashboard_module)
+          end
+        end
+
+        context "with controller name in nested" do
+          let(:dashboard_module) do
+            {
+              "engine_name" => "alchemy",
+              "name" => "dashboard",
+              "navigation" => {
+                "controller" => "some/thing",
+                "action" => "foo",
+                "nested" => [
+                  {
+                    "controller" => "alchemy/admin/dashboard",
+                    "action" => "index",
+                  },
+                ],
+              },
+            }
+          end
 
           it "returns the module definition" do
             is_expected.to eq(dashboard_module)
@@ -45,8 +109,9 @@ module Alchemy
       end
 
       context "with nil given as name" do
-        let(:name) { nil }
-        it "raises an error" do
+        let(:params_or_name) { nil }
+
+        it do
           expect { subject }.to raise_error(ArgumentError)
         end
       end


### PR DESCRIPTION
## What is this pull request for?

A controller defined as `Alchemy::Admin::Pages::ListController` is currently not supported in Alchemy module definitions.

This adds support for it.

### Notable changes

Changes controller names in the core modules definition from relative to absolute.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
