### PR TITLE
Allow to safe hidden elements

### DIFF
--- a/app/views/alchemy/admin/elements/_element_footer.html.erb
+++ b/app/views/alchemy/admin/elements/_element_footer.html.erb
@@ -5,7 +5,7 @@
     </p>
   <% end %>
 
-  <button type="submit" <%= "disabled" unless element.public? %> form="element_<%= element.id %>_form" class="button" data-alchemy-button>
+  <button type="submit" form="element_<%= element.id %>_form" class="button" data-alchemy-button>
     <%= Alchemy.t(:save) %>
   </button>
 </div>


### PR DESCRIPTION
## What is this pull request for?

In b3a2763b21753a0ec3e9d9c311cbee9736dbb4db we disabled the element safe button for hidden elements.

It turns out that users are actually update hidden elements to make them visible shortly after.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
