### PR TITLE
Store current pictures size in session

### DIFF
--- a/app/views/alchemy/admin/pictures/_archive.html.erb
+++ b/app/views/alchemy/admin/pictures/_archive.html.erb
@@ -31,7 +31,7 @@
       admin_pictures_path(
         q: search_filter_params[:q],
         tagged_with: search_filter_params[:tagged_with],
-        size: params[:size],
+        size: @size,
         filter: search_filter_params[:filter]
       ),
       class: 'secondary button with_icon',

--- a/app/views/alchemy/admin/pictures/_form.html.erb
+++ b/app/views/alchemy/admin/pictures/_form.html.erb
@@ -6,7 +6,7 @@
     <small class="hint"><%= Alchemy.t('Please seperate the tags with commata') %></small>
   </div>
   <%= hidden_field_tag :q, search_filter_params[:q] %>
-  <%= hidden_field_tag :size, params[:size] %>
+  <%= hidden_field_tag :size, @size %>
   <%= hidden_field_tag :tagged_with, search_filter_params[:tagged_with] %>
   <%= hidden_field_tag :filter, search_filter_params[:filter] %>
   <%= f.submit Alchemy.t(:save) %>

--- a/app/views/alchemy/admin/pictures/_picture.html.erb
+++ b/app/views/alchemy/admin/pictures/_picture.html.erb
@@ -12,7 +12,7 @@
         q: search_filter_params[:q],
         page: params[:page],
         tagged_with: search_filter_params[:tagged_with],
-        size: params[:size],
+        size: @size,
         filter: search_filter_params[:filter]
       ),
       {
@@ -34,7 +34,7 @@
         q: search_filter_params[:q],
         page: params[:page],
         tagged_with: search_filter_params[:tagged_with],
-        size: params[:size],
+        size: @size,
         filter: search_filter_params[:filter]
       ),
       class: 'thumbnail_background'

--- a/app/views/alchemy/admin/pictures/edit_multiple.html.erb
+++ b/app/views/alchemy/admin/pictures/edit_multiple.html.erb
@@ -1,6 +1,6 @@
 <%= form_tag update_multiple_admin_pictures_path do %>
   <%= hidden_field_tag :q, search_filter_params[:q] %>
-  <%= hidden_field_tag :size, params[:size] %>
+  <%= hidden_field_tag :size, @size %>
   <%= hidden_field_tag :tagged_with, search_filter_params[:tagged_with] %>
   <%= hidden_field_tag :filter, search_filter_params[:filter] %>
 

--- a/app/views/alchemy/admin/pictures/index.html.erb
+++ b/app/views/alchemy/admin/pictures/index.html.erb
@@ -5,7 +5,7 @@
         object: Alchemy::Picture.new,
         file_attribute: 'image_file',
         redirect_url: alchemy.admin_pictures_path(
-          size: params[:size],
+          size: @size,
           filter: 'last_upload'
         ) %>
       <div class="toolbar_spacer"></div>

--- a/app/views/alchemy/admin/pictures/show.html.erb
+++ b/app/views/alchemy/admin/pictures/show.html.erb
@@ -9,7 +9,7 @@
         q: search_filter_params[:q],
         page: params[:page],
         tagged_with: search_filter_params[:tagged_with],
-        size: params[:size],
+        size: @size,
         filter: search_filter_params[:filter]
       ),
       class: "previous-picture",
@@ -23,7 +23,7 @@
         q: search_filter_params[:q],
         page: params[:page],
         tagged_with: search_filter_params[:tagged_with],
-        size: params[:size],
+        size: @size,
         filter: search_filter_params[:filter]
       ),
       class: "next-picture",

--- a/spec/controllers/alchemy/admin/pictures_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/pictures_controller_spec.rb
@@ -73,15 +73,35 @@ module Alchemy
         end
       end
 
-      it "assigns @size to default value" do
-        get :index
-        expect(assigns(:size)).to eq("medium")
+      context "with params[:size] not set" do
+        subject { get(:index) }
+
+        context "and session pictures size not set" do
+          it "sets size to default value" do
+            subject
+            expect(assigns(:size)).to eq("medium")
+            expect(session[:alchemy_pictures_size]).to eq("medium")
+          end
+
+          context "but with pictures size set in session" do
+            before do
+              session[:alchemy_pictures_size] = "small"
+            end
+
+            it "sets size to that value" do
+              subject
+              expect(assigns(:size)).to eq("small")
+              expect(session[:alchemy_pictures_size]).to eq("small")
+            end
+          end
+        end
       end
 
       context "with params[:size] set to 'large'" do
-        it "assigns @size to large" do
-          get :index, params: {size: "large"}
+        it "sets size to large" do
+          get :index, params: { size: "large" }
           expect(assigns(:size)).to eq("large")
+          expect(session[:alchemy_pictures_size]).to eq("large")
         end
       end
 
@@ -361,6 +381,7 @@ module Alchemy
       subject { controller.send(:items_per_page) }
 
       before do
+        controller.instance_variable_set(:@size, params[:size] || "medium")
         expect(controller).to receive(:params).at_least(:once) { params }
       end
 


### PR DESCRIPTION
## What is this pull request for?

The current picture size is stored in the current user session so that the setting persists over requests.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
