### PR TITLE
Fix height of search input field

### DIFF
--- a/app/assets/stylesheets/alchemy/search.scss
+++ b/app/assets/stylesheets/alchemy/search.scss
@@ -54,7 +54,7 @@
 
   .search_input_field {
     width: 0;
-    height: inherit;
+    height: 100%;
     border: none;
     background-color: transparentize($form-field-background-color, 0.25);
     transition:


### PR DESCRIPTION
## What is this pull request for?

Since we nested the input field in the label we cannot inherit the height anymore.

### Screenshots

![Screenshot from 2020-12-01 12-31-49](https://user-images.githubusercontent.com/42868/100735263-3a0c5400-33d1-11eb-8ba3-d103d7d7aee3.png)

![Screenshot from 2020-12-01 12-31-57](https://user-images.githubusercontent.com/42868/100735265-3aa4ea80-33d1-11eb-8098-b1150fc76f10.png)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
