### PR TITLE
Do not enable image cropper if file is missing

### DIFF
--- a/app/models/alchemy/essence_picture.rb
+++ b/app/models/alchemy/essence_picture.rb
@@ -143,7 +143,7 @@ module Alchemy
         picture.can_be_cropped_to(
           content.settings[:size],
           content.settings[:upsample],
-        )
+        ) && !!picture.image_file
     end
 
     def crop_values_present?

--- a/spec/models/alchemy/essence_picture_spec.rb
+++ b/spec/models/alchemy/essence_picture_spec.rb
@@ -350,10 +350,22 @@ module Alchemy
 
             context "with crop set to true" do
               before do
-                allow(content).to receive(:settings) { {crop: true} }
+                allow(content).to receive(:settings) { { crop: true } }
               end
 
-              it { is_expected.to be(true) }
+              context "if picture.image_file is nil" do
+                before do
+                  expect(picture).to receive(:image_file) { nil }
+                end
+
+                it { is_expected.to be_falsy }
+              end
+
+              context "if picture.image_file is present" do
+                let(:picture) { build_stubbed(:alchemy_picture) }
+
+                it { is_expected.to be(true) }
+              end
             end
           end
         end


### PR DESCRIPTION
## What is this pull request for?

There is nothing to crop, if the image file is missing.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
