### PR TITLE
Use Ubuntu 18.04 on GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   RSpec:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Use Ubuntu 18.04 to run GH actions.

With Ubuntu 20 lots of gems need to be recompiled. Sticking with 18 for now.