### PR TITLE
Allow to set a custom Page::UrlPath class

### DIFF
--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -149,6 +149,21 @@ module Alchemy
     # Class methods
     #
     class << self
+      # The url_path class
+      # @see Alchemy::Page::UrlPath
+      def url_path_class
+        @_url_path_class ||= Alchemy::Page::UrlPath
+      end
+
+      # Set a custom url path class
+      #
+      #     # config/initializers/alchemy.rb
+      #     Alchemy::Page.url_path_class = MyPageUrlPathClass
+      #
+      def url_path_class=(klass)
+        @_url_path_class = klass
+      end
+
       # Used to store the current page previewed in the edit page template.
       #
       def current_preview=(page)
@@ -298,7 +313,7 @@ module Alchemy
     #
     # @see Alchemy::Page::UrlPath#call
     def url_path
-      Alchemy::Page::UrlPath.new(self).call
+      self.class.url_path_class.new(self).call
     end
 
     # The page's view partial is dependent from its page layout

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -266,6 +266,24 @@ module Alchemy
 
     # ClassMethods (a-z)
 
+    describe ".url_path_class" do
+      subject { described_class.url_path_class }
+
+      it { is_expected.to eq(Alchemy::Page::UrlPath) }
+
+      context "if set to another url path class" do
+        class AnotherUrlPathClass; end
+
+        before do
+          described_class.url_path_class = AnotherUrlPathClass
+        end
+
+        it { is_expected.to eq(AnotherUrlPathClass) }
+
+        after { described_class.instance_variable_set(:@_url_path_class, nil) }
+      end
+    end
+
     describe ".all_from_clipboard_for_select" do
       context "with clipboard holding pages having non unique page layout" do
         it "should return the pages" do


### PR DESCRIPTION
## What is this pull request for?

Allow to set a custom `Page#url_path` class to for instance add a custom mount point.

Closes #1918

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
