### PR TITLE
Dont show sizes selection if using srcset

### DIFF
--- a/app/views/alchemy/admin/essence_pictures/edit.html.erb
+++ b/app/views/alchemy/admin/essence_pictures/edit.html.erb
@@ -4,7 +4,7 @@
   <%= f.input :caption, as: @content.settings[:caption_as_textarea] ? 'text' : 'string' %>
   <%= f.input :title %>
   <%= f.input :alt_tag %>
-  <%- if @content.settings[:sizes].present? -%>
+  <%- if @content.settings[:sizes].present? && @content.settings[:srcset].blank? -%>
     <%= f.input :render_size,
       collection: [
         [Alchemy.t('Layout default'), @content.settings[:size]]

--- a/spec/views/alchemy/admin/essence_pictures/edit_spec.rb
+++ b/spec/views/alchemy/admin/essence_pictures/edit_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "alchemy/admin/essence_pictures/edit.html.erb" do
+  let(:image) do
+    fixture_file_upload(
+      File.expand_path("../../../../fixtures/500x500.png", __dir__),
+      "image/png"
+    )
+  end
+
+  let(:picture) do
+    create(:alchemy_picture, {
+      image_file: image,
+      name: "img",
+      image_file_name: "img.png",
+    })
+  end
+
+  let(:content) { Alchemy::Content.new(id: 1) }
+  let(:essence) { Alchemy::EssencePicture.new(id: 1, content: content, picture: picture) }
+
+  before do
+    view.extend Alchemy::Admin::FormHelper
+    view.instance_variable_set(:@essence_picture, essence)
+    view.instance_variable_set(:@content, content)
+  end
+
+  it "displays render_size selection if sizes present" do
+    allow(content).to receive(:settings).and_return({
+      sizes: [
+        ["Medium, 400x400", "400x400"],
+        ["Small, 200x200", "200x200"],
+      ],
+    })
+
+    render
+
+    expect(rendered).to have_selector(".input.essence_picture_render_size")
+  end
+
+  it "does not display render_size selection if srcset present" do
+    # As the same sizes setting is used in another way here
+    allow(content).to receive(:settings).and_return({
+      sizes: ["(min-width: 600px) 600px", "100vw"],
+      srcset: ["200x100", "400x200", "600x300"],
+    })
+
+    render
+
+    expect(rendered).to_not have_selector(".input.essence_picture_render_size")
+  end
+end


### PR DESCRIPTION
sizes can be used standalone or as part of srcset. If used for srcset standalone sizes selection has to be disabled as the data is incompatible

Otherwise picture properties are broken

![image](https://user-images.githubusercontent.com/9784434/92717639-d4c03e00-f360-11ea-9610-ee2e90ddd641.png)

Broken out from #1786

## Checklist
- [X] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/master/CONTRIBUTING.md)
- [X] I have added a detailed description into each commit message
- [X] I have added tests to cover this change
