### PR TITLE
Deprecate page layout change

### DIFF
--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -38,8 +38,12 @@ module Alchemy
       after_update :trash_not_allowed_elements!,
         if: :saved_change_to_page_layout?
 
-      after_update :generate_elements,
-        if: :saved_change_to_page_layout?
+      after_update(if: :saved_change_to_page_layout?) do
+        Alchemy::Deprecation.warn(
+          "Autogenerating elements on page_layout change is deprecated and will be removed from Alchemy 6.0"
+        )
+        generate_elements
+      end
     end
 
     module ClassMethods
@@ -212,6 +216,7 @@ module Alchemy
       ])
       not_allowed_elements.to_a.map(&:trash!)
     end
+    deprecate :trash_not_allowed_elements!, deprecator: Alchemy::Deprecation
 
     # Deletes unique and already present definitions from @_element_definitions.
     #

--- a/lib/alchemy/page_layout.rb
+++ b/lib/alchemy/page_layout.rb
@@ -74,6 +74,7 @@ module Alchemy
         end
         mapped_layouts_for_select(layouts)
       end
+      deprecate :layouts_with_own_for_select, deprecator: Alchemy::Deprecation
 
       # Returns all layouts that can be used for creating a new page.
       #


### PR DESCRIPTION
## What is this pull request for?

Being able to switch the page type (the `page_layout` value) will be removed soon. 
Trashing existing elements and auto generate not existing elements on page layout change will not be supported anymore in Alchemy 6.0

This feature is hard to carry over to the new page versions and is rarely used on established sites.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
