### PR TITLE
Always show original image as zoomed image

### DIFF
--- a/app/views/alchemy/admin/pictures/show.html.erb
+++ b/app/views/alchemy/admin/pictures/show.html.erb
@@ -1,5 +1,5 @@
 <div class="zoomed-picture-background">
-  <%= image_tag @picture.url(format: @picture.image_file_format) %>
+  <%= image_tag @picture.url %>
 </div>
 
 <div class="picture-overlay-navigation">


### PR DESCRIPTION
## What is this pull request for?

There is no need to process the image, we always want to dimply it as it was uploaded.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
