### PR TITLE
Deprecate elements fallbacks

### DIFF
--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -28,22 +28,6 @@ module Alchemy
     #     <%= render_elements from_page: 'footer' %>
     #   </footer>
     #
-    # === Fallback to elements from global page:
-    #
-    # You can use the fallback option as an override for elements that are stored on another page.
-    # So you can take elements from a global page and only if the user adds an element on current page the
-    # local one gets rendered.
-    #
-    # 1. You have to pass the the name of the element the fallback is for as <tt>for</tt> key.
-    # 2. You have to pass a <tt>page_layout</tt> name or {Alchemy::Page} from where the fallback elements is taken from as <tt>from</tt> key.
-    # 3. You can pass the name of element to fallback with as <tt>with</tt> key. This is optional (the element name from the <tt>for</tt> key is taken as default).
-    #
-    #   <%= render_elements(fallback: {
-    #     for: 'contact_teaser',
-    #     from: 'sidebar',
-    #     with: 'contact_teaser'
-    #   }) %>
-    #
     # === Custom elements finder:
     #
     # Having a custom element finder class:
@@ -76,8 +60,6 @@ module Alchemy
     #   The amount of elements to be rendered (begins with first element found)
     # @option options [Number] :offset
     #   The offset to begin loading elements from
-    # @option options [Hash] :fallback
-    #   Define elements that are rendered from another page.
     # @option options [Boolean] :random (false)
     #   Randomize the output of elements
     # @option options [Boolean] :reverse (false)

--- a/lib/alchemy/elements_finder.rb
+++ b/lib/alchemy/elements_finder.rb
@@ -26,8 +26,6 @@ module Alchemy
     #   Randomize the output of elements
     # @option options [Boolean] :reverse (false)
     #   Reverse the load order
-    # @option options [Hash] :fallback
-    #   Define elements that are loaded from another page if no element was found on given page.
     def initialize(options = {})
       @options = options
     end
@@ -92,6 +90,9 @@ module Alchemy
     end
 
     def fallback_required?(elements)
+      if options[:fallback]
+        Alchemy::Deprecation.warn "Passing `fallback` options to `render_elements` is deprecated an will be removed with Alchemy 6.0."
+      end
       options[:fallback] && elements
         .where(Alchemy::Element.table_name => {name: options[:fallback][:for]})
         .none?

--- a/lib/alchemy/elements_finder.rb
+++ b/lib/alchemy/elements_finder.rb
@@ -81,6 +81,9 @@ module Alchemy
       when Alchemy::Page
         page_or_layout
       when String
+        Alchemy::Deprecation.warn "Passing a String as `from_page` option to " \
+          "`render_elements` is deprecated and will be removed with Alchemy 6.0. " \
+          "Please load the page beforehand and pass it as an object instead."
         Alchemy::Page.find_by(
           language: Alchemy::Language.current,
           page_layout: page_or_layout,

--- a/spec/dummy/app/views/alchemy/page_layouts/_standard.html.erb
+++ b/spec/dummy/app/views/alchemy/page_layouts/_standard.html.erb
@@ -1,6 +1,6 @@
 <div id="header">
   <div id="header_image">
-    <%= render_elements(:only => 'header', :fallback => {:for => 'header', :from => 'layout_header'}) %>
+    <%= render_elements(:only => 'header') %>
   </div>
   <%- claim = render_elements :only => ["claim"] -%>
   <%- if !claim.blank? -%>


### PR DESCRIPTION
## What is this pull request for?

1. Deprecate fallback option of elements finder
    Providing `fallback` to `render_elements` or the `ElementsFinder` class will be removed from Alchemy 6.0
2.  Deprecate passing a String to `render_elements` `from_page`
    Passing a String to `render_elements` `from_page` option will not be supported anymore in Alchemy 6. Please load the page beforehand and pass it as object instead.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have removed tests that cover this behavior
