### PR TITLE
Remove page layout change of persisted pages

### DIFF
--- a/app/controllers/alchemy/admin/layoutpages_controller.rb
+++ b/app/controllers/alchemy/admin/layoutpages_controller.rb
@@ -16,7 +16,6 @@ module Alchemy
 
       def edit
         @page = Page.find(params[:id])
-        @page_layouts = PageLayout.layouts_with_own_for_select(@page.page_layout, @current_language.id, true)
       end
     end
   end

--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -118,7 +118,6 @@ module Alchemy
 
       # Set page configuration like page names, meta tags and states.
       def configure
-        @page_layouts = PageLayout.layouts_with_own_for_select(@page.page_layout, @current_language.id, @page.layoutpage?)
       end
 
       # Updates page

--- a/app/views/alchemy/admin/layoutpages/edit.html.erb
+++ b/app/views/alchemy/admin/layoutpages/edit.html.erb
@@ -1,9 +1,4 @@
 <%= alchemy_form_for [:admin, @page], class: 'edit_page' do |f| %>
-  <%= f.input :page_layout,
-    collection: @page_layouts,
-    label: page_layout_label(@page),
-    include_blank: Alchemy.t('Please choose'),
-    input_html: {class: 'alchemy_selectbox'} %>
   <%= f.input :name, autofocus: true %>
   <div class="input string">
     <%= f.label :tag_list %>

--- a/app/views/alchemy/admin/pages/_form.html.erb
+++ b/app/views/alchemy/admin/pages/_form.html.erb
@@ -1,10 +1,4 @@
 <%= alchemy_form_for [:admin, @page], class: 'edit_page' do |f| %>
-  <%= f.input :page_layout,
-    collection: @page_layouts,
-    label: page_layout_label(@page),
-    include_blank: Alchemy.t('Please choose'),
-    input_html: {class: 'alchemy_selectbox'} %>
-
   <div class="input check_boxes">
     <label class="control-label"><%= Alchemy.t(:page_status) %></label>
     <div class="control_group">

--- a/lib/alchemy/page_layout.rb
+++ b/lib/alchemy/page_layout.rb
@@ -63,19 +63,6 @@ module Alchemy
         mapped_layouts_for_select(selectable_layouts(language_id, only_layoutpages))
       end
 
-      # Returns page layouts including given layout ready for Rails' select form helper.
-      #
-      def layouts_with_own_for_select(page_layout_name, language_id, only_layoutpages = false)
-        layouts = selectable_layouts(language_id, only_layoutpages)
-        if layouts.detect { |l| l["name"] == page_layout_name }.nil?
-          @map_array = [[human_layout_name(page_layout_name), page_layout_name]]
-        else
-          @map_array = []
-        end
-        mapped_layouts_for_select(layouts)
-      end
-      deprecate :layouts_with_own_for_select, deprecator: Alchemy::Deprecation
-
       # Returns all layouts that can be used for creating a new page.
       #
       # It removes all layouts from available layouts that are unique and already taken and that are marked as hide.

--- a/spec/dummy/config/alchemy/page_layouts.yml
+++ b/spec/dummy/config/alchemy/page_layouts.yml
@@ -3,7 +3,6 @@
 
 - name: readonly
   fixed_attributes:
-    page_layout: readonly
     public_on: ~
     public_until: ~
     restricted: false

--- a/spec/libraries/page_layout_spec.rb
+++ b/spec/libraries/page_layout_spec.rb
@@ -76,14 +76,6 @@ module Alchemy
       end
     end
 
-    describe ".layouts_with_own_for_select" do
-      it "should not hold a layout twice" do
-        layouts = PageLayout.layouts_with_own_for_select("standard", 1, false)
-        layouts = layouts.collect(&:last)
-        expect(layouts.select { |l| l == "standard" }.length).to eq(1)
-      end
-    end
-
     describe ".selectable_layouts" do
       let(:site) { create(:alchemy_site) }
       let(:language) { create(:alchemy_language, code: :de) }

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -187,17 +187,6 @@ module Alchemy
           expect(page.elements).not_to be_empty
         end
 
-        context "with elements already on the page" do
-          before do
-            page.elements << create(:alchemy_element, name: "header")
-          end
-
-          it "does not autogenerate" do
-            page.save!
-            expect(page.elements.select { |e| e.name == "header" }.length).to eq(1)
-          end
-        end
-
         context "with children getting restricted set to true" do
           before do
             page.save
@@ -235,22 +224,6 @@ module Alchemy
             page.save
             expect(page.elements).to be_empty
           end
-        end
-      end
-
-      context "after changing the page layout" do
-        it "all elements not allowed on this page should be hidden" do
-          expect(news_page.elements.hidden).to be_empty
-          news_page.update!(page_layout: "standard")
-          hidden = news_page.all_elements.hidden.pluck(:name)
-          published = news_page.elements.published.pluck(:name)
-          expect(hidden).to eq(["news"])
-          expect(published).to match_array(["article", "header", "download"])
-        end
-
-        it "should autogenerate elements" do
-          news_page.update(page_layout: "contact")
-          expect(news_page.elements.pluck(:name)).to include("contactform")
         end
       end
 

--- a/spec/models/alchemy/site_spec.rb
+++ b/spec/models/alchemy/site_spec.rb
@@ -264,7 +264,6 @@ module Alchemy
                   "meta_description" => nil,
                   "meta_keywords" => nil,
                   "name" => false,
-                  "page_layout" => "readonly",
                   "public_on" => nil,
                   "public_until" => nil,
                   "restricted" => false,


### PR DESCRIPTION
## What is this pull request for?

Removes the possibilty to change the page type (the `page_layout` attribute) of an already persisted page.

This code is hard to carry over to the upcoming page versions and is rarely used on estblished sites. It mostly is
used during developing a new site. This should then be done with a data migration and not by humans anyway.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
