### PR TITLE
Persist deprecated flag on elements and contents

### DIFF
--- a/app/models/alchemy/content.rb
+++ b/app/models/alchemy/content.rb
@@ -192,10 +192,6 @@ module Alchemy
       essence && !essence.link.blank?
     end
 
-    def deprecated?
-      !!definition["deprecated"]
-    end
-
     # Returns true if this content should be taken for element preview.
     def preview_content?
       !!definition["as_element_title"]

--- a/app/models/alchemy/content/factory.rb
+++ b/app/models/alchemy/content/factory.rb
@@ -7,6 +7,17 @@ module Alchemy
     extend ActiveSupport::Concern
 
     module ClassMethods
+      SKIPPED_DEFINITION_ATTRIBUTES = %w(
+        type
+        settings
+        hint
+        default
+        validate
+        as_element_title
+        rss_title
+        rss_description
+      ).freeze
+
       SKIPPED_ATTRIBUTES_ON_COPY = %w(position created_at updated_at creator_id updater_id id)
 
       # Builds a new content as descriped in the elements.yml file.
@@ -24,9 +35,10 @@ module Alchemy
         end
 
         super(
-          name: definition[:name],
-          essence_type: normalize_essence_type(definition[:type]),
-          element_id: element.id
+          definition.except(*SKIPPED_DEFINITION_ATTRIBUTES).merge(
+            essence_type: normalize_essence_type(definition[:type]),
+            element: element
+          )
         ).tap(&:build_essence)
       end
 

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -37,7 +37,6 @@ module Alchemy
       "taggable",
       "compact",
       "message",
-      "deprecated",
     ].freeze
 
     SKIPPED_ATTRIBUTES_ON_COPY = [
@@ -251,38 +250,6 @@ module Alchemy
     # Defined as compact element?
     def compact?
       definition["compact"] == true
-    end
-
-    # Defined as deprecated element?
-    #
-    # You can either set true or a String on your elements definition.
-    #
-    # == Passing true
-    #
-    #     - name: old_element
-    #       deprecated: true
-    #
-    # The deprecation notice can be translated. Either as global notice for all deprecated elements.
-    #
-    #     en:
-    #       alchemy:
-    #         element_deprecation_notice: Foo baz widget is deprecated
-    #
-    # Or add a translation to your locale file for a per element notice.
-    #
-    #     en:
-    #       alchemy:
-    #         element_deprecation_notices:
-    #           old_element: Foo baz widget is deprecated
-    #
-    # == Pass a String
-    #
-    #     - name: old_element
-    #       deprecated: This element will be removed soon.
-    #
-    # @return Boolean
-    def deprecated?
-      !!definition["deprecated"]
     end
 
     # The element's view partial is dependent from its name

--- a/db/migrate/20210114152444_add_deprecated_to_alchemy_elements.rb
+++ b/db/migrate/20210114152444_add_deprecated_to_alchemy_elements.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDeprecatedToAlchemyElements < ActiveRecord::Migration[5.2]
+  def change
+    add_column :alchemy_elements, :deprecated, :boolean, null: false, default: false
+    add_index :alchemy_elements, :deprecated
+  end
+end

--- a/db/migrate/20210114163147_add_deprecated_to_alchemy_contents.rb
+++ b/db/migrate/20210114163147_add_deprecated_to_alchemy_contents.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDeprecatedToAlchemyContents < ActiveRecord::Migration[5.2]
+  def change
+    add_column :alchemy_contents, :deprecated, :boolean, default: false, null: false
+    add_index :alchemy_contents, :deprecated
+  end
+end

--- a/spec/dummy/db/migrate/20210114152444_add_deprecated_to_alchemy_elements.rb
+++ b/spec/dummy/db/migrate/20210114152444_add_deprecated_to_alchemy_elements.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20210114152444_add_deprecated_to_alchemy_elements.rb

--- a/spec/dummy/db/migrate/20210114163147_add_deprecated_to_alchemy_contents.rb
+++ b/spec/dummy/db/migrate/20210114163147_add_deprecated_to_alchemy_contents.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20210114163147_add_deprecated_to_alchemy_contents.rb

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_14_152444) do
+ActiveRecord::Schema.define(version: 2021_01_14_163147) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string "name"
@@ -32,6 +32,8 @@ ActiveRecord::Schema.define(version: 2021_01_14_152444) do
     t.string "essence_type", null: false
     t.integer "essence_id", null: false
     t.integer "element_id", null: false
