### PR TITLE
Unset render_size on layout default selection

### DIFF
--- a/app/views/alchemy/admin/essence_pictures/edit.html.erb
+++ b/app/views/alchemy/admin/essence_pictures/edit.html.erb
@@ -7,7 +7,7 @@
   <%- if @content.settings[:sizes].present? -%>
     <%= f.input :render_size,
       collection: [
-        [Alchemy.t('Layout default'), @content.settings[:size]]
+        [Alchemy.t('Layout default'), ""]
       ] + @content.settings[:sizes].to_a,
       include_blank: false,
       input_html: {class: 'alchemy_selectbox'} %>


### PR DESCRIPTION
If no size is selected (layout default), db should be unset to give layout/settings size priority again.

Broken out from https://github.com/AlchemyCMS/alchemy_cms/pull/1786