### PR TITLE
Fix jpeg quality option for jpeg files

### DIFF
--- a/app/models/alchemy/picture_variant.rb
+++ b/app/models/alchemy/picture_variant.rb
@@ -93,7 +93,7 @@ module Alchemy
 
       convert_format = render_format.sub("jpeg", "jpg") != picture.image_file_format.sub("jpeg", "jpg")
 
-      if render_format =~ /jpe?g/ && convert_format
+      if render_format =~ /jpe?g/ && (convert_format || options[:quality])
         quality = options[:quality] || Config.get(:output_image_jpg_quality)
         encoding_options << "-quality #{quality}"
       end

--- a/spec/models/alchemy/picture_variant_spec.rb
+++ b/spec/models/alchemy/picture_variant_spec.rb
@@ -223,6 +223,18 @@ RSpec.describe Alchemy::PictureVariant do
         it "does not convert the picture format" do
           expect(subject).to_not respond_to(:steps)
         end
+
+        context "and quality is passed in options" do
+          let(:options) do
+            { format: format, quality: "30" }
+          end
+
+          it "sets the quality" do
+            step = subject.steps[0]
+            expect(step.name).to eq(:encode)
+            expect(step.arguments).to eq([format, "-quality 30"])
+          end
+        end
       end
 
       context "and image has jpeg format" do
@@ -232,6 +244,18 @@ RSpec.describe Alchemy::PictureVariant do
 
         it "does not convert the picture format" do
           expect(subject).to_not respond_to(:steps)
+        end
+
+        context "and quality is passed in options" do
+          let(:options) do
+            { format: format, quality: "30" }
+          end
+
+          it "sets the quality" do
+            step = subject.steps[0]
+            expect(step.name).to eq(:encode)
+            expect(step.arguments).to eq([format, "-quality 30"])
+          end
         end
       end
     end

--- a/spec/models/alchemy/picture_variant_spec.rb
+++ b/spec/models/alchemy/picture_variant_spec.rb
@@ -189,76 +189,50 @@ RSpec.describe Alchemy::PictureVariant do
     end
   end
 
-  context "when jpg format is requested" do
-    let(:options) do
-      { format: "jpg" }
-    end
-
-    context "and the image file format is not JPG" do
-      it "sets the default quality" do
-        step = subject.steps[0]
-        expect(step.name).to eq(:encode)
-        expect(step.arguments).to eq(["jpg", "-quality 85"])
+  %w[jpg jpeg].each do |format|
+    context "when #{format} format is requested" do
+      let(:options) do
+        { format: format }
       end
 
-      context "and quality is passed" do
-        let(:options) do
-          { format: "jpg", quality: "30" }
-        end
-
-        it "sets the quality" do
+      context "and the image file format is not JPG" do
+        it "sets the default quality" do
           step = subject.steps[0]
           expect(step.name).to eq(:encode)
-          expect(step.arguments).to eq(["jpg", "-quality 30"])
+          expect(step.arguments).to eq([format, "-quality 85"])
+        end
+
+        context "and quality is passed" do
+          let(:options) do
+            { format: format, quality: "30" }
+          end
+
+          it "sets the quality" do
+            step = subject.steps[0]
+            expect(step.name).to eq(:encode)
+            expect(step.arguments).to eq([format, "-quality 30"])
+          end
         end
       end
-    end
 
-    context "and image has jpg format" do
-      let(:alchemy_picture) do
-        build_stubbed(:alchemy_picture, image_file: image_file, image_file_format: "jpg")
+      context "and image has jpg format" do
+        let(:alchemy_picture) do
+          build_stubbed(:alchemy_picture, image_file: image_file, image_file_format: "jpg")
+        end
+
+        it "does not convert the picture format" do
+          expect(subject).to_not respond_to(:steps)
+        end
       end
 
-      it "does not convert the picture format" do
-        expect(subject).to_not respond_to(:steps)
-      end
-    end
+      context "and image has jpeg format" do
+        let(:alchemy_picture) do
+          build_stubbed(:alchemy_picture, image_file: image_file, image_file_format: "jpeg")
+        end
 
-    context "and image has jpeg format" do
-      let(:alchemy_picture) do
-        build_stubbed(:alchemy_picture, image_file: image_file, image_file_format: "jpeg")
-      end
-
-      it "does not convert the picture format" do
-        expect(subject).to_not respond_to(:steps)
-      end
-    end
-  end
-
-  context "when jpeg format is requested" do
-    let(:options) do
-      {
-        format: "jpeg",
-      }
-    end
-
-    context "and image has jpg format" do
-      let(:alchemy_picture) do
-        build_stubbed(:alchemy_picture, image_file: image_file, image_file_format: "jpg")
-      end
-
-      it "does not convert the picture format" do
-        expect(subject).to_not respond_to(:steps)
-      end
-    end
-
-    context "and image has jpeg format" do
-      let(:alchemy_picture) do
-        build_stubbed(:alchemy_picture, image_file: image_file, image_file_format: "jpeg")
-      end
-
-      it "does not convert the picture format" do
-        expect(subject).to_not respond_to(:steps)
+        it "does not convert the picture format" do
+          expect(subject).to_not respond_to(:steps)
+        end
       end
     end
   end


### PR DESCRIPTION
## What is this pull request for?

The quality option was previously ignored, if the image was a JPEG. Now the quality configuration will be added, if the file isn't a JPEG or the quality - option was set.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
