### PR TITLE
Allow Element and Content deprecation notices

### DIFF
--- a/app/assets/stylesheets/alchemy/_variables.scss
+++ b/app/assets/stylesheets/alchemy/_variables.scss
@@ -145,6 +145,8 @@ $elements-window-min-width: 400px !default;
 $element-header-bg-color: $medium-gray !default;
 $element-header-active-bg-color: $dark-blue !default;
 $element-header-active-color: $white !default;
+$element-header-deprecated-bg-color: rgba(253, 213, 175, 0.25) !default;
+$element-deprecated-border-color: rgb(253, 213, 175) !default;
 $top-menu-height: 75px !default;
 
 $tabs-height: 31px !default;

--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -689,6 +689,24 @@ select.long {
     }
   }
 
+  &.deprecated {
+    border-radius: $default-border-radius;
+    background-color: $element-header-deprecated-bg-color;
+    background-image: linear-gradient(
+      45deg,
+      $element-header-deprecated-bg-color 25%,
+      $element-header-bg-color 25%,
+      $element-header-bg-color 50%,
+      $element-header-deprecated-bg-color 50%,
+      $element-header-deprecated-bg-color 75%,
+      $element-header-bg-color 75%,
+      $element-header-bg-color 100%
+    );
+    background-size: 28.28px 28.28px;
+    padding-left: 2px;
+    padding-right: 2px;
+  }
+
   label {
     display: block;
     margin: $default-margin 0;

--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -170,13 +170,32 @@
     }
   }
 
