### PR TITLE
Remove page from search form query

### DIFF
--- a/app/views/alchemy/admin/partials/_search_form.html.erb
+++ b/app/views/alchemy/admin/partials/_search_form.html.erb
@@ -1,4 +1,4 @@
-<%- url ||= resource_url_proxy.url_for({ action: 'index' }.merge(search_filter_params.except(:q))) -%>
+<%- url ||= resource_url_proxy.url_for({ action: 'index' }.merge(search_filter_params.except(:q, :page))) -%>
 
 <%= search_form_for @query, url: url, class: 'search_form' do |f| %>
   <div class="search_field">


### PR DESCRIPTION
## What is this pull request for?

We need to reset the page when ever we search, because the result set will be much smaller so pagination needs to be reseted.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
