### PR TITLE
Pin Ransack to below 2.4.2

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'originator',                       ['~> 3.1']
   gem.add_runtime_dependency 'non-stupid-digest-assets',         ['~> 1.0.8']
   gem.add_runtime_dependency 'rails',                            ['>= 5.2.0', '< 6.1']
-  gem.add_runtime_dependency 'ransack',                          ['>= 1.8', '< 3.0']
+  gem.add_runtime_dependency 'ransack',                          ['>= 1.8', '< 2.4.2'] # 2.4.2 dropped Ruby 2.5 support in a patch level release
   gem.add_runtime_dependency 'request_store',                    ['~> 1.2']
   gem.add_runtime_dependency 'responders',                       ['>= 2.0', '< 4.0']
   gem.add_runtime_dependency 'sassc-rails',                      ['~> 2.1']


### PR DESCRIPTION
## What is this pull request for?

They dropped Ruby 2.5 support in a patch level release. Since we still support Ruby 2.5 and will remove it in the next major release we need to pin Ransack to the last version that still supports Ruby 2.5

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