+  &.deprecated {
+    border-color: $element-deprecated-border-color;
+
+    > .element-header {
+      background-color: $element-header-deprecated-bg-color;
+      background-image: linear-gradient(
+        45deg,
+        $element-header-deprecated-bg-color 25%,
+        $element-header-bg-color 25%,
+        $element-header-bg-color 50%,
+        $element-header-deprecated-bg-color 50%,
+        $element-header-deprecated-bg-color 75%,
+        $element-header-bg-color 75%,
+        $element-header-bg-color 100%
+      );
+      background-size: 28.28px 28.28px;
+    }
+  }
+
   &.selected:not(.is-fixed), &:hover {
     &:not(.hidden) {
       box-shadow: 0 2px 8px rgba(#9b9b9b, 0.75);
     }
   }
 
-  &.selected:not(.is-fixed):not(.folded):not(.dirty):not(.hidden) {
+  &.selected:not(.is-fixed):not(.folded):not(.dirty):not(.hidden):not(.deprecated) {
     > .element-header {
       background-color: $element-header-active-bg-color;
       color: $element-header-active-color;
@@ -800,10 +819,6 @@ textarea.has_tinymce {
       left: 16px;
     }
   }
-}
-
-.element-handle .hint-with-icon {
-  top: -1px;
 }
 
 .is-fixed {

--- a/app/decorators/alchemy/content_editor.rb
+++ b/app/decorators/alchemy/content_editor.rb
@@ -12,6 +12,7 @@ module Alchemy
       [
         "content_editor",
         essence_partial_name,
+        deprecated? ? "deprecated" : nil,
       ].compact
     end
 
@@ -50,6 +51,54 @@ module Alchemy
       return false if method_name == :to_model
 
       super
+    end
+
+    # Returns a deprecation notice for contents marked deprecated
+    #
+    # You can either use localizations or pass a String as notice
+    # in the content definition.
+    #
+    # == Custom deprecation notices
+    #
+    # Use general content deprecation notice
+    #
+    #     - name: element_name
+    #       contents:
+    #         - name: old_content
+    #           type: EssenceText
+    #           deprecated: true
+    #
+    # Add a translation to your locale file for a per content notice.
+    #
+    #     en:
+    #       alchemy:
+    #         content_deprecation_notices:
+    #           element_name:
+    #             old_content: Foo baz widget is deprecated
+    #
+    # or use the global translation that apply to all deprecated contents.
+    #
+    #     en:
+    #       alchemy:
+    #         content_deprecation_notice: Foo baz widget is deprecated
+    #
+    # or pass string as deprecation notice.
+    #
+    #     - name: element_name
+    #       contents:
+    #         - name: old_content
+    #           type: EssenceText
+    #           deprecated: This content will be removed soon.
+    #
+    def deprecation_notice
+      case definition["deprecated"]
+      when String
+        definition["deprecated"]
+      when TrueClass
+        Alchemy.t(name,
+                  scope: [:content_deprecation_notices, element.name],
+                  default: Alchemy.t(:content_deprecated))
+      end
     end
   end
 end

--- a/app/decorators/alchemy/content_editor.rb
+++ b/app/decorators/alchemy/content_editor.rb
@@ -53,6 +53,21 @@ module Alchemy
       super
     end
 
+    def has_warnings?
+      definition.blank? || deprecated?
+    end
+
+    def warnings
+      return unless has_warnings?
+
+      if definition.blank?
+        Logger.warn("Content #{name} is missing its definition", caller(1..1))
+        Alchemy.t(:content_definition_missing)
+      else
+        deprecation_notice
+      end
+    end
+
     # Returns a deprecation notice for contents marked deprecated
     #
     # You can either use localizations or pass a String as notice

--- a/app/decorators/alchemy/element_editor.rb
+++ b/app/decorators/alchemy/element_editor.rb
@@ -17,6 +17,7 @@ module Alchemy
         taggable? ? "taggable" : "not-taggable",
         folded ? "folded" : "expanded",
         compact? ? "compact" : nil,
+        deprecated? ? "deprecated" : nil,
         fixed? ? "is-fixed" : "not-fixed",
         public? ? "visible" : "hidden",
       ].join(" ")
@@ -35,6 +36,47 @@ module Alchemy
       return false if method_name == :to_model
 
       super
+    end
+
+    # Returns a deprecation notice for elements marked deprecated
+    #
+    # You can either use localizations or pass a String as notice
+    # in the element definition.
+    #
+    # == Custom deprecation notices
+    #
+    # Use general element deprecation notice
+    #
+    #     - name: old_element
+    #       deprecated: true
+    #
+    # Add a translation to your locale file for a per element notice.
+    #
+    #     en:
+    #       alchemy:
+    #         element_deprecation_notices:
+    #           old_element: Foo baz widget is deprecated
+    #
+    # or use the global translation that apply to all deprecated elements.
+    #
+    #     en:
+    #       alchemy:
+    #         element_deprecation_notice: Foo baz widget is deprecated
+    #
+    # or pass string as deprecation notice.
+    #
+    #     - name: old_element
+    #       deprecated: This element will be removed soon.
+    #
+    def deprecation_notice
+      case definition["deprecated"]
+      when String
+        definition["deprecated"]
+      when TrueClass
+        Alchemy.t(name,
+                  scope: :element_deprecation_notices,
+                  default: Alchemy.t(:element_deprecated))
+      end
     end
   end
 end

--- a/app/helpers/alchemy/admin/contents_helper.rb
+++ b/app/helpers/alchemy/admin/contents_helper.rb
@@ -19,14 +19,8 @@ module Alchemy
 
         content_name = content.name_for_label
 
-        if content.definition.blank? || content.deprecated?
-          if content.definition.blank?
-            warning("Content #{content.name} is missing its definition")
-            message = Alchemy.t(:content_definition_missing)
-          else
-            message = content.deprecation_notice
-          end
-          icon = hint_with_tooltip(message)
+        if content.has_warnings?
+          icon = hint_with_tooltip(content.warnings)
           content_name = "#{icon} #{content_name}".html_safe
         end
 

--- a/app/helpers/alchemy/admin/contents_helper.rb
+++ b/app/helpers/alchemy/admin/contents_helper.rb
@@ -19,13 +19,14 @@ module Alchemy
 
         content_name = content.name_for_label
 
-        if content.definition.blank?
-          warning("Content #{content.name} is missing its definition")
-
-          icon = hint_with_tooltip(
-            Alchemy.t(:content_definition_missing),
-          )
-
+        if content.definition.blank? || content.deprecated?
+          if content.definition.blank?
+            warning("Content #{content.name} is missing its definition")
+            message = Alchemy.t(:content_definition_missing)
+          else
+            message = content.deprecation_notice
+          end
+          icon = hint_with_tooltip(message)
           content_name = "#{icon} #{content_name}".html_safe
         end
 

--- a/app/helpers/alchemy/admin/contents_helper.rb
+++ b/app/helpers/alchemy/admin/contents_helper.rb
@@ -40,7 +40,7 @@ module Alchemy
       # Renders the label and a remove link for a content.
       def content_label(content)
         content_tag :label, for: content.form_field_id do
-          [render_hint_for(content), render_content_name(content)].compact.join("&nbsp;").html_safe
+          [render_content_name(content), render_hint_for(content)].compact.join("&nbsp;").html_safe
         end
       end
     end

--- a/app/models/alchemy/content.rb
+++ b/app/models/alchemy/content.rb
@@ -192,6 +192,10 @@ module Alchemy
       essence && !essence.link.blank?
     end
 
+    def deprecated?
+      !!definition["deprecated"]
+    end
+
     # Returns true if this content should be taken for element preview.
     def preview_content?
       !!definition["as_element_title"]

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -37,6 +37,7 @@ module Alchemy
       "taggable",
       "compact",
       "message",
+      "deprecated",
     ].freeze
 
     SKIPPED_ATTRIBUTES_ON_COPY = [
@@ -250,6 +251,38 @@ module Alchemy
     # Defined as compact element?
     def compact?
       definition["compact"] == true
+    end
+
+    # Defined as deprecated element?
+    #
+    # You can either set true or a String on your elements definition.
+    #
+    # == Passing true
+    #
+    #     - name: old_element
+    #       deprecated: true
+    #
+    # The deprecation notice can be translated. Either as global notice for all deprecated elements.
+    #
+    #     en:
+    #       alchemy:
+    #         element_deprecation_notice: Foo baz widget is deprecated
+    #
+    # Or add a translation to your locale file for a per element notice.
+    #
+    #     en:
+    #       alchemy:
+    #         element_deprecation_notices:
+    #           old_element: Foo baz widget is deprecated
+    #
+    # == Pass a String
+    #
+    #     - name: old_element
+    #       deprecated: This element will be removed soon.
+    #
+    # @return Boolean
+    def deprecated?
+      !!definition["deprecated"]
     end
 
     # The element's view partial is dependent from its name

--- a/app/views/alchemy/admin/elements/_element_header.html.erb
+++ b/app/views/alchemy/admin/elements/_element_header.html.erb
@@ -2,6 +2,8 @@
   <span class="element-handle">
     <% if element.definition.blank? %>
       <%= hint_with_tooltip Alchemy.t(:element_definition_missing) %>
+    <% elsif element.deprecated? %>
+      <%= hint_with_tooltip element.deprecation_notice %>
     <% else %>
       <% if element.public? %>
         <%= render_icon('window-maximize', style: 'regular', class: 'element') %>

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -295,6 +295,7 @@ en:
     "Visit page": "Visit page"
     "Warning!": "Warning!"
     content_definition_missing: "Warning: Content is missing its definition. Please check the elements.yml"
+    content_deprecated: "WARNING! This content is deprecated and will be removed soon. Please do not use it anymore."
     element_definition_missing: "WARNING! Missing element definition. Please check your elements.yml file."
     element_deprecated: "WARNING! This element is deprecated and will be removed soon. Please do not use it anymore."
     page_definition_missing: "WARNING! Missing page layout definition. Please check your page_layouts.yml file."

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -296,6 +296,7 @@ en:
     "Warning!": "Warning!"
     content_definition_missing: "Warning: Content is missing its definition. Please check the elements.yml"
     element_definition_missing: "WARNING! Missing element definition. Please check your elements.yml file."
+    element_deprecated: "WARNING! This element is deprecated and will be removed soon. Please do not use it anymore."
     page_definition_missing: "WARNING! Missing page layout definition. Please check your page_layouts.yml file."
     "Welcome to Alchemy": "Welcome to Alchemy"
     "Who else is online": "Who else is online"

--- a/spec/decorators/alchemy/content_editor_spec.rb
+++ b/spec/decorators/alchemy/content_editor_spec.rb
@@ -14,12 +14,24 @@ RSpec.describe Alchemy::ContentEditor do
   end
 
   describe "#css_classes" do
+    subject { content_editor.css_classes }
+
     it "includes content_editor class" do
-      expect(content_editor.css_classes).to include("content_editor")
+      is_expected.to include("content_editor")
     end
 
     it "includes essence partial class" do
-      expect(content_editor.css_classes).to include(content_editor.essence_partial_name)
+      is_expected.to include(content_editor.essence_partial_name)
+    end
+
+    context "when deprecated" do
+      before do
+        expect(content).to receive(:deprecated?) { true }
+      end
+
+      it "includes deprecated" do
+        is_expected.to include("deprecated")
+      end
     end
   end
 
@@ -69,5 +81,57 @@ RSpec.describe Alchemy::ContentEditor do
     subject { content_editor.respond_to?(:to_model) }
 
     it { is_expected.to be(false) }
+  end
+
+  describe "#deprecation_notice" do
+    subject { content_editor.deprecation_notice }
+
+    context "when content is not deprecated" do
+      let(:content) { build(:alchemy_content) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when content is deprecated" do
+      let(:element) { build(:alchemy_element, name: "all_you_can_eat") }
+      let(:content) { build(:alchemy_content, name: "essence_html", element: element) }
+
+      context "with custom content translation" do
+        it { is_expected.to eq("Old content is deprecated") }
+      end
+
+      context "without custom content translation" do
+        let(:content) { build(:alchemy_content, name: "old_too", element: element) }
+
+        before do
+          allow(content).to receive(:definition) do
+            {
+              "name" => "old_too",
+              "deprecated" => true,
+            }
+          end
+        end
+
+        it do
+          is_expected.to eq(
+            "WARNING! This content is deprecated and will be removed soon. " \
+            "Please do not use it anymore."
+          )
+        end
+      end
+
+      context "with String as deprecation" do
+        before do
+          allow(content).to receive(:definition) do
+            {
+              "name" => "old",
+              "deprecated" => "Foo baz widget",
+            }
+          end
+        end
+
+        it { is_expected.to eq("Foo baz widget") }
+      end
+    end
   end
 end

--- a/spec/decorators/alchemy/content_editor_spec.rb
+++ b/spec/decorators/alchemy/content_editor_spec.rb
@@ -83,6 +83,68 @@ RSpec.describe Alchemy::ContentEditor do
     it { is_expected.to be(false) }
   end
 
+  describe "#has_warnings?" do
+    subject { content_editor.has_warnings? }
+
+    context "when content is not deprecated" do
+      let(:content) { build(:alchemy_content) }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when content is deprecated" do
+      let(:content) do
+        mock_model("Content", definition: { deprecated: true }, deprecated?: true)
+      end
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when content is missing its definition" do
+      let(:content) do
+        mock_model("Content", definition: {})
+      end
+
+      it { is_expected.to be(true) }
+    end
+  end
+
+  describe "#warnings" do
+    subject { content_editor.warnings }
+
+    context "when content has no warnings" do
+      let(:content) { build(:alchemy_content) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when content is missing its definition" do
+      let(:content) do
+        mock_model("Content", name: "foo", definition: {})
+      end
+
+      it { is_expected.to eq Alchemy.t(:content_definition_missing) }
+
+      it "logs a warning" do
+        expect(Alchemy::Logger).to receive(:warn)
+        subject
+      end
+    end
+
+    context "when content is deprecated" do
+      let(:content) do
+        mock_model("Content",
+          name: "foo",
+          definition: { "name" => "foo", "deprecated" => "Deprecated" },
+          deprecated?: true)
+      end
+
+      it "returns a deprecation notice" do
+        is_expected.to eq("Deprecated")
+      end
+    end
+  end
+
   describe "#deprecation_notice" do
     subject { content_editor.deprecation_notice }
 

--- a/spec/dummy/config/alchemy/elements.yml
+++ b/spec/dummy/config/alchemy/elements.yml
@@ -169,3 +169,11 @@
   contents:
   - name: menu
     type: EssenceNode
+
+- name: old
+  deprecated: true
+  contents:
+    - name: title
+      type: EssenceText
+    - name: text
+      type: EssenceRichtext

--- a/spec/dummy/config/alchemy/elements.yml
+++ b/spec/dummy/config/alchemy/elements.yml
@@ -110,6 +110,7 @@
     - name: essence_html
       type: EssenceHtml
       hint: true
+      deprecated: true
     - name: essence_link
       type: EssenceLink
       hint: true

--- a/spec/dummy/config/alchemy/page_layouts.yml
+++ b/spec/dummy/config/alchemy/page_layouts.yml
@@ -20,7 +20,7 @@
   autogenerate: [header, article, download]
 
 - name: everything
-  elements: [text, all_you_can_eat, gallery, right_column, left_column]
+  elements: [text, all_you_can_eat, gallery, right_column, left_column, old]
   autogenerate: [all_you_can_eat, right_column, left_column]
 
 - name: news

--- a/spec/dummy/config/locales/alchemy.en.yml
+++ b/spec/dummy/config/locales/alchemy.en.yml
@@ -29,6 +29,9 @@ en:
     resource_help_texts:
       party:
         name: Party
+    content_deprecation_notices:
+      all_you_can_eat:
+        essence_html: Old content is deprecated
     element_deprecation_notices:
       old: Old element is deprecated
 

--- a/spec/dummy/config/locales/alchemy.en.yml
+++ b/spec/dummy/config/locales/alchemy.en.yml
@@ -29,6 +29,8 @@ en:
     resource_help_texts:
       party:
         name: Party
+    element_deprecation_notices:
+      old: Old element is deprecated
 
   activemodel:
     models:

--- a/spec/helpers/alchemy/admin/contents_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/contents_helper_spec.rb
@@ -22,10 +22,12 @@ describe Alchemy::Admin::ContentsHelper do
     let(:content) do
       mock_model "Content",
         name: "intro",
-        definition: {name: "intro", type: "EssenceText"},
+        definition: { name: "intro", type: "EssenceText" },
         name_for_label: "Intro",
-        has_validations?: false
+        has_validations?: false,
+        deprecated?: false
     end
+
     subject { helper.render_content_name(content) }
 
     it "returns the content name" do
@@ -41,11 +43,35 @@ describe Alchemy::Admin::ContentsHelper do
     end
 
     context "with missing definition" do
-      before { expect(content).to receive(:definition).and_return({}) }
+      let(:content) do
+        mock_model "Content",
+          name: "intro",
+          definition: { },
+          name_for_label: "Intro",
+          has_validations?: false,
+          deprecated?: false
+      end
 
       it "renders a warning with tooltip" do
         is_expected.to have_selector(".hint-with-icon .hint-bubble")
-        is_expected.to have_content("Intro")
+        is_expected.to have_content Alchemy.t(:content_definition_missing)
+      end
+    end
+
+    context "when deprecated" do
+      let(:content) do
+        mock_model "Content",
+          name: "intro",
+          definition: { name: "intro", type: "EssenceText" },
+          name_for_label: "Intro",
+          has_validations?: false,
+          deprecated?: true,
+          deprecation_notice: Alchemy.t(:content_deprecated)
+      end
+
+      it "renders a deprecation notice with tooltip" do
+        is_expected.to have_selector(".hint-with-icon .hint-bubble")
+        is_expected.to have_content Alchemy.t(:content_deprecated)
       end
     end
 

--- a/spec/helpers/alchemy/admin/contents_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/contents_helper_spec.rb
@@ -25,7 +25,8 @@ describe Alchemy::Admin::ContentsHelper do
         definition: { name: "intro", type: "EssenceText" },
         name_for_label: "Intro",
         has_validations?: false,
-        deprecated?: false
+        deprecated?: false,
+        has_warnings?: false
     end
 
     subject { helper.render_content_name(content) }
@@ -49,7 +50,9 @@ describe Alchemy::Admin::ContentsHelper do
           definition: { },
           name_for_label: "Intro",
           has_validations?: false,
-          deprecated?: false
+          deprecated?: false,
+          has_warnings?: true,
+          warnings: Alchemy.t(:content_definition_missing)
       end
 
       it "renders a warning with tooltip" do
@@ -66,7 +69,8 @@ describe Alchemy::Admin::ContentsHelper do
           name_for_label: "Intro",
           has_validations?: false,
           deprecated?: true,
-          deprecation_notice: Alchemy.t(:content_deprecated)
+          has_warnings?: true,
+          warnings: Alchemy.t(:content_deprecated)
       end
 
       it "renders a deprecation notice with tooltip" do

--- a/spec/models/alchemy/content_spec.rb
+++ b/spec/models/alchemy/content_spec.rb
@@ -263,6 +263,42 @@ module Alchemy
       end
     end
 
+    describe "#deprecated?" do
+      let(:content) { build_stubbed(:alchemy_content) }
+
+      subject { content.deprecated? }
+
+      context "not defined as deprecated" do
+        it "returns false" do
+          expect(content.deprecated?).to be false
+        end
+      end
+
+      context "defined as deprecated" do
+        before do
+          expect(content).to receive(:definition).at_least(:once).and_return({
+            "deprecated" => true,
+          })
+        end
+
+        it "returns true" do
+          expect(content.deprecated?).to be true
+        end
+      end
+
+      context "defined as deprecated per String" do
+        before do
+          expect(content).to receive(:definition).at_least(:once).and_return({
+            "deprecated" => "This content is deprecated",
+          })
+        end
+
+        it "returns true" do
+          expect(content.deprecated?).to be true
+        end
+      end
+    end
+
     describe "#preview_content?" do
       let(:content) { build_stubbed(:alchemy_content) }
 

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -771,6 +771,31 @@ module Alchemy
       end
     end
 
+    describe "#deprecated?" do
+      subject { element.deprecated? }
+
+      let(:element) { build(:alchemy_element) }
+
+      before do
+        expect(element).to receive(:definition) { definition }
+      end
+
+      context "definition has 'deprecated' key with true value" do
+        let(:definition) { { "deprecated" => true } }
+        it { is_expected.to be(true) }
+      end
+
+      context "definition has 'deprecated' key with foo value" do
+        let(:definition) { { "deprecated" => "This is deprecated" } }
+        it { is_expected.to be(true) }
+      end
+
+      context "definition has no 'deprecated' key" do
+        let(:definition) { { "name" => "article" } }
+        it { is_expected.to be(false) }
+      end
+    end
+
     describe "#trash!" do
       let(:element) { create(:alchemy_element) }
 

--- a/spec/models/alchemy/site_spec.rb
+++ b/spec/models/alchemy/site_spec.rb
@@ -301,6 +301,7 @@ module Alchemy
                   "gallery",
                   "right_column",
                   "left_column",
+                  "old",
                 ],
               },
               {


### PR DESCRIPTION
## What is this pull request for?

Elements and Contents can be marked as deprecated.

They will be visually displayed with a warning. The deprecation notice can be localized.

This also changes the position of the content hint icon.

### Screenshots

![Screenshot from 2020-12-28 14-14-04](https://user-images.githubusercontent.com/42868/103216731-044a8480-4917-11eb-9683-0fae02e30b01.png)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
