### PR TITLE
Introduce a pages list view

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -54,6 +54,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'webdrivers',                   ['~> 4.0']
   gem.add_development_dependency 'webmock',                      ['~> 3.3']
   gem.add_development_dependency 'shoulda-matchers',             ['~> 4.0']
+  gem.add_development_dependency 'timecop',                      ['~> 0.9']
 
   gem.post_install_message = <<-MSG
 -------------------------------------------------------------

--- a/app/assets/stylesheets/alchemy/buttons.scss
+++ b/app/assets/stylesheets/alchemy/buttons.scss
@@ -1,4 +1,7 @@
-button, input[type="submit"], a.button, input.button {
+button,
+input[type="submit"],
+a.button,
+input.button {
   @include button-defaults;
   position: relative;
 
@@ -14,7 +17,8 @@ button, input[type="submit"], a.button, input.button {
       );
     }
 
-    &:active, &:active:focus {
+    &:active,
+    &:active:focus {
       border-color: $button-hover-border-color;
       box-shadow: none;
     }
@@ -23,7 +27,7 @@ button, input[type="submit"], a.button, input.button {
   &.small {
     padding: $small-button-padding;
     vertical-align: inherit;
-    line-height: 4*$default-padding;
+    line-height: 4 * $default-padding;
     font-size: inherit;
   }
 
@@ -83,13 +87,14 @@ button, input[type="submit"], a.button, input.button {
       border: $default-border-width $default-border-style $icon-color;
       color: $icon-color;
 
-      .icon { color: inherit }
+      .icon {
+        color: inherit;
+      }
     }
   }
 
   &.disabled,
   &[disabled] {
-
     span {
       opacity: 0.3;
       cursor: not-allowed;
@@ -118,7 +123,8 @@ button.icon_button {
   border: 0 none;
   box-shadow: none;
 
-  &:disabled, &.disabled {
+  &:disabled,
+  &.disabled {
     background: transparent;
   }
 }
@@ -131,10 +137,15 @@ button.icon_button {
   position: relative;
   display: inline-block;
   text-align: center;
-  margin: 0 2*$default-margin;
 
-  &.active, &:active, &:hover {
-   .icon_button:not([disabled]) {
+  .toolbar_buttons & {
+    margin: 0 2 * $default-margin;
+  }
+
+  &.active,
+  &:active,
+  &:hover {
+    .icon_button:not([disabled]) {
       background-color: $default-border-color;
       cursor: pointer;
     }
@@ -161,8 +172,8 @@ button.icon_button {
   }
 }
 
-.button_with_label, .button_group {
-
+.button_with_label,
+.button_group {
   .icon_button {
     width: 29px;
     height: 29px;
@@ -179,16 +190,16 @@ button.icon_button {
     z-index: 30;
     background-color: $tooltip-background-color;
     color: $white;
-    padding: $default-padding 2*$default-padding 1.5*$default-padding;
+    padding: $default-padding 2 * $default-padding 1.5 * $default-padding;
     line-height: 1;
     box-shadow: 0 0 4px $default-border-color;
     white-space: nowrap;
     pointer-events: none;
     opacity: 0;
-    transition: .3s;
+    transition: 0.3s;
 
     &:before {
-      content: '';
+      content: "";
       position: absolute;
       bottom: -10px;
       left: 8px;
@@ -238,6 +249,6 @@ button.icon_button {
     visibility: visible;
     opacity: 1;
     top: -25px;
-    transition-delay: .2s;
+    transition-delay: 0.2s;
   }
 }

--- a/app/assets/stylesheets/alchemy/tables.scss
+++ b/app/assets/stylesheets/alchemy/tables.scss
@@ -6,7 +6,8 @@ table {
   width: 100%;
 
   &.list .tools {
-    button, a {
+    button,
+    a {
       display: inline-block;
       width: 18px;
       height: 18px;
@@ -22,8 +23,9 @@ table {
   }
 }
 
-.list td, .list th {
-  padding: 2*$default-padding;
+.list td,
+.list th {
+  padding: 2 * $default-padding;
   vertical-align: top;
   line-height: 18px;
   border-right: 1px solid $medium-gray;
@@ -93,9 +95,10 @@ td.heading {
   background-color: $table-row-hover-color;
 }
 
-td, th {
-
-  &.center, &.boolean {
+td,
+th {
+  &.center,
+  &.boolean {
     text-align: center;
   }
 
@@ -105,7 +108,6 @@ td, th {
 }
 
 td {
-
   &.file_name {
     word-break: break-all;
   }
@@ -118,7 +120,8 @@ td {
     width: 80px;
   }
 
-  &.date, &.datetime {
+  &.date,
+  &.datetime {
     width: 150px;
   }
 
@@ -137,9 +140,35 @@ td {
   &.rights {
     width: 60px;
   }
+
+  &.page_layout {
+    width: 160px;
+  }
+
+  &.status {
+    width: 80px;
+
+    .page_status {
+      margin: 0 $default-margin;
+    }
+  }
+
+  &.tags {
+    width: 180px;
+
+    .tag {
+      margin: 0;
+      padding: 0 2 + $default-padding;
+
+      &:before {
+        padding-right: $default-padding;
+      }
+    }
+  }
 }
 
-th.count, td.count {
+th.count,
+td.count {
   width: 120px;
   text-align: right;
   padding-right: 16px;

--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -31,10 +31,12 @@ module Alchemy
         unless: -> { @page_root },
         only: [:index]
 
+      before_action :set_view, only: [:index]
+
       def index
         @query = @current_language.pages.contentpages.ransack(search_filter_params[:q])
 
-        if params[:view] == "list"
+        if @view == "list"
           @query.sorts = default_sort_order if @query.sorts.empty?
           items = @query.result
 
@@ -255,6 +257,11 @@ module Alchemy
 
       def common_search_filter_includes
         super.push(:page_layout, :view)
+      end
+
+      def set_view
+        @view = params[:view] || session[:alchemy_pages_view] || "tree"
+        session[:alchemy_pages_view] = @view
       end
 
       def copy_of_language_root

--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -2,12 +2,12 @@
 
 module Alchemy
   module Admin
-    class PagesController < Alchemy::Admin::BaseController
+    class PagesController < ResourcesController
       include OnPageLayout::CallbacksRunner
 
       helper "alchemy/pages"
 
-      before_action :load_page, except: [:index, :flush, :new, :order, :create, :copy_language_tree, :link, :sort]
+      before_action :load_resource, except: [:index, :flush, :new, :order, :create, :copy_language_tree, :link, :sort]
 
       authorize_resource class: Alchemy::Page, except: [:index, :tree]
 
@@ -310,7 +310,7 @@ module Alchemy
         { my_urlname: default_urlname, children_path: default_urlname }
       end
 
-      def load_page
+      def load_resource
         @page = Page.find(params[:id])
       end
 

--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -27,6 +27,10 @@ module Alchemy
         if: :run_on_page_layout_callbacks?,
         only: [:show]
 
+      before_action :load_languages_and_layouts,
+        unless: -> { @page_root },
+        only: [:index]
+
       def index
         @query = @current_language.pages.contentpages.ransack(search_filter_params[:q])
 
@@ -396,6 +400,12 @@ module Alchemy
         PageTreeSerializer.new(@page, ability: current_ability,
                                       user: current_alchemy_user,
                                       full: params[:full] == "true")
+      end
+
+      def load_languages_and_layouts
+        @language = @current_language
+        @languages_with_page_tree = Language.on_current_site.with_root_page
+        @page_layouts = PageLayout.layouts_for_select(@language.id)
       end
     end
   end

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -164,6 +164,14 @@ module Alchemy
         @_url_path_class = klass
       end
 
+      def alchemy_resource_filters
+        %w[published not_public restricted]
+      end
+
+      def searchable_alchemy_resource_attributes
+        %w[name urlname title]
+      end
+
       # Used to store the current page previewed in the edit page template.
       #
       def current_preview=(page)

--- a/app/models/alchemy/site/layout.rb
+++ b/app/models/alchemy/site/layout.rb
@@ -25,10 +25,38 @@ module Alchemy
       end
     end
 
-    # Returns site's layout definition
+    # Returns sites layout definition
     #
     def definition
-      self.class.definitions.detect { |l| l["name"] == partial_name }
+      self.class.definitions.detect { |l| l["name"] == partial_name } || {}
+    end
+
+    # Returns sites page layout names
+    #
+    # If no site layout file is defined all page layouts are returned
+    #
+    # @param [Boolean] layoutpages Return layout pages only (default false)
+    #
+    # @return [Array<String>] Array of page layout names
+    #
+    def page_layout_names(layoutpages: false)
+      page_layout_definitions.select do |layout|
+        !!layout["layoutpage"] && layoutpages || !layout["layoutpage"] && !layoutpages
+      end.collect { |layout| layout["name"] }
+    end
+
+    # Returns sites page layout definitions
+    #
+    # If no site layout file is defined all page layouts are returned
+    #
+    def page_layout_definitions
+      if definition["page_layouts"].presence
+        Alchemy::PageLayout.all.select do |layout|
+          layout["name"].in?(definition["page_layouts"])
+        end
+      else
+        Alchemy::PageLayout.all
+      end
     end
 
     # Returns the name for the layout partial

--- a/app/views/alchemy/admin/pages/_create_language_form.html.erb
+++ b/app/views/alchemy/admin/pages/_create_language_form.html.erb
@@ -1,8 +1,7 @@
 <div class="panel">
   <%= render_message do %>
-    <p><%= Alchemy.t(:language_does_not_exist) %></p>
+    <p><%= Alchemy.t(:homepage_does_not_exist) %></p>
   <% end %>
-<%- if @language -%>
 
   <%- if @languages_with_page_tree.size >= 1 -%>
     <%= form_tag(alchemy.copy_language_tree_admin_pages_path) do %>
@@ -19,32 +18,23 @@
     <% end %>
   <%- end -%>
 
-  <%- if params[:action] == "index" -%>
-    <%= alchemy_form_for([:admin, Alchemy::Page.new], id: 'create_language_tree') do |form| %>
-      <% if @languages_with_page_tree.size >= 1 %>
-        <h3><%= Alchemy.t(:create_language_tree_heading) %></h3>
-        <p><%= Alchemy.t(:want_to_create_new_language) %></p>
-      <% end %>
-      <%= form.input :name, input_html: {value: @language.frontpage_name} %>
-      <%= form.input :page_layout,
-        collection: @page_layouts,
-        selected: @language.page_layout,
-        label: Alchemy.t(:page_type),
-        include_blank: Alchemy.t('Please choose'),
-        required: true,
-        input_html: {class: 'alchemy_selectbox'} %>
-      <%= form.hidden_field :language_id, value: @language.id %>
-      <%= form.hidden_field :language_code, value: @language.code %>
-      <%= form.hidden_field :language_root, value: true %>
-      <%= form.hidden_field :public, value: Alchemy::Language.all.size == 1 %>
-      <%= form.submit Alchemy.t("create_tree_as_new_language", language: @language.name), autofocus: true %>
+  <%= alchemy_form_for([:admin, Alchemy::Page.new], id: 'create_language_tree') do |form| %>
+    <% if @languages_with_page_tree.size >= 1 %>
+      <h3><%= Alchemy.t(:create_language_tree_heading) %></h3>
+      <p><%= Alchemy.t(:want_to_create_new_language) %></p>
     <% end %>
-  <%- end -%>
-
-<%- else -%>
-
-  <p><%= Alchemy.t("Actually this language does not exist. Please create this language first.") %></p>
-
-<%- end -%>
-
+    <%= form.input :name, input_html: {value: @language.frontpage_name} %>
+    <%= form.input :page_layout,
+      collection: @page_layouts,
+      selected: @language.page_layout,
+      label: Alchemy.t(:page_type),
+      include_blank: Alchemy.t('Please choose'),
+      required: true,
+      input_html: {class: 'alchemy_selectbox'} %>
+    <%= form.hidden_field :language_id, value: @language.id %>
+    <%= form.hidden_field :language_code, value: @language.code %>
+    <%= form.hidden_field :language_root, value: true %>
+    <%= form.hidden_field :public, value: Alchemy::Language.all.size == 1 %>
+    <%= form.submit Alchemy.t(:create), autofocus: true %>
+  <% end %>
 </div>

--- a/app/views/alchemy/admin/pages/_new_page_form.html.erb
+++ b/app/views/alchemy/admin/pages/_new_page_form.html.erb
@@ -1,5 +1,14 @@
 <%= alchemy_form_for([:admin, @page]) do |f| %>
-  <%= f.hidden_field(:parent_id) %>
+  <% if @page.parent_id || @page.layoutpage %>
+    <%= f.hidden_field(:parent_id) %>
+  <% else %>
+    <% @page.parent = @current_language.root_page %>
+    <%= f.input :parent_id,
+      collection: @current_language.pages.contentpages,
+      label_method: :name,
+      value_method: :id,
+      input_html: { class: "alchemy_selectbox" } %>
+  <% end %>
   <%= f.hidden_field(:language_id) %>
   <%= f.hidden_field(:layoutpage) %>
   <%= f.input :page_layout,

--- a/app/views/alchemy/admin/pages/_page_layout_filter.html.erb
+++ b/app/views/alchemy/admin/pages/_page_layout_filter.html.erb
@@ -1,0 +1,29 @@
+<div id="page_layout_filter">
+  <label>
+    <h3><%= Alchemy::Page.human_attribute_name(:page_layout) %></h3>
+    <%= select_tag(
+      "page_layout",
+      options_for_select(
+        @current_language.site.page_layout_names.map do |layout|
+          [
+            Alchemy::PageLayout.human_layout_name(layout),
+            layout
+          ]
+        end,
+        search_filter_params[:page_layout]
+      ),
+      include_blank: Alchemy.t(:all, scope: ["resources", "page", "filters"]),
+      class: "alchemy_selectbox full_width"
+    ) %>
+  </label>
+</div>
+
+<script type="text/javascript">
+  $(function() {
+    $("#page_layout").on("change", function(e) {
+      var url = "<%= alchemy.admin_pages_path(search_filter_params.except(:page_layout, :page).merge(view: "list")) %>";
+      delimiter = url.match(/\?/) ? "&" : "?";
+      Turbolinks.visit(url + delimiter + "page_layout=" + encodeURIComponent($(this).val()));
+    });
+  });
+</script>

--- a/app/views/alchemy/admin/pages/_table.html.erb
+++ b/app/views/alchemy/admin/pages/_table.html.erb
@@ -1,0 +1,27 @@
+<table class="list">
+  <thead>
+    <tr>
+      <th class="icon"></th>
+      <th class="string name">
+        <%= sort_link [:alchemy, @query],
+          "name",
+          Alchemy::Page.human_attribute_name(:name),
+          default_order: "asc" %>
+      </th>
+      <th><%= Alchemy::Page.human_attribute_name(:urlname) %></th>
+      <th><%= Alchemy::Page.human_attribute_name(:page_type) %></th>
+      <th><%= Alchemy::Page.human_attribute_name(:tag_list) %></th>
+      <th>
+        <%= sort_link [:alchemy, @query],
+          :updated_at,
+          Alchemy::Page.human_attribute_name(:updated_at),
+          default_order: "desc" %>
+      </th>
+      <th class="status center"><%= Alchemy::Page.human_attribute_name(:status) %></th>
+      <th class="tools"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= render partial: "table_row", collection: @pages, as: "page" %>
+  </tbody>
+</table>

--- a/app/views/alchemy/admin/pages/_table_row.html.erb
+++ b/app/views/alchemy/admin/pages/_table_row.html.erb
@@ -1,0 +1,107 @@
+<tr class="<%= cycle(:even, :odd) %>" data-page-id="<%= page.id %>">
+  <td class="icon">
+    <% if can?(:edit_content, page) %>
+      <% if page.locked? %>
+        <span class="with-hint">
+          <i class="icon fas fa-edit fa-fw"></i>
+          <span class="hint-bubble">
+            <%= Alchemy.t("This page is locked", name: page.locker_name) %>
+          </span>
+        </span>
+      <% else %>
+        <i class="icon far fa-file fa-lg"></i>
+      <% end %>
+    <% else %>
+      <span class="with-hint">
+        <i class="icon fas fa-ban fa-fw"></i>
+        <span class="hint-bubble">
+          <%= Alchemy.t("Your user role does not allow you to edit this page") %>
+        </span>
+      </span>
+    <% end %>
+  </td>
+  <td class="string name">
+    <%= link_to_if(
+      can?(:edit_content, page),
+      page.name,
+      alchemy.edit_admin_page_path(page),
+      title: Alchemy.t(:edit_page),
+    ) { content_tag(:span, page.name) } -%>
+  </td>
+  <td class="url">
+    <%= page.url_path %>
+  </td>
+  <td class="page_layout">
+    <%= Alchemy.t(page.page_layout, scope: "page_layout_names", default: page.page_layout.to_s.humanize) %>
+  </td>
+  <td class="tags">
+    <% page.tag_list.each do |tag| %>
+      <%= content_tag(:span, tag, class: "tag") %>
+    <% end %>
+  </td>
+  <td class="date">
+    <%= l(page.updated_at, format: :"alchemy.default") %>
+  </td>
+  <td class="status center">
+    <span class="page_status with-hint">
+      <i class="icon fas fa-fw fa-compass <% unless page.public? %>disabled<% end %>" data-fa-transform="shrink-2"></i>
+      <span class="hint-bubble"><%= page.status_title(:public) %></span>
+    </span>
+    <span class="page_status with-hint">
+      <i class="icon fas fa-fw fa-lock <% unless page.restricted? %>disabled<% end %>" data-fa-transform="shrink-2"></i>
+      <span class="hint-bubble"><%= page.status_title(:restricted) %></span>
+    </span>
+  </td>
+  <td class="tools">
+    <% if can?(:info, page) %>
+      <div class="button_with_label">
+        <%= link_to_dialog(
+          render_icon('info-circle'),
+          alchemy.info_admin_page_path(page),
+          {
+            title: Alchemy.t(:page_infos),
+            size: '520x290'
+          }
+        ) %>
+        <label class="center"><%= Alchemy.t(:page_infos) %></label>
+      </div>
+    <% end %>
+    <% if can?(:configure, page) %>
+      <div class="button_with_label sitemap_tool">
+        <%= link_to_dialog(
+          render_icon(:cog),
+          alchemy.configure_admin_page_path(page),
+          {
+            title: Alchemy.t(:edit_page_properties),
+            size: '450x680'
+          }
+        ) -%>
+        <label class="center"><%= Alchemy.t(:edit_page_properties) %></label>
+      </div>
+    <% end %>
+    <% if can?(:copy, page) %>
+      <div class="button_with_label sitemap_tool">
+        <%= link_to(
+          render_icon(:copy),
+          alchemy.insert_admin_clipboard_path(
+            remarkable_type: :pages,
+            remarkable_id: page.id,
+          ),
+          remote: true,
+          method: :post
+        ) %>
+        <label class="center"><%= Alchemy.t(:copy_page) %></label>
+      </div>
+    <% end %>
+    <% if can?(:destroy, page) %>
+      <div class="button_with_label">
+        <%= link_to_confirm_dialog(
+          render_icon(:minus),
+          Alchemy.t(:confirm_to_delete_page),
+          alchemy.admin_page_path(page)
+        ) -%>
+        <label class="center"><%= Alchemy.t(:delete_page) %></label>
+      </div>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/alchemy/admin/pages/_toolbar.html.erb
+++ b/app/views/alchemy/admin/pages/_toolbar.html.erb
@@ -1,0 +1,42 @@
+<div class="toolbar_buttons">
+  <%= render "alchemy/admin/partials/site_select" %>
+  <%= render "alchemy/admin/partials/language_tree_select" %>
+  <% if can?(:flush, Alchemy::Page) %>
+    <div class="button_with_label">
+      <%= link_to(
+        render_icon(:eraser),
+        alchemy.flush_admin_pages_path,
+        remote: true,
+        method: :post,
+        class: "icon_button please_wait",
+        title: Alchemy.t("Flush page cache")
+      ) %>
+      <label><%= Alchemy.t("Flush page cache") %></label>
+    </div>
+  <% end %>
+  <% if can?(:sort, Alchemy::Page) %>
+    <div class="button_with_label">
+      <%= link_to(
+        render_icon(:random),
+        alchemy.sort_admin_pages_path,
+        method: :get,
+        class: "icon_button",
+        title: Alchemy.t("Sort pages")
+      ) %>
+      <label><%= Alchemy.t("Sort pages") %></label>
+    </div>
+  <% end %>
+  <div class="button_with_label" id="clipboard_button">
+    <%= link_to_dialog(
+      render_icon(clipboard_empty?("pages") ? :clipboard : :paste),
+      alchemy.admin_clipboard_path(remarkable_type: "pages"),
+      {
+        title: Alchemy.t("Clipboard"),
+        size: "380x305"
+      },
+      class: "icon_button",
+      title: Alchemy.t("Show clipboard")
+    ) %>
+    <label><%= Alchemy.t("Show clipboard") %></label>
+  </div>
+</div>

--- a/app/views/alchemy/admin/pages/_toolbar.html.erb
+++ b/app/views/alchemy/admin/pages/_toolbar.html.erb
@@ -54,7 +54,7 @@
     <label><%= Alchemy.t("Show clipboard") %></label>
   </div>
   <div class="toolbar_spacer"></div>
-  <div class="button_with_label<%= params[:view] != "list" ? " active" : nil %>">
+  <div class="button_with_label<%= @view != "list" ? " active" : nil %>">
     <%= link_to(
       render_icon(:stream),
       alchemy.admin_pages_path(view: "tree"),
@@ -62,7 +62,7 @@
     ) %>
     <label><%= Alchemy.t("Hierarchical") %></label>
   </div>
-  <div class="button_with_label<%= params[:view] == "list" ? " active" : nil %>">
+  <div class="button_with_label<%= @view == "list" ? " active" : nil %>">
     <%= link_to(
       render_icon("sort-amount-down-alt"),
       alchemy.admin_pages_path(view: "list"),

--- a/app/views/alchemy/admin/pages/_toolbar.html.erb
+++ b/app/views/alchemy/admin/pages/_toolbar.html.erb
@@ -39,4 +39,25 @@
     ) %>
     <label><%= Alchemy.t("Show clipboard") %></label>
   </div>
+  <div class="toolbar_spacer"></div>
+  <div class="button_with_label<%= params[:view] != "list" ? " active" : nil %>">
+    <%= link_to(
+      render_icon(:stream),
+      alchemy.admin_pages_path(view: "tree"),
+      class: "icon_button"
+    ) %>
+    <label><%= Alchemy.t("Hierarchical") %></label>
+  </div>
+  <div class="button_with_label<%= params[:view] == "list" ? " active" : nil %>">
+    <%= link_to(
+      render_icon("sort-amount-down-alt"),
+      alchemy.admin_pages_path(view: "list"),
+      class: "icon_button"
+    ) %>
+    <label><%= Alchemy.t("Sortable List") %></label>
+  </div>
 </div>
+<% search_filter_params[:view] = "list" %>
+<%= render "alchemy/admin/partials/search_form",
+  url: alchemy.admin_pages_path(search_filter_params.except(:q, :page)),
+  additional_params: [:view, :page_layout, :tagged_with, :filter] %>

--- a/app/views/alchemy/admin/pages/_toolbar.html.erb
+++ b/app/views/alchemy/admin/pages/_toolbar.html.erb
@@ -1,6 +1,20 @@
 <div class="toolbar_buttons">
   <%= render "alchemy/admin/partials/site_select" %>
   <%= render "alchemy/admin/partials/language_tree_select" %>
+  <%= toolbar_button(
+    icon: :plus,
+    url: alchemy.new_admin_page_path(language: @current_language),
+    hotkey: 'alt+n',
+    dialog_options: {
+      title: Alchemy.t('Add a page'),
+      size: '340x215',
+      overflow: true
+    },
+    title: Alchemy.t('Add a page'),
+    label: Alchemy.t('Add a page'),
+    if_permitted_to: [:create, Alchemy::Page]
+  ) %>
+  <div class="toolbar_spacer"></div>
   <% if can?(:flush, Alchemy::Page) %>
     <div class="button_with_label">
       <%= link_to(

--- a/app/views/alchemy/admin/pages/index.html.erb
+++ b/app/views/alchemy/admin/pages/index.html.erb
@@ -3,63 +3,22 @@
 <% end %>
 
 <% content_for :toolbar do %>
-<div class="toolbar_buttons">
-  <%= render 'alchemy/admin/partials/site_select' %>
-  <%= render 'alchemy/admin/partials/language_tree_select' %>
-  <% if can?(:flush, Alchemy::Page) %>
-  <div class="button_with_label">
-    <%= link_to(
-      render_icon(:eraser),
-      alchemy.flush_admin_pages_path,
-      :remote => true,
-      :method => :post,
-      :class => 'icon_button please_wait',
-      :title => Alchemy.t('Flush page cache')
-    ) %>
-    <label><%= Alchemy.t('Flush page cache') %></label>
+  <%= render "alchemy/admin/pages/toolbar" %>
+  <div class="search_form">
+    <div class="search_field">
+      <label>
+        <%= text_field_tag 'filter', '',
+          class: 'search_input_field',
+          placeholder: Alchemy.t(:search),
+          id: nil %>
+        <%= render_icon :search %>
+      </label>
+      <%= link_to(render_icon(:times, size: 'xs'), '#', {
+        class: "search_field_clear",
+        title: Alchemy.t(:click_to_show_all)
+      }) %>
+    </div>
   </div>
-  <% end %>
-  <% if can?(:sort, Alchemy::Page) %>
-  <div class="button_with_label">
-    <%= link_to(
-      render_icon(:random),
-      alchemy.sort_admin_pages_path,
-      method: :get,
-      class: 'icon_button',
-      title: Alchemy.t('Sort pages')
-    ) %>
-    <label><%= Alchemy.t('Sort pages') %></label>
-  </div>
-  <% end %>
-  <div class="button_with_label" id="clipboard_button">
-    <%= link_to_dialog(
-      render_icon(clipboard_empty?('pages') ? :clipboard : :paste),
-      alchemy.admin_clipboard_path(:remarkable_type => 'pages'),
-      {
-        :title => Alchemy.t('Clipboard'),
-        :size => '380x305'
-      },
-      :class => 'icon_button',
-      :title => Alchemy.t('Show clipboard')
-    ) %>
-    <label><%= Alchemy.t('Show clipboard') %></label>
-  </div>
-</div>
-<div class="search_form">
-  <div class="search_field">
-    <label>
-      <%= text_field_tag 'filter', '',
-        class: 'search_input_field',
-        placeholder: Alchemy.t(:search),
-        id: nil %>
-      <%= render_icon :search %>
-    </label>
-    <%= link_to(render_icon(:times, size: 'xs'), '#', {
-      class: "search_field_clear",
-      title: Alchemy.t(:click_to_show_all)
-    }) %>
-  </div>
-</div>
 <% end %>
 
 <div id="archive_all">

--- a/app/views/alchemy/admin/pages/index.html.erb
+++ b/app/views/alchemy/admin/pages/index.html.erb
@@ -8,8 +8,8 @@
 
 <%= content_tag :div,
   id: "archive_all",
-  class: [params[:view] == "list" && "resources-table-wrapper with_tag_filter"] do %>
-  <% if params[:view] == "list" %>
+  class: [@view == "list" && "resources-table-wrapper with_tag_filter"] do %>
+  <% if @view == "list" %>
     <%= render "alchemy/admin/resources/table_header", resources_instance_variable: @pages %>
     <% if @pages.any? %>
       <%= render "table" %>

--- a/app/views/alchemy/admin/pages/index.html.erb
+++ b/app/views/alchemy/admin/pages/index.html.erb
@@ -4,39 +4,47 @@
 
 <% content_for :toolbar do %>
   <%= render "alchemy/admin/pages/toolbar" %>
-  <div class="search_form">
-    <div class="search_field">
-      <label>
-        <%= text_field_tag 'filter', '',
-          class: 'search_input_field',
-          placeholder: Alchemy.t(:search),
-          id: nil %>
-        <%= render_icon :search %>
-      </label>
-      <%= link_to(render_icon(:times, size: 'xs'), '#', {
-        class: "search_field_clear",
-        title: Alchemy.t(:click_to_show_all)
-      }) %>
+<% end %>
+
+<%= content_tag :div,
+  id: "archive_all",
+  class: [params[:view] == "list" && "resources-table-wrapper with_tag_filter"] do %>
+  <% if params[:view] == "list" %>
+    <%= render "alchemy/admin/resources/table_header", resources_instance_variable: @pages %>
+    <% if @pages.any? %>
+      <%= render "table" %>
+    <% elsif search_filter_params.present? %>
+      <%= render_message do %>
+        <%= Alchemy.t("No pages found") %>
+      <% end %>
+    <% elsif can?(:create, Alchemy::Page) %>
+      <%= render partial: "create_language_form" %>
+    <% end %>
+
+    <%= paginate @pages, scope: alchemy, theme: "alchemy" %>
+
+    <div id="library_sidebar">
+      <%= render "page_layout_filter" %>
+
+      <%= render "filter_bar",
+        label: Alchemy::Page.human_attribute_name(:status),
+        url: alchemy.admin_pages_path(search_filter_params.except(:filter, :page).merge(view: "list")) %>
+
+      <% if resource_has_tags %>
+        <%= render "tag_list" %>
+      <% end %>
     </div>
-  </div>
-<% end %>
-
-<div id="archive_all">
-<% if @page_root %>
-  <h2 id="page_filter_result"></h2>
-
-  <%= render 'sitemap', page_partial: 'page', full: !!@sorting %>
-
-<% elsif can?(:create, Alchemy::Page) %>
-
-  <%= render partial: 'create_language_form' %>
-
-<% else %>
-
-  <%= render_message :warn do %>
-    <h2>No language root page found.</h2>
-    <p>Please ask the admin to create one.</p>
+  <% else %>
+    <% if @page_root %>
+      <h2 id="page_filter_result"></h2>
+      <%= render "sitemap", page_partial: "page", full: !!@sorting %>
+    <% elsif can?(:create, Alchemy::Page) %>
+      <%= render partial: "create_language_form" %>
+    <% else %>
+      <%= render_message :warn do %>
+        <h2>No language root page found.</h2>
+        <p>Please ask the admin to create one.</p>
+      <% end %>
+    <% end %>
   <% end %>
-
 <% end %>
-</div>

--- a/app/views/alchemy/admin/pages/list/_table.html.erb
+++ b/app/views/alchemy/admin/pages/list/_table.html.erb
@@ -1,0 +1,27 @@
+<% if @pages.any? %>
+  <table class="list">
+    <thead>
+      <tr>
+        <th class="icon"></th>
+        <th class="string name">
+          <%= sort_link [:alchemy, @query],
+            "name",
+            Alchemy::Page.human_attribute_name(:name),
+            default_order: "asc" %>
+        </th>
+        <th><%= Alchemy::Page.human_attribute_name(:urlname) %></th>
+        <th><%= Alchemy::Page.human_attribute_name(:page_type) %></th>
+        <th><%= Alchemy::Page.human_attribute_name(:tag_list) %></th>
+        <th class="status center"><%= Alchemy::Page.human_attribute_name(:status) %></th>
+        <th class="tools"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <%= render partial: "page", collection: @pages %>
+    </tbody>
+  </table>
+<% elsif search_filter_params[:q].present? %>
+  <p><%= Alchemy.t('Nothing found') %></p>
+<% end %>
+
+<%= paginate @pages, scope: alchemy, theme: 'alchemy' %>

--- a/app/views/alchemy/admin/pages/list/_table.html.erb
+++ b/app/views/alchemy/admin/pages/list/_table.html.erb
@@ -20,8 +20,12 @@
       <%= render partial: "page", collection: @pages %>
     </tbody>
   </table>
-<% elsif search_filter_params[:q].present? %>
-  <p><%= Alchemy.t('Nothing found') %></p>
+<% elsif search_filter_params.present? %>
+  <%= render_message do %>
+    <%= Alchemy.t('No pages found') %>
+  <% end %>
+<% else %>
+  <%= render partial: 'alchemy/admin/pages/create_language_form' %>
 <% end %>
 
 <%= paginate @pages, scope: alchemy, theme: 'alchemy' %>

--- a/app/views/alchemy/admin/pages/unlock.js.erb
+++ b/app/views/alchemy/admin/pages/unlock.js.erb
@@ -2,12 +2,12 @@
   var locked_page_tab = document.querySelector('#locked_page_<%= @page.id -%>')
   var locked_page_icon = document.querySelector(
     '#page_<%= @page.id -%> > .sitemap_page > .sitemap_left_images .with-hint'
-  )
+  ) || document.querySelector('[data-page-id="<%= @page.id -%>"] > .icon')
   if (locked_page_tab) {
     locked_page_tab.remove()
   }
   if (locked_page_icon) {
-    locked_page_icon.innerHTML = '<%= j render_icon(:file, style: 'regular', size: 'lg') %>'
+    locked_page_icon.innerHTML = '<i class="icon far fa-file fa-lg"></i>'
   }
   Alchemy.growl('<%= flash[:notice] -%>')
 })()

--- a/app/views/alchemy/admin/pages/update.js.erb
+++ b/app/views/alchemy/admin/pages/update.js.erb
@@ -1,5 +1,5 @@
 (function() {
-  var $page;
+  var page = document.querySelector('#page_<%= @page.id %>');
 
 <% if @old_page_layout != @page.page_layout -%>
   Alchemy.ElementsWindow.reload();
@@ -9,18 +9,27 @@
 <% if @while_page_edit -%>
 
   Alchemy.reloadPreview();
-  $('#page_<%= @page.id %>_status').replaceWith('<%= j render("current_page", current_page: @page) %>');
+  document.querySelector('#page_<%= @page.id %>_status').outerHTML = '<%= j render("current_page", current_page: @page) %>';
+  Alchemy.growl("<%= j @notice %>");
+  Alchemy.closeCurrentDialog();
 
 <% else -%>
 
-  var page_html = "<%= j render('page', page: @page) %>";
-  var compiler = Handlebars.compile(page_html);
-  var tree = <%== @tree.to_json %>;
-  var html = compiler(tree.pages[0]);
-  $('#page_<%= @page.id %>').replaceWith(html);
+  if (page) {
+    var page_html = "<%= j render('page', page: @page) %>";
+    var compiler = Handlebars.compile(page_html);
+    var tree = <%== @tree.to_json %>;
+    page.outerHTML = compiler(tree.pages[0]);
+    Alchemy.growl("<%= j @notice %>");
+    Alchemy.closeCurrentDialog();
+  } else {
+    document.addEventListener('turbolinks:load', function () {
+      Alchemy.growl("<%= j @notice %>");
+    }, { once: true })
+    Alchemy.closeCurrentDialog(function() {
+      Turbolinks.visit(location.toString(), { action: "replace" });
+    });
+  }
 
 <% end -%>
-
-  Alchemy.growl("<%= j @notice %>");
-  Alchemy.closeCurrentDialog();
 })()

--- a/app/views/alchemy/admin/resources/_filter_bar.html.erb
+++ b/app/views/alchemy/admin/resources/_filter_bar.html.erb
@@ -1,6 +1,6 @@
 <div id="filter_bar">
   <label>
-    <h3><%= Alchemy.t('Filter') %></h3>
+    <h3><%= local_assigns[:label] || Alchemy.t('Filter') %></h3>
     <%= select_tag(
       'resource_filter',
       options_for_select(

--- a/app/views/alchemy/admin/resources/_filter_bar.html.erb
+++ b/app/views/alchemy/admin/resources/_filter_bar.html.erb
@@ -1,14 +1,16 @@
 <div id="filter_bar">
-  <h3><%= Alchemy.t('Filter') %></h3>
-  <%= select_tag(
-    'resource_filter',
-    options_for_select(
-      resource_filter_select, search_filter_params[:filter]
-    ),
-    include_blank: Alchemy.t(:all, scope: ['resources', resource_name, 'filters']),
-    data: { remote: !!request.xhr? },
-    class: 'alchemy_selectbox'
-  ) %>
+  <label>
+    <h3><%= Alchemy.t('Filter') %></h3>
+    <%= select_tag(
+      'resource_filter',
+      options_for_select(
+        resource_filter_select, search_filter_params[:filter]
+      ),
+      include_blank: Alchemy.t(:all, scope: ['resources', resource_name, 'filters']),
+      data: { remote: !!request.xhr? },
+      class: 'alchemy_selectbox'
+    ) %>
+  </label>
 </div>
 
 <script type="text/javascript">

--- a/app/views/alchemy/admin/resources/_filter_bar.html.erb
+++ b/app/views/alchemy/admin/resources/_filter_bar.html.erb
@@ -15,7 +15,7 @@
   $(function() {
     $('#resource_filter').on('change', function(e) {
       var $this = $(this);
-      var url = '<%= resources_path(resource_handler.namespaced_resources_name, search_filter_params.except(:filter).to_h) %>';
+      var url = '<%= local_assigns[:url] || resources_path(resource_handler.namespaced_resources_name, search_filter_params.except(:filter).to_h) %>';
       if ($this.data('remote') === true) {
         $.get(url, {filter: $this.val()}, null, 'script');
       } else {

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -172,6 +172,7 @@ en:
     attribute_fixed: Value can't be changed for this page type
     back: 'back'
     locked_pages: "Active pages"
+    "Add a page": "Add a page"
     "Add global page": "Add global page"
     "Add page link": "Add page link"
     "Alchemy is open software and itself uses open software and free resources:": "Alchemy is open software and itself uses open software and free resources:"

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -171,7 +171,6 @@ en:
     anchor_link_headline: "You can link to an element anchor from the actual page."
     attribute_fixed: Value can't be changed for this page type
     back: 'back'
-    create_tree_as_new_language: "Create %{language} as a new language tree"
     locked_pages: "Active pages"
     "Add global page": "Add global page"
     "Add page link": "Add page link"
@@ -339,13 +338,13 @@ en:
     copy_element: "Copy this element"
     copy_page: "Copy page"
     "Could not delete Pictures": "Could not delete Pictures"
-    copy_language_tree_heading: "Copy page tree"
+    copy_language_tree_heading: "Copy pages"
     country_code_placeholder: 'i.e. US (optional)'
     country_code_foot_note: "You only need to set a country code if you want to support multiple countries with the same language."
     create: "create"
     "Create language": "Create a new language"
     "Create site": "Create a new site"
-    create_language_tree_heading: "Create empty language tree"
+    create_language_tree_heading: "Create new homepage"
     create_menu: "Add a menu"
     create_node: "Add a menu node"
     create_page: "Create a new subpage"
@@ -402,6 +401,7 @@ en:
         "Open upload form": "Open upload form"
         "Select all pictures": "Select all pictures"
     hide_element_content: "Hide this elements content."
+    homepage_does_not_exist: "This language has no homepage yet"
     dashboard: "Dashboard"
     image_alt_tag: "Alt-tag"
     image_caption: "Caption"
@@ -415,7 +415,6 @@ en:
     javascript_disabled_headline: "Javascript is disabled!"
     javascript_disabled_text: "Alchemy needs Javascript to run smoothly. Please enable it in your browser settings."
     language_code_placeholder: 'i.e. en'
-    language_does_not_exist: "This language tree does not exist"
     language_pages_copied: "Language tree successfully copied."
     last_upload_only: "Last upload only"
     left: "left"

--- a/lib/alchemy/permissions.rb
+++ b/lib/alchemy/permissions.rb
@@ -220,6 +220,7 @@ module Alchemy
         :update,
         :unlock,
         :visit,
+        :tree,
         to: :edit_content
     end
 

--- a/spec/controllers/alchemy/admin/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/pages_controller_spec.rb
@@ -9,6 +9,43 @@ RSpec.describe Alchemy::Admin::PagesController do
     authorize_user(:as_admin)
   end
 
+  describe "#index" do
+    let!(:page) { create(:alchemy_page) }
+
+    context "with params[:view] set" do
+      subject! { get(:index, params: { view: "list" }) }
+
+      it "sets view to that value" do
+        expect(session[:alchemy_pages_view]).to eq("list")
+        expect(assigns[:view]).to eq("list")
+      end
+    end
+
+    context "with params[:view] not set" do
+      subject { get(:index) }
+
+      context "with session[:view] not set" do
+        it "uses tree view" do
+          subject
+          expect(session[:alchemy_pages_view]).to eq("tree")
+          expect(assigns[:view]).to eq("tree")
+        end
+      end
+
+      context "with session[:view] set" do
+        before do
+          session[:alchemy_pages_view] = "list"
+        end
+
+        it "uses the view from session" do
+          subject
+          expect(session[:alchemy_pages_view]).to eq("list")
+          expect(assigns[:view]).to eq("list")
+        end
+      end
+    end
+  end
+
   describe "#publish" do
     let(:page) { create(:alchemy_page) }
 

--- a/spec/features/admin/language_tree_feature_spec.rb
+++ b/spec/features/admin/language_tree_feature_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "Language tree feature", type: :system, js: true do
     it "displays a form for creating language root with preselected page layout and front page name" do
       visit("/admin/pages")
       select2 "Klingon", from: "Language tree"
-      expect(page).to have_content("This language tree does not exist")
+      expect(page).to have_content("This language has no homepage yet")
 
       within("form#create_language_tree") do
         expect(page).to \

--- a/spec/features/admin/page_creation_feature_spec.rb
+++ b/spec/features/admin/page_creation_feature_spec.rb
@@ -5,6 +5,24 @@ require "rails_helper"
 RSpec.describe "Page creation", type: :system do
   before { authorize_user(:as_admin) }
 
+  describe "parent selection" do
+    let!(:homepage) { create(:alchemy_page, :language_root) }
+
+    context "without having a parent id in the params" do
+      it "contains a parent select" do
+        visit new_admin_page_path
+        expect(page).to have_select("Parent", selected: homepage.name)
+      end
+    end
+
+    context "with having a parent id in the params" do
+      it "contains a hidden parent_id field" do
+        visit new_admin_page_path(parent_id: homepage)
+        expect(page).to have_field("page_parent_id", type: "hidden")
+      end
+    end
+  end
+
   describe "overlay GUI" do
     context "without having a Page in the clipboard" do
       it "does not contain tabs" do

--- a/spec/features/admin/page_list_feature_spec.rb
+++ b/spec/features/admin/page_list_feature_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "timecop"
+
+RSpec.describe "Admin page list", type: :system do
+  context "not logged in" do
+    specify "it redirects to login" do
+      visit admin_pages_path(view: "list")
+      expect(page.current_path).to eq(Alchemy.login_path)
+    end
+  end
+
+  context "as author" do
+    let!(:alchemy_page) { create(:alchemy_page, name: "Page 1").tap { |p| p.update!(updated_at: Time.parse("2020-08-20")) } }
+    let!(:alchemy_page_2) { create(:alchemy_page, name: "Contact", page_layout: "contact").tap { |p| p.update(updated_at: Time.parse("2020-08-24")) } }
+    let!(:alchemy_page_3) { create(:alchemy_page, :layoutpage, name: "Footer") }
+
+    before do
+      authorize_user(:as_author)
+    end
+
+    specify "displays a table of non layout pages" do
+      visit admin_pages_path(view: "list")
+      within("table.list") do
+        expect(page).to have_css("tr:nth-child(1) td.name:contains('Contact')")
+        expect(page).to have_css("tr:nth-child(2) td.name:contains('Intro')")
+        expect(page).to have_css("tr:nth-child(3) td.name:contains('Page 1')")
+        expect(page).to_not have_css("td.name:contains('Footer')")
+      end
+    end
+
+    specify "can sort table of pages by name" do
+      visit admin_pages_path(view: "list")
+      page.find(".sort_link", text: "Name").click
+      within("table.list") do
+        expect(page).to have_css("tr:nth-child(1) td.name:contains('Page 1')")
+        expect(page).to have_css("tr:nth-child(2) td.name:contains('Intro')")
+        expect(page).to have_css("tr:nth-child(3) td.name:contains('Contact')")
+      end
+    end
+
+    specify "can sort table of pages by update date" do
+      Timecop.travel("2020-08-25") do
+        visit admin_pages_path(view: "list")
+        page.find(".sort_link", text: "Updated at").click
+        within("table.list") do
+          expect(page).to have_css("tr:nth-child(1) td.name:contains('Intro')")
+          expect(page).to have_css("tr:nth-child(2) td.name:contains('Contact')")
+          expect(page).to have_css("tr:nth-child(3) td.name:contains('Page 1')")
+        end
+      end
+    end
+
+    specify "can filter table of pages by name" do
+      visit admin_pages_path(view: "list")
+      page.find(".search_input_field").set("Page")
+      page.find(".search_field button").click
+      within("table.list") do
+        expect(page).to have_css("tr:nth-child(1) td.name:contains('Page 1')")
+        expect(page).to_not have_css("tr:nth-child(2)")
+        expect(page).to_not have_css("tr:nth-child(3)")
+      end
+    end
+
+    specify "can filter table of pages by status", :js do
+      visit admin_pages_path(view: "list")
+      select2("Published", from: "Status")
+      within("table.list") do
+        expect(page.find("tr:nth-child(1) td.name", text: "Intro")).to be
+        expect(page).to_not have_css("tr:nth-child(2)")
+        expect(page).to_not have_css("tr:nth-child(3)")
+      end
+    end
+
+    specify "can filter table of pages by type", :js do
+      visit admin_pages_path(view: "list")
+      select2("Contact", from: "Page type")
+      within("table.list") do
+        expect(page.find("tr:nth-child(1) td.name", text: "Contact")).to be
+        expect(page).to_not have_css("tr:nth-child(2)")
+        expect(page).to_not have_css("tr:nth-child(3)")
+      end
+    end
+  end
+end

--- a/spec/models/alchemy/site_spec.rb
+++ b/spec/models/alchemy/site_spec.rb
@@ -174,6 +174,181 @@ module Alchemy
       end
     end
 
+    describe "#page_layout_names" do
+      before do
+        Alchemy::PageLayout.instance_variable_set(:@definitions, nil)
+      end
+
+      context "if site has a layout definition file" do
+        let(:site) { Site.new(name: "My custom site") }
+        let(:definitions) { [{ "name" => "my_custom_site", "page_layouts" => %w[standard footer] }] }
+
+        before do
+          allow(Site).to receive(:definitions).and_return(definitions)
+        end
+
+        it "returns all non 'layoutpage' page layout names" do
+          expect(site.page_layout_names).to eq(%w[standard])
+        end
+
+        context "when layoutpages are requested" do
+          it "returns all 'layoutpage' page layout names" do
+            expect(site.page_layout_names(layoutpages: true)).to eq(%w[footer])
+          end
+        end
+      end
+
+      context "if site has no layout definition file" do
+        let(:site) { Site.new(name: "My custom site") }
+
+        it "returns all non 'layoutpage' page layout names" do
+          allow(Site).to receive(:definitions).and_return([])
+          expect(site.page_layout_names).to eq(%w[index readonly standard everything news contact erb_layout])
+        end
+
+        context "when layoutpages are requested" do
+          it "returns all 'layoutpage' page layout names" do
+            allow(Site).to receive(:definitions).and_return([])
+            expect(site.page_layout_names(layoutpages: true)).to eq(%w[footer])
+          end
+        end
+      end
+    end
+
+    describe "#page_layout_definitions" do
+      before do
+        Alchemy::PageLayout.instance_variable_set(:@definitions, nil)
+      end
+
+      context "if site has a layout definition file" do
+        let(:site) { Site.new(name: "My custom site") }
+        let(:definitions) { [{ "name" => "my_custom_site", "page_layouts" => %w[standard] }] }
+
+        it "returns page layouts defined" do
+          allow(Site).to receive(:definitions).and_return(definitions)
+          expect(site.page_layout_definitions).to eq(
+            [
+              {
+                "name" => "standard",
+                "autogenerate" => [
+                  "header",
+                  "article",
+                  "download",
+                ],
+                "elements" => [
+                  "article",
+                  "header",
+                  "slider",
+                  "download",
+                ],
+              },
+            ]
+          )
+        end
+      end
+
+      context "if site has no layout definition file" do
+        let(:site) { Site.new(name: "My custom site") }
+
+        it "returns all page layout definitions" do
+          allow(Site).to receive(:definitions).and_return([])
+          expect(site.page_layout_definitions).to eq(
+            [
+              {
+                "name" => "index",
+                "unique" => true,
+              },
+              {
+                "name" => "readonly",
+                "fixed_attributes" => {
+                  "meta_description" => nil,
+                  "meta_keywords" => nil,
+                  "name" => false,
+                  "page_layout" => "readonly",
+                  "public_on" => nil,
+                  "public_until" => nil,
+                  "restricted" => false,
+                  "robot_follow" => false,
+                  "robot_index" => false,
+                  "title" => false,
+                  "urlname" => false,
+                },
+              },
+              {
+                "name" => "standard",
+                "autogenerate" => [
+                  "header",
+                  "article",
+                  "download",
+                ],
+                "elements" => [
+                  "article",
+                  "header",
+                  "slider",
+                  "download",
+                ],
+              },
+              {
+                "name" => "everything",
+                "autogenerate" => [
+                  "all_you_can_eat",
+                  "right_column",
+                  "left_column",
+                ],
+                "elements" => [
+                  "text",
+                  "all_you_can_eat",
+                  "gallery",
+                  "right_column",
+                  "left_column",
+                ],
+              },
+              {
+                "name" => "news",
+                "autogenerate" => [
+                  "news",
+                ],
+                "elements" => [
+                  "headline",
+                  "news",
+                ],
+                "feed" => true,
+                "feed_elements" => ["news"],
+                "insert_elements_at" => "top",
+                "unique" => true,
+              },
+              {
+                "name" => "contact",
+                "unique" => true,
+                "autogenerate" => [
+                  "headline",
+                  "text",
+                  "contactform",
+                ],
+                "cache" => false,
+                "elements" => [
+                  "headline",
+                  "text",
+                  "contactform",
+                ],
+              },
+              {
+                "name" => "footer",
+                "elements" => [
+                  "menu",
+                ],
+                "layoutpage" => true,
+              },
+              {
+                "name" => "erb_layout",
+                "unique" => true,
+              },
+            ]
+          )
+        end
+      end
+    end
+
     describe "#default_language" do
       let!(:default_language) do
         create(:alchemy_language, default: true, site: site)


### PR DESCRIPTION
## What is this pull request for?

Adds a second view to the pages admin: A list view. This view is a normal Alchemy resources view with all the filtering, pagination and sorting goodies we gain from it. This helps managing large sets of pages in a very efficient manner.

You can switch the views via a toolbar button. It also automatically switches to that view if you submit the search form on the page tree view.

### Screenshots

![Screen Shot 2020-07-22 at 11 12 32](https://user-images.githubusercontent.com/42868/88158379-4525cb00-cc0c-11ea-92c0-84286eadb3a3.png)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
