### PR TITLE
 Respect Language public status for page public status

### DIFF
--- a/app/assets/stylesheets/alchemy/buttons.scss
+++ b/app/assets/stylesheets/alchemy/buttons.scss
@@ -40,10 +40,6 @@ input.button {
 
   &[disabled] {
     cursor: not-allowed;
-
-    & + label {
-      display: none;
-    }
   }
 }
 

--- a/app/models/alchemy/language.rb
+++ b/app/models/alchemy/language.rb
@@ -54,9 +54,6 @@ module Alchemy
     after_update :set_pages_language,
       if: :should_set_pages_language?
 
-    after_update :unpublish_pages,
-      if: :should_unpublish_pages?
-
     before_destroy if: -> { pages.any? } do
       errors.add(:pages, :still_present)
       throw(:abort)
@@ -169,14 +166,6 @@ module Alchemy
 
     def set_pages_language
       pages.update_all language_code: code
-    end
-
-    def should_unpublish_pages?
-      saved_changes[:public] == [true, false]
-    end
-
-    def unpublish_pages
-      pages.update_all(public_on: nil, public_until: nil)
     end
   end
 end

--- a/app/models/alchemy/page/page_natures.rb
+++ b/app/models/alchemy/page/page_natures.rb
@@ -6,7 +6,7 @@ module Alchemy
 
     def public?
       current_time = Time.current
-      already_public_for?(current_time) && still_public_for?(current_time)
+      language.public? && already_public_for?(current_time) && still_public_for?(current_time)
     end
 
     def expiration_time

--- a/app/models/alchemy/page/page_scopes.rb
+++ b/app/models/alchemy/page/page_scopes.rb
@@ -96,6 +96,7 @@ module Alchemy
       # All public pages
       #
       def published
+        joins(:language).merge(Language.published).
         where("#{table_name}.public_on <= :time AND " \
               "(#{table_name}.public_until IS NULL " \
               "OR #{table_name}.public_until >= :time)", time: Time.current)

--- a/app/views/alchemy/admin/pages/edit.html.erb
+++ b/app/views/alchemy/admin/pages/edit.html.erb
@@ -56,23 +56,35 @@
     <% end %>
     <label><%= Alchemy.t(:page_properties) %></label>
   </div>
-  <% if can?(:publish, @page) %>
-    <div class="button_with_label">
-      <%= form_tag alchemy.publish_admin_page_path(@page), id: 'publish_page_form' do %>
-        <%= button_tag class: 'icon_button', title: Alchemy.t(:explain_publishing) do %>
-          <%= render_icon('cloud-upload-alt') %>
-        <% end %>
-        <label><%= Alchemy.t("Publish page") %></label>
+  <div class="button_with_label">
+    <%= form_tag alchemy.publish_admin_page_path(@page), id: 'publish_page_form' do %>
+      <%= button_tag class: 'icon_button', disabled: cannot?(:publish, @page) do %>
+        <%= render_icon('cloud-upload-alt') %>
       <% end %>
-    </div>
-  <% end %>
+      <label>
+        <% if @page.language.public? %>
+          <%= Alchemy.t(:explain_publishing) %>
+        <% elsif @page.editable_by?(current_alchemy_user) %>
+          <%= Alchemy.t(:publish_page_language_not_public) %>
+        <% else %>
+          <%= Alchemy.t(:publish_page_not_allowed) %>
+        <% end %>
+      </label>
+    <% end %>
+  </div>
   <% unless @page.layoutpage? %>
     <div class="button_with_label">
       <%= form_tag alchemy.visit_admin_page_path(@page), id: 'visit_page_form' do %>
         <%= button_tag class: 'icon_button', disabled: !@page.public? do %>
           <%= render_icon('external-link-alt') %>
         <% end %>
-        <label><%= Alchemy.t("Visit page") %></label>
+        <label>
+          <% if @page.public? %>
+            <%= Alchemy.t("Visit page") %>
+          <% else %>
+            <%= Alchemy.t(:cannot_visit_unpublic_page) %>
+          <% end %>
+        </label>
       <% end %>
     </div>
   <% end %>

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -266,7 +266,6 @@ en:
     "Please log in": "Please log in."
     "Please seperate the tags with commata": "* Please seperate the tags with commas."
     "Properties": "Properties"
-    "Publish page": "Publish page"
     "Read the License": "Read the License"
     "Redirects to": "Redirects to"
     "Reload Preview": "Reload Preview"
@@ -334,6 +333,7 @@ en:
     big_thumbnails: "Big thumbnails"
     cancel: "cancel"
     cannot_delete_picture_notice: "Cannot delete Picture %{name}, because it's still in use."
+    cannot_visit_unpublic_page: "Publish page before visiting it."
     choose_file_to_link: "Please choose a file to link"
     "clear clipboard": "clear clipboard"
     click_to_show_all: "Click to show all again."
