### PR TITLE
Remove toolbar helper

### DIFF
--- a/app/helpers/alchemy/admin/base_helper.rb
+++ b/app/helpers/alchemy/admin/base_helper.rb
@@ -272,50 +272,6 @@ module Alchemy
         end
       end
 
-      # Renders the toolbar shown on top of the records.
-      #
-      # == Example
-      #
-      #   <% label_title = Alchemy.t("Create #{resource_name}", default: Alchemy.t('Create')) %>
-      #   <% toolbar(
-      #     buttons: [
-      #       {
-      #         icon: :plus,
-      #         label: label_title,
-      #         url: new_resource_path,
-      #         title: label_title,
-      #         hotkey: 'alt+n',
-      #         dialog_options: {
-      #           title: label_title,
-      #           size: "430x400"
-      #         },
-      #         if_permitted_to: [:create, resource_model]
-      #       }
-      #     ]
-      #   ) %>
-      #
-      # @option options [Array] :buttons ([])
-      #   Pass an Array with button options. They will be passed to {#toolbar_button} helper.
-      # @option options [Boolean] :search (true)
-      #   Show searchfield.
-      #
-      def toolbar(options = {})
-        defaults = {
-          buttons: [],
-          search: true,
-        }
-        options = defaults.merge(options)
-        content_for(:toolbar) do
-          content = <<-CONTENT.strip_heredoc
-            #{options[:buttons].map { |button_options| toolbar_button(button_options) }.join}
-            #{render("alchemy/admin/partials/search_form", url: options[:search_url]) if options[:search]}
-          CONTENT
-          content.html_safe
-        end
-      end
-
-      deprecate toolbar: "Please use `content_for(:toolbar)` instead", deprecator: Alchemy::Deprecation
-
       # (internal) Used by upload form
       def new_asset_path_with_session_information(asset_type)
         session_key = Rails.application.config.session_options[:key]

--- a/app/views/alchemy/admin/dashboard/index.html.erb
+++ b/app/views/alchemy/admin/dashboard/index.html.erb
@@ -1,20 +1,17 @@
-<%= toolbar(
-  buttons: [
-    {
-      icon: 'info-circle',
-      label: Alchemy.t(:info),
-      url: alchemy.dashboard_info_path,
+<%= content_for :toolbar do %>
+  <%= toolbar_button(
+    icon: 'info-circle',
+    label: Alchemy.t(:info),
+    url: alchemy.dashboard_info_path,
+    title: Alchemy.t(:info),
+    dialog_options: {
       title: Alchemy.t(:info),
-      dialog_options: {
-        title: Alchemy.t(:info),
-        size: "420x435"
-      },
-      if_permitted_to: [:info, :alchemy_admin_dashboard],
-      hotkey: 'alt+i'
-    }
-  ],
-  search: false
-) %>
+      size: "420x435"
+    },
+    if_permitted_to: [:info, :alchemy_admin_dashboard],
+    hotkey: 'alt+i'
+  ) %>
+<% end %>
 
 <div id="dashboard">
   <h1>

--- a/app/views/alchemy/admin/tags/index.html.erb
+++ b/app/views/alchemy/admin/tags/index.html.erb
@@ -1,19 +1,18 @@
-<%= toolbar(
-  buttons: [
-    {
-      icon: :plus,
-      label: Alchemy.t('New Tag'),
-      url: alchemy.new_admin_tag_path,
+<% content_for :toolbar do %>
+  <%= toolbar_button(
+    icon: :plus,
+    label: Alchemy.t('New Tag'),
+    url: alchemy.new_admin_tag_path,
+    title: Alchemy.t('New Tag'),
+    hotkey: 'alt+n',
+    dialog_options: {
       title: Alchemy.t('New Tag'),
-      hotkey: 'alt+n',
-      dialog_options: {
-        title: Alchemy.t('New Tag'),
-        size: '310x180'
-      },
-      if_permitted_to: [:create, Alchemy::Tag]
-    }
-  ]
-) %>
+      size: '310x180'
+    },
+    if_permitted_to: [:create, Alchemy::Tag]
+  ) %>
+  <%= render 'alchemy/admin/partials/search_form' %>
+<% end %>
 
 <div id="archive_all" class="resources-table-wrapper">
   <%= render 'alchemy/admin/resources/table_header' %>

--- a/app/views/alchemy/base/500.html.erb
+++ b/app/views/alchemy/base/500.html.erb
@@ -1,16 +1,14 @@
-<%= toolbar(
-  buttons: [
-    {
-      icon: 'angle-double-left',
-      url: request.referer || alchemy.admin_dashboard_path,
-      label: Alchemy.t(:back),
-      title: Alchemy.t(:back),
-      hotkey: 'alt+z',
-      dialog: false,
-      skip_permission_check: true
-    }
-  ], search: false
-) %>
+<%= content_for :toolbar do %>
+  <%= toolbar_button(
+    icon: 'angle-double-left',
+    url: request.referer || alchemy.admin_dashboard_path,
+    label: Alchemy.t(:back),
+    title: Alchemy.t(:back),
+    hotkey: 'alt+z',
+    dialog: false,
+    skip_permission_check: true
+  ) %>
+<% end %>
 
 <% content_for(:alchemy_body_class) { 'error' } %>
 


### PR DESCRIPTION
Includes #1908 

## What is this pull request for?

Removes the deprecated `toolbar` helper. You are supposed to use `content_for(:toolbar)` and the `toolbar_button` helper instead.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
