### PR TITLE
Add Page Versions

### DIFF
--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -8,8 +8,8 @@ module Alchemy
 
       def index
         @page = Page.find(params[:page_id])
-        @elements = @page.all_elements.not_nested.unfixed.includes(*element_includes)
-        @fixed_elements = @page.all_elements.fixed.includes(*element_includes)
+        @elements = @page.draft_version.elements.not_nested.unfixed.includes(*element_includes)
+        @fixed_elements = @page.draft_version.elements.fixed.includes(*element_includes)
       end
 
       def new

--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -28,7 +28,9 @@ module Alchemy
           if @paste_from_clipboard = params[:paste_from_clipboard].present?
             @element = paste_element_from_clipboard
           else
-            @element = Element.create(create_element_params)
+            @element = Element.new(create_element_params)
+            @element.page_version = @page.draft_version
+            @element.save
           end
           if @page.definition["insert_elements_at"] == "top"
             @insert_at_top = true

--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -7,30 +7,32 @@ module Alchemy
       authorize_resource class: Alchemy::Element
 
       def index
-        @page = Page.find(params[:page_id])
-        @elements = @page.draft_version.elements.not_nested.unfixed.includes(*element_includes)
-        @fixed_elements = @page.draft_version.elements.fixed.includes(*element_includes)
+        @page_version = PageVersion.find(params[:page_version_id])
+        @page = @page_version.page
+        elements = @page_version.elements.order(:position).includes(*element_includes)
+        @elements = elements.not_nested.unfixed
+        @fixed_elements = elements.not_nested.fixed
       end
 
       def new
-        @page = Page.find(params[:page_id])
+        @page_version = PageVersion.find(params[:page_version_id])
+        @page = @page_version.page
         @parent_element = Element.find_by(id: params[:parent_element_id])
         @elements = @page.available_elements_within_current_scope(@parent_element)
-        @element = @page.elements.build
+        @element = @page_version.elements.build
         @clipboard = get_clipboard("elements")
         @clipboard_items = Element.all_from_clipboard_for_page(@clipboard, @page)
       end
 
       # Creates a element as discribed in config/alchemy/elements.yml on page via AJAX.
       def create
-        @page = Page.find(params[:element][:page_id])
+        @page_version = PageVersion.find(params[:element][:page_version_id])
+        @page = @page_version.page
         Element.transaction do
           if @paste_from_clipboard = params[:paste_from_clipboard].present?
             @element = paste_element_from_clipboard
           else
-            @element = Element.new(create_element_params)
-            @element.page_version = @page.draft_version
-            @element.save
+            @element = Element.create(create_element_params)
           end
           if @page.definition["insert_elements_at"] == "top"
             @insert_at_top = true
@@ -40,7 +42,7 @@ module Alchemy
         if @element.valid?
           render :create
         else
-          @element.page = @page
+          @element.page_version = @page_version
           @elements = @page.available_element_definitions
           @clipboard = get_clipboard("elements")
           @clipboard_items = Element.all_from_clipboard_for_page(@clipboard, @page)
@@ -133,7 +135,7 @@ module Alchemy
         @source_element = Element.find(element_from_clipboard["id"])
         element = Element.copy(@source_element, {
           parent_element_id: create_element_params[:parent_element_id],
-          page_id: @page.id,
+          page_version_id: @page_version.id,
         })
         if element_from_clipboard["action"] == "cut"
           @cut_element_id = @source_element.id
@@ -156,7 +158,7 @@ module Alchemy
       end
 
       def create_element_params
-        params.require(:element).permit(:name, :page_id, :parent_element_id)
+        params.require(:element).permit(:name, :page_version_id, :parent_element_id)
       end
     end
   end

--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -33,6 +33,8 @@ module Alchemy
 
       before_action :set_view, only: [:index]
 
+      before_action :set_page_version, only: [:show, :edit]
+
       def index
         @query = @current_language.pages.contentpages.ransack(search_filter_params[:q])
 
@@ -400,6 +402,10 @@ module Alchemy
 
       def set_root_page
         @page_root = @current_language.root_page
+      end
+
+      def set_page_version
+        @page_version = @page.draft_version
       end
 
       def serialized_page_tree

--- a/app/controllers/alchemy/api/elements_controller.rb
+++ b/app/controllers/alchemy/api/elements_controller.rb
@@ -9,13 +9,16 @@ module Alchemy
     # If you want to only load a specific type of element pass ?named=an_element_name
     #
     def index
-      @elements = Element.not_nested
+      if params[:page_id].present?
+        @page = Page.find(params[:page_id])
+        @elements = @page.elements.not_nested
+      else
+        @elements = Element.not_nested.joins(:page_version).merge(PageVersion.published)
+      end
+
       # Fix for cancancan not able to merge multiple AR scopes for logged in users
       if cannot? :manage, Alchemy::Element
         @elements = @elements.accessible_by(current_ability, :index)
-      end
-      if params[:page_id].present?
-        @elements = @elements.where(page_id: params[:page_id])
       end
       if params[:named].present?
         @elements = @elements.named(params[:named])

--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -74,7 +74,7 @@ module Alchemy
       options = {
         from_page: @page,
         render_format: "html",
-        page_version: :public_version
+        page_version: @preview_mode ? :draft_version : :public_version,
       }.update(options)
 
       finder = options[:finder] || Alchemy::ElementsFinder.new(options)

--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -74,13 +74,11 @@ module Alchemy
       options = {
         from_page: @page,
         render_format: "html",
-        page_version: @preview_mode ? :draft_version : :public_version,
       }.update(options)
 
       finder = options[:finder] || Alchemy::ElementsFinder.new(options)
-      elements = finder.elements(
-        page_version: options[:from_page]&.send(options[:page_version])
-      )
+      page_version = @page_version || options[:from_page]&.public_version
+      elements = finder.elements(page_version: page_version)
 
       buff = []
       elements.each_with_index do |element, i|
@@ -136,7 +134,7 @@ module Alchemy
     def render_element(element, options = {}, counter = 1)
       if element.nil?
         warning("Element is nil")
-        render "alchemy/elements/view_not_found", {name: "nil"}
+        render "alchemy/elements/view_not_found", { name: "nil" }
         return
       end
 

--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -74,10 +74,13 @@ module Alchemy
       options = {
         from_page: @page,
         render_format: "html",
+        page_version: :public_version
       }.update(options)
 
       finder = options[:finder] || Alchemy::ElementsFinder.new(options)
-      elements = finder.elements(page: options[:from_page])
+      elements = finder.elements(
+        page_version: options[:from_page]&.send(options[:page_version])
+      )
 
       buff = []
       elements.each_with_index do |element, i|

--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -72,12 +72,16 @@ module Alchemy
     #
     def render_elements(options = {})
       options = {
-        from_page: @page,
         render_format: "html",
       }.update(options)
 
+      if options.key?(:from_page)
+        page_version = options[:from_page]&.public_version
+      else
+        page_version = @page_version || @page.public_version
+      end
+
       finder = options[:finder] || Alchemy::ElementsFinder.new(options)
-      page_version = @page_version || options[:from_page]&.public_version
       elements = finder.elements(page_version: page_version)
 
       buff = []

--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -77,7 +77,13 @@ module Alchemy
       }.update(options)
 
       finder = options[:finder] || Alchemy::ElementsFinder.new(options)
-      page_version = @page_version || options[:from_page]&.public_version
+
+      page_version = if @preview_mode
+          options[:from_page]&.draft_version
+        else
+          options[:from_page]&.public_version
+        end
+
       elements = finder.elements(page_version: page_version)
 
       buff = []

--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -72,16 +72,12 @@ module Alchemy
     #
     def render_elements(options = {})
       options = {
+        from_page: @page,
         render_format: "html",
       }.update(options)
 
-      if options.key?(:from_page)
-        page_version = options[:from_page]&.public_version
-      else
-        page_version = @page_version || @page.public_version
-      end
-
       finder = options[:finder] || Alchemy::ElementsFinder.new(options)
+      page_version = @page_version || options[:from_page]&.public_version
       elements = finder.elements(page_version: page_version)
 
       buff = []

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -7,7 +7,7 @@
 #  id                :integer          not null, primary key
 #  name              :string
 #  position          :integer
-#  page_id           :integer          not null
+#  page_version_id   :integer          not null
 #  public            :boolean          default(TRUE)
 #  fixed             :boolean          default(FALSE)
 #  folded            :boolean          default(FALSE)
@@ -83,8 +83,8 @@ module Alchemy
       dependent: :destroy,
       inverse_of: :parent_element
 
-    belongs_to :page, touch: true, inverse_of: :elements
-    belongs_to :page_version, touch: true, inverse_of: :elements, optional: true
+    belongs_to :page_version, touch: true, inverse_of: :elements
+    has_one :page, through: :page_version
 
     # A nested element belongs to a parent element.
     belongs_to :parent_element,
@@ -316,7 +316,6 @@ module Alchemy
       nested_elements.map do |nested_element|
         Element.copy(nested_element, {
           parent_element_id: target_element.id,
-          page_id: target_element.page_id,
           page_version_id: target_element.page_version_id,
         })
       end

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -56,15 +56,15 @@ module Alchemy
       "updater_id",
     ].freeze
 
-    # All Elements that share the same page id and parent element id and are fixed or not are considered a list.
+    # All Elements that share the same page version and parent element and are fixed or not are considered a list.
     #
-    # If parent element id is nil (typical case for a simple page),
+    # If parent_element_id is nil (typical case for a simple page),
     # then all elements on that page are still in one list,
     # because acts_as_list correctly creates this statement:
     #
-    #   WHERE page_id = 1 and fixed = FALSE AND parent_element_id = NULL
+    #   WHERE page_version_id = 1 and fixed = FALSE AND parent_element_id = NULL
     #
-    acts_as_list scope: [:page_id, :fixed, :parent_element_id]
+    acts_as_list scope: [:page_version_id, :fixed, :parent_element_id]
 
     stampable stamper_class_name: Alchemy.user_class_name
 

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -84,6 +84,7 @@ module Alchemy
       inverse_of: :parent_element
 
     belongs_to :page, touch: true, inverse_of: :elements
+    belongs_to :page_version, touch: true, inverse_of: :elements, optional: true
 
     # A nested element belongs to a parent element.
     belongs_to :parent_element,

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -317,6 +317,7 @@ module Alchemy
         Element.copy(nested_element, {
           parent_element_id: target_element.id,
           page_id: target_element.page_id,
+          page_version_id: target_element.page_version_id,
         })
       end
     end

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -117,6 +117,7 @@ module Alchemy
     has_many :nodes, class_name: "Alchemy::Node", inverse_of: :page
     has_many :versions, class_name: "Alchemy::PageVersion", inverse_of: :page, dependent: :destroy
     has_one :draft_version, -> { drafts }, class_name: "Alchemy::PageVersion"
+    has_one :public_version, -> { published }, class_name: "Alchemy::PageVersion"
 
     before_validation :set_language,
       if: -> { language.nil? }

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -116,6 +116,7 @@ module Alchemy
     has_many :legacy_urls, class_name: "Alchemy::LegacyPageUrl"
     has_many :nodes, class_name: "Alchemy::Node", inverse_of: :page
     has_many :versions, class_name: "Alchemy::PageVersion", inverse_of: :page, dependent: :destroy
+    has_one :draft_version, -> { drafts }, class_name: "Alchemy::PageVersion"
 
     before_validation :set_language,
       if: -> { language.nil? }

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -302,7 +302,9 @@ module Alchemy
     # Instance methods
     #
 
-    # Returns elements from page.
+    # Returns elements from pages public version.
+    #
+    # You can pass another page_version to load elements from in the options.
     #
     # @option options [Array<String>|String] :only
     #   Returns only elements with given names
@@ -321,11 +323,14 @@ module Alchemy
     # @option options [Class] :finder (Alchemy::ElementsFinder)
     #   A class that will return elements from page.
     #   Use this for your custom element loading logic.
+    # @option options [Alchemy::PageVersion] :page_version
+    #   A page version to load elements from.
+    #   Uses the pages public_version by default.
     #
     # @return [ActiveRecord::Relation]
     def find_elements(options = {})
       finder = options[:finder] || Alchemy::ElementsFinder.new(options)
-      finder.elements(page: self)
+      finder.elements(page_version: options[:page_version] || public_version)
     end
 
     # = The url_path for this page

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -453,17 +453,7 @@ module Alchemy
         public_on: already_public_for?(current_time) ? public_on : current_time,
         public_until: still_public_for?(current_time) ? public_until : nil,
       )
-      self.class.transaction do
-        versions.create!(public_on: current_time).tap do |version|
-          # We must not use .find_each here to not mess up the order of elements
-          draft_version.elements.not_nested.available.each do |element|
-            Element.copy(element, page_version_id: version.id)
-          end
-          # unpublish all currently published versions
-          # TODO: Add a exclusion constraint to database so that we never have more than one published version
-          versions.published(on: current_time).where.not(id: version.id).update_all(public_until: current_time)
-        end
-      end
+      Publisher.new(self).publish!(public_on: current_time)
     end
 
     # Updates an Alchemy::Page based on a new ordering to be applied to it

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -449,7 +449,8 @@ module Alchemy
         public_until: still_public_for?(current_time) ? public_until : nil,
       )
       versions.create!(public_on: current_time).tap do |version|
-        Element.where(page_version_id: draft_version.id).not_nested.available.order(:position).find_each do |element|
+        # We must not use .find_each here to not mess up the order of elements
+        draft_version.elements.not_nested.available.each do |element|
           Element.copy(element, page_version_id: version.id)
         end
       end

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -434,7 +434,7 @@ module Alchemy
       end
     end
 
-    # Publishes the page.
+    # Creates a public version of the page.
     #
     # Sets +public_on+ and the +published_at+ value to current time
     # and resets +public_until+ to nil
@@ -448,6 +448,7 @@ module Alchemy
         public_on: already_public_for?(current_time) ? public_on : current_time,
         public_until: still_public_for?(current_time) ? public_until : nil,
       )
+      versions.create!(public_on: current_time)
     end
 
     # Updates an Alchemy::Page based on a new ordering to be applied to it

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -137,9 +137,6 @@ module Alchemy
     before_save :inherit_restricted_status,
       if: -> { parent && parent.restricted? }
 
-    before_save :set_published_at,
-      if: -> { public_on.present? && published_at.nil? }
-
     before_save :set_fixed_attributes,
       if: -> { fixed_attributes.any? }
 
@@ -572,10 +569,6 @@ module Alchemy
     # Stores the old urlname in a LegacyPageUrl
     def create_legacy_url
       legacy_urls.find_or_create_by(urlname: urlname_before_last_save)
-    end
-
-    def set_published_at
-      self.published_at = Time.current
     end
   end
 end

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -115,6 +115,7 @@ module Alchemy
     has_many :folded_pages
     has_many :legacy_urls, class_name: "Alchemy::LegacyPageUrl"
     has_many :nodes, class_name: "Alchemy::Node", inverse_of: :page
+    has_many :versions, class_name: "Alchemy::PageVersion", inverse_of: :page, dependent: :destroy
 
     before_validation :set_language,
       if: -> { language.nil? }

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -438,20 +438,28 @@ module Alchemy
 
     # Creates a public version of the page.
     #
-    # Sets +public_on+ and the +published_at+ value to current time
-    # and resets +public_until+ to nil
+    # Sets the +published_at+ value to current time
     #
     # The +published_at+ attribute is used as +cache_key+.
     #
-    def publish!
-      current_time = Time.current
-      update_columns(
-        published_at: current_time,
-        public_on: already_public_for?(current_time) ? public_on : current_time,
-        public_until: still_public_for?(current_time) ? public_until : nil,
-      )
+    def publish!(current_time = Time.current)
+      update_columns(published_at: current_time)
       Publisher.new(self).publish!(public_on: current_time)
     end
+
+    # Sets the public_on date on the published version
+    #
+    # Builds a new version if none exists yet.
+    #
+    def public_on=(time)
+      if public_version
+        public_version.public_on = time
+      else
+        versions.build(public_on: time)
+      end
+    end
+
+    delegate :public_until=, to: :public_version, allow_nil: true
 
     # Updates an Alchemy::Page based on a new ordering to be applied to it
     #
@@ -493,12 +501,12 @@ module Alchemy
       (editor_roles & user.alchemy_roles).any?
     end
 
-    # Returns the value of +public_on+ attribute
+    # Returns the value of +public_on+ attribute from public version
     #
     # If it's a fixed attribute then the fixed value is returned instead
     #
     def public_on
-      attribute_fixed?(:public_on) ? fixed_attributes[:public_on] : self[:public_on]
+      attribute_fixed?(:public_on) ? fixed_attributes[:public_on] : public_version&.public_on
     end
 
     # Returns the value of +public_until+ attribute
@@ -506,7 +514,7 @@ module Alchemy
     # If it's a fixed attribute then the fixed value is returned instead
     #
     def public_until
-      attribute_fixed?(:public_until) ? fixed_attributes[:public_until] : self[:public_until]
+      attribute_fixed?(:public_until) ? fixed_attributes[:public_until] : public_version&.public_until
     end
 
     # Returns the name of the creator of this page.

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -448,7 +448,11 @@ module Alchemy
         public_on: already_public_for?(current_time) ? public_on : current_time,
         public_until: still_public_for?(current_time) ? public_until : nil,
       )
-      versions.create!(public_on: current_time)
+      versions.create!(public_on: current_time).tap do |version|
+        Element.where(page_id: id).not_nested.available.order(:position).find_each do |element|
+          Element.copy(element, page_version_id: version.id)
+        end
+      end
     end
 
     # Updates an Alchemy::Page based on a new ordering to be applied to it

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -154,6 +154,14 @@ module Alchemy
     # site_name accessor
     delegate :name, to: :site, prefix: true, allow_nil: true
 
+    # Old public_on and public_until attributes for historical reasons
+    #
+    # These attributes now exist on the page versions
+    #
+    attr_readonly :legacy_public_on, :legacy_public_until
+    deprecate :legacy_public_on, deprecator: Alchemy::Deprecation
+    deprecate :legacy_public_until, deprecator: Alchemy::Deprecation
+
     # Class methods
     #
     class << self

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -448,10 +448,15 @@ module Alchemy
         public_on: already_public_for?(current_time) ? public_on : current_time,
         public_until: still_public_for?(current_time) ? public_until : nil,
       )
-      versions.create!(public_on: current_time).tap do |version|
-        # We must not use .find_each here to not mess up the order of elements
-        draft_version.elements.not_nested.available.each do |element|
-          Element.copy(element, page_version_id: version.id)
+      self.class.transaction do
+        versions.create!(public_on: current_time).tap do |version|
+          # We must not use .find_each here to not mess up the order of elements
+          draft_version.elements.not_nested.available.each do |element|
+            Element.copy(element, page_version_id: version.id)
+          end
+          # unpublish all currently published versions
+          # TODO: Add a exclusion constraint to database so that we never have more than one published version
+          versions.published(on: current_time).where.not(id: version.id).update_all(public_until: current_time)
         end
       end
     end

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -124,6 +124,8 @@ module Alchemy
     validates_format_of :page_layout, with: /\A[a-z0-9_-]+\z/, unless: -> { page_layout.blank? }
     validates_presence_of :parent, unless: -> { layoutpage? || language_root? }
 
+    before_create -> { versions.build }
+
     before_save :set_language_code,
       if: -> { language.present? }
 

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -449,7 +449,7 @@ module Alchemy
         public_until: still_public_for?(current_time) ? public_until : nil,
       )
       versions.create!(public_on: current_time).tap do |version|
-        Element.where(page_id: id).not_nested.available.order(:position).find_each do |element|
+        Element.where(page_version_id: draft_version.id).not_nested.available.order(:position).find_each do |element|
           Element.copy(element, page_version_id: version.id)
         end
       end

--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -19,10 +19,6 @@ module Alchemy
           has_many :fixed_elements, -> { fixed.available }
         end
 
-        has_many :trashed_elements,
-          -> { Element.trashed.order(:position) },
-          class_name: "Alchemy::Element",
-          inverse_of: :page
         has_many :dependent_destroyable_elements,
           -> { not_nested },
           class_name: "Alchemy::Element",

--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -185,7 +185,7 @@ module Alchemy
       #
       def generate_elements
         definition.fetch("autogenerate", []).each do |element_name|
-          Element.create(page: self, name: element_name)
+          Element.create(page: self, page_version: draft_version, name: element_name)
         end
       end
 

--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -80,7 +80,7 @@ module Alchemy
 
         return [] if @_element_definitions.blank?
 
-        existing_elements = all_elements.not_nested
+        existing_elements = draft_version.elements.not_nested
         @_existing_element_names = existing_elements.pluck(:name)
         delete_unique_element_definitions!
         delete_outnumbered_element_definitions!

--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -40,10 +40,11 @@ module Alchemy
         # @return [Array]
         #
         def copy_elements(source, target)
-          source_elements = source.all_elements.not_nested
+          source_elements = source.draft_version.elements.not_nested
           source_elements.order(:position).map do |source_element|
             Element.copy(source_element, {
               page_id: target.id,
+              page_version_id: target.draft_version.id,
             }).tap(&:move_to_bottom)
           end
         end

--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -19,10 +19,6 @@ module Alchemy
           has_many :fixed_elements, -> { fixed.available }
         end
 
-        has_many :dependent_destroyable_elements,
-          -> { not_nested },
-          class_name: "Alchemy::Element",
-          dependent: :destroy
         has_many :contents, through: :elements
         has_and_belongs_to_many :to_be_swept_elements, -> { distinct },
           class_name: "Alchemy::Element",
@@ -43,7 +39,6 @@ module Alchemy
           source_elements = source.draft_version.elements.not_nested
           source_elements.order(:position).map do |source_element|
             Element.copy(source_element, {
-              page_id: target.id,
               page_version_id: target.draft_version.id,
             }).tap(&:move_to_bottom)
           end
@@ -172,7 +167,7 @@ module Alchemy
       #
       def richtext_contents_ids
         Alchemy::Content.joins(:element)
-          .where(Element.table_name => { page_id: id, folded: false })
+          .where(Element.table_name => { page_version_id: draft_version.id, folded: false })
           .select(&:has_tinymce?)
           .collect(&:id)
       end

--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -8,16 +8,19 @@ module Alchemy
       included do
         attr_accessor :autogenerate_elements
 
-        has_many :all_elements,
-          -> { order(:position) },
+        with_options(
           class_name: "Alchemy::Element",
-          inverse_of: :page
-        has_many :elements,
-          -> { order(:position).not_nested.unfixed.available },
-          class_name: "Alchemy::Element",
-          inverse_of: :page
-        has_many :fixed_elements,
-          -> { order(:position).fixed.available },
+          through: :public_version,
+          inverse_of: :page,
+          source: :elements,
+        ) do
+          has_many :all_elements
+          has_many :elements, -> { not_nested.unfixed.available }
+          has_many :fixed_elements, -> { fixed.available }
+        end
+
+        has_many :trashed_elements,
+          -> { Element.trashed.order(:position) },
           class_name: "Alchemy::Element",
           inverse_of: :page
         has_many :dependent_destroyable_elements,

--- a/app/models/alchemy/page/page_natures.rb
+++ b/app/models/alchemy/page/page_natures.rb
@@ -14,7 +14,7 @@ module Alchemy
       end
 
       def expiration_time
-        public_until? ? public_until - Time.current : nil
+        public_until ? public_until - Time.current : nil
       end
 
       def taggable?

--- a/app/models/alchemy/page/page_natures.rb
+++ b/app/models/alchemy/page/page_natures.rb
@@ -5,9 +5,12 @@ module Alchemy
     module PageNatures
       extend ActiveSupport::Concern
 
+      # Determines if this page has a public version and this version is public.
+      #
+      # @see PageVersion#public?
+      # @returns Boolean
       def public?
-        current_time = Time.current
-        language.public? && already_public_for?(current_time) && still_public_for?(current_time)
+        language.public? && !!public_version&.public?
       end
 
       def expiration_time
@@ -159,14 +162,6 @@ module Alchemy
       def caching_enabled?
         Alchemy::Config.get(:cache_pages) &&
           Rails.application.config.action_controller.perform_caching
-      end
-
-      def already_public_for?(time)
-        !public_on.nil? && public_on <= time
-      end
-
-      def still_public_for?(time)
-        public_until.nil? || public_until >= time
       end
     end
   end

--- a/app/models/alchemy/page/page_scopes.rb
+++ b/app/models/alchemy/page/page_scopes.rb
@@ -41,6 +41,15 @@ module Alchemy
         #
         scope :restricted, -> { where(restricted: true) }
 
+        # All public pages
+        #
+        scope :published,
+          -> {
+            joins(:language, :versions).
+              merge(Language.published).
+              merge(PageVersion.public_on(Time.current))
+          }
+
         # All pages that are a published language root
         #
         scope :public_language_roots,
@@ -94,15 +103,6 @@ module Alchemy
       end
 
       module ClassMethods
-        # All public pages
-        #
-        def published
-          joins(:language).merge(Language.published).
-          where("#{table_name}.public_on <= :time AND " \
-                "(#{table_name}.public_until IS NULL " \
-                "OR #{table_name}.public_until >= :time)", time: Time.current)
-        end
-
         # All not public pages
         #
         def not_public

--- a/app/models/alchemy/page/page_scopes.rb
+++ b/app/models/alchemy/page/page_scopes.rb
@@ -103,12 +103,20 @@ module Alchemy
       end
 
       module ClassMethods
-        # All not public pages
+        # All pages that do not have any public version
         #
-        def not_public
-          where("#{table_name}.public_on IS NULL OR " \
-                "#{table_name}.public_on >= :time OR " \
-                "#{table_name}.public_until <= :time", time: Time.current)
+        def not_public(time = Time.current)
+          where <<~SQL
+            alchemy_pages.id NOT IN (
+              SELECT alchemy_page_versions.page_id
+              FROM alchemy_page_versions
+              WHERE alchemy_page_versions.public_on <= '#{connection.quoted_date(time)}'
+              AND (
+                alchemy_page_versions.public_until IS NULL
+                OR alchemy_page_versions.public_until >= '#{connection.quoted_date(time)}'
+              )
+            )
+          SQL
         end
       end
     end

--- a/app/models/alchemy/page/publisher.rb
+++ b/app/models/alchemy/page/publisher.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_dependency "alchemy/page"
+
+module Alchemy
+  class Page < BaseRecord
+    # Handles publishing of pages
+    class Publisher
+      def initialize(page)
+        @page = page
+      end
+
+      # Copies all currently visible elements to the public version of page
+      #
+      # Creates a new published version if none exists yet.
+      #
+      def publish!(public_on:)
+        Page.transaction do
+          version = public_version(public_on)
+          version.elements.destroy_all
+
+          # We must not use .find_each here to not mess up the order of elements
+          page.draft_version.elements.not_nested.available.each do |element|
+            Element.copy(element, page_version_id: version.id)
+          end
+        end
+      end
+
+      private
+
+      attr_reader :page
+
+      # Load the pages public version or create one
+      def public_version(public_on)
+        page.public_version || page.versions.create!(public_on: public_on)
+      end
+    end
+  end
+end

--- a/app/models/alchemy/page_version.rb
+++ b/app/models/alchemy/page_version.rb
@@ -7,5 +7,7 @@ module Alchemy
     has_many :elements, -> { order(:position) },
       class_name: "Alchemy::Element",
       inverse_of: :page_version
+
+    scope :drafts, -> { where(public_on: nil).order(updated_at: :desc) }
   end
 end

--- a/app/models/alchemy/page_version.rb
+++ b/app/models/alchemy/page_version.rb
@@ -9,5 +9,13 @@ module Alchemy
       inverse_of: :page_version
 
     scope :drafts, -> { where(public_on: nil).order(updated_at: :desc) }
+
+    # All published versions
+    #
+    def self.published
+      where("#{table_name}.public_on <= :time AND " \
+            "(#{table_name}.public_until IS NULL " \
+            "OR #{table_name}.public_until >= :time)", time: Time.current).order(public_on: :desc)
+    end
   end
 end

--- a/app/models/alchemy/page_version.rb
+++ b/app/models/alchemy/page_version.rb
@@ -9,13 +9,38 @@ module Alchemy
       inverse_of: :page_version
 
     scope :drafts, -> { where(public_on: nil).order(updated_at: :desc) }
+    scope :published, -> { where.not(public_on: nil).order(public_on: :desc) }
 
-    # All published versions
-    #
-    def self.published(on: Time.current)
+    def self.public_on(time = Time.current)
       where("#{table_name}.public_on <= :time AND " \
             "(#{table_name}.public_until IS NULL " \
-            "OR #{table_name}.public_until >= :time)", time: on).order(public_on: :desc)
+            "OR #{table_name}.public_until >= :time)", time: time)
+    end
+
+    # Determines if this version is public
+    #
+    # Takes the two timestamps +public_on+ and +public_until+
+    # and returns true if the time given (+Time.current+ per default)
+    # is in this timespan.
+    #
+    # @param time [DateTime] (Time.current)
+    # @returns Boolean
+    def public?(time = Time.current)
+      already_public_for?(time) && still_public_for?(time)
+    end
+
+    # Determines if this version is already public for given time
+    # @param time [DateTime] (Time.current)
+    # @returns Boolean
+    def already_public_for?(time = Time.current)
+      !public_on.nil? && public_on <= time
+    end
+
+    # Determines if this version is still public for given time
+    # @param time [DateTime] (Time.current)
+    # @returns Boolean
+    def still_public_for?(time = Time.current)
+      public_until.nil? || public_until >= time
     end
   end
 end

--- a/app/models/alchemy/page_version.rb
+++ b/app/models/alchemy/page_version.rb
@@ -3,5 +3,9 @@
 module Alchemy
   class PageVersion < BaseRecord
     belongs_to :page, class_name: "Alchemy::Page", inverse_of: :versions
+
+    has_many :elements, -> { order(:position) },
+      class_name: "Alchemy::Element",
+      inverse_of: :page_version
   end
 end

--- a/app/models/alchemy/page_version.rb
+++ b/app/models/alchemy/page_version.rb
@@ -12,10 +12,10 @@ module Alchemy
 
     # All published versions
     #
-    def self.published
+    def self.published(on: Time.current)
       where("#{table_name}.public_on <= :time AND " \
             "(#{table_name}.public_until IS NULL " \
-            "OR #{table_name}.public_until >= :time)", time: Time.current).order(public_on: :desc)
+            "OR #{table_name}.public_until >= :time)", time: on).order(public_on: :desc)
     end
   end
 end

--- a/app/models/alchemy/page_version.rb
+++ b/app/models/alchemy/page_version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Alchemy
+  class PageVersion < BaseRecord
+    belongs_to :page, class_name: "Alchemy::Page", inverse_of: :versions
+  end
+end

--- a/app/serializers/alchemy/element_serializer.rb
+++ b/app/serializers/alchemy/element_serializer.rb
@@ -6,6 +6,7 @@ module Alchemy
       :name,
       :position,
       :page_id,
+      :page_version_id,
       :tag_list,
       :created_at,
       :updated_at,
@@ -22,6 +23,10 @@ module Alchemy
 
     def display_name
       object.display_name_with_preview_text
+    end
+
+    def page_id
+      object.page.id
     end
   end
 end

--- a/app/serializers/alchemy/page_tree_serializer.rb
+++ b/app/serializers/alchemy/page_tree_serializer.rb
@@ -83,10 +83,11 @@ module Alchemy
     end
 
     def page_elements(page)
+      elements = page.public_version&.elements || Alchemy::Element.none
       if opts[:elements] == "true"
-        page.elements
+        elements
       else
-        page.elements.named(opts[:elements].split(",") || [])
+        elements.named(opts[:elements].split(",") || [])
       end
     end
 

--- a/app/views/alchemy/admin/elements/_element.html.erb
+++ b/app/views/alchemy/admin/elements/_element.html.erb
@@ -57,7 +57,7 @@
           <%= form_for [:admin, Alchemy::Element.new(name: nestable_element)],
             remote: true, html: { class: 'add-nested-element-form', id: nil } do |f| %>
             <%= f.hidden_field :name %>
-            <%= f.hidden_field :page_id, value: element.page_id %>
+            <%= f.hidden_field :page_version_id, value: element.page_version_id %>
             <%= f.hidden_field :parent_element_id, value: element.id %>
             <button class="button add-nestable-element-button" data-alchemy-button>
               <%= Alchemy.t(:add_nested_element) % { name: Alchemy.t(nestable_element, scope: 'element_names') } %>

--- a/app/views/alchemy/admin/elements/_new_element_form.html.erb
+++ b/app/views/alchemy/admin/elements/_new_element_form.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 <%- else -%>
   <%= alchemy_form_for [:admin, @element] do |form| %>
-    <%= form.hidden_field :page_id %>
+    <%= form.hidden_field :page_version_id %>
     <%= form.input :name,
       label: Alchemy.t(:element_of_type),
       collection: elements_for_select(@elements),

--- a/app/views/alchemy/admin/pages/edit.html.erb
+++ b/app/views/alchemy/admin/pages/edit.html.erb
@@ -147,7 +147,7 @@
     });
     Alchemy.Sitemap.watchPagePublicationState();
     Alchemy.PageLeaveObserver();
-    Alchemy.ElementsWindow.init('<%= alchemy.admin_elements_path(page_id: @page.id) %>', {
+    Alchemy.ElementsWindow.init('<%= alchemy.admin_elements_path(page_version_id: @page.draft_version.id) %>', {
       texts: {
         title: '<%= Alchemy.t("Elements") %>',
         dirtyTitle: '<%= Alchemy.t("Warning!") %>',
@@ -164,7 +164,7 @@
           hotkey: 'alt+n',
           iconClass: 'plus',
           onClick: function() {
-            Alchemy.openDialog('<%= alchemy.new_admin_element_path(page_id: @page.id) %>', {
+            Alchemy.openDialog('<%= alchemy.new_admin_element_path(page_version_id: @page_version.id) %>', {
               title: '<%= Alchemy.t("New Element") %>',
               size: '320x125'
             });

--- a/app/views/alchemy/admin/pages/edit.html.erb
+++ b/app/views/alchemy/admin/pages/edit.html.erb
@@ -147,7 +147,7 @@
     });
     Alchemy.Sitemap.watchPagePublicationState();
     Alchemy.PageLeaveObserver();
-    Alchemy.ElementsWindow.init('<%= alchemy.admin_elements_path(page_version_id: @page.draft_version.id) %>', {
+    Alchemy.ElementsWindow.init('<%= alchemy.admin_elements_path(page_version_id: @page_version.id) %>', {
       texts: {
         title: '<%= Alchemy.t("Elements") %>',
         dirtyTitle: '<%= Alchemy.t("Warning!") %>',

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -15,7 +15,7 @@
           "type": "controller",
           "class": "Alchemy::Admin::ElementsController",
           "method": "update",
-          "line": 55,
+          "line": 59,
           "file": "app/controllers/alchemy/admin/elements_controller.rb",
           "rendered": {
             "name": "alchemy/admin/elements/update",
@@ -117,7 +117,7 @@
           "type": "controller",
           "class": "Alchemy::Admin::ElementsController",
           "method": "fold",
-          "line": 90,
+          "line": 94,
           "file": "app/controllers/alchemy/admin/elements_controller.rb",
           "rendered": {
             "name": "alchemy/admin/elements/fold",
@@ -140,7 +140,7 @@
       "check_name": "MassAssignment",
       "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
       "file": "app/controllers/alchemy/admin/elements_controller.rb",
-      "line": 141,
+      "line": 145,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.fetch(:contents, {}).permit!",
       "render_path": null,
@@ -204,6 +204,68 @@
       "note": ""
     },
     {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "80b9b11d658cd393c549d568b3655c62566862f55b2fa16ed688de7c2e9343ac",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/alchemy/admin/elements/index.html.erb",
+      "line": 18,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => PageVersion.find(params[:page_version_id]).elements.order(:position).includes(*element_includes).not_nested.unfixed.map do\n Alchemy::ElementEditor.new(element)\n end, {})",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Alchemy::Admin::ElementsController",
+          "method": "index",
+          "line": 15,
+          "file": "app/controllers/alchemy/admin/elements_controller.rb",
+          "rendered": {
+            "name": "alchemy/admin/elements/index",
+            "file": "app/views/alchemy/admin/elements/index.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "alchemy/admin/elements/index"
+      },
+      "user_input": "params[:page_version_id]",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "80b9b11d658cd393c549d568b3655c62566862f55b2fa16ed688de7c2e9343ac",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/alchemy/admin/elements/index.html.erb",
+      "line": 31,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => PageVersion.find(params[:page_version_id]).elements.order(:position).includes(*element_includes).not_nested.unfixed.map do\n Alchemy::ElementEditor.new(element)\n end, {})",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Alchemy::Admin::ElementsController",
+          "method": "index",
+          "line": 15,
+          "file": "app/controllers/alchemy/admin/elements_controller.rb",
+          "rendered": {
+            "name": "alchemy/admin/elements/index",
+            "file": "app/views/alchemy/admin/elements/index.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "alchemy/admin/elements/index"
+      },
+      "user_input": "params[:page_version_id]",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
       "warning_type": "File Access",
       "warning_code": 16,
       "fingerprint": "a1197cfa89e3a66e6d10ee060cd87af97d5e978d6d93b5936eb987288f1c02e6",
@@ -253,70 +315,8 @@
       "user_input": "params[:content_id]",
       "confidence": "Weak",
       "note": ""
-    },
-    {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "e47b12a64ca94227190b5077c3acfa16403bb7fd3a155e9a0d63c1a29d329aa4",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "app/views/alchemy/admin/elements/index.html.erb",
-      "line": 18,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => Page.find(params[:page_id]).all_elements.not_nested.unfixed.includes(*element_includes).map do\n Alchemy::ElementEditor.new(element)\n end, {})",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "Alchemy::Admin::ElementsController",
-          "method": "index",
-          "line": 13,
-          "file": "app/controllers/alchemy/admin/elements_controller.rb",
-          "rendered": {
-            "name": "alchemy/admin/elements/index",
-            "file": "app/views/alchemy/admin/elements/index.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "alchemy/admin/elements/index"
-      },
-      "user_input": "params[:page_id]",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "e47b12a64ca94227190b5077c3acfa16403bb7fd3a155e9a0d63c1a29d329aa4",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "app/views/alchemy/admin/elements/index.html.erb",
-      "line": 31,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => Page.find(params[:page_id]).all_elements.not_nested.unfixed.includes(*element_includes).map do\n Alchemy::ElementEditor.new(element)\n end, {})",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "Alchemy::Admin::ElementsController",
-          "method": "index",
-          "line": 13,
-          "file": "app/controllers/alchemy/admin/elements_controller.rb",
-          "rendered": {
-            "name": "alchemy/admin/elements/index",
-            "file": "app/views/alchemy/admin/elements/index.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "alchemy/admin/elements/index"
-      },
-      "user_input": "params[:page_id]",
-      "confidence": "Weak",
-      "note": ""
     }
   ],
-  "updated": "2021-01-04 16:43:03 +0100",
-  "brakeman_version": "4.10.1"
+  "updated": "2021-02-15 11:47:56 +0100",
+  "brakeman_version": "5.0.0"
 }

--- a/db/migrate/20201207131309_create_page_versions.rb
+++ b/db/migrate/20201207131309_create_page_versions.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreatePageVersions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :alchemy_page_versions do |t|
+      t.references :page,
+                   null: false,
+                   index: true,
+                   foreign_key: {
+                     to_table: :alchemy_pages,
+                     on_delete: :cascade,
+                   }
+      t.datetime :public_on
+      t.datetime :public_until
+      t.index [:public_on, :public_until]
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201207135820_add_page_version_id_to_alchemy_elements.rb
+++ b/db/migrate/20201207135820_add_page_version_id_to_alchemy_elements.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddPageVersionIdToAlchemyElements < ActiveRecord::Migration[5.2]
+  def change
+    change_table :alchemy_elements do |t|
+      t.references :page_version,
+                   null: true,
+                   index: true,
+                   foreign_key: {
+                     to_table: :alchemy_page_versions,
+                     on_delete: :cascade,
+                   }
+    end
+  end
+end

--- a/db/migrate/20201207135820_add_page_version_id_to_alchemy_elements.rb
+++ b/db/migrate/20201207135820_add_page_version_id_to_alchemy_elements.rb
@@ -1,15 +1,76 @@
 # frozen_string_literal: true
 
 class AddPageVersionIdToAlchemyElements < ActiveRecord::Migration[5.2]
+  class LocalPage < ActiveRecord::Base
+    self.table_name = :alchemy_pages
+    has_many :elements, class_name: "LocalElement", inverse_of: :page
+    has_many :versions, class_name: "LocalVersion", inverse_of: :page, foreign_key: :page_id
+  end
+
+  class LocalVersion < ActiveRecord::Base
+    self.table_name = :alchemy_page_versions
+    belongs_to :page, class_name: "LocalPage", inverse_of: :versions
+    has_many :elements, class_name: "LocalElement", inverse_of: :versions
+  end
+
+  class LocalElement < ActiveRecord::Base
+    self.table_name = :alchemy_elements
+    belongs_to :page, class_name: "LocalPage", inverse_of: :elements
+    belongs_to :page_version, class_name: "LocalVersion", inverse_of: :elements
+  end
+
   def change
-    change_table :alchemy_elements do |t|
-      t.references :page_version,
-                   null: true,
-                   index: true,
-                   foreign_key: {
-                     to_table: :alchemy_page_versions,
-                     on_delete: :cascade,
-                   }
+    add_reference :alchemy_elements, :page_version,
+                  index: false,
+                  foreign_key: {
+                    to_table: :alchemy_page_versions,
+                    on_delete: :cascade,
+                  }
+    add_index :alchemy_elements, [:page_version_id, :parent_element_id],
+              name: "idx_alchemy_elements_on_page_version_id_and_parent_element_id"
+    add_index :alchemy_elements, [:page_version_id, :position],
+              name: "idx_alchemy_elements_on_page_version_id_and_position"
+
+    # Add a page version for each page so we can add a not null constraint
+    reversible do |dir|
+      dir.up do
+        say_with_time "Create draft version for each page." do
+          LocalPage.find_each do |page|
+            next if page.versions.any?
+
+            page.versions.create!.tap do |version|
+              Alchemy::Element.where(page_id: page.id).update_all(page_version_id: version.id)
+            end
+          end
+          LocalVersion.count
+        end
+      end
+    end
+
+    change_column_null :alchemy_elements, :page_version_id, false
+
+    # Remove the existing page relation
+    remove_reference :alchemy_elements, :page,
+                     null: false,
+                     index: false,
+                     foreign_key: {
+                       to_table: :alchemy_pages,
+                       on_delete: :cascade,
+                       on_update: :cascade,
+                     }
+    if index_exists? :alchemy_elements,
+                     :parent_element_id,
+                     name: "index_alchemy_elements_on_page_id_and_parent_element_id"
+      remove_index :alchemy_elements,
+                   column: [:parent_element_id],
+                   name: "index_alchemy_elements_on_page_id_and_parent_element_id"
+    end
+    if index_exists? :alchemy_elements,
+                     :position,
+                     name: "index_elements_on_page_id_and_position"
+      remove_index :alchemy_elements,
+                   column: [:position],
+                   name: "index_elements_on_page_id_and_position"
     end
   end
 end

--- a/db/migrate/20210205143548_rename_public_on_and_public_until_on_alchemy_pages.rb
+++ b/db/migrate/20210205143548_rename_public_on_and_public_until_on_alchemy_pages.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class RenamePublicOnAndPublicUntilOnAlchemyPages < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :alchemy_pages, column: [:public_on, :public_until],
+      name: "index_alchemy_pages_on_public_on_and_public_until"
+    rename_column :alchemy_pages, :public_on, :legacy_public_on
+    rename_column :alchemy_pages, :public_until, :legacy_public_until
+  end
+end

--- a/lib/alchemy/deprecation.rb
+++ b/lib/alchemy/deprecation.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Alchemy
-  Deprecation = ActiveSupport::Deprecation.new("6.0", "Alchemy")
+  Deprecation = ActiveSupport::Deprecation.new("7.0", "Alchemy")
 end

--- a/lib/alchemy/elements_finder.rb
+++ b/lib/alchemy/elements_finder.rb
@@ -3,7 +3,7 @@
 require "alchemy/logger"
 
 module Alchemy
-  # Loads elements from given page
+  # Loads elements from given page version.
   #
   # Used by {Alchemy::Page#find_elements} and {Alchemy::ElementsHelper#render_elements} helper.
   #
@@ -30,12 +30,11 @@ module Alchemy
       @options = options
     end
 
-    # @param page [Alchemy::Page]
-    #   The page the elements are loaded from.
+    # @param page [Alchemy::PageVersion]
+    #   The page version the elements are loaded from.
     # @return [ActiveRecord::Relation]
-    def elements(page:)
-      @page = page
-      elements = find_elements
+    def elements(page_version:)
+      elements = find_elements(page_version)
 
       if options[:reverse]
         elements = elements.reverse_order
@@ -50,16 +49,13 @@ module Alchemy
 
     private
 
-    attr_reader :page, :options
+    attr_reader :options
 
-    def find_elements
-      return Alchemy::Element.none unless page
+    def find_elements(page_version)
+      return Alchemy::Element.none unless page_version
 
-      if options[:fixed]
-        elements = page.fixed_elements
-      else
-        elements = page.elements
-      end
+      elements = page_version.elements.not_nested.available
+      elements = options[:fixed] ? elements.fixed : elements.unfixed
 
       if options[:only]
         elements = elements.named(options[:only])

--- a/lib/alchemy/test_support/factories/element_factory.rb
+++ b/lib/alchemy/test_support/factories/element_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :alchemy_element, class: "Alchemy::Element" do
     name { "article" }
     autogenerate_contents { false }
-    association :page, factory: :alchemy_page
+    association :page_version, factory: :alchemy_page_version
 
     trait :fixed do
       fixed { true }

--- a/lib/alchemy/test_support/factories/element_factory.rb
+++ b/lib/alchemy/test_support/factories/element_factory.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
     end
 
     trait :nested do
-      association :parent_element, factory: :alchemy_element, name: "slider"
+      parent_element { build(:alchemy_element, name: "slider", page_version: page_version) }
       name { "slide" }
     end
 

--- a/lib/alchemy/test_support/factories/page_factory.rb
+++ b/lib/alchemy/test_support/factories/page_factory.rb
@@ -31,9 +31,13 @@ FactoryBot.define do
       sequence(:name) { |n| "A Public Page #{n}" }
       transient do
         public_on { Time.current }
+        public_until { nil }
       end
       after(:build) do |page, evaluator|
-        page.build_public_version(public_on: evaluator.public_on)
+        page.build_public_version(
+          public_on: evaluator.public_on,
+          public_until: evaluator.public_until,
+        )
       end
       after(:create) do |page|
         if page.autogenerate_elements

--- a/lib/alchemy/test_support/factories/page_factory.rb
+++ b/lib/alchemy/test_support/factories/page_factory.rb
@@ -30,6 +30,20 @@ FactoryBot.define do
     trait :public do
       sequence(:name) { |n| "A Public Page #{n}" }
       public_on { Time.current }
+      after(:build) do |page|
+        page.build_public_version(public_on: page.public_on)
+      end
+      after(:create) do |page|
+        if page.autogenerate_elements
+          page.definition["autogenerate"].each do |name|
+            create(:alchemy_element,
+              name: name,
+              page: page,
+              page_version: page.public_version,
+              autogenerate_contents: true)
+          end
+        end
+      end
     end
 
     trait :layoutpage do

--- a/lib/alchemy/test_support/factories/page_factory.rb
+++ b/lib/alchemy/test_support/factories/page_factory.rb
@@ -38,7 +38,6 @@ FactoryBot.define do
           page.definition["autogenerate"].each do |name|
             create(:alchemy_element,
               name: name,
-              page: page,
               page_version: page.public_version,
               autogenerate_contents: true)
           end

--- a/lib/alchemy/test_support/factories/page_factory.rb
+++ b/lib/alchemy/test_support/factories/page_factory.rb
@@ -29,9 +29,11 @@ FactoryBot.define do
 
     trait :public do
       sequence(:name) { |n| "A Public Page #{n}" }
-      public_on { Time.current }
-      after(:build) do |page|
-        page.build_public_version(public_on: page.public_on)
+      transient do
+        public_on { Time.current }
+      end
+      after(:build) do |page, evaluator|
+        page.build_public_version(public_on: evaluator.public_on)
       end
       after(:create) do |page|
         if page.autogenerate_elements

--- a/lib/alchemy/test_support/factories/page_version_factory.rb
+++ b/lib/alchemy/test_support/factories/page_version_factory.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :alchemy_page_version, class: "Alchemy::PageVersion" do
+    association :page, factory: :alchemy_page
+  end
+end

--- a/lib/alchemy/test_support/factories/page_version_factory.rb
+++ b/lib/alchemy/test_support/factories/page_version_factory.rb
@@ -7,5 +7,11 @@ FactoryBot.define do
     trait :published do
       public_on { Time.current }
     end
+
+    trait :with_elements do
+      after(:build) do |page_version|
+        page_version.elements.build(name: "article")
+      end
+    end
   end
 end

--- a/lib/alchemy/test_support/factories/page_version_factory.rb
+++ b/lib/alchemy/test_support/factories/page_version_factory.rb
@@ -8,9 +8,15 @@ FactoryBot.define do
       public_on { Time.current }
     end
 
+    transient do
+      element_count { 1 }
+    end
+
     trait :with_elements do
-      after(:build) do |page_version|
-        page_version.elements.build(name: "article")
+      after(:build) do |page_version, evaluator|
+        evaluator.element_count.times do
+          page_version.elements.build(name: "article")
+        end
       end
     end
   end

--- a/lib/alchemy/test_support/factories/page_version_factory.rb
+++ b/lib/alchemy/test_support/factories/page_version_factory.rb
@@ -3,5 +3,9 @@
 FactoryBot.define do
   factory :alchemy_page_version, class: "Alchemy::PageVersion" do
     association :page, factory: :alchemy_page
+
+    trait :published do
+      public_on { Time.current }
+    end
   end
 end

--- a/lib/alchemy/upgrader/six_point_zero.rb
+++ b/lib/alchemy/upgrader/six_point_zero.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative "tasks/add_page_versions"
+
+module Alchemy
+  class Upgrader::SixPointZero < Upgrader
+    class << self
+      def create_public_page_versions
+        desc "Create public page versions for pages"
+        Alchemy::Upgrader::Tasks::AddPageVersions.new.create_public_page_versions
+      end
+    end
+  end
+end

--- a/lib/alchemy/upgrader/tasks/add_page_versions.rb
+++ b/lib/alchemy/upgrader/tasks/add_page_versions.rb
@@ -7,30 +7,24 @@ module Alchemy::Upgrader::Tasks
     include Thor::Actions
 
     no_tasks do
-      def create_page_versions_for_pages
-        puts "Create page versions for pages.\n"
-        Alchemy::Page.find_each do |page|
-          next if page.versions.any?
+      def create_public_page_versions_for_pages
+        puts "Create public page versions for pages.\n"
+        Alchemy::Page.where.not(public_on: nil).find_each do |page|
+          next if page.versions.published.any?
 
           Alchemy::Page.transaction do
-            page.versions.create!.tap do |version|
-              Alchemy::Element.where(page_id: page.id).update_all(page_version_id: version.id)
-            end
-
-            if page.public_on?
-              page.versions.create!(
-                public_on: page.public_on,
-                public_until: page.public_until
-              ).tap do |version|
-                Alchemy::Element.where(page_id: page.id).not_nested.available.order(:position).find_each do |element|
-                  Alchemy::Element.copy(element, page_version_id: version.id)
-                end
+            page.versions.create!(
+              public_on: page.public_on,
+              public_until: page.public_until
+            ).tap do |version|
+              Alchemy::Element.where(page_id: page.id).not_nested.available.order(:position).find_each do |element|
+                Alchemy::Element.copy(element, page_version_id: version.id)
               end
             end
           end
-
           print "."
         end
+
         puts "\nDone."
       end
     end

--- a/lib/alchemy/upgrader/tasks/add_page_versions.rb
+++ b/lib/alchemy/upgrader/tasks/add_page_versions.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "alchemy/upgrader"
+
+module Alchemy::Upgrader::Tasks
+  class AddPageVersions < Thor
+    include Thor::Actions
+
+    no_tasks do
+      def create_page_versions_for_pages
+        puts "Create page versions for pages.\n"
+        Alchemy::Page.find_each do |page|
+          next if page.versions.any?
+
+          version = page.versions.create!
+          page.elements.update_all(page_version_id: version.id)
+          print "."
+        end
+        puts "\nDone."
+      end
+    end
+  end
+end

--- a/lib/alchemy/upgrader/tasks/add_page_versions.rb
+++ b/lib/alchemy/upgrader/tasks/add_page_versions.rb
@@ -7,8 +7,7 @@ module Alchemy::Upgrader::Tasks
     include Thor::Actions
 
     no_tasks do
-      def create_public_page_versions_for_pages
-        puts "Create public page versions for pages.\n"
+      def create_public_page_versions
         Alchemy::Page.where.not(public_on: nil).find_each do |page|
           next if page.versions.published.any?
 
@@ -17,15 +16,14 @@ module Alchemy::Upgrader::Tasks
               public_on: page.public_on,
               public_until: page.public_until
             ).tap do |version|
-              Alchemy::Element.where(page_id: page.id).not_nested.available.order(:position).find_each do |element|
+              Alchemy::Element.where(page_version_id: page.draft_version.id).not_nested.available.order(:position).find_each do |element|
                 Alchemy::Element.copy(element, page_version_id: version.id)
               end
             end
           end
+
           print "."
         end
-
-        puts "\nDone."
       end
     end
   end

--- a/lib/alchemy/upgrader/tasks/add_page_versions.rb
+++ b/lib/alchemy/upgrader/tasks/add_page_versions.rb
@@ -16,7 +16,8 @@ module Alchemy::Upgrader::Tasks
               public_on: page.public_on,
               public_until: page.public_until
             ).tap do |version|
-              Alchemy::Element.where(page_version_id: page.draft_version.id).not_nested.available.order(:position).find_each do |element|
+              # We must not use .find_each here to not mess up the order of elements
+              page.draft_version.elements.not_nested.available.each do |element|
                 Alchemy::Element.copy(element, page_version_id: version.id)
               end
             end

--- a/lib/alchemy/upgrader/tasks/add_page_versions.rb
+++ b/lib/alchemy/upgrader/tasks/add_page_versions.rb
@@ -13,7 +13,12 @@ module Alchemy::Upgrader::Tasks
           next if page.versions.any?
 
           version = page.versions.create!
+          version = page.versions.create!(
+            public_on: page.public_on,
+            public_until: page.public_until
+          ) if page.public?
           page.elements.update_all(page_version_id: version.id)
+
           print "."
         end
         puts "\nDone."

--- a/lib/alchemy/upgrader/tasks/add_page_versions.rb
+++ b/lib/alchemy/upgrader/tasks/add_page_versions.rb
@@ -8,22 +8,24 @@ module Alchemy::Upgrader::Tasks
 
     no_tasks do
       def create_public_page_versions
-        Alchemy::Page.where.not(public_on: nil).find_each do |page|
-          next if page.versions.published.any?
+        Alchemy::Deprecation.silence do
+          Alchemy::Page.where.not(legacy_public_on: nil).find_each do |page|
+            next if page.versions.published.any?
 
-          Alchemy::Page.transaction do
-            page.versions.create!(
-              public_on: page.public_on,
-              public_until: page.public_until
-            ).tap do |version|
-              # We must not use .find_each here to not mess up the order of elements
-              page.draft_version.elements.not_nested.available.each do |element|
-                Alchemy::Element.copy(element, page_version_id: version.id)
+            Alchemy::Page.transaction do
+              page.versions.create!(
+                public_on: page.legacy_public_on,
+                public_until: page.legacy_public_until
+              ).tap do |version|
+                # We must not use .find_each here to not mess up the order of elements
+                page.draft_version.elements.not_nested.available.each do |element|
+                  Alchemy::Element.copy(element, page_version_id: version.id)
+                end
               end
             end
-          end
 
-          print "."
+            print "."
+          end
         end
       end
     end

--- a/lib/tasks/alchemy/upgrade.rake
+++ b/lib/tasks/alchemy/upgrade.rake
@@ -7,6 +7,7 @@ namespace :alchemy do
   task upgrade: [
     "alchemy:upgrade:prepare",
     "alchemy:upgrade:5.0:run",
+    "alchemy:upgrade:6.0:run",
   ] do
     Alchemy::Upgrader.display_todos
   end
@@ -57,6 +58,25 @@ namespace :alchemy do
       desc "Remove root page"
       task remove_root_page: [:environment] do
         Alchemy::Upgrader::FivePointZero.remove_root_page
+      end
+    end
+
+    desc "Upgrade Alchemy to v6.0"
+    task "6.0" => [
+      "alchemy:upgrade:prepare",
+      "alchemy:upgrade:6.0:run",
+    ] do
+      Alchemy::Upgrader.display_todos
+    end
+
+    namespace "6.0" do
+      task "run" => [
+        "alchemy:upgrade:6.0:create_public_page_versions",
+      ]
+
+      desc "Install Gutentag migrations"
+      task create_public_page_versions: [:environment] do
+        Alchemy::Upgrader::SixPointZero.create_public_page_versions
       end
     end
   end

--- a/spec/controllers/alchemy/admin/clipboard_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/clipboard_controller_spec.rb
@@ -6,9 +6,8 @@ module Alchemy
   describe Admin::ClipboardController do
     routes { Alchemy::Engine.routes }
 
-    let(:public_page)     { build_stubbed(:alchemy_page, :public) }
-    let(:element)         { build_stubbed(:alchemy_element, page: public_page) }
-    let(:another_element) { build_stubbed(:alchemy_element, page: public_page) }
+    let(:element)         { build_stubbed(:alchemy_element) }
+    let(:another_element) { build_stubbed(:alchemy_element) }
 
     before do
       authorize_user(:as_admin)
@@ -70,6 +69,8 @@ module Alchemy
       end
 
       context "with pages as remarkable_type" do
+        let(:public_page) { build_stubbed(:alchemy_page, :public) }
+
         it "should clear the pages clipboard" do
           session[:alchemy_clipboard]["pages"] = [{"id" => public_page.id.to_s}]
           delete :clear, params: {remarkable_type: "pages"}, xhr: true

--- a/spec/controllers/alchemy/admin/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/elements_controller_spec.rb
@@ -15,20 +15,22 @@ module Alchemy
 
     describe "#index" do
       let!(:alchemy_page)    { create(:alchemy_page) }
-      let!(:element)         { create(:alchemy_element, page: alchemy_page) }
-      let!(:nested_element)  { create(:alchemy_element, :nested, page: alchemy_page) }
-      let!(:hidden_element)  { create(:alchemy_element, page: alchemy_page, public: false) }
+      let!(:element)         { create(:alchemy_element, page: alchemy_page, page_version: alchemy_page.draft_version) }
+      let!(:nested_element)  { create(:alchemy_element, :nested, page: alchemy_page, page_version: alchemy_page.draft_version) }
+      let!(:hidden_element)  { create(:alchemy_element, page: alchemy_page, page_version: alchemy_page.draft_version, public: false) }
 
       context "with fixed elements" do
         let!(:fixed_element) do
           create(:alchemy_element, :fixed,
-            page: alchemy_page)
+            page: alchemy_page,
+            page_version: alchemy_page.draft_version)
         end
 
         let!(:fixed_hidden_element) do
           create(:alchemy_element, :fixed,
             public: false,
-            page: alchemy_page)
+            page: alchemy_page,
+            page_version: alchemy_page.draft_version)
         end
 
         it "assigns fixed elements" do

--- a/spec/controllers/alchemy/admin/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/elements_controller_spec.rb
@@ -7,8 +7,8 @@ module Alchemy
     routes { Alchemy::Engine.routes }
 
     let(:alchemy_page)         { create(:alchemy_page) }
-    let(:element)              { create(:alchemy_element, page: alchemy_page) }
-    let(:element_in_clipboard) { create(:alchemy_element, page: alchemy_page) }
+    let(:element)              { create(:alchemy_element, page: alchemy_page, page_version: alchemy_page.draft_version) }
+    let(:element_in_clipboard) { create(:alchemy_element, page: alchemy_page, page_version: alchemy_page.draft_version) }
     let(:clipboard)            { session[:alchemy_clipboard] = {} }
 
     before { authorize_user(:as_author) }
@@ -93,19 +93,15 @@ module Alchemy
     end
 
     describe "#new" do
-      let(:alchemy_page) { build_stubbed(:alchemy_page) }
-
-      before do
-        expect(Page).to receive(:find).and_return(alchemy_page)
-      end
+      let(:alchemy_page) { create(:alchemy_page) }
 
       it "assign variable for all available element definitions" do
-        expect(alchemy_page).to receive(:available_element_definitions)
+        expect_any_instance_of(Alchemy::Page).to receive(:available_element_definitions)
         get :new, params: {page_id: alchemy_page.id}
       end
 
       context "with elements in clipboard" do
-        let(:element) { build_stubbed(:alchemy_element) }
+        let(:element) { create(:alchemy_element, page_version: alchemy_page.draft_version) }
         let(:clipboard_items) { [{"id" => element.id.to_s, "action" => "copy"}] }
 
         before { clipboard["elements"] = clipboard_items }
@@ -124,8 +120,8 @@ module Alchemy
 
         it "should insert the element at bottom of list" do
           post :create, params: {element: {name: "news", page_id: alchemy_page.id}}, xhr: true
-          expect(alchemy_page.elements.count).to eq(2)
-          expect(alchemy_page.elements.last.name).to eq("news")
+          expect(alchemy_page.draft_version.elements.count).to eq(2)
+          expect(alchemy_page.draft_version.elements.order(:position).last.name).to eq("news")
         end
 
         context "on a page with a setting for insert_elements_at of top" do
@@ -139,8 +135,8 @@ module Alchemy
 
           it "should insert the element at top of list" do
             post :create, params: {element: {name: "news", page_id: alchemy_page.id}}, xhr: true
-            expect(alchemy_page.elements.count).to eq(2)
-            expect(alchemy_page.elements.first.name).to eq("news")
+            expect(alchemy_page.draft_version.elements.count).to eq(2)
+            expect(alchemy_page.draft_version.elements.order(:position).first.name).to eq("news")
           end
         end
       end

--- a/spec/controllers/alchemy/admin/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/elements_controller_spec.rb
@@ -6,51 +6,46 @@ module Alchemy
   describe Admin::ElementsController do
     routes { Alchemy::Engine.routes }
 
-    let(:alchemy_page)         { create(:alchemy_page) }
-    let(:element)              { create(:alchemy_element, page: alchemy_page, page_version: alchemy_page.draft_version) }
-    let(:element_in_clipboard) { create(:alchemy_element, page: alchemy_page, page_version: alchemy_page.draft_version) }
+    let(:page_version)         { create(:alchemy_page_version) }
+    let(:element)              { create(:alchemy_element, page_version: page_version) }
+    let(:element_in_clipboard) { create(:alchemy_element, page_version: page_version) }
     let(:clipboard)            { session[:alchemy_clipboard] = {} }
 
     before { authorize_user(:as_author) }
 
     describe "#index" do
-      let!(:alchemy_page)    { create(:alchemy_page) }
-      let!(:element)         { create(:alchemy_element, page: alchemy_page, page_version: alchemy_page.draft_version) }
-      let!(:nested_element)  { create(:alchemy_element, :nested, page: alchemy_page, page_version: alchemy_page.draft_version) }
-      let!(:hidden_element)  { create(:alchemy_element, page: alchemy_page, page_version: alchemy_page.draft_version, public: false) }
+      let!(:page_version)    { create(:alchemy_page_version) }
+      let!(:element)         { create(:alchemy_element, page_version: page_version) }
+      let!(:nested_element)  { create(:alchemy_element, :nested, page_version: page_version) }
+      let!(:hidden_element)  { create(:alchemy_element, page_version: page_version, public: false) }
 
       context "with fixed elements" do
         let!(:fixed_element) do
-          create(:alchemy_element, :fixed,
-            page: alchemy_page,
-            page_version: alchemy_page.draft_version)
+          create(:alchemy_element, :fixed, page_version: page_version)
         end
 
         let!(:fixed_hidden_element) do
-          create(:alchemy_element, :fixed,
-            public: false,
-            page: alchemy_page,
-            page_version: alchemy_page.draft_version)
+          create(:alchemy_element, :fixed, public: false, page_version: page_version)
         end
 
         it "assigns fixed elements" do
-          get :index, params: {page_id: alchemy_page.id}
+          get :index, params: { page_version_id: page_version.id }
           expect(assigns(:fixed_elements)).to eq([fixed_element, fixed_hidden_element])
         end
       end
 
-      it "assigns page elements" do
-        get :index, params: {page_id: alchemy_page.id}
-        expect(assigns(:elements)).to eq([element, hidden_element])
+      it "assigns elements" do
+        get :index, params: { page_version_id: page_version.id }
+        expect(assigns(:elements)).to eq([element, nested_element.parent_element, hidden_element])
       end
     end
 
     describe "#order" do
       let!(:element_1)   { create(:alchemy_element) }
-      let!(:element_2)   { create(:alchemy_element, page: page) }
-      let!(:element_3)   { create(:alchemy_element, page: page) }
+      let!(:element_2)   { create(:alchemy_element, page_version: page_version) }
+      let!(:element_3)   { create(:alchemy_element, page_version: page_version) }
       let(:element_ids) { [element_1.id, element_3.id, element_2.id] }
-      let(:page)        { element_1.page }
+      let(:page_version) { element_1.page_version }
 
       it "sets new position for given element ids" do
         post :order, params: { element_ids: element_ids }, xhr: true
@@ -93,22 +88,22 @@ module Alchemy
     end
 
     describe "#new" do
-      let(:alchemy_page) { create(:alchemy_page) }
+      let(:page_version) { create(:alchemy_page_version) }
 
       it "assign variable for all available element definitions" do
         expect_any_instance_of(Alchemy::Page).to receive(:available_element_definitions)
-        get :new, params: {page_id: alchemy_page.id}
+        get :new, params: {page_version_id: page_version.id}
       end
 
       context "with elements in clipboard" do
-        let(:element) { create(:alchemy_element, page_version: alchemy_page.draft_version) }
+        let(:element) { create(:alchemy_element, page_version: page_version) }
         let(:clipboard_items) { [{"id" => element.id.to_s, "action" => "copy"}] }
 
         before { clipboard["elements"] = clipboard_items }
 
         it "should load all elements from clipboard" do
           expect(Element).to receive(:all_from_clipboard_for_page).and_return(clipboard_items)
-          get :new, params: {page_id: alchemy_page.id}
+          get :new, params: {page_version_id: page_version.id}
           expect(assigns(:clipboard_items)).to eq(clipboard_items)
         end
       end
@@ -119,9 +114,9 @@ module Alchemy
         before { element }
 
         it "should insert the element at bottom of list" do
-          post :create, params: {element: {name: "news", page_id: alchemy_page.id}}, xhr: true
-          expect(alchemy_page.draft_version.elements.count).to eq(2)
-          expect(alchemy_page.draft_version.elements.order(:position).last.name).to eq("news")
+          post :create, params: { element: { name: "news", page_version_id: page_version.id } }, xhr: true
+          expect(page_version.elements.count).to eq(2)
+          expect(page_version.elements.order(:position).last.name).to eq("news")
         end
 
         context "on a page with a setting for insert_elements_at of top" do
@@ -134,18 +129,20 @@ module Alchemy
           end
 
           it "should insert the element at top of list" do
-            post :create, params: {element: {name: "news", page_id: alchemy_page.id}}, xhr: true
-            expect(alchemy_page.draft_version.elements.count).to eq(2)
-            expect(alchemy_page.draft_version.elements.order(:position).first.name).to eq("news")
+            post :create, params: { element: { name: "news", page_version_id: page_version.id } }, xhr: true
+            expect(page_version.elements.count).to eq(2)
+            expect(page_version.elements.order(:position).first.name).to eq("news")
           end
         end
       end
 
       context "with parent_element_id given" do
-        let(:parent_element) { create(:alchemy_element, :with_nestable_elements, page: alchemy_page) }
+        let(:parent_element) do
+          create(:alchemy_element, :with_nestable_elements, page_version: page_version)
+        end
 
         it "creates the element in the parent element" do
-          post :create, params: {element: {name: "slide", page_id: alchemy_page.id, parent_element_id: parent_element.id}}, xhr: true
+          post :create, params: { element: { name: "slide", page_version_id: page_version.id, parent_element_id: parent_element.id } }, xhr: true
           expect(Alchemy::Element.last.parent_element_id).to eq(parent_element.id)
         end
       end
@@ -158,31 +155,31 @@ module Alchemy
         end
 
         it "should create an element from clipboard" do
-          post :create, params: {paste_from_clipboard: element_in_clipboard.id, element: {page_id: alchemy_page.id}}, xhr: true
+          post :create, params: { paste_from_clipboard: element_in_clipboard.id, element: { page_version_id: page_version.id } }, xhr: true
           expect(response.status).to eq(200)
           expect(response.body).to match(/Successfully added new element/)
         end
 
         context "and with cut as action parameter" do
           it "should also remove the element id from clipboard" do
-            post :create, params: {paste_from_clipboard: element_in_clipboard.id, element: {page_id: alchemy_page.id}}, xhr: true
+            post :create, params: { paste_from_clipboard: element_in_clipboard.id, element: { page_version_id: page_version.id } }, xhr: true
             expect(session[:alchemy_clipboard]["elements"].detect { |item| item["id"] == element_in_clipboard.id.to_s }).to be_nil
           end
         end
 
         context "with parent_element_id given" do
-          let(:element_in_clipboard) { create(:alchemy_element, :nested, page: alchemy_page) }
-          let(:parent_element) { create(:alchemy_element, :with_nestable_elements, page: alchemy_page) }
+          let(:element_in_clipboard) { create(:alchemy_element, :nested, page_version: page_version) }
+          let(:parent_element) { create(:alchemy_element, :with_nestable_elements) }
 
           it "moves the element to new parent" do
-            post :create, params: {paste_from_clipboard: element_in_clipboard.id, element: {page_id: alchemy_page.id, parent_element_id: parent_element.id}}, xhr: true
+            post :create, params: { paste_from_clipboard: element_in_clipboard.id, element: { page_version_id: page_version.id, parent_element_id: parent_element.id } }, xhr: true
             expect(Alchemy::Element.last.parent_element_id).to eq(parent_element.id)
           end
         end
       end
 
       context "if element could not be saved" do
-        subject { post :create, params: {element: {page_id: alchemy_page.id}} }
+        subject { post :create, params: { element: { page_version_id: page_version.id } } }
 
         before do
           expect_any_instance_of(Element).to receive(:save).and_return false
@@ -195,8 +192,7 @@ module Alchemy
     end
 
     describe "#update" do
-      let(:page)    { build_stubbed(:alchemy_page) }
-      let(:element) { build_stubbed(:alchemy_element, page: page) }
+      let(:element) { build_stubbed(:alchemy_element) }
       let(:contents_parameters) { ActionController::Parameters.new(1 => {ingredient: "Title"}) }
       let(:element_parameters) { ActionController::Parameters.new(tag_list: "Tag 1", public: false) }
 

--- a/spec/controllers/alchemy/api/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/api/pages_controller_spec.rb
@@ -163,22 +163,24 @@ module Alchemy
             expect(result).to have_key("pages")
             expect(result["pages"][0]).to have_key("elements")
           end
+        end
 
-          context "and elements is a comma separated list of element names" do
-            before do
-              page.send(:generate_elements)
+        context "when elements is a comma separated list of element names" do
+          before do
+            %i(headline text contactform).map do |name|
+              create(:alchemy_element, name: name, page: page, page_version: page.public_version)
             end
+          end
 
-            it "returns all pages as nested json tree with only these elements included" do
-              get :nested, params: { elements: "headline,text", format: :json }
+          it "returns all pages as nested json tree with only these elements included" do
+            get :nested, params: { elements: "headline,text", format: :json }
 
-              result = JSON.parse(response.body)
+            result = JSON.parse(response.body)
 
-              elements = result["pages"][0]["children"][0]["elements"]
-              element_names = elements.collect { |element| element["name"] }
-              expect(element_names).to include("headline", "text")
-              expect(element_names).to_not include("contactform")
-            end
+            elements = result["pages"][0]["children"][0]["elements"]
+            element_names = elements.collect { |element| element["name"] }
+            expect(element_names).to include("headline", "text")
+            expect(element_names).to_not include("contactform")
           end
         end
       end

--- a/spec/controllers/alchemy/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/pages_controller_spec.rb
@@ -58,8 +58,8 @@ module Alchemy
           end
 
           context "and the root page is not public" do
-            before do
-              default_language_root.update!(public_on: nil)
+            let(:default_language_root) do
+              create(:alchemy_page, :language_root, public_on: nil, language: default_language, name: "Home")
             end
 
             it "raises routing error (404)" do
@@ -128,7 +128,7 @@ module Alchemy
 
       describe "requesting a no longer public page" do
         let(:no_longer_public) do
-          create :alchemy_page,
+          create :alchemy_page, :public,
             parent: default_language_root,
             public_on: 2.days.ago,
             public_until: 1.day.ago

--- a/spec/dummy/Gemfile
+++ b/spec/dummy/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "alchemy_cms", path: "../.."

--- a/spec/dummy/db/migrate/20201207131309_create_page_versions.rb
+++ b/spec/dummy/db/migrate/20201207131309_create_page_versions.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20201207131309_create_page_versions.rb

--- a/spec/dummy/db/migrate/20201207135820_add_page_version_id_to_alchemy_elements.rb
+++ b/spec/dummy/db/migrate/20201207135820_add_page_version_id_to_alchemy_elements.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20201207135820_add_page_version_id_to_alchemy_elements.rb

--- a/spec/dummy/db/migrate/20210205143548_rename_public_on_and_public_until_on_alchemy_pages.rb
+++ b/spec/dummy/db/migrate/20210205143548_rename_public_on_and_public_until_on_alchemy_pages.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20210205143548_rename_public_on_and_public_until_on_alchemy_pages.rb

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -39,7 +39,6 @@ ActiveRecord::Schema.define(version: 2020_12_07_135820) do
   create_table "alchemy_elements", force: :cascade do |t|
     t.string "name"
     t.integer "position"
-    t.integer "page_id", null: false
     t.boolean "public", default: true, null: false
     t.boolean "folded", default: false, null: false
     t.boolean "unique", default: false, null: false
@@ -49,12 +48,11 @@ ActiveRecord::Schema.define(version: 2020_12_07_135820) do
     t.integer "updater_id"
     t.integer "parent_element_id"
     t.boolean "fixed", default: false, null: false
-    t.integer "page_version_id"
+    t.integer "page_version_id", null: false
     t.index ["creator_id"], name: "index_alchemy_elements_on_creator_id"
     t.index ["fixed"], name: "index_alchemy_elements_on_fixed"
-    t.index ["page_id", "parent_element_id"], name: "index_alchemy_elements_on_page_id_and_parent_element_id"
-    t.index ["page_id", "position"], name: "index_elements_on_page_id_and_position"
-    t.index ["page_version_id"], name: "index_alchemy_elements_on_page_version_id"
+    t.index ["page_version_id", "parent_element_id"], name: "idx_alchemy_elements_on_page_version_id_and_parent_element_id"
+    t.index ["page_version_id", "position"], name: "idx_alchemy_elements_on_page_version_id_and_position"
     t.index ["updater_id"], name: "index_alchemy_elements_on_updater_id"
   end
 
@@ -354,7 +352,6 @@ ActiveRecord::Schema.define(version: 2020_12_07_135820) do
 
   add_foreign_key "alchemy_contents", "alchemy_elements", column: "element_id", on_update: :cascade, on_delete: :cascade
   add_foreign_key "alchemy_elements", "alchemy_page_versions", column: "page_version_id", on_delete: :cascade
-  add_foreign_key "alchemy_elements", "alchemy_pages", column: "page_id", on_update: :cascade, on_delete: :cascade
   add_foreign_key "alchemy_essence_nodes", "alchemy_nodes", column: "node_id"
   add_foreign_key "alchemy_essence_pages", "alchemy_pages", column: "page_id"
   add_foreign_key "alchemy_nodes", "alchemy_languages", column: "language_id"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_07_131309) do
+ActiveRecord::Schema.define(version: 2020_12_07_135820) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string "name"
@@ -49,10 +49,12 @@ ActiveRecord::Schema.define(version: 2020_12_07_131309) do
     t.integer "updater_id"
     t.integer "parent_element_id"
     t.boolean "fixed", default: false, null: false
+    t.integer "page_version_id"
     t.index ["creator_id"], name: "index_alchemy_elements_on_creator_id"
     t.index ["fixed"], name: "index_alchemy_elements_on_fixed"
     t.index ["page_id", "parent_element_id"], name: "index_alchemy_elements_on_page_id_and_parent_element_id"
     t.index ["page_id", "position"], name: "index_elements_on_page_id_and_position"
+    t.index ["page_version_id"], name: "index_alchemy_elements_on_page_version_id"
     t.index ["updater_id"], name: "index_alchemy_elements_on_updater_id"
   end
 
@@ -351,6 +353,7 @@ ActiveRecord::Schema.define(version: 2020_12_07_131309) do
   end
 
   add_foreign_key "alchemy_contents", "alchemy_elements", column: "element_id", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "alchemy_elements", "alchemy_page_versions", column: "page_version_id", on_delete: :cascade
   add_foreign_key "alchemy_elements", "alchemy_pages", column: "page_id", on_update: :cascade, on_delete: :cascade
   add_foreign_key "alchemy_essence_nodes", "alchemy_nodes", column: "node_id"
   add_foreign_key "alchemy_essence_pages", "alchemy_pages", column: "page_id"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_07_111332) do
+ActiveRecord::Schema.define(version: 2020_12_07_131309) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string "name"
@@ -203,6 +203,16 @@ ActiveRecord::Schema.define(version: 2020_09_07_111332) do
     t.index ["updater_id"], name: "index_alchemy_nodes_on_updater_id"
   end
 
+  create_table "alchemy_page_versions", force: :cascade do |t|
+    t.integer "page_id", null: false
+    t.datetime "public_on"
+    t.datetime "public_until"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["page_id"], name: "index_alchemy_page_versions_on_page_id"
+    t.index ["public_on", "public_until"], name: "index_alchemy_page_versions_on_public_on_and_public_until"
+  end
+
   create_table "alchemy_pages", force: :cascade do |t|
     t.string "name"
     t.string "urlname"
@@ -346,6 +356,7 @@ ActiveRecord::Schema.define(version: 2020_09_07_111332) do
   add_foreign_key "alchemy_essence_pages", "alchemy_pages", column: "page_id"
   add_foreign_key "alchemy_nodes", "alchemy_languages", column: "language_id"
   add_foreign_key "alchemy_nodes", "alchemy_pages", column: "page_id", on_delete: :cascade
+  add_foreign_key "alchemy_page_versions", "alchemy_pages", column: "page_id", on_delete: :cascade
   add_foreign_key "alchemy_pages", "alchemy_languages", column: "language_id"
   add_foreign_key "alchemy_picture_thumbs", "alchemy_pictures", column: "picture_id"
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_07_135820) do
+ActiveRecord::Schema.define(version: 2021_02_05_143548) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string "name"
@@ -238,14 +238,13 @@ ActiveRecord::Schema.define(version: 2020_12_07_135820) do
     t.integer "updater_id"
     t.integer "language_id", null: false
     t.datetime "published_at"
