### PR TITLE
Fix copy element feature

### DIFF
--- a/app/views/alchemy/admin/elements/_element_toolbar.html.erb
+++ b/app/views/alchemy/admin/elements/_element_toolbar.html.erb
@@ -1,4 +1,4 @@
-<% remarkable_type = element.class.name.demodulize.underscore.pluralize %>
+<% remarkable_type = "elements" %>
 <div class="element-toolbar">
   <span class="element_tools">
     <div class="button_with_label">

--- a/spec/features/admin/edit_elements_feature_spec.rb
+++ b/spec/features/admin/edit_elements_feature_spec.rb
@@ -35,4 +35,17 @@ RSpec.describe "The edit elements feature", type: :system do
       expect(page).to have_selector(".add-nestable-element-button")
     end
   end
+
+  describe "Copy element", :js do
+    let!(:element) { create(:alchemy_element, page: a_page) }
+
+    scenario "is possible to copy element into clipboard" do
+      visit alchemy.admin_elements_path(page_id: element.page_id)
+      expect(page).to have_selector(".element-toolbar")
+      find(".fa-clone").click
+      within "#flash_notices" do
+        expect(page).to have_content(/Copied Article/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What is this pull request for?

With the introduction of the Element Editor decorator this feature broke.

Instead of using the class of the element_editor local variable we use the remarkable type string that we exactly know in this case.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
