### PR TITLE
Do not include unpublished pages in breadcrumb

### DIFF
--- a/app/helpers/alchemy/pages_helper.rb
+++ b/app/helpers/alchemy/pages_helper.rb
@@ -125,7 +125,7 @@ module Alchemy
 
       pages = options[:page].
         self_and_ancestors.contentpages.
-        accessible_by(current_ability, :see)
+        published
 
       if options.delete(:restricted_only)
         pages = pages.restricted

--- a/lib/alchemy/permissions.rb
+++ b/lib/alchemy/permissions.rb
@@ -36,7 +36,6 @@ module Alchemy
     module GuestUser
       def alchemy_guest_user_rules
         can([:show, :download], Alchemy::Attachment) { |a| !a.restricted? }
-        can :see, Alchemy::Page, restricted: false
 
         can :read, Alchemy::Content, Alchemy::Content.available.not_restricted do |c|
           c.public? && !c.restricted?
@@ -64,7 +63,6 @@ module Alchemy
 
         # Resources
         can [:show, :download], Alchemy::Attachment
-        can :see, Alchemy::Page, restricted: true
 
         can :read, Alchemy::Content, Alchemy::Content.available do |c|
           c.public?

--- a/spec/helpers/alchemy/pages_helper_spec.rb
+++ b/spec/helpers/alchemy/pages_helper_spec.rb
@@ -99,49 +99,72 @@ module Alchemy
         allow(helper).to receive(:current_ability).and_return(Alchemy::Permissions.new(user))
       end
 
+      subject do
+        helper.render_breadcrumb(page: page)
+      end
+
       it "should render a breadcrumb to current page" do
-        expect(helper.render_breadcrumb(page: page)).to have_selector(".active.last[contains('#{page.name}')]")
+        is_expected.to have_selector(".active.last[contains('#{page.name}')]")
       end
 
       context "with options[:separator] given" do
+        subject do
+          helper.render_breadcrumb(page: page, separator: "<span>###</span>")
+        end
+
         it "should render a breadcrumb with an alternative separator" do
-          expect(helper.render_breadcrumb(page: page, separator: "<span>###</span>")).to have_selector('span[contains("###")]')
+          is_expected.to have_selector('span[contains("###")]')
         end
       end
 
       context "with options[:reverse] set to true" do
+        subject do
+          helper.render_breadcrumb(page: page, reverse: true)
+        end
+
         it "should render a breadcrumb in reversed order" do
-          expect(helper.render_breadcrumb(page: page, reverse: true)).to have_selector('.active.first[contains("A Public Page")]')
+          is_expected.to have_selector('.active.first[contains("A Public Page")]')
         end
       end
 
       context "with options[:restricted_only] set to true" do
         let(:user) { build(:alchemy_dummy_user) }
 
+        subject do
+          helper.render_breadcrumb(page: page, restricted_only: true).strip
+        end
+
         it "should render a breadcrumb of restricted pages only" do
           page.update_columns(restricted: true, urlname: "a-restricted-public-page", name: "A restricted Public Page", title: "A restricted Public Page")
-          result = helper.render_breadcrumb(page: page, restricted_only: true).strip
-          expect(result).to have_selector("*[contains(\"#{page.name}\")]")
-          expect(result).to_not have_selector("*[contains(\"#{parent.name}\")]")
+          is_expected.to have_selector("*[contains(\"#{page.name}\")]")
+          is_expected.to_not have_selector("*[contains(\"#{parent.name}\")]")
         end
       end
 
-      it "should render a breadcrumb of unpublished pages" do
+      it "should not include unpublished pages" do
         page.update_columns(public_on: nil, urlname: "a-unpublic-page", name: "A Unpublic Page", title: "A Unpublic Page")
-        expect(helper.render_breadcrumb(page: page)).to match(/A Unpublic Page/)
+        is_expected.to_not match(/A Unpublic Page/)
       end
 
       context "with options[:without]" do
+        subject do
+          helper.render_breadcrumb(page: page, without: page)
+        end
+
         it "should render a breadcrumb without this page" do
           page.update_columns(urlname: "not-me", name: "Not Me", title: "Not Me")
-          expect(helper.render_breadcrumb(page: page, without: page)).not_to match(/Not Me/)
+          is_expected.not_to match(/Not Me/)
         end
       end
 
       context "with options[:without] as array" do
+        subject do
+          helper.render_breadcrumb(page: page, without: [page])
+        end
+
         it "should render a breadcrumb without these pages." do
           page.update_columns(urlname: "not-me", name: "Not Me", title: "Not Me")
-          expect(helper.render_breadcrumb(page: page, without: [page])).not_to match(/Not Me/)
+          is_expected.not_to match(/Not Me/)
         end
       end
     end

--- a/spec/libraries/permissions_spec.rb
+++ b/spec/libraries/permissions_spec.rb
@@ -39,11 +39,6 @@ describe Alchemy::Permissions do
       is_expected.not_to be_able_to(:index, restricted_page)
     end
 
-    it "can only see public not restricted pages" do
-      is_expected.to be_able_to(:see, public_page)
-      is_expected.not_to be_able_to(:see, restricted_page)
-    end
-
     it "can only see public not restricted elements" do
       is_expected.to be_able_to(:show, published_element)
       is_expected.not_to be_able_to(:show, restricted_element)
@@ -77,10 +72,6 @@ describe Alchemy::Permissions do
       is_expected.to be_able_to(:show, restricted_page)
       is_expected.to be_able_to(:index, public_page)
       is_expected.to be_able_to(:index, restricted_page)
-    end
-
-    it "can see restricted pages" do
-      is_expected.to be_able_to(:see, restricted_page)
     end
 
     it "can see public restricted elements" do
@@ -213,8 +204,8 @@ describe Alchemy::Permissions do
     let(:user) { mock_model(Alchemy.user_class, alchemy_roles: []) }
 
     it "can only see public not restricted pages (like the guest role)" do
-      is_expected.to be_able_to(:see, public_page)
-      is_expected.not_to be_able_to(:see, restricted_page)
+      is_expected.to be_able_to(:show, public_page)
+      is_expected.not_to be_able_to(:show, restricted_page)
     end
   end
 end


### PR DESCRIPTION
## What is this pull request for?

It does not make sense to include an unpublished page in a breadcrumb since the user is not able to navigate to it anyway.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
