### PR TITLE
Fix tri-Boolean check in PageNaming Module

### DIFF
--- a/app/models/alchemy/page/page_naming.rb
+++ b/app/models/alchemy/page/page_naming.rb
@@ -68,7 +68,7 @@ module Alchemy
           base.push(parent) if parent.visible?
         end
       else
-        ancestors.visible.contentpages.where(language_root: nil).to_a
+        ancestors.visible.contentpages.where(language_root: [nil, false]).to_a
       end
     end
 


### PR DESCRIPTION
## What is this pull request for?

If language_root is set to `false`, non-language-root pages will not be
recognised as such, leading to odd behaviours.

## Checklist
- [x I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [x I have added a detailed description into each commit message
- [ ] I have added tests to cover this change 

Not adding specs, as this behaviour is hard to test and will be fixed by removing the tri-booleans soon.