### PR TITLE
Fix vertical position of site name in page tab

### DIFF
--- a/app/assets/stylesheets/alchemy/navigation.scss
+++ b/app/assets/stylesheets/alchemy/navigation.scss
@@ -286,5 +286,6 @@
     color: $muted-text-color;
     margin-right: $default-margin;
     font-size: $small-font-size;
+    line-height: 31px;
   }
 }


### PR DESCRIPTION
## What is this pull request for?

Fix vertical position of site name in locked page tab.

### Screenshots

#### Before 

![Screen Shot 2020-07-14 at 23 12 01](https://user-images.githubusercontent.com/42868/87476889-74927180-c627-11ea-9a3c-4bf653f2892a.png)

#### After

![Screen Shot 2020-07-14 at 23 11 37](https://user-images.githubusercontent.com/42868/87476892-752b0800-c627-11ea-99b0-6bd1968123a2.png)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
