### PR TITLE
Remove poltergeist and phantomjs leftovers

### DIFF
--- a/lib/alchemy/test_support/integration_helpers.rb
+++ b/lib/alchemy/test_support/integration_helpers.rb
@@ -17,14 +17,7 @@ module Alchemy
         else
           user = build(:alchemy_dummy_user, user_or_role)
         end
-        set_phantomjs_browser_language("en")
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
-      end
-
-      def set_phantomjs_browser_language(lang = nil)
-        if Capybara.current_driver == :poltergeist
-          page.driver.headers = {"Accept-Language" => lang}
-        end
       end
     end
   end


### PR DESCRIPTION
We do not use poltergeist and PhantomJS any more for integration testing.
