### PR TITLE
Do not convert JPG images into JPEG

### DIFF
--- a/app/models/alchemy/picture_variant.rb
+++ b/app/models/alchemy/picture_variant.rb
@@ -91,7 +91,7 @@ module Alchemy
 
       encoding_options = []
 
-      convert_format = render_format != picture.image_file_format.sub("jpeg", "jpg")
+      convert_format = render_format.sub("jpeg", "jpg") != picture.image_file_format.sub("jpeg", "jpg")
 
       if render_format =~ /jpe?g/ && convert_format
         quality = options[:quality] || Config.get(:output_image_jpg_quality)

--- a/spec/models/alchemy/picture_variant_spec.rb
+++ b/spec/models/alchemy/picture_variant_spec.rb
@@ -234,4 +234,32 @@ RSpec.describe Alchemy::PictureVariant do
       end
     end
   end
+
+  context "when jpeg format is requested" do
+    let(:options) do
+      {
+        format: "jpeg",
+      }
+    end
+
+    context "and image has jpg format" do
+      let(:alchemy_picture) do
+        build_stubbed(:alchemy_picture, image_file: image_file, image_file_format: "jpg")
+      end
+
+      it "does not convert the picture format" do
+        expect(subject).to_not respond_to(:steps)
+      end
+    end
+
+    context "and image has jpeg format" do
+      let(:alchemy_picture) do
+        build_stubbed(:alchemy_picture, image_file: image_file, image_file_format: "jpeg")
+      end
+
+      it "does not convert the picture format" do
+        expect(subject).to_not respond_to(:steps)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What is this pull request for?

As JPG and JPEG are technically the same image we must not convert them.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
