### PR TITLE
Always show the full page name in active page tab

### DIFF
--- a/app/assets/stylesheets/alchemy/frame.scss
+++ b/app/assets/stylesheets/alchemy/frame.scss
@@ -74,7 +74,6 @@ div#overlay_text_box {
 
   .page_name {
     display: inline-block;
-    max-width: 100px;
     margin-right: $default-margin;
     line-height: $header-height;
     white-space: nowrap;


### PR DESCRIPTION
## What is this pull request for?

The active page tab should show the full page name

### Screenshots

![Screenshot from 2020-12-01 12-27-03](https://user-images.githubusercontent.com/42868/100734847-94f17b80-33d0-11eb-845f-ef40f6047f99.png)

![Screenshot from 2020-12-01 12-27-16](https://user-images.githubusercontent.com/42868/100734849-958a1200-33d0-11eb-8159-71213a2afd29.png)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
