### PR TITLE
Fix setting current_user in integration helper

### DIFF
--- a/lib/alchemy/test_support/integration_helpers.rb
+++ b/lib/alchemy/test_support/integration_helpers.rb
@@ -6,16 +6,16 @@ module Alchemy
     # This file is included in spec_helper.rb
     #
     module IntegrationHelpers
-      # Used to stub the current_alchemy_user
+      # Used to stub the current_user in integration specs
       #
       # Pass either a user object or a symbol in the format of ':as_admin'.
-      # The browser language is set to english ('en')
       #
       def authorize_user(user_or_role = nil)
-        if user_or_role.is_a?(Alchemy.user_class)
-          user = user_or_role
-        else
+        case user_or_role
+        when Symbol, String
           user = build(:alchemy_dummy_user, user_or_role)
+        else
+          user = user_or_role
         end
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
       end


### PR DESCRIPTION
Under some circumstances it might be that the `Alchemy.user_class` has not the same object id as the actual `Alchemy.user_class`

This fixes this by using the class name instead.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] The current tests cover this change