@@ -390,7 +390,7 @@ en:
     element_saved: "Saved element."
     enter_external_link: "Please enter the URL you want to link with"
     explain_cropping: "<p>Move the frame and change its size with the mouse or arrow keys to adjust the image mask. Click on \"apply\" when you are satisfied with your selection.</p><p>If you want to return to the original centered image mask like it was defined in the layout, click \"reset\" and \"apply\" afterwards.</p>"
-    explain_publishing: "Publish the page and remove the cached version from the server."
+    explain_publishing: "Publish current page content"
     explain_sitemap_dragndrop_sorting: "Tip: Drag the pages at the icon in order to sort them."
     explain_unlocking: "Leave page and unlock it for other users."
     external_link_notice_1: "Please enter the complete url with http:// or a similar protocol."
@@ -535,6 +535,8 @@ en:
       '1024': '1024px (iPad - Landscape)'
       '1280': '1280px (Desktop)'
     preview_url: Preview
+    publish_page_language_not_public: Cannot publish page if language is not public
+    publish_page_not_allowed: You have not the permission to publish this page
     recently_uploaded_only: 'Recently uploaded only'
     "regular method": "Regular method"
     remove: "Remove"

--- a/lib/alchemy/permissions.rb
+++ b/lib/alchemy/permissions.rb
@@ -158,8 +158,11 @@ module Alchemy
         can([
           :create,
           :destroy,
-          :publish,
         ], Alchemy::Page) { |p| p.editable_by?(@user) }
+
+        can(:publish, Alchemy::Page) do |page|
+          page.language.public? && page.editable_by?(@user)
+        end
 
         can :manage, Alchemy::Picture
         can :manage, Alchemy::Attachment

--- a/spec/features/admin/page_editing_feature_spec.rb
+++ b/spec/features/admin/page_editing_feature_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Page editing feature", type: :system do
 
     it "cannot publish page." do
       visit alchemy.edit_admin_page_path(a_page)
-      expect(page).to_not have_selector("#publish_page_form")
+      expect(page).to have_selector("#publish_page_form button[disabled]")
     end
 
     describe "the preview frame", :js do

--- a/spec/libraries/permissions_spec.rb
+++ b/spec/libraries/permissions_spec.rb
@@ -167,8 +167,22 @@ describe Alchemy::Permissions do
       is_expected.to be_able_to(:switch_language, Alchemy::Page)
     end
 
-    it "can publish pages" do
-      is_expected.to be_able_to(:publish, Alchemy::Page)
+    context "if page language is public" do
+      let(:language) { create(:alchemy_language, :german, public: true) }
+      let(:page) { create(:alchemy_page, language: language) }
+
+      it "can publish pages" do
+        is_expected.to be_able_to(:publish, page)
+      end
+    end
+
+    context "if page language is not public" do
+      let(:language) { create(:alchemy_language, :german, public: false) }
+      let(:page) { create(:alchemy_page, language: language) }
+
+      it "cannot publish pages" do
+        is_expected.to_not be_able_to(:publish, page)
+      end
     end
 
     it "can manage attachments" do

--- a/spec/models/alchemy/language_spec.rb
+++ b/spec/models/alchemy/language_spec.rb
@@ -83,16 +83,6 @@ module Alchemy
           expect([page.language_code, @other_page.language_code]).to eq([language.code, language.code])
         end
       end
-
-      describe "#unpublish_pages" do
-        it "should set all pages to unpublic if it gets set to unpublic" do
-          page = create(:alchemy_page, language: language)
-          @other_page = create(:alchemy_page, language: language)
-          language.update(public: false)
-          language.reload; page.reload; @other_page.reload
-          expect([page.public?, @other_page.public?]).to eq([false, false])
-        end
-      end
     end
 
     describe ".default" do

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -558,11 +558,14 @@ module Alchemy
       let!(:public_one) { create(:alchemy_page, :public) }
       let!(:public_two) { create(:alchemy_page, :public) }
       let!(:non_public_page) { create(:alchemy_page) }
+      let!(:page_with_non_public_language) { create(:alchemy_page, :public, language: non_public_language) }
+      let(:non_public_language) { create(:alchemy_language, :german, public: false) }
 
       it "returns public available pages" do
         expect(published).to include(public_one)
         expect(published).to include(public_two)
         expect(published).to_not include(non_public_page)
+        expect(published).to_not include(page_with_non_public_language)
       end
     end
 
@@ -1311,6 +1314,13 @@ module Alchemy
 
       context "when public_on is set to future date" do
         let(:page) { create(:alchemy_page, public_on: Time.current + 2.days) }
+
+        it { is_expected.to be(false) }
+      end
+
+      context "when language is not public" do
+        let(:language) { create(:alchemy_language, public: false, default: false) }
+        let(:page) { create(:alchemy_page, :public, language: language) }
 
         it { is_expected.to be(false) }
       end


### PR DESCRIPTION
## What is this pull request for?

A page is only considered public if the language is also public. This is always the case for the default language, because there cannot be at least one public default language (assurred in the language validations).

Also do not unpublish all pages if language gets unpublished. This was a very destrutive behavior and should not be done.
Instead we should take the languages public status into account for the page publication status.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
