### PR TITLE
Drop Rails 5.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ jobs:
       fail-fast: false
       matrix:
         rails:
-          - '5.2'
           - '6.0'
         ruby:
           - '2.5.x'

--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ or visit the existing demo at https://alchemy-demo.herokuapp.com
 
 ## 🚂 Rails Version
 
-**This version of AlchemyCMS runs with Rails 5.2 and Rails 6.0**
+**This version of AlchemyCMS runs with Rails 6.0**
 
+* For a Rails 5.2 compatible version use the [`5.2-stable` branch](https://github.com/AlchemyCMS/alchemy_cms/tree/5.2-stable).
 * For a Rails 5.0 or 5.1 compatible version use the [`4.5-stable` branch](https://github.com/AlchemyCMS/alchemy_cms/tree/4.5-stable).
 * For a Rails 4.2 compatible version use the [`3.6-stable` branch](https://github.com/AlchemyCMS/alchemy_cms/tree/3.6-stable).
 * For a Rails 4.0/4.1 compatible version use the [`3.1-stable` branch](https://github.com/AlchemyCMS/alchemy_cms/tree/3.1-stable).

--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'kaminari',                         ['~> 1.1']
   gem.add_runtime_dependency 'originator',                       ['~> 3.1']
   gem.add_runtime_dependency 'non-stupid-digest-assets',         ['~> 1.0.8']
-  gem.add_runtime_dependency 'rails',                            ['>= 5.2.0', '< 6.1']
+  gem.add_runtime_dependency 'rails',                            ['>= 6.0', '< 6.1']
   gem.add_runtime_dependency 'ransack',                          ['>= 1.8', '< 3.0']
   gem.add_runtime_dependency 'request_store',                    ['~> 1.2']
   gem.add_runtime_dependency 'responders',                       ['>= 2.0', '< 4.0']


### PR DESCRIPTION
## What is this pull request for?

Rails 6.1 has been released and 5.2 is no longer maintained. Also Ruby 3.0 will not be supported in Rails 5.2

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