-    t.datetime "public_on"
-    t.datetime "public_until"
+    t.datetime "legacy_public_on"
+    t.datetime "legacy_public_until"
     t.datetime "locked_at"
     t.index ["creator_id"], name: "index_alchemy_pages_on_creator_id"
     t.index ["language_id"], name: "index_alchemy_pages_on_language_id"
     t.index ["locked_at", "locked_by"], name: "index_alchemy_pages_on_locked_at_and_locked_by"
     t.index ["parent_id", "lft"], name: "index_pages_on_parent_id_and_lft"
-    t.index ["public_on", "public_until"], name: "index_alchemy_pages_on_public_on_and_public_until"
     t.index ["rgt"], name: "index_alchemy_pages_on_rgt"
     t.index ["updater_id"], name: "index_alchemy_pages_on_updater_id"
     t.index ["urlname"], name: "index_pages_on_urlname"

--- a/spec/features/admin/edit_elements_feature_spec.rb
+++ b/spec/features/admin/edit_elements_feature_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "The edit elements feature", type: :system do
 
     context "with a page_id and parent_element_id passed" do
       let!(:element) do
-        create(:alchemy_element, :with_nestable_elements, page: a_page, page_version: a_page.draft_version)
+        create(:alchemy_element, :with_nestable_elements, page_version: a_page.draft_version)
       end
 
       scenario "a hidden field with parent element id is in the form." do
@@ -31,7 +31,7 @@ RSpec.describe "The edit elements feature", type: :system do
 
   context "With an element having nestable elements defined" do
     let!(:element) do
-      create(:alchemy_element, :with_nestable_elements, page: a_page, page_version: a_page.draft_version)
+      create(:alchemy_element, :with_nestable_elements, page_version: a_page.draft_version)
     end
 
     scenario "a button to add an nestable element appears." do
@@ -44,7 +44,7 @@ RSpec.describe "The edit elements feature", type: :system do
     let!(:element) { create(:alchemy_element, page: a_page) }
 
     scenario "is possible to copy element into clipboard" do
-      visit alchemy.admin_elements_path(page_id: element.page_id)
+      visit alchemy.admin_elements_path(page_version_id: element.page_version_id)
       expect(page).to have_selector(".element-toolbar")
       find(".fa-clone").click
       within "#flash_notices" do

--- a/spec/features/admin/edit_elements_feature_spec.rb
+++ b/spec/features/admin/edit_elements_feature_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe "The edit elements feature", type: :system do
     end
 
     context "with a page_id and parent_element_id passed" do
-      let!(:element) { create(:alchemy_element, :with_nestable_elements, page: a_page) }
+      let!(:element) do
+        create(:alchemy_element, :with_nestable_elements, page: a_page, page_version: a_page.draft_version)
+      end
 
       scenario "a hidden field with parent element id is in the form." do
         visit alchemy.new_admin_element_path(page_id: a_page.id, parent_element_id: element.id)
@@ -28,7 +30,9 @@ RSpec.describe "The edit elements feature", type: :system do
   end
 
   context "With an element having nestable elements defined" do
-    let!(:element) { create(:alchemy_element, :with_nestable_elements, page: a_page) }
+    let!(:element) do
+      create(:alchemy_element, :with_nestable_elements, page: a_page, page_version: a_page.draft_version)
+    end
 
     scenario "a button to add an nestable element appears." do
       visit alchemy.admin_elements_path(page_id: element.page_id)

--- a/spec/features/admin/edit_elements_feature_spec.rb
+++ b/spec/features/admin/edit_elements_feature_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "The edit elements feature", type: :system do
   context "Visiting the new element form" do
     context "with a page_id passed" do
       scenario "a form to select a new element for the page appears." do
-        visit alchemy.new_admin_element_path(page_id: a_page.id)
+        visit alchemy.new_admin_element_path(page_version_id: a_page.draft_version.id)
         expect(page).to have_selector('select[name="element[name]"]')
       end
     end
@@ -23,7 +23,7 @@ RSpec.describe "The edit elements feature", type: :system do
       end
 
       scenario "a hidden field with parent element id is in the form." do
-        visit alchemy.new_admin_element_path(page_id: a_page.id, parent_element_id: element.id)
+        visit alchemy.new_admin_element_path(page_version_id: a_page.draft_version.id, parent_element_id: element.id)
         expect(page).to have_selector(%(input[type="hidden"][name="element[parent_element_id]"][value="#{element.id}"]))
       end
     end
@@ -35,7 +35,7 @@ RSpec.describe "The edit elements feature", type: :system do
     end
 
     scenario "a button to add an nestable element appears." do
-      visit alchemy.admin_elements_path(page_id: element.page_id)
+      visit alchemy.admin_elements_path(page_version_id: element.page_version_id)
       expect(page).to have_selector(".add-nestable-element-button")
     end
   end

--- a/spec/features/admin/link_overlay_spec.rb
+++ b/spec/features/admin/link_overlay_spec.rb
@@ -44,10 +44,12 @@ RSpec.describe "Link overlay", type: :system do
       create(:alchemy_page, :public, parent_id: lang_root.id)
     end
 
-    let(:article) { page1.elements.named(:article).first }
-
-    before do
-      page1.elements.create!(name: "article")
+    let!(:article) do
+      create(:alchemy_element,
+        name: "article",
+        page: page1,
+        page_version: page1.draft_version,
+        autogenerate_contents: true)
     end
 
     it "should be possible to link a page" do

--- a/spec/features/admin/page_editing_feature_spec.rb
+++ b/spec/features/admin/page_editing_feature_spec.rb
@@ -60,6 +60,19 @@ RSpec.describe "Page editing feature", type: :system do
         expect(page).to have_selector("#publish_page_form")
       end
     end
+
+    it "can create a new element", :js do
+      visit alchemy.edit_admin_page_path(a_page)
+      expect(page).to have_link("New element")
+      click_link("New element")
+      expect(page).to have_selector(".alchemy-dialog-body .simple_form")
+      within ".alchemy-dialog-body .simple_form" do
+        select2("Article", from: "Element")
+        click_button("Add")
+      end
+      expect(page).to_not have_selector(".alchemy-dialog-body")
+      expect(page).to have_selector('.element-editor[data-element-name="article"]')
+    end
   end
 
   context "as admin" do
@@ -143,7 +156,7 @@ RSpec.describe "Page editing feature", type: :system do
       end
 
       it "renders essence editors for all element contents" do
-        visit alchemy.admin_elements_path(page_id: everything_page.id)
+        visit alchemy.admin_elements_path(page_version_id: everything_page.draft_version.id)
 
         expect(page).to have_selector("div.content_editor.essence_boolean")
         expect(page).to have_selector("div.content_editor.essence_date")
@@ -157,7 +170,7 @@ RSpec.describe "Page editing feature", type: :system do
       end
 
       it "renders data attribute based on content name" do
-        visit alchemy.admin_elements_path(page_id: everything_page.id)
+        visit alchemy.admin_elements_path(page_version_id: everything_page.draft_version.id)
 
         expect(page).to have_selector("div[data-content-name=essence_boolean]")
         expect(page).to have_selector("div[data-content-name=essence_date]")

--- a/spec/features/page_redirects_spec.rb
+++ b/spec/features/page_redirects_spec.rb
@@ -83,11 +83,7 @@ RSpec.describe "Requesting a page" do
 
     context "if requested page is unpublished" do
       before do
-        public_page.update(
-          public_on: nil,
-          name: "Not Public",
-          urlname: "",
-        )
+        create(:alchemy_page, name: "Not Public")
       end
 
       it "should raise not found error" do

--- a/spec/helpers/alchemy/elements_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_helper_spec.rb
@@ -74,7 +74,7 @@ module Alchemy
       context "without any options" do
         let(:options) { {} }
 
-        it "should render all elements from current page." do
+        it "should render all elements from current pages public version." do
           is_expected.to have_selector("##{element.name}_#{element.id}")
           is_expected.to have_selector("##{another_element.name}_#{another_element.id}")
         end

--- a/spec/helpers/alchemy/elements_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_helper_spec.rb
@@ -5,11 +5,10 @@ include Alchemy::BaseHelper
 
 module Alchemy
   describe ElementsHelper do
-    let(:page)    { build_stubbed(:alchemy_page, :public) }
-    let(:element) { build_stubbed(:alchemy_element, name: "headline", page: page) }
+    let(:element) { create(:alchemy_element, name: "headline") }
 
     before do
-      assign(:page, page)
+      assign(:page, element&.page)
       allow_any_instance_of(Element).to receive(:store_page).and_return(true)
     end
 
@@ -69,8 +68,8 @@ module Alchemy
       subject { helper.render_elements(options) }
 
       let(:page) { create(:alchemy_page, :public) }
-      let!(:element) { create(:alchemy_element, name: "headline", page: page, page_version: page.public_version) }
-      let!(:another_element) { create(:alchemy_element, page: page, page_version: page.public_version) }
+      let!(:element) { create(:alchemy_element, name: "headline", page_version: page.public_version) }
+      let!(:another_element) { create(:alchemy_element, page_version: page.public_version) }
 
       context "without any options" do
         let(:options) { {} }

--- a/spec/helpers/alchemy/elements_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_helper_spec.rb
@@ -69,8 +69,8 @@ module Alchemy
       subject { helper.render_elements(options) }
 
       let(:page) { create(:alchemy_page, :public) }
-      let!(:element) { create(:alchemy_element, name: "headline", page: page) }
-      let!(:another_element) { create(:alchemy_element, page: page) }
+      let!(:element) { create(:alchemy_element, name: "headline", page: page, page_version: page.public_version) }
+      let!(:another_element) { create(:alchemy_element, page: page, page_version: page.public_version) }
 
       context "without any options" do
         let(:options) { {} }
@@ -89,8 +89,8 @@ module Alchemy
             { from_page: another_page }
           end
 
-          let!(:element) { create(:alchemy_element, name: "headline", page: another_page) }
-          let!(:another_element) { create(:alchemy_element, page: another_page) }
+          let!(:element) { create(:alchemy_element, name: "headline", page: another_page, page_version: another_page.public_version) }
+          let!(:another_element) { create(:alchemy_element, page: another_page, page_version: another_page.public_version) }
 
           it "should render all elements from that page." do
             is_expected.to have_selector("##{element.name}_#{element.id}")

--- a/spec/helpers/alchemy/elements_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_helper_spec.rb
@@ -123,6 +123,33 @@ module Alchemy
           is_expected.to have_selector("#news_1001")
         end
       end
+
+      context "with option page_version given" do
+        let(:options) { { page_version: :draft_version } }
+
+        before do
+          assign(:page, page)
+        end
+
+        it "uses this version of page" do
+          expect(page).to receive(:draft_version)
+          subject
+        end
+      end
+
+      context "in preview mode" do
+        let(:options) { {} }
+
+        before do
+          assign(:page, page)
+          assign(:preview_mode, :draft_version)
+        end
+
+        it "the pages draft version is used" do
+          expect(page).to receive(:draft_version)
+          subject
+        end
+      end
     end
 
     describe "#element_preview_code_attributes" do

--- a/spec/helpers/alchemy/elements_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_helper_spec.rb
@@ -124,30 +124,17 @@ module Alchemy
         end
       end
 
-      context "with option page_version given" do
-        let(:options) { { page_version: :draft_version } }
-
-        before do
-          assign(:page, page)
-        end
-
-        it "uses this version of page" do
-          expect(page).to receive(:draft_version)
-          subject
-        end
-      end
-
-      context "in preview mode" do
+      context "with page_version assigned" do
         let(:options) { {} }
+        let(:page_version) { create(:alchemy_page_version, :with_elements) }
 
         before do
           assign(:page, page)
-          assign(:preview_mode, :draft_version)
+          assign(:page_version, page_version)
         end
 
-        it "the pages draft version is used" do
-          expect(page).to receive(:draft_version)
-          subject
+        it "this page version is used" do
+          expect(subject).to have_selector(".article")
         end
       end
     end

--- a/spec/helpers/alchemy/elements_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_helper_spec.rb
@@ -78,6 +78,19 @@ module Alchemy
           is_expected.to have_selector("##{element.name}_#{element.id}")
           is_expected.to have_selector("##{another_element.name}_#{another_element.id}")
         end
+
+        context "with page_version assigned" do
+          let(:page_version) { create(:alchemy_page_version, :with_elements) }
+
+          before do
+            assign(:page, page)
+            assign(:page_version, page_version)
+          end
+
+          it "this page version elements get rendered" do
+            expect(subject).to have_selector(".article")
+          end
+        end
       end
 
       context "with from_page option" do
@@ -91,13 +104,26 @@ module Alchemy
           let!(:element) { create(:alchemy_element, name: "headline", page: another_page, page_version: another_page.public_version) }
           let!(:another_element) { create(:alchemy_element, page: another_page, page_version: another_page.public_version) }
 
-          it "should render all elements from that page." do
+          it "should render all elements from that pages public version." do
             is_expected.to have_selector("##{element.name}_#{element.id}")
             is_expected.to have_selector("##{another_element.name}_#{another_element.id}")
           end
+
+          context "with page_version assigned" do
+            let(:page_version) { create(:alchemy_page_version, :with_elements) }
+
+            before do
+              assign(:page_version, page_version)
+            end
+
+            it "still renders all elements from the pages public version." do
+              is_expected.to have_selector("##{element.name}_#{element.id}")
+              is_expected.to have_selector("##{another_element.name}_#{another_element.id}")
+            end
+          end
         end
 
-        context "if from_page is nil" do
+        context "that is nil" do
           let(:options) do
             { from_page: nil }
           end
@@ -121,20 +147,6 @@ module Alchemy
 
         it "uses that to load elements to render" do
           is_expected.to have_selector("#news_1001")
-        end
-      end
-
-      context "with page_version assigned" do
-        let(:options) { {} }
-        let(:page_version) { create(:alchemy_page_version, :with_elements) }
-
-        before do
-          assign(:page, page)
-          assign(:page_version, page_version)
-        end
-
-        it "this page version is used" do
-          expect(subject).to have_selector(".article")
         end
       end
     end

--- a/spec/helpers/alchemy/elements_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_helper_spec.rb
@@ -78,19 +78,6 @@ module Alchemy
           is_expected.to have_selector("##{element.name}_#{element.id}")
           is_expected.to have_selector("##{another_element.name}_#{another_element.id}")
         end
-
-        context "with page_version assigned" do
-          let(:page_version) { create(:alchemy_page_version, :with_elements) }
-
-          before do
-            assign(:page, page)
-            assign(:page_version, page_version)
-          end
-
-          it "this page version elements get rendered" do
-            expect(subject).to have_selector(".article")
-          end
-        end
       end
 
       context "with from_page option" do
@@ -104,26 +91,13 @@ module Alchemy
           let!(:element) { create(:alchemy_element, name: "headline", page: another_page, page_version: another_page.public_version) }
           let!(:another_element) { create(:alchemy_element, page: another_page, page_version: another_page.public_version) }
 
-          it "should render all elements from that pages public version." do
+          it "should render all elements from that page." do
             is_expected.to have_selector("##{element.name}_#{element.id}")
             is_expected.to have_selector("##{another_element.name}_#{another_element.id}")
           end
-
-          context "with page_version assigned" do
-            let(:page_version) { create(:alchemy_page_version, :with_elements) }
-
-            before do
-              assign(:page_version, page_version)
-            end
-
-            it "still renders all elements from the pages public version." do
-              is_expected.to have_selector("##{element.name}_#{element.id}")
-              is_expected.to have_selector("##{another_element.name}_#{another_element.id}")
-            end
-          end
         end
 
-        context "that is nil" do
+        context "if from_page is nil" do
           let(:options) do
             { from_page: nil }
           end
@@ -147,6 +121,20 @@ module Alchemy
 
         it "uses that to load elements to render" do
           is_expected.to have_selector("#news_1001")
+        end
+      end
+
+      context "with page_version assigned" do
+        let(:options) { {} }
+        let(:page_version) { create(:alchemy_page_version, :with_elements) }
+
+        before do
+          assign(:page, page)
+          assign(:page_version, page_version)
+        end
+
+        it "this page version is used" do
+          expect(subject).to have_selector(".article")
         end
       end
     end

--- a/spec/helpers/alchemy/elements_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_helper_spec.rb
@@ -78,6 +78,18 @@ module Alchemy
           is_expected.to have_selector("##{element.name}_#{element.id}")
           is_expected.to have_selector("##{another_element.name}_#{another_element.id}")
         end
+
+        context "in preview_mode" do
+          let!(:draft_element) { create(:alchemy_element, name: "headline", page_version: page.draft_version) }
+
+          before do
+            assign(:preview_mode, true)
+          end
+
+          it "page draft version is used" do
+            is_expected.to have_selector("##{draft_element.name}_#{draft_element.id}")
+          end
+        end
       end
 
       context "with from_page option" do
@@ -94,6 +106,18 @@ module Alchemy
           it "should render all elements from that page." do
             is_expected.to have_selector("##{element.name}_#{element.id}")
             is_expected.to have_selector("##{another_element.name}_#{another_element.id}")
+          end
+
+          context "in preview_mode" do
+            let!(:draft_element) { create(:alchemy_element, name: "headline", page_version: another_page.draft_version) }
+
+            before do
+              assign(:preview_mode, true)
+            end
+
+            it "page draft version is used" do
+              is_expected.to have_selector("##{draft_element.name}_#{draft_element.id}")
+            end
           end
         end
 
@@ -121,20 +145,6 @@ module Alchemy
 
         it "uses that to load elements to render" do
           is_expected.to have_selector("#news_1001")
-        end
-      end
-
-      context "with page_version assigned" do
-        let(:options) { {} }
-        let(:page_version) { create(:alchemy_page_version, :with_elements) }
-
-        before do
-          assign(:page, page)
-          assign(:page_version, page_version)
-        end
-
-        it "this page version is used" do
-          expect(subject).to have_selector(".article")
         end
       end
     end

--- a/spec/helpers/alchemy/pages_helper_spec.rb
+++ b/spec/helpers/alchemy/pages_helper_spec.rb
@@ -142,7 +142,8 @@ module Alchemy
       end
 
       it "should not include unpublished pages" do
-        page.update_columns(public_on: nil, urlname: "a-unpublic-page", name: "A Unpublic Page", title: "A Unpublic Page")
+        page.update_columns(urlname: "a-unpublic-page", name: "A Unpublic Page", title: "A Unpublic Page")
+        page.public_version.destroy
         is_expected.to_not match(/A Unpublic Page/)
       end
 

--- a/spec/helpers/alchemy/url_helper_spec.rb
+++ b/spec/helpers/alchemy/url_helper_spec.rb
@@ -147,7 +147,7 @@ module Alchemy
     describe "#full_url_for_element" do
       subject { full_url_for_element(element) }
 
-      let(:element) { build_stubbed(:alchemy_element, name: "headline", page: page) }
+      let(:element) { create(:alchemy_element, name: "headline") }
       let(:current_server) { "" }
 
       it "returns the url to this element" do

--- a/spec/libraries/elements_finder_spec.rb
+++ b/spec/libraries/elements_finder_spec.rb
@@ -9,30 +9,34 @@ RSpec.describe Alchemy::ElementsFinder do
   describe "#elements" do
     subject { finder.elements }
 
-    let(:page) { create(:alchemy_page, :public) }
-    let!(:visible_element) { create(:alchemy_element, public: true, page_version: page.public_version) }
-    let!(:hidden_element) { create(:alchemy_element, public: false, page_version: page.public_version) }
+    let(:page_version) { create(:alchemy_page_version, :published) }
+    let!(:visible_element) { create(:alchemy_element, page_version: page_version) }
+    let!(:hidden_element) { create(:alchemy_element, public: false, page_version: page_version) }
 
-    context "without page given" do
+    context "without page_version given" do
       it do
         expect { subject }.to raise_error(ArgumentError)
       end
     end
 
-    context "with page object given" do
-      subject { finder.elements(page: page) }
+    context "with page_version object given" do
+      subject { finder.elements(page_version: page_version) }
 
-      it "returns all public elements from page" do
+      it "returns all public elements from page_version" do
         is_expected.to eq([visible_element])
       end
 
       context "with multiple ordered elements" do
         let!(:element_2) do
-          create(:alchemy_element, public: true, page_version: page.public_version).tap { |el| el.update_columns(position: 3) }
+          create(:alchemy_element, page_version: page_version).tap do |el|
+            el.update_columns(position: 3)
+          end
         end
 
         let!(:element_3) do
-          create(:alchemy_element, public: true, page_version: page.public_version).tap { |el| el.update_columns(position: 2) }
+          create(:alchemy_element, page_version: page_version).tap do |el|
+            el.update_columns(position: 2)
+          end
         end
 
         it "returns elements ordered by position" do
@@ -41,7 +45,7 @@ RSpec.describe Alchemy::ElementsFinder do
       end
 
       context "with fixed elements present" do
-        let!(:fixed_element) { create(:alchemy_element, :fixed, page_version: page.public_version) }
+        let!(:fixed_element) { create(:alchemy_element, :fixed, page_version: page_version) }
 
         it "does not include fixed elements" do
           is_expected.to_not include(fixed_element)
@@ -59,7 +63,7 @@ RSpec.describe Alchemy::ElementsFinder do
       end
 
       context "with nested elements present" do
-        let!(:nested_element) { create(:alchemy_element, :nested, page_version: page.public_version) }
+        let!(:nested_element) { create(:alchemy_element, :nested, page_version: page_version) }
 
         it "does not include nested elements" do
           is_expected.to_not include(nested_element)
@@ -91,8 +95,8 @@ RSpec.describe Alchemy::ElementsFinder do
           { offset: 2 }
         end
 
-        let!(:visible_element_2) { create(:alchemy_element, public: true, page_version: page.public_version) }
-        let!(:visible_element_3) { create(:alchemy_element, public: true, page_version: page.public_version) }
+        let!(:visible_element_2) { create(:alchemy_element, page_version: page_version) }
+        let!(:visible_element_3) { create(:alchemy_element, page_version: page_version) }
 
         it "returns elements beginning from that offset" do
           is_expected.to eq([visible_element_3])
@@ -104,7 +108,7 @@ RSpec.describe Alchemy::ElementsFinder do
           { count: 1 }
         end
 
-        let!(:visible_element_2) { create(:alchemy_element, public: true, page_version: page.public_version) }
+        let!(:visible_element_2) { create(:alchemy_element, page_version: page_version) }
 
         it "returns elements beginning from that offset" do
           is_expected.to eq([visible_element])
@@ -116,7 +120,7 @@ RSpec.describe Alchemy::ElementsFinder do
           { reverse: true }
         end
 
-        let!(:visible_element_2) { create(:alchemy_element, public: true, page_version: page.public_version) }
+        let!(:visible_element_2) { create(:alchemy_element, page_version: page_version) }
 
         it "returns elements in reverse order" do
           is_expected.to eq([visible_element_2, visible_element])

--- a/spec/libraries/elements_finder_spec.rb
+++ b/spec/libraries/elements_finder_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Alchemy::ElementsFinder do
     subject { finder.elements }
 
     let(:page) { create(:alchemy_page, :public) }
-    let!(:visible_element) { create(:alchemy_element, public: true, page: page, page_version: page.public_version) }
-    let!(:hidden_element) { create(:alchemy_element, public: false, page: page, page_version: page.public_version) }
+    let!(:visible_element) { create(:alchemy_element, public: true, page_version: page.public_version) }
+    let!(:hidden_element) { create(:alchemy_element, public: false, page_version: page.public_version) }
 
     context "without page given" do
       it do
@@ -28,11 +28,11 @@ RSpec.describe Alchemy::ElementsFinder do
 
       context "with multiple ordered elements" do
         let!(:element_2) do
-          create(:alchemy_element, public: true, page: page, page_version: page.public_version).tap { |el| el.update_columns(position: 3) }
+          create(:alchemy_element, public: true, page_version: page.public_version).tap { |el| el.update_columns(position: 3) }
         end
 
         let!(:element_3) do
-          create(:alchemy_element, public: true, page: page, page_version: page.public_version).tap { |el| el.update_columns(position: 2) }
+          create(:alchemy_element, public: true, page_version: page.public_version).tap { |el| el.update_columns(position: 2) }
         end
 
         it "returns elements ordered by position" do
@@ -41,7 +41,7 @@ RSpec.describe Alchemy::ElementsFinder do
       end
 
       context "with fixed elements present" do
-        let!(:fixed_element) { create(:alchemy_element, :fixed, page: page, page_version: page.public_version) }
+        let!(:fixed_element) { create(:alchemy_element, :fixed, page_version: page.public_version) }
 
         it "does not include fixed elements" do
           is_expected.to_not include(fixed_element)
@@ -59,7 +59,7 @@ RSpec.describe Alchemy::ElementsFinder do
       end
 
       context "with nested elements present" do
-        let!(:nested_element) { create(:alchemy_element, :nested, page: page, page_version: page.public_version) }
+        let!(:nested_element) { create(:alchemy_element, :nested, page_version: page.public_version) }
 
         it "does not include nested elements" do
           is_expected.to_not include(nested_element)
@@ -91,8 +91,8 @@ RSpec.describe Alchemy::ElementsFinder do
           { offset: 2 }
         end
 
-        let!(:visible_element_2) { create(:alchemy_element, public: true, page: page, page_version: page.public_version) }
-        let!(:visible_element_3) { create(:alchemy_element, public: true, page: page, page_version: page.public_version) }
+        let!(:visible_element_2) { create(:alchemy_element, public: true, page_version: page.public_version) }
+        let!(:visible_element_3) { create(:alchemy_element, public: true, page_version: page.public_version) }
 
         it "returns elements beginning from that offset" do
           is_expected.to eq([visible_element_3])
@@ -104,7 +104,7 @@ RSpec.describe Alchemy::ElementsFinder do
           { count: 1 }
         end
 
-        let!(:visible_element_2) { create(:alchemy_element, public: true, page: page, page_version: page.public_version) }
+        let!(:visible_element_2) { create(:alchemy_element, public: true, page_version: page.public_version) }
 
         it "returns elements beginning from that offset" do
           is_expected.to eq([visible_element])
@@ -116,7 +116,7 @@ RSpec.describe Alchemy::ElementsFinder do
           { reverse: true }
         end
 
-        let!(:visible_element_2) { create(:alchemy_element, public: true, page: page, page_version: page.public_version) }
+        let!(:visible_element_2) { create(:alchemy_element, public: true, page_version: page.public_version) }
 
         it "returns elements in reverse order" do
           is_expected.to eq([visible_element_2, visible_element])

--- a/spec/libraries/elements_finder_spec.rb
+++ b/spec/libraries/elements_finder_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Alchemy::ElementsFinder do
     subject { finder.elements }
 
     let(:page) { create(:alchemy_page, :public) }
-    let!(:visible_element) { create(:alchemy_element, public: true, page: page) }
-    let!(:hidden_element) { create(:alchemy_element, public: false, page: page) }
+    let!(:visible_element) { create(:alchemy_element, public: true, page: page, page_version: page.public_version) }
+    let!(:hidden_element) { create(:alchemy_element, public: false, page: page, page_version: page.public_version) }
 
     context "without page given" do
       it do
@@ -28,11 +28,11 @@ RSpec.describe Alchemy::ElementsFinder do
 
       context "with multiple ordered elements" do
         let!(:element_2) do
-          create(:alchemy_element, public: true, page: page).tap { |el| el.update_columns(position: 3) }
+          create(:alchemy_element, public: true, page: page, page_version: page.public_version).tap { |el| el.update_columns(position: 3) }
         end
 
         let!(:element_3) do
-          create(:alchemy_element, public: true, page: page).tap { |el| el.update_columns(position: 2) }
+          create(:alchemy_element, public: true, page: page, page_version: page.public_version).tap { |el| el.update_columns(position: 2) }
         end
 
         it "returns elements ordered by position" do
@@ -41,7 +41,7 @@ RSpec.describe Alchemy::ElementsFinder do
       end
 
       context "with fixed elements present" do
-        let!(:fixed_element) { create(:alchemy_element, :fixed, page: page) }
+        let!(:fixed_element) { create(:alchemy_element, :fixed, page: page, page_version: page.public_version) }
 
         it "does not include fixed elements" do
           is_expected.to_not include(fixed_element)
@@ -59,7 +59,7 @@ RSpec.describe Alchemy::ElementsFinder do
       end
 
       context "with nested elements present" do
-        let!(:nested_element) { create(:alchemy_element, :nested, page: page) }
+        let!(:nested_element) { create(:alchemy_element, :nested, page: page, page_version: page.public_version) }
 
         it "does not include nested elements" do
           is_expected.to_not include(nested_element)
@@ -91,8 +91,8 @@ RSpec.describe Alchemy::ElementsFinder do
           { offset: 2 }
         end
 
-        let!(:visible_element_2) { create(:alchemy_element, public: true, page: page) }
-        let!(:visible_element_3) { create(:alchemy_element, public: true, page: page) }
+        let!(:visible_element_2) { create(:alchemy_element, public: true, page: page, page_version: page.public_version) }
+        let!(:visible_element_3) { create(:alchemy_element, public: true, page: page, page_version: page.public_version) }
 
         it "returns elements beginning from that offset" do
           is_expected.to eq([visible_element_3])
@@ -104,7 +104,7 @@ RSpec.describe Alchemy::ElementsFinder do
           { count: 1 }
         end
 
-        let!(:visible_element_2) { create(:alchemy_element, public: true, page: page) }
+        let!(:visible_element_2) { create(:alchemy_element, public: true, page: page, page_version: page.public_version) }
 
         it "returns elements beginning from that offset" do
           is_expected.to eq([visible_element])
@@ -116,7 +116,7 @@ RSpec.describe Alchemy::ElementsFinder do
           { reverse: true }
         end
 
-        let!(:visible_element_2) { create(:alchemy_element, public: true, page: page) }
+        let!(:visible_element_2) { create(:alchemy_element, public: true, page: page, page_version: page.public_version) }
 
         it "returns elements in reverse order" do
           is_expected.to eq([visible_element_2, visible_element])

--- a/spec/libraries/permissions_spec.rb
+++ b/spec/libraries/permissions_spec.rb
@@ -11,9 +11,9 @@ describe Alchemy::Permissions do
   let(:restricted_attachment) { mock_model(Alchemy::Attachment, restricted?: true) }
   let(:picture) { mock_model(Alchemy::Picture, restricted?: false) }
   let(:restricted_picture) { mock_model(Alchemy::Picture, restricted?: true) }