+    t.boolean "deprecated", default: false, null: false
+    t.index ["deprecated"], name: "index_alchemy_contents_on_deprecated"
     t.index ["element_id"], name: "index_alchemy_contents_on_element_id"
     t.index ["essence_type", "essence_id"], name: "index_alchemy_contents_on_essence_type_and_essence_id", unique: true
   end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_07_111332) do
+ActiveRecord::Schema.define(version: 2021_01_14_152444) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string "name"
@@ -49,7 +49,9 @@ ActiveRecord::Schema.define(version: 2020_09_07_111332) do
     t.integer "updater_id"
     t.integer "parent_element_id"
     t.boolean "fixed", default: false, null: false
+    t.boolean "deprecated", default: false, null: false
     t.index ["creator_id"], name: "index_alchemy_elements_on_creator_id"
+    t.index ["deprecated"], name: "index_alchemy_elements_on_deprecated"
     t.index ["fixed"], name: "index_alchemy_elements_on_fixed"
     t.index ["page_id", "parent_element_id"], name: "index_alchemy_elements_on_page_id_and_parent_element_id"
     t.index ["page_id", "position"], name: "index_elements_on_page_id_and_position"

--- a/spec/models/alchemy/content_spec.rb
+++ b/spec/models/alchemy/content_spec.rb
@@ -264,7 +264,8 @@ module Alchemy
     end
 
     describe "#deprecated?" do
-      let(:content) { build_stubbed(:alchemy_content) }
+      let(:element) { build(:alchemy_element, page: build(:alchemy_page)) }
+      let(:content) { described_class.new(name: "text", element: element) }
 
       subject { content.deprecated? }
 
@@ -276,21 +277,33 @@ module Alchemy
 
       context "defined as deprecated" do
         before do
-          expect(content).to receive(:definition).at_least(:once).and_return({
-            "deprecated" => true,
-          })
+          expect(element).to receive(:content_definition_for).at_least(:once) do
+            {
+              name: "text",
+              type: "EssenceText",
+              deprecated: true,
+            }.with_indifferent_access
+          end
         end
 
         it "returns true" do
           expect(content.deprecated?).to be true
         end
+
+        it "deprecated is persisted" do
+          expect(content.tap(&:save!).reload).to be_deprecated
+        end
       end
 
       context "defined as deprecated per String" do
         before do
-          expect(content).to receive(:definition).at_least(:once).and_return({
-            "deprecated" => "This content is deprecated",
-          })
+          expect(element).to receive(:content_definition_for).at_least(:once) do
+            {
+              name: "text",
+              type: "EssenceText",
+              deprecated: "This content is deprecated",
+            }.with_indifferent_access
+          end
         end
 
         it "returns true" do

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -774,24 +774,29 @@ module Alchemy
     describe "#deprecated?" do
       subject { element.deprecated? }
 
-      let(:element) { build(:alchemy_element) }
+      let(:element) { described_class.new(name: "foo") }
 
       before do
-        expect(element).to receive(:definition) { definition }
+        expect(described_class).to receive(:definition_by_name).at_least(:once) { definition }
       end
 
       context "definition has 'deprecated' key with true value" do
-        let(:definition) { { "deprecated" => true } }
+        let(:definition) { { "name" => "foo", "deprecated" => true } }
         it { is_expected.to be(true) }
+
+        it "deprecated is persisted" do
+          element.page = build(:alchemy_page)
+          expect(element.tap(&:save!).reload).to be_deprecated
+        end
       end
 
       context "definition has 'deprecated' key with foo value" do
-        let(:definition) { { "deprecated" => "This is deprecated" } }
+        let(:definition) { { "name" => "foo", "deprecated" => "This is deprecated" } }
         it { is_expected.to be(true) }
       end
 
       context "definition has no 'deprecated' key" do
-        let(:definition) { { "name" => "article" } }
+        let(:definition) { { "name" => "foo" } }
         it { is_expected.to be(false) }
       end
     end


### PR DESCRIPTION
## What is this pull request for?

The newly introduced `deprecated` flag on elements and contents is now persisted in the database.
That way we are able to filter by that attribute.


## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
