### PR TITLE
Fix Ruby 2.7 deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         ruby:
           - '2.5.x'
           - '2.6.x'
+          - '2.7.x'
         database:
           - mysql
           - postgresql

--- a/lib/alchemy/essence.rb
+++ b/lib/alchemy/essence.rb
@@ -83,7 +83,7 @@ module Alchemy #:nodoc:
 
         if configuration[:belongs_to]
           class_eval <<-RUBY, __FILE__, __LINE__ + 1
-            belongs_to :ingredient_association, #{configuration[:belongs_to]}
+            belongs_to :ingredient_association, **#{configuration[:belongs_to]}
 
             alias_method :#{configuration[:ingredient_column]}, :ingredient_association
             alias_method :#{configuration[:ingredient_column]}=, :ingredient_association=
@@ -108,9 +108,9 @@ module Alchemy #:nodoc:
       # Register the current class as has_many association on +Alchemy::Page+ and +Alchemy::Element+ models
       def register_as_essence_association!
         klass_name = model_name.to_s
-        arguments = [:has_many, klass_name.demodulize.tableize.to_sym, through: :contents,
-                                                                       source: :essence, source_type: klass_name]
-        %w(Page Element).each { |k| "Alchemy::#{k}".constantize.send(*arguments) }
+        arguments = [:has_many, klass_name.demodulize.tableize.to_sym]
+        kwargs = { through: :contents, source: :essence, source_type: klass_name }
+        %w(Page Element).each { |k| "Alchemy::#{k}".constantize.send(*arguments, **kwargs) }
       end
     end
 

--- a/lib/alchemy/forms/builder.rb
+++ b/lib/alchemy/forms/builder.rb
@@ -11,7 +11,7 @@ module Alchemy
         if object.respond_to?(:attribute_fixed?) && object.attribute_fixed?(attribute_name)
           options[:disabled] = true
           options[:input_html] = options.fetch(:input_html, {}).merge(
-            "data-alchemy-tooltip" => Alchemy.t(:attribute_fixed, attribute_name),
+            "data-alchemy-tooltip" => Alchemy.t(:attribute_fixed, attribute: attribute_name),
           )
         end
 

--- a/lib/alchemy/i18n.rb
+++ b/lib/alchemy/i18n.rb
@@ -12,8 +12,8 @@ module Alchemy
     #
     #     Alchemy.t(:hello)
     #
-    def t(msg, *args)
-      Alchemy::I18n.translate(msg, *args)
+    def t(msg, **kwargs)
+      Alchemy::I18n.translate(msg, **kwargs)
     end
   end
 
@@ -47,11 +47,10 @@ module Alchemy
       #       world:
       #         hello: Hallo
       #
-      def translate(msg, *args)
-        options = args.extract_options!
+      def translate(msg, **options)
         humanize_default_string!(msg, options)
         scope = alchemy_scoped_scope(options)
-        ::I18n.t(msg, options.merge(scope: scope))
+        ::I18n.t(msg, **options.merge(scope: scope))
       end
 
       def available_locales

--- a/spec/libraries/kaminari/scoped_pagination_url_helper_spec.rb
+++ b/spec/libraries/kaminari/scoped_pagination_url_helper_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe Kaminari::Helpers::Tag do
-  subject { Kaminari::Helpers::Tag.new(template, options) }
+  subject { Kaminari::Helpers::Tag.new(template, **options) }
 
   let(:template) { double(params: {}) }
   let(:scope)    { double(url_for: "") }


### PR DESCRIPTION
## What is this pull request for?

Separate positional and keyword arguments. In Ruby 2.7 this is deprecated and it will be removed in Ruby 3.0.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