-  let(:public_page) { build_stubbed(:alchemy_page, :public, restricted: false) }
-  let(:unpublic_page) { build_stubbed(:alchemy_page) }
-  let(:restricted_page) { build_stubbed(:alchemy_page, :public, restricted: true) }
+  let(:public_page) { build(:alchemy_page, :public, restricted: false) }
+  let(:unpublic_page) { build(:alchemy_page) }
+  let(:restricted_page) { build(:alchemy_page, :public, restricted: true) }
   let(:published_element) { mock_model(Alchemy::Element, restricted?: false, public?: true) }
   let(:restricted_element) { mock_model(Alchemy::Element, restricted?: true, public?: true) }
   let(:published_content) { mock_model(Alchemy::Content, restricted?: false, public?: true) }

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 
 module Alchemy
   describe Element do
+    it { is_expected.to belong_to(:page_version).optional }
+
     # to prevent memoization
     before { ElementDefinition.instance_variable_set("@definitions", nil) }
 

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -565,17 +565,17 @@ module Alchemy
       end
     end
 
-    context "previous and next elements." do
-      let(:page) { create(:alchemy_page, :language_root) }
+    describe "previous and next elements." do
+      let(:page) { create(:alchemy_page, :public, :language_root) }
 
       before(:each) do
-        @element1 = create(:alchemy_element, page: page, name: "headline")
-        @element2 = create(:alchemy_element, page: page)
-        @element3 = create(:alchemy_element, page: page, name: "text")
+        @element1 = create(:alchemy_element, page: page, page_version: page.public_version, name: "headline")
+        @element2 = create(:alchemy_element, page: page, page_version: page.public_version)
+        @element3 = create(:alchemy_element, page: page, page_version: page.public_version, name: "text")
       end
 
       describe "#prev" do
-        it "should return previous element on same page" do
+        it "should return previous element on same page version" do
           expect(@element3.prev).to eq(@element2)
         end
 
@@ -587,7 +587,7 @@ module Alchemy
       end
 
       describe "#next" do
-        it "should return next element on same page" do
+        it "should return next element on same page version" do
           expect(@element2.next).to eq(@element3)
         end
 

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -175,6 +175,22 @@ module Alchemy
             end
           end
         end
+
+        context "copy to new page version" do
+          let(:public_version) do
+            element.page.versions.create!(public_on: Time.current)
+          end
+
+          subject(:new_element) do
+            Element.copy(element, { page_version_id: public_version.id })
+          end
+
+          it "sets page_version id" do
+            new_element.nested_elements.each do |nested_element|
+              expect(nested_element.page_version_id).to eq(public_version.id)
+            end
+          end
+        end
       end
     end
 

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -349,9 +349,9 @@ module Alchemy
     end
 
     describe ".all_from_clipboard_for_page" do
-      let(:element_1) { build_stubbed(:alchemy_element) }
-      let(:element_2) { build_stubbed(:alchemy_element, name: "news") }
-      let(:page) { build_stubbed(:alchemy_page, :public) }
+      let(:element_1) { create(:alchemy_element, page_version: page.draft_version) }
+      let(:element_2) { create(:alchemy_element, name: "news", page_version: page.draft_version) }
+      let(:page) { create(:alchemy_page, :public) }
       let(:clipboard) { [{ "id" => element_1.id.to_s }, { "id" => element_2.id.to_s }] }
 
       before do

--- a/spec/models/alchemy/page/publisher_spec.rb
+++ b/spec/models/alchemy/page/publisher_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "timecop"
+
+RSpec.describe Alchemy::Page::Publisher do
+  describe "#publish!" do
+    let(:current_time) { Time.current.change(usec: 0) }
+    let(:page) do
+      create(:alchemy_page,
+             public_on: public_on,
+             public_until: public_until,
+             published_at: published_at)
+    end
+    let(:published_at) { nil }
+    let(:public_on) { nil }
+    let(:public_until) { nil }
+    let(:publisher) { described_class.new(page) }
+
+    subject(:publish) { publisher.publish!(public_on: current_time) }
+
+    around do |example|
+      Timecop.freeze(current_time) do
+        example.run
+      end
+    end
+
+    shared_context "with elements" do
+      let(:page) do
+        create(:alchemy_page, autogenerate_elements: true).tap do |page|
+          page.draft_version.elements.first.update!(public: false)
+        end
+      end
+    end
+
+    it "creates a public version" do
+      expect { publish }.to change { page.versions.published.count }.by(1)
+    end
+
+    context "with elements" do
+      include_context "with elements"
+
+      it "copies all published elements to page version" do
+        publish
+        expect(page.reload.public_version.elements.count).to eq(2)
+      end
+    end
+
+    context "with published version existing" do
+      let!(:public_version) do
+        create(:alchemy_page_version, :with_elements, element_count: 3, public_on: Date.yesterday.to_time, page: page)
+      end
+
+      it "does not change current public versions public on date" do
+        expect { publish }.to_not change(page.public_version, :public_on)
+      end
+
+      it "does not create another public version" do
+        expect { publish }.to_not change(page.versions, :count)
+      end
+
+      context "with elements" do
+        include_context "with elements"
+
+        it "copies all published elements to public version" do
+          publish
+          expect(public_version.reload.elements.count).to eq(2)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -984,13 +984,13 @@ module Alchemy
     describe "#find_elements" do
       subject { page.find_elements(options) }
 
-      let(:page) { build(:alchemy_page) }
+      let(:page) { create(:alchemy_page, :public) }
       let(:options) { {} }
       let(:finder) { instance_double(Alchemy::ElementsFinder) }
 
-      it "passes self and all options to elements finder" do
+      it "passes public_version and all options to elements finder" do
         expect(Alchemy::ElementsFinder).to receive(:new).with(options) { finder }
-        expect(finder).to receive(:elements).with(page: page)
+        expect(finder).to receive(:elements).with(page_version: page.public_version)
         subject
       end
 

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1368,11 +1368,15 @@ module Alchemy
 
       before do
         allow(Time).to receive(:current).and_return(current_time)
-        page.publish!
+      end
+
+      it "creates a public version" do
+        expect { page.publish! }.to change { page.versions.published.count }.by(1)
       end
 
       context "with unpublished page" do
         it "sets public_on and published_at", aggregate_failures: true do
+          page.publish!
           expect(page.published_at).to eq(current_time)
           expect(page.public_on).to eq(current_time)
           expect(page.public_until).to eq(nil)
@@ -1385,6 +1389,7 @@ module Alchemy
         let(:public_on) { past_time }
 
         it "only sets published_at", aggregate_failures: true do
+          page.publish!
           expect(page.published_at).to eq(current_time)
           expect(page.public_on).to eq(public_on)
           expect(page.public_until).to eq(nil)
@@ -1394,6 +1399,7 @@ module Alchemy
           let(:public_until) { current_time + 2.weeks }
 
           it "does not change public_until" do
+            page.publish!
             expect(page.public_until).to eq(public_until)
           end
         end
@@ -1403,6 +1409,7 @@ module Alchemy
         let(:public_on) { current_time + 3.hours }
 
         it "resets public_on and sets published_at", aggregate_failures: true do
+          page.publish!
           expect(page.published_at).to eq(current_time)
           expect(page.public_on).to eq(current_time)
           expect(page.public_until).to eq(nil)
@@ -1417,6 +1424,7 @@ module Alchemy
 
         it "resets public_on and published_at and sets public_until to nil",
           aggregate_failures: true do
+          page.publish!
           expect(page.published_at).to eq(current_time)
           expect(page.public_on).to eq(public_on)
           expect(page.public_until).to eq(nil)

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1409,6 +1409,37 @@ module Alchemy
         expect { page.publish! }.to change { page.versions.published.count }.by(1)
       end
 
+      context "with more than one published page to that time" do
+        let!(:public_version) do
+          create(:alchemy_page_version, public_on: Date.yesterday.to_time, page: page)
+        end
+
+        it "sets all other versions to not public" do
+          expect {
+            page.publish!
+          }.to change { public_version.reload.public_until }.from(nil)
+        end
+
+        it "does not change current public version" do
+          page.publish!
+          expect(page.reload.versions.published.first.public_until).to be_nil
+        end
+
+        context "with former published versions" do
+          let(:the_day_before) { Date.yesterday - 1 }
+
+          let!(:former_published_version) do
+            create(:alchemy_page_version, public_on: the_day_before.to_time, public_until: Date.yesterday.to_time, page: page)
+          end
+
+          it "does not change public_until on those" do
+            expect {
+              page.publish!
+            }.to_not change(former_published_version.reload, :public_until)
+          end
+        end
+      end
+
       context "with elements" do
         let(:page) do
           create(:alchemy_page, autogenerate_elements: true).tap do |page|

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -133,47 +133,6 @@ module Alchemy
             expect(page.legacy_urls).to be_empty
           end
         end
-
-        context "set_published_at hook" do
-          let(:current_time) { Time.current.change(usec: 0) }
-          let(:page) do
-            create(:alchemy_page, public_on: public_on, published_at: published_at)
-          end
-
-          before do
-            allow(Time).to receive(:current).and_return(current_time)
-            page.save!
-          end
-
-          context "page is scheduled for publication" do
-            let(:public_on) { current_time + 3.hours }
-
-            context "and published_at is nil" do
-              let(:published_at) { nil }
-
-              it "should set published_at to current time" do
-                expect(page.published_at).to eq(current_time)
-              end
-            end
-
-            context "and published_at is already set" do
-              let(:published_at) { public_on }
-
-              it "should not set published_at" do
-                expect(page.published_at).to eq(public_on)
-              end
-            end
-          end
-
-          context "page is not public and not scheduled for publication" do
-            let(:public_on) { nil }
-            let(:published_at) { nil }
-
-            it "should not update published_at" do
-              expect(page.read_attribute(:published_at)).to eq(nil)
-            end
-          end
-        end
       end
 
       context "after_move" do

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -78,6 +78,18 @@ module Alchemy
         create(:alchemy_page, name: "My Testpage", language: language, parent: language_root)
       end
 
+      context "before_create" do
+        let(:page) do
+          build(:alchemy_page, language: language, parent: language_root)
+        end
+
+        it "builds a version" do
+          expect {
+            page.save!
+          }.to change { page.versions.length }.by(1)
+        end
+      end
+
       context "before_save" do
         it "should not set the title automatically if the name changed but title is not blank" do
           page.name = "My Renaming Test"

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1374,6 +1374,19 @@ module Alchemy
         expect { page.publish! }.to change { page.versions.published.count }.by(1)
       end
 
+      context "with elements" do
+        let(:page) do
+          create(:alchemy_page, autogenerate_elements: true).tap do |page|
+            page.elements.first.update!(public: false)
+          end
+        end
+
+        it "copies all published elements to new page version" do
+          page.publish!
+          expect(page.public_version.elements.count).to eq(2)
+        end
+      end
+
       context "with unpublished page" do
         it "sets public_on and published_at", aggregate_failures: true do
           page.publish!

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 
 module Alchemy
   describe Page do
+    it { is_expected.to have_many(:versions) }
+
     let(:language) { create(:alchemy_language, :german, default: true) }
     let(:klingon) { create(:alchemy_language, :klingon) }
     let(:language_root) { create(:alchemy_page, :language_root) }

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -6,6 +6,7 @@ module Alchemy
   describe Page do
     it { is_expected.to have_many(:versions) }
     it { is_expected.to have_one(:draft_version) }
+    it { is_expected.to have_one(:public_version) }
 
     let(:language) { create(:alchemy_language, :german, default: true) }
     let(:klingon) { create(:alchemy_language, :klingon) }
@@ -720,6 +721,18 @@ module Alchemy
         let(:preview) { nil }
 
         it { is_expected.to eq("alchemy/pages/#{page.id}-#{page.published_at}") }
+      end
+    end
+
+    describe "#public_version" do
+      subject(:public_version) { page.public_version }
+
+      let(:page) { create(:alchemy_page) }
+      let!(:public_one) { Alchemy::PageVersion.create!(page: page, public_on: Date.yesterday) }
+      let!(:public_two) { Alchemy::PageVersion.create!(page: page, public_on: Time.current) }
+
+      it "returns latest published version" do
+        is_expected.to eq(public_two)
       end
     end
 

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1903,14 +1903,14 @@ module Alchemy
       let!(:expanded_element) do
         create :alchemy_element, :with_contents,
           name: "article",
-          page: page,
+          page_version: page.draft_version,
           folded: false
       end
 
       let!(:folded_element) do
         create :alchemy_element, :with_contents,
           name: "article",
-          page: page,
+          page_version: page.draft_version,
           folded: true
       end
 
@@ -1927,7 +1927,7 @@ module Alchemy
         let!(:nested_expanded_element) do
           create :alchemy_element, :with_contents,
             name: "article",
-            page: page,
+            page_version: page.draft_version,
             parent_element: expanded_element,
             folded: false
         end
@@ -1935,7 +1935,7 @@ module Alchemy
         let!(:nested_folded_element) do
           create :alchemy_element, :with_contents,
             name: "article",
-            page: page,
+            page_version: page.draft_version,
             parent_element: folded_element,
             folded: true
         end

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 module Alchemy
   describe Page do
     it { is_expected.to have_many(:versions) }
+    it { is_expected.to have_one(:draft_version) }
 
     let(:language) { create(:alchemy_language, :german, default: true) }
     let(:klingon) { create(:alchemy_language, :klingon) }

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -589,6 +589,20 @@ module Alchemy
       end
     end
 
+    describe ".not_public" do
+      subject(:not_public) { Page.not_public }
+
+      let!(:public_one) { create(:alchemy_page, :public) }
+      let!(:not_yet_public) { create(:alchemy_page, :public, public_on: Date.tomorrow) }
+      let!(:non_public_page) { create(:alchemy_page) }
+
+      it "returns pages without any public page version" do
+        expect(not_public).to_not include(public_one)
+        expect(not_public).to include(not_yet_public)
+        expect(not_public).to include(non_public_page)
+      end
+    end
+
     describe ".public_language_roots" do
       let!(:public_language_root) { create(:alchemy_page, :public, :language_root) }
 

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -738,105 +738,136 @@ module Alchemy
 
     describe "#all_elements" do
       let(:page) { create(:alchemy_page) }
-      let!(:element_1) { create(:alchemy_element, page: page) }
-      let!(:element_2) { create(:alchemy_element, page: page) }
-      let!(:element_3) { create(:alchemy_element, page: page) }
 
-      before do
-        element_3.move_to_top
-      end
-
-      it "returns a ordered active record collection of elements on that page" do
-        expect(page.all_elements).to eq([element_3, element_1, element_2])
-      end
-
-      context "with nestable elements" do
-        let!(:nestable_element) do
-          create(:alchemy_element, page: page)
-        end
-
-        let!(:nested_element) do
-          create(:alchemy_element, name: "slide", parent_element: nestable_element, page: page)
-        end
-
-        it "contains nested elements of an element" do
-          expect(page.all_elements).to include(nested_element)
+      context "with no published version" do
+        it "returns an empty active record collection" do
+          expect(page.all_elements).to eq([])
         end
       end
 
-      context "with hidden elements" do
-        let(:hidden_element) { create(:alchemy_element, page: page, public: false) }
+      context "with published version" do
+        let(:page) { create(:alchemy_page, :public) }
+        let!(:element_1) { create(:alchemy_element, page: page, page_version: page.public_version) }
+        let!(:element_2) { create(:alchemy_element, page: page, page_version: page.public_version) }
+        let!(:element_3) { create(:alchemy_element, page: page, page_version: page.public_version) }
 
-        it "contains hidden elements" do
-          expect(page.all_elements).to include(hidden_element)
+        before do
+          element_3.move_to_top
         end
-      end
 
-      context "with fixed elements" do
-        let(:fixed_element) { create(:alchemy_element, page: page, fixed: true) }
+        it "returns a ordered active record collection of elements on that pages published version" do
+          expect(page.all_elements).to eq([element_3, element_1, element_2])
+        end
 
-        it "contains hidden elements" do
-          expect(page.all_elements).to include(fixed_element)
+        context "with nestable elements" do
+          let!(:nestable_element) do
+            create(:alchemy_element, page: page, page_version: page.public_version)
+          end
+
+          let!(:nested_element) do
+            create(:alchemy_element, name: "slide", parent_element: nestable_element, page: page, page_version: page.public_version)
+          end
+
+          it "contains nested elements of an element" do
+            expect(page.all_elements).to include(nested_element)
+          end
+        end
+
+        context "with hidden elements" do
+          let(:hidden_element) { create(:alchemy_element, page: page, public: false, page_version: page.public_version) }
+
+          it "contains hidden elements" do
+            expect(page.all_elements).to include(hidden_element)
+          end
+        end
+
+        context "with fixed elements" do
+          let(:fixed_element) { create(:alchemy_element, page: page, fixed: true, page_version: page.public_version) }
+
+          it "contains fixed elements" do
+            expect(page.all_elements).to include(fixed_element)
+          end
         end
       end
     end
 
     describe "#elements" do
       let(:page) { create(:alchemy_page) }
-      let!(:element_1) { create(:alchemy_element, page: page) }
-      let!(:element_2) { create(:alchemy_element, page: page) }
-      let!(:element_3) { create(:alchemy_element, page: page) }
 
-      before do
-        element_3.move_to_top
+      context "with no published version" do
+        it "returns an empty active record collection" do
+          expect(page.all_elements).to eq([])
+        end
       end
 
-      it "returns a ordered active record collection of elements on that page" do
-        expect(page.elements).to eq([element_3, element_1, element_2])
-      end
-
-      context "with nestable elements" do
-        let(:nestable_element) { create(:alchemy_element, :with_nestable_elements) }
+      context "with published version" do
+        let(:page) { create(:alchemy_page, :public) }
+        let!(:element_1) { create(:alchemy_element, page: page, page_version: page.public_version) }
+        let!(:element_2) { create(:alchemy_element, page: page, page_version: page.public_version) }
+        let!(:element_3) { create(:alchemy_element, page: page, page_version: page.public_version) }
 
         before do
-          nestable_element.nested_elements << create(:alchemy_element, name: "slide")
-          page.elements << nestable_element
+          element_3.move_to_top
         end
 
-        it "does not contain nested elements of an element" do
-          expect(nestable_element.nested_elements).to_not be_empty
-          expect(page.elements).to_not include(nestable_element.nested_elements.first)
+        it "returns a ordered active record collection of top level elements on that page" do
+          expect(page.elements).to eq([element_3, element_1, element_2])
         end
-      end
 
-      context "with hidden elements" do
-        let(:hidden_element) { create(:alchemy_element, page: page, public: false) }
+        context "with nestable elements" do
+          let!(:nestable_element) do
+            create(:alchemy_element, page: page, page_version: page.public_version)
+          end
 
