### PR TITLE
Deprecate trash

### DIFF
--- a/app/controllers/alchemy/admin/base_controller.rb
+++ b/app/controllers/alchemy/admin/base_controller.rb
@@ -72,6 +72,7 @@ module Alchemy
       def trash_empty?(category)
         "alchemy/#{category.singularize}".classify.constantize.trashed.blank?
       end
+      deprecate :trash_empty?, deprecator: Alchemy::Deprecation
 
       def set_stamper
         if Alchemy.user_class < ActiveRecord::Base

--- a/app/controllers/alchemy/admin/trash_controller.rb
+++ b/app/controllers/alchemy/admin/trash_controller.rb
@@ -12,12 +12,14 @@ module Alchemy
         @page = Page.find(params[:page_id])
         @allowed_elements = @page.available_element_definitions
       end
+      deprecate :index, deprecator: Alchemy::Deprecation
 
       def clear
         @page = Page.find(params[:page_id])
         @elements = Element.trashed
         @elements.map(&:destroy)
       end
+      deprecate :clear, deprecator: Alchemy::Deprecation
 
       private
 

--- a/app/models/alchemy/content.rb
+++ b/app/models/alchemy/content.rb
@@ -46,9 +46,12 @@ module Alchemy
 
     delegate :restricted?, to: :page, allow_nil: true
     delegate :trashed?, to: :element, allow_nil: true
+    deprecate :trashed?, deprecator: Alchemy::Deprecation
     delegate :public?, to: :element, allow_nil: true
 
     class << self
+      deprecate :not_trashed, deprecator: Alchemy::Deprecation
+
       # Returns the translated label for a content name.
       #
       # Translate it in your locale yml file:

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -124,6 +124,9 @@ module Alchemy
 
     # class methods
     class << self
+      deprecate :trashed, deprecator: Alchemy::Deprecation
+      deprecate :not_trashed, deprecator: Alchemy::Deprecation
+
       # Builds a new element as described in +/config/alchemy/elements.yml+
       #
       # - Returns a new Alchemy::Element object if no name is given in attributes,
@@ -227,10 +230,12 @@ module Alchemy
       self.folded = true
       remove_from_list
     end
+    deprecate :trash!, deprecator: Alchemy::Deprecation
 
     def trashed?
       position.nil?
     end
+    deprecate :trashed?, deprecator: Alchemy::Deprecation
 
     # Returns true if the definition of this element has a taggable true value.
     def taggable?

--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -43,6 +43,8 @@ module Alchemy
     end
 
     module ClassMethods
+      deprecate :trashed_elements, deprecator: Alchemy::Deprecation
+
       # Copy page elements
       #
       # @param source [Alchemy::Page]

--- a/lib/alchemy/deprecation.rb
+++ b/lib/alchemy/deprecation.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Alchemy
-  Deprecation = ActiveSupport::Deprecation.new("5.1", "Alchemy")
+  Deprecation = ActiveSupport::Deprecation.new("6.0", "Alchemy")
 end


### PR DESCRIPTION
## What is this pull request for?

Deprecate Element trash methods.

The element trash will be removed in Alchemy 6.0.

With the avent of page versions and the already existing feature of hiding elements there is no need to keep deleted elements for ever.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
