### PR TITLE
Do not freeze common_search_filter_includes

### DIFF
--- a/app/controllers/alchemy/admin/resources_controller.rb
+++ b/app/controllers/alchemy/admin/resources_controller.rb
@@ -148,15 +148,15 @@ module Alchemy
 
       def common_search_filter_includes
         [
-          {q: [
+          { q: [
             resource_handler.search_field_name,
             :s,
-          ]},
+          ] },
           :tagged_with,
           :filter,
           :page,
           :per_page,
-        ].freeze
+        ]
       end
 
       def items_per_page

--- a/spec/controllers/alchemy/admin/resources_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/resources_controller_spec.rb
@@ -149,4 +149,14 @@ describe Admin::EventsController do
       end
     end
   end
+
+  describe "#common_search_filter_includes" do
+    before do
+      allow(controller).to receive(:alchemy_module) { { name: "events" } }
+    end
+
+    it "should not be frozen" do
+      expect(controller.send(:common_search_filter_includes)).to_not be_frozen
+    end
+  end
 end


### PR DESCRIPTION
## What is this pull request for?

That way we can add more custom filters to the search without overwriting the method

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
