### PR TITLE
Do not add id attributes to hidden fields in search and filters

### DIFF
--- a/app/views/alchemy/admin/partials/_remote_search_form.html.erb
+++ b/app/views/alchemy/admin/partials/_remote_search_form.html.erb
@@ -2,8 +2,8 @@
     action: 'index',
     size: @size
   ), remote: true, html: {class: 'search_form', id: nil} do |f| %>
-  <%= hidden_field_tag("element_id", @element.blank? ? "" : @element.id) %>
-  <%= hidden_field_tag("content_id", @content.blank? ? "" : @content.id) %>
+  <%= hidden_field_tag("element_id", @element.blank? ? "" : @element.id, id: nil) %>
+  <%= hidden_field_tag("content_id", @content.blank? ? "" : @content.id, id: nil) %>
   <div class="search_field">
     <label>
       <%= render_icon('search') %>

--- a/app/views/alchemy/admin/partials/_search_form.html.erb
+++ b/app/views/alchemy/admin/partials/_search_form.html.erb
@@ -9,7 +9,7 @@
         placeholder: Alchemy.t(:search) %>
     </label>
     <% local_assigns.fetch(:additional_query_fields, []).each do |field| %>
-      <%= f.hidden_field field %>
+      <%= f.hidden_field field, id: nil %>
     <% end %>
     <%= link_to render_icon(:times, size: 'xs'), url,
         class: 'search_field_clear',
@@ -17,7 +17,7 @@
         title: Alchemy.t(:click_to_show_all),
         style: search_filter_params.fetch(:q, {}).fetch(resource_handler.search_field_name, '').present? ? 'display: block' : 'display: none' %>
     <% local_assigns.fetch(:additional_params, []).each do |additional_param| %>
-      <%= hidden_field_tag additional_param, search_filter_params[additional_param] %>
+      <%= hidden_field_tag additional_param, search_filter_params[additional_param], id: nil %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/alchemy/admin/resources/_per_page_select.html.erb
+++ b/app/views/alchemy/admin/resources/_per_page_select.html.erb
@@ -2,10 +2,10 @@
   <% search_filter_params.reject { |k, _| k == 'page' || k == 'per_page' }.each do |key, value| %>
     <% if value.is_a? Hash %>
       <% value.each do |k, v| %>
-        <%= hidden_field_tag "#{key}[#{k}]", v %>
+        <%= hidden_field_tag "#{key}[#{k}]", v, id: nil %>
       <% end %>
     <% else %>
-      <%= hidden_field_tag key, value %>
+      <%= hidden_field_tag key, value, id: nil %>
     <% end %>
   <% end %>
   <label>


### PR DESCRIPTION
## What is this pull request for?

Do not add id attributes to hidden fields in search and filters.

Those ids may collide with actual fields making the JS on them not work.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
