### PR TITLE
Deprecate toolbar helper

### DIFF
--- a/app/helpers/alchemy/admin/base_helper.rb
+++ b/app/helpers/alchemy/admin/base_helper.rb
@@ -314,6 +314,8 @@ module Alchemy
         end
       end
 
+      deprecate toolbar: "Please use `content_for(:toolbar)` instead", deprecator: Alchemy::Deprecation
+
       # (internal) Used by upload form
       def new_asset_path_with_session_information(asset_type)
         session_key = Rails.application.config.session_options[:key]

--- a/app/views/alchemy/admin/resources/index.html.erb
+++ b/app/views/alchemy/admin/resources/index.html.erb
@@ -1,29 +1,28 @@
 <% label_title = Alchemy.t("Create #{resource_name}", default: Alchemy.t('Create')) %>
 
-<% toolbar(
-  buttons: [
-    {
-      icon: :plus,
-      label: label_title,
-      url: new_resource_path,
+<% content_for(:toolbar) do %>
+  <%= toolbar_button(
+    icon: :plus,
+    label: label_title,
+    url: new_resource_path,
+    title: label_title,
+    hotkey: 'alt+n',
+    dialog_options: {
       title: label_title,
-      hotkey: 'alt+n',
-      dialog_options: {
-        title: label_title,
-        size: resource_window_size
-      },
-      if_permitted_to: [:create, resource_model]
+      size: resource_window_size
     },
-    {
-      icon: 'download',
-      url: resource_url_proxy.url_for(action: 'index', format: 'csv', q: search_filter_params[:q], sort: params[:sort]),
-      label: Alchemy.t(:download_csv),
-      title: Alchemy.t(:download_csv),
-      dialog: false,
-      if_permitted_to: [:index, resource_model]
-    }
-  ]
-) %>
+    if_permitted_to: [:create, resource_model]
+  ) %>
+  <%= toolbar_button(
+    icon: :download,
+    url: resource_url_proxy.url_for(action: 'index', format: 'csv', q: search_filter_params[:q], sort: params[:sort]),
+    label: Alchemy.t(:download_csv),
+    title: Alchemy.t(:download_csv),
+    dialog: false,
+    if_permitted_to: [:index, resource_model]
+  ) %>
+  <%= render 'alchemy/admin/partials/search_form' %>
+<% end %>
 
 <div id="archive_all" class="resources-table-wrapper<%= ' with_tag_filter' if resource_has_tags || resource_has_filters %>">
   <%= render 'alchemy/admin/resources/table_header' %>


### PR DESCRIPTION
## What is this pull request for?

Please use `content_for(:toolbar)` instead

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
