### PR TITLE
Use Node 12 on CI runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,13 @@ cache:
 rvm:
   - 2.6.6
   - 2.7.1
+
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
+  - nvm use 12
+
 script: bundle exec rake
 
 after_script:


### PR DESCRIPTION
## What is this pull request for?

Webpacker needs Node >= 10.17. Let's use the current LTS version of Node

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
