### PR TITLE
Allow pound sign in legacy url

### DIFF
--- a/app/models/alchemy/legacy_page_url.rb
+++ b/app/models/alchemy/legacy_page_url.rb
@@ -18,5 +18,5 @@ class Alchemy::LegacyPageUrl < ActiveRecord::Base
 
   validates :urlname,
     presence: true,
-    format: {with: /\A[:\.\w\-+_\/\?&%;=]*\z/}
+    format: {with: /\A[:\.\w\-+_\/\?&%;=#]*\z/}
 end

--- a/spec/models/alchemy/legacy_page_url_spec.rb
+++ b/spec/models/alchemy/legacy_page_url_spec.rb
@@ -5,25 +5,27 @@ require "rails_helper"
 describe Alchemy::LegacyPageUrl do
   let(:page) { build_stubbed(:alchemy_page) }
 
-  let(:page_url_with_parameters) do
-    Alchemy::LegacyPageUrl.new(urlname: "index.php?id=2", page: page)
+  it "is invalid with invalid URL characters" do
+    expect(
+      described_class.new(urlname: "<foo>{bar}", page: page)
+    ).to be_invalid
   end
 
-  let(:valid_page_url) do
-    Alchemy::LegacyPageUrl.new(urlname: "my/0-work+is-nice_stuff", page: page)
+  it "is valid with correct urlname format" do
+    expect(
+      described_class.new(urlname: "my/0-work+is-nice_stuff", page: page)
+    ).to be_valid
   end
 
-  it "is only valid with correct urlname format" do
-    expect(valid_page_url).to be_valid
-  end
-
-  it "is also valid with get parameters in urlname" do
-    expect(page_url_with_parameters).to be_valid
+  it "is valid with get parameters in urlname" do
+    expect(
+      described_class.new(urlname: "index.php?id=2", page: page)
+    ).to be_valid
   end
 
   it "is valid with pound sign in urlname" do
     expect(
-      Alchemy::LegacyPageUrl.new(urlname: "with#anchor", page: page)
+      described_class.new(urlname: "with#anchor", page: page)
     ).to be_valid
   end
 end

--- a/spec/models/alchemy/legacy_page_url_spec.rb
+++ b/spec/models/alchemy/legacy_page_url_spec.rb
@@ -20,4 +20,10 @@ describe Alchemy::LegacyPageUrl do
   it "is also valid with get parameters in urlname" do
     expect(page_url_with_parameters).to be_valid
   end
+
+  it "is valid with pound sign in urlname" do
+    expect(
+      Alchemy::LegacyPageUrl.new(urlname: "with#anchor", page: page)
+    ).to be_valid
+  end
 end


### PR DESCRIPTION
## What is this pull request for?

Currently its not possible to add a `LegacyPageUrl` with an anchor (e.g `foo/bar.php#baz`).
This change allows to add such HTML anchors (hash/pound signs) when adding/updating `LegacyPageUrl` objects.

I believe this is a tiny but legit addition since `#` signs are valid URI characters and it is a valid use case for the `LegacyPageUrl` feature.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
