### PR TITLE
Add Publish Targets

### DIFF
--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -178,6 +178,10 @@ module Alchemy
       def publish
         # fetching page via before filter
         @page.publish!
+
+        # Send publish notification to all registered publish targets
+        Alchemy.publish_targets.each { |p| p.perform_later(@page) }
+
         flash[:notice] = Alchemy.t(:page_published, name: @page.name)
         redirect_back(fallback_location: admin_pages_path)
       end

--- a/lib/alchemy.rb
+++ b/lib/alchemy.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Alchemy
+  YAML_WHITELIST_CLASSES = %w(Symbol Date Regexp)
+end

--- a/lib/alchemy.rb
+++ b/lib/alchemy.rb
@@ -2,4 +2,28 @@
 
 module Alchemy
   YAML_WHITELIST_CLASSES = %w(Symbol Date Regexp)
+
+  # Define page publish targets
+  #
+  # A publish target is a ActiveJob that gets performed
+  # whenever a user clicks the publish page button.
+  #
+  # Use this to trigger deployment hooks of external
+  # services in an asychronous way.
+  #
+  # == Example
+  #
+  #     # app/jobs/publish_job.rb
+  #     class PublishJob < ApplicationJob
+  #       def perform(page)
+  #         RestClient.post(ENV['BUILD_HOOK_URL'])
+  #       end
+  #     end
+  #
+  #     # config/initializers/alchemy.rb
+  #     Alchemy.publish_targets << PublishJob
+  #
+  def self.publish_targets
+    @_publish_targets ||= Set.new
+  end
 end

--- a/lib/alchemy_cms.rb
+++ b/lib/alchemy_cms.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
+
 # Instantiate the global Alchemy namespace
-module Alchemy
-  YAML_WHITELIST_CLASSES = %w(Symbol Date Regexp)
-end
+require "alchemy"
 
 # Require globally used external libraries
 require "acts_as_list"

--- a/spec/controllers/alchemy/admin/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/pages_controller_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::Admin::PagesController do
+  routes { Alchemy::Engine.routes }
+
+  before do
+    authorize_user(:as_admin)
+  end
+
+  describe "#publish" do
+    let(:page) { create(:alchemy_page) }
+
+    it "publishes the page" do
+      expect_any_instance_of(Alchemy::Page).to receive(:publish!)
+      post :publish, params: { id: page }
+    end
+
+    context "with publish targets" do
+      class FooTarget < ActiveJob::Base
+        def perform(_page)
+        end
+      end
+
+      around do |example|
+        Alchemy.publish_targets << FooTarget
+        example.run
+        Alchemy.instance_variable_set(:@_publish_targets, nil)
+      end
+
+      it "performs each target" do
+        expect(FooTarget).to receive(:perform_later).with(page)
+        post :publish, params: { id: page }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

A publish target is a ActiveJob compatible Ruby class that gets performed when the user publishes a page. 

You can use that to send webhooks to hosting services, notification services or ci services.

### Example

```rb
# app/jobs/publish_job.rb
class PublishJob < ApplicationJob
  def perform(page)
    RestClient.post(ENV['BUILD_HOOK_URL'])
  end
end
```

```rb
# config/initializers/alchemy.rb
Alchemy.publish_targets << PublishJob
```

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
