### PR TITLE
Add support for custom mount points in Page::UrlPath

### DIFF
--- a/app/models/alchemy/page/url_path.rb
+++ b/app/models/alchemy/page/url_path.rb
@@ -20,8 +20,6 @@ module Alchemy
     #     link_to page.url
     #
     class UrlPath
-      ROOT_PATH = "/"
-
       def initialize(page)
         @page = page
         @language = @page.language
@@ -41,7 +39,7 @@ module Alchemy
       private
 
       def language_root_path
-        @language.default? ? ROOT_PATH : language_path
+        @language.default? ? root_path : language_path
       end
 
       def page_path_with_language_prefix
@@ -49,15 +47,19 @@ module Alchemy
       end
 
       def page_path_with_leading_slash
-        @page.language_root? ? ROOT_PATH : page_path
+        @page.language_root? ? root_path : page_path
       end
 
       def language_path
-        "/#{@page.language_code}"
+        "#{root_path}#{@page.language_code}"
       end
 
       def page_path
-        "/#{@page.urlname}"
+        "#{root_path}#{@page.urlname}"
+      end
+
+      def root_path
+        Engine.routes.url_helpers.root_path
       end
     end
   end

--- a/spec/models/alchemy/page/url_path_spec.rb
+++ b/spec/models/alchemy/page/url_path_spec.rb
@@ -65,4 +65,20 @@ RSpec.describe Alchemy::Page::UrlPath do
       end
     end
   end
+
+  context "mounted on a non-root path" do
+    let(:page) do
+      create(:alchemy_page)
+    end
+
+    before do
+      expect(Alchemy::Engine.routes).to receive(:url_helpers) do
+        double(root_path: "/pages/")
+      end
+    end
+
+    it "prefixes the path" do
+      is_expected.to eq("/pages/#{page.urlname}")
+    end
+  end
 end


### PR DESCRIPTION
## What is this pull request for?

If an app mounts Alchemy at a non-root path we need to return that as prefix.

Closes #1918

Remove if no visual changes have been made.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
