### PR TITLE
Update alchemy_cms.gemspec

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'acts_as_list',                     ['>= 0.3', '< 2']
   gem.add_runtime_dependency 'awesome_nested_set',               ['~> 3.1']
   gem.add_runtime_dependency 'cancancan',                        ['>= 2.1', '< 4.0']
-  gem.add_runtime_dependency 'coffee-rails',                     ['~> 4.0', '< 5.0']
+  gem.add_runtime_dependency 'coffee-rails',                     ['>= 4.0', '<= 6.0']
   gem.add_runtime_dependency 'dragonfly',                        ['~> 1.0', '>= 1.0.7']
   gem.add_runtime_dependency 'dragonfly_svg',                    ['~> 0.0.4']
   gem.add_runtime_dependency 'gutentag',                         ['~> 2.2', '>= 2.2.1']

--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'acts_as_list',                     ['>= 0.3', '< 2']
   gem.add_runtime_dependency 'awesome_nested_set',               ['~> 3.1']
   gem.add_runtime_dependency 'cancancan',                        ['>= 2.1', '< 4.0']
-  gem.add_runtime_dependency 'coffee-rails',                     ['>= 4.0', '<= 6.0']
+  gem.add_runtime_dependency 'coffee-rails',                     ['>= 4.0', '< 6.0']
   gem.add_runtime_dependency 'dragonfly',                        ['~> 1.0', '>= 1.0.7']
   gem.add_runtime_dependency 'dragonfly_svg',                    ['~> 0.0.4']
   gem.add_runtime_dependency 'gutentag',                         ['~> 2.2', '>= 2.2.1']


### PR DESCRIPTION
Let last coffee version works

## What is this pull request for?

Solidus last version requires coffee-rails 5.0.0. Make sure that alchemy_cms use at least 5.0.0 version
