### PR TITLE
Remove deprecated Attachment#urlname

### DIFF
--- a/app/models/alchemy/attachment.rb
+++ b/app/models/alchemy/attachment.rb
@@ -101,9 +101,6 @@ module Alchemy
       CGI.escape(file_name.gsub(/\.#{extension}$/, "").tr(".", " "))
     end
 
-    alias_method :urlname, :slug
-    deprecate urlname: :slug, deprecator: Alchemy::Deprecation
-
     # Checks if the attachment is restricted, because it is attached on restricted pages only
     def restricted?
       pages.any? && pages.not_restricted.blank?

--- a/spec/models/alchemy/attachment_spec.rb
+++ b/spec/models/alchemy/attachment_spec.rb
@@ -76,11 +76,11 @@ module Alchemy
 
           context "with extra params given" do
             subject do
-              attachment.url(download: true, name: attachment.urlname, format: attachment.suffix)
+              attachment.url(download: true, name: attachment.slug, format: attachment.suffix)
             end
 
             it "returns local download path with name and suffix" do
-              is_expected.to eq "/attachment/#{attachment.id}/download/#{attachment.urlname}.#{attachment.suffix}"
+              is_expected.to eq "/attachment/#{attachment.id}/download/#{attachment.slug}.#{attachment.suffix}"
             end
           end
         end
@@ -94,11 +94,11 @@ module Alchemy
 
           context "with extra params given" do
             subject do
-              attachment.url(download: false, name: attachment.urlname, format: attachment.suffix)
+              attachment.url(download: false, name: attachment.slug, format: attachment.suffix)
             end
 
             it "returns local path with name and suffix" do
-              is_expected.to eq "/attachment/#{attachment.id}/show/#{attachment.urlname}.#{attachment.suffix}"
+              is_expected.to eq "/attachment/#{attachment.id}/show/#{attachment.slug}.#{attachment.suffix}"
             end
           end
         end


### PR DESCRIPTION
## What is this pull request for?

Remove deprecated `Attachment#urlname`
Please use `slug` instead.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