-        it "does not contain hidden elements" do
-          expect(page.elements).to_not include(hidden_element)
+          let!(:nested_element) do
+            create(:alchemy_element, name: "slide", parent_element: nestable_element, page: page, page_version: page.public_version)
+          end
+
+          it "does not contain nested elements of an element" do
+            expect(nestable_element.nested_elements).to_not be_empty
+            expect(page.elements).to_not include(nestable_element.nested_elements)
+          end
+        end
+
+        context "with hidden elements" do
+          let(:hidden_element) { create(:alchemy_element, page: page, public: false, page_version: page.public_version) }
+
+          it "does not contain hidden elements" do
+            expect(page.elements).to_not include(hidden_element)
+          end
         end
       end
     end
 
     describe "#fixed_elements" do
       let(:page) { create(:alchemy_page) }
-      let!(:element_1) { create(:alchemy_element, fixed: true, page: page) }
-      let!(:element_2) { create(:alchemy_element, fixed: true, page: page) }
-      let!(:element_3) { create(:alchemy_element, fixed: true, page: page) }
 
-      before do
-        element_3.move_to_top
+      context "with no published version" do
+        it "returns an empty active record collection" do
+          expect(page.all_elements).to eq([])
+        end
       end
 
-      it "returns a ordered active record collection of fixed elements on that page" do
-        expect(page.fixed_elements).to eq([element_3, element_1, element_2])
-      end
+      context "with published version" do
+        let(:page) { create(:alchemy_page, :public) }
+        let!(:element_1) { create(:alchemy_element, fixed: true, page: page, page_version: page.public_version) }
+        let!(:element_2) { create(:alchemy_element, fixed: true, page: page, page_version: page.public_version) }
+        let!(:element_3) { create(:alchemy_element, fixed: true, page: page, page_version: page.public_version) }
 
-      context "with hidden fixed elements" do
-        let(:hidden_element) { create(:alchemy_element, page: page, fixed: true, public: false) }
+        before do
+          element_3.move_to_top
+        end
 
-        it "does not contain hidden fixed elements" do
-          expect(page.fixed_elements).to_not include(hidden_element)
+        it "returns a ordered active record collection of fixed elements on that page" do
+          expect(page.fixed_elements).to eq([element_3, element_1, element_2])
+        end
+
+        context "with hidden fixed elements" do
+          let(:hidden_element) { create(:alchemy_element, page: page, fixed: true, public: false, page_version: page.public_version) }
+
+          it "does not contain hidden fixed elements" do
+            expect(page.fixed_elements).to_not include(hidden_element)
+          end
         end
       end
     end
@@ -934,15 +965,16 @@ module Alchemy
     end
 
     describe "#feed_elements" do
-      let(:news_element) { create(:alchemy_element, name: "news", public: false, page: news_page) }
+      let(:news_page) { create(:alchemy_page, :public, name: "News", page_layout: "news") }
+      let(:news_element) { create(:alchemy_element, name: "news", page: news_page, page_version: news_page.public_version) }
+      let(:unpublic_news_element) { create(:alchemy_element, name: "news", public: false, page: news_page, page_version: news_page.draft_version) }
 
       it "should return all published rss feed elements" do
-        expect(news_page.feed_elements).not_to be_empty
-        expect(news_page.feed_elements).to eq(Element.where(name: "news").available.to_a)
+        expect(news_page.feed_elements).to eq([news_element])
       end
 
       it "should not return unpublished rss feed elements" do
-        expect(news_page.feed_elements).not_to include(news_element)
+        expect(news_page.feed_elements).not_to include(unpublic_news_element)
       end
     end
 
@@ -1377,7 +1409,7 @@ module Alchemy
       context "with elements" do
         let(:page) do
           create(:alchemy_page, autogenerate_elements: true).tap do |page|
-            page.elements.first.update!(public: false)
+            page.draft_version.elements.first.update!(public: false)
           end
         end
 

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -393,6 +393,10 @@ module Alchemy
         expect(subject.name).to eq("#{page.name} (Copy)")
       end
 
+      it "the copy should have a draft version" do
+        expect(subject.draft_version).to_not be_nil
+      end
+
       context "a public page" do
         let(:page) { create(:alchemy_page, :public, name: "Source", public_until: Time.current) }
 
@@ -426,20 +430,20 @@ module Alchemy
       end
 
       context "page with elements" do
-        before { page.elements << create(:alchemy_element) }
+        before { create(:alchemy_element, page: page, page_version: page.draft_version) }
 
-        it "the copy should have source elements" do
-          expect(subject.elements).not_to be_empty
-          expect(subject.elements.count).to eq(page.elements.count)
+        it "the copy should have source elements on its draft version" do
+          expect(subject.draft_version.elements).not_to be_empty
+          expect(subject.draft_version.elements.count).to eq(page.draft_version.elements.count)
         end
       end
 
       context "page with fixed elements" do
-        before { page.elements << create(:alchemy_element, :fixed) }
+        before { create(:alchemy_element, :fixed, page: page, page_version: page.draft_version) }
 
-        it "the copy should have source fixed elements" do
-          expect(subject.fixed_elements).not_to be_empty
-          expect(subject.fixed_elements.count).to eq(page.fixed_elements.count)
+        it "the copy should have source fixed elements on its draft version" do
+          expect(subject.draft_version.elements.fixed).not_to be_empty
+          expect(subject.draft_version.elements.fixed.count).to eq(page.draft_version.elements.fixed.count)
         end
       end
 
@@ -454,7 +458,7 @@ module Alchemy
         end
 
         it "the copy should not autogenerate elements" do
-          expect(subject.elements).to be_empty
+          expect(subject.draft_version.elements).to be_empty
         end
       end
 

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -610,7 +610,7 @@ module Alchemy
     describe "#available_element_definitions" do
       subject { page.available_element_definitions }
 
-      let(:page) { create(:alchemy_page, :public) }
+      let(:page) { create(:alchemy_page) }
 
       it "returns all element definitions of available elements" do
         expect(subject).to be_an(Array)
@@ -618,7 +618,7 @@ module Alchemy
       end
 
       context "with unique elements already on page" do
-        let!(:element) { create(:alchemy_element, :unique, page: page) }
+        let!(:element) { create(:alchemy_element, :unique, page: page, page_version: page.draft_version) }
 
         it "does not return unique element definitions" do
           expect(subject.collect { |e| e["name"] }).to include("article")
@@ -630,12 +630,12 @@ module Alchemy
         let(:page) { create(:alchemy_page, page_layout: "columns") }
 
         let!(:unique_element) do
-          create(:alchemy_element, :unique, name: "unique_headline", page: page)
+          create(:alchemy_element, :unique, name: "unique_headline", page: page, page_version: page.draft_version)
         end
 
-        let!(:element_1) { create(:alchemy_element, name: "column_headline", page: page) }
-        let!(:element_2) { create(:alchemy_element, name: "column_headline", page: page) }
-        let!(:element_3) { create(:alchemy_element, name: "column_headline", page: page) }
+        let!(:element_1) { create(:alchemy_element, name: "column_headline", page: page, page_version: page.draft_version) }
+        let!(:element_2) { create(:alchemy_element, name: "column_headline", page: page, page_version: page.draft_version) }
+        let!(:element_3) { create(:alchemy_element, name: "column_headline", page: page, page_version: page.draft_version) }
 
         before do
           allow(Element).to receive(:definitions).and_return([
@@ -675,13 +675,12 @@ module Alchemy
 
     describe "#available_elements_within_current_scope" do
       let(:page) { create(:alchemy_page, page_layout: "columns") }
-      let(:nestable_element) { create(:alchemy_element, :with_nestable_elements) }
+      let(:nestable_element) { create(:alchemy_element, :with_nestable_elements, page_version: page.draft_version) }
       let(:currently_available_elements) { page.available_elements_within_current_scope(nestable_element) }
 
       context "When unique element is already nested" do
         before do
-          nestable_element.nested_elements << create(:alchemy_element, name: "slide", unique: true, page: page)
-          page.elements << nestable_element
+          create(:alchemy_element, name: "slide", unique: true, page: page, page_version: page.draft_version, parent_element: nestable_element)
         end
 
         it "returns no available elements" do
@@ -697,7 +696,7 @@ module Alchemy
     end
 
     describe "#available_element_names" do
-      let(:page) { build_stubbed(:alchemy_page) }
+      let(:page) { create(:alchemy_page) }
 
       it "returns all names of elements that could be placed on current page" do
         page.available_element_names == %w(header article)

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -198,9 +198,9 @@ module Alchemy
           expect(page.language_code).to eq("kl")
         end
 
-        it "autogenerates the elements" do
+        it "autogenerates the elements on the draft version" do
           page.save!
-          expect(page.elements).not_to be_empty
+          expect(page.draft_version.elements).not_to be_empty
         end
 
         context "with children getting restricted set to true" do

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1297,12 +1297,22 @@ module Alchemy
       end
 
       context "when is not fixed attribute" do
-        let(:page) do
-          create(:alchemy_page, page_layout: "standard", public_until: "2016-11-01")
+        context "and a public version is available" do
+          let(:page) do
+            create(:alchemy_page, :public, public_until: "2016-11-01")
+          end
+
+          it "returns public_until from public version" do
+            is_expected.to eq("2016-11-01".to_time(:utc))
+          end
         end
 
-        it "returns value" do
-          is_expected.to eq("2016-11-01".to_time(:utc))
+        context "and a public version is not available" do
+          let(:page) do
+            create(:alchemy_page, public_until: "2016-11-01")
+          end
+
+          it { is_expected.to be_nil }
         end
       end
     end

--- a/spec/models/alchemy/page_version_spec.rb
+++ b/spec/models/alchemy/page_version_spec.rb
@@ -6,8 +6,9 @@ describe Alchemy::PageVersion do
   it { is_expected.to belong_to(:page) }
   it { is_expected.to have_many(:elements) }
 
+  let(:page) { create(:alchemy_page) }
+
   describe ".drafts" do
-    let(:page) { create(:alchemy_page) }
     let!(:draft_versions) { page.versions.to_a }
 
     subject { described_class.drafts }
@@ -18,6 +19,24 @@ describe Alchemy::PageVersion do
 
     it "only includes pages without public_on date" do
       expect(subject.map(&:public_on).uniq).to eq [nil]
+    end
+  end
+
+  describe ".published" do
+    subject(:published) { described_class.published }
+
+    let!(:public_one) { Alchemy::PageVersion.create!(page: page, public_on: Date.yesterday) }
+    let!(:public_two) { Alchemy::PageVersion.create!(page: page, public_on: Time.current) }
+    let!(:non_public) { page.draft_version }
+
+    it "returns published page versions" do
+      expect(published).to include(public_one)
+      expect(published).to include(public_two)
+      expect(published).to_not include(non_public)
+    end
+
+    it "latest published version is first in order" do
+      expect(published.first).to eq(public_two)
     end
   end
 end

--- a/spec/models/alchemy/page_version_spec.rb
+++ b/spec/models/alchemy/page_version_spec.rb
@@ -4,4 +4,5 @@ require "rails_helper"
 
 describe Alchemy::PageVersion do
   it { is_expected.to belong_to(:page) }
+  it { is_expected.to have_many(:elements) }
 end

--- a/spec/models/alchemy/page_version_spec.rb
+++ b/spec/models/alchemy/page_version_spec.rb
@@ -38,23 +38,83 @@ describe Alchemy::PageVersion do
     it "latest currently published version is first in order" do
       expect(published.first).to eq(public_two)
     end
+  end
 
-    context "with another time passed" do
-      subject(:published) { described_class.published(on: tomorrow) }
+  describe ".public_on" do
+    let!(:public_one) { create(:alchemy_page_version, :published) }
+    let!(:public_two) { create(:alchemy_page_version, public_on: Date.tomorrow) }
+    let!(:non_public) { create(:alchemy_page_version) }
 
-      let(:tomorrow) { Date.tomorrow.to_time }
+    context "without time given" do
+      subject(:public_on) { described_class.public_on }
 
-      before do
-        public_one.update_columns(public_until: Time.current)
+      it "returns page versions currently public" do
+        aggregate_failures do
+          expect(public_on).to include(public_one)
+          expect(public_on).to_not include(public_two)
+          expect(public_on).to_not include(non_public)
+        end
+      end
+    end
+
+    context "with time given" do
+      subject(:public_on) { described_class.public_on(Date.tomorrow + 1.day) }
+
+      it "returns page versions public on that time" do
+        aggregate_failures do
+          expect(public_on).to include(public_one)
+          expect(public_on).to include(public_two)
+          expect(public_on).to_not include(non_public)
+        end
+      end
+    end
+  end
+
+  describe "#public?" do
+    subject { page_version.public? }
+
+    context "when public_on is not set" do
+      let(:page_version) { build(:alchemy_page_version, public_on: nil) }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when public_on is set to past date" do
+      context "and public_until is set to nil" do
+        let(:page_version) do
+          build(:alchemy_page_version,
+                public_on: Time.current - 2.days,
+                public_until: nil)
+        end
+
+        it { is_expected.to be(true) }
       end
 
-      let!(:public_three) { Alchemy::PageVersion.create!(page: page, public_on: tomorrow) }
+      context "and public_until is set to future date" do
+        let(:page_version) do
+          build(:alchemy_page_version,
+                public_on: Time.current - 2.days,
+                public_until: Time.current + 2.days)
+        end
 
-      it "returns page versions published on that time" do
-        expect(published).to_not include(public_one)
-        expect(published).to include(public_two)
-        expect(published).to include(public_three)
+        it { is_expected.to be(true) }
       end
+
+      context "and public_until is set to past date" do
+        let(:page_version) do
+          build(:alchemy_page_version,
+                public_on: Time.current - 2.days,
+                public_until: Time.current - 1.days)
+        end
+
+        it { is_expected.to be(false) }
+      end
+    end
+
+    context "when public_on is set to future date" do
+      let(:page_version) { build(:alchemy_page_version, public_on: Time.current + 2.days) }
+
+      it { is_expected.to be(false) }
     end
   end
 end

--- a/spec/models/alchemy/page_version_spec.rb
+++ b/spec/models/alchemy/page_version_spec.rb
@@ -29,14 +29,32 @@ describe Alchemy::PageVersion do
     let!(:public_two) { Alchemy::PageVersion.create!(page: page, public_on: Time.current) }
     let!(:non_public) { page.draft_version }
 
-    it "returns published page versions" do
+    it "returns currently published page versions" do
       expect(published).to include(public_one)
       expect(published).to include(public_two)
       expect(published).to_not include(non_public)
     end
 
-    it "latest published version is first in order" do
+    it "latest currently published version is first in order" do
       expect(published.first).to eq(public_two)
+    end
+
+    context "with another time passed" do
+      subject(:published) { described_class.published(on: tomorrow) }
+
+      let(:tomorrow) { Date.tomorrow.to_time }
+
+      before do
+        public_one.update_columns(public_until: Time.current)
+      end
+
+      let!(:public_three) { Alchemy::PageVersion.create!(page: page, public_on: tomorrow) }
+
+      it "returns page versions published on that time" do
+        expect(published).to_not include(public_one)
+        expect(published).to include(public_two)
+        expect(published).to include(public_three)
+      end
     end
   end
 end

--- a/spec/models/alchemy/page_version_spec.rb
+++ b/spec/models/alchemy/page_version_spec.rb
@@ -5,4 +5,19 @@ require "rails_helper"
 describe Alchemy::PageVersion do
   it { is_expected.to belong_to(:page) }
   it { is_expected.to have_many(:elements) }
+
+  describe ".drafts" do
+    let(:page) { create(:alchemy_page) }
+    let!(:draft_versions) { page.versions.to_a }
+
+    subject { described_class.drafts }
+
+    before do
+      Alchemy::PageVersion.create!(page: page, public_on: Time.current)
+    end
+
+    it "only includes pages without public_on date" do
+      expect(subject.map(&:public_on).uniq).to eq [nil]
+    end
+  end
 end

--- a/spec/models/alchemy/page_version_spec.rb
+++ b/spec/models/alchemy/page_version_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Alchemy::PageVersion do
+  it { is_expected.to belong_to(:page) }
+end

--- a/spec/requests/alchemy/page_request_caching_spec.rb
+++ b/spec/requests/alchemy/page_request_caching_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Page request caching" do
 
           before do
             allow(Time).to receive(:current) { now }
-            page.update_column(:public_until, public_until)
+            page.public_version.update(public_until: public_until)
           end
 
           it "sets max-age cache control header" do

--- a/spec/serializers/alchemy/element_serializer_spec.rb
+++ b/spec/serializers/alchemy/element_serializer_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Alchemy::ElementSerializer do
   subject { described_class.new(element).to_json }
 
-  let(:element) { build_stubbed(:alchemy_element) }
+  let(:element) { create(:alchemy_element) }
 
   it "includes all attributes" do
     json = JSON.parse(subject)
@@ -18,8 +18,9 @@ RSpec.describe Alchemy::ElementSerializer do
       "ingredients" => [],
       "name" => element.name,
       "nested_elements" => [],
-      "page_id" => element.page_id,
-      "position" => nil,
+      "page_id" => element.page.id,
+      "page_version_id" => element.page_version_id,
+      "position" => 1,
       "tag_list" => [],
       "updated_at" => element.updated_at.strftime("%FT%T.%LZ"),
     )


### PR DESCRIPTION
## What is this pull request for?

Adds page versions in order to fix a fundamental issue we are having for a long time now:

Once a page is published all further changes to elements on that page are immediately public as well.

Although we have the "Publish" button this really never was a stable fix to that problem, since this relied on a cached version of that page that not always is guaranteed to exist.

This now is fixed by associating elements to a page version and moving the publication timestamps from the page to the page version model.

Every page has at least one draft version (a not published version) and - once published - a public version.

A page is considered public if the page has a public page version. Elements are always loaded from the public version of a page. The preview always shows the draft version and updates to elements are always only made on the draft version.

When publishing the page the currently visible elements are copied to the public version and never get touched again.

For now subsequent publishes will re-create the public version and does not - yet - store a version history. This way we do not create too many versions (and elements/contents/essences , etc.) that would needed to be cleaned up ans such.

There are lots of opportunities with this new layer, but we want to keep the impact as limited as possible right now.

For instance there is currently no change in the UI. What we consider a good thing for now. 

So there is currently no version management or switching possible (say necessary), but this is lays the foundation for it.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change

## TODO

- [x] Clicking an element in preview mode does not hightlight the element editor
