### PR TITLE
Fix element re-ordering

### DIFF
--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -73,13 +73,16 @@ module Alchemy
       def order
         @parent_element = Element.find_by(id: params[:parent_element_id])
         Element.transaction do
-          Element.where(id: params.fetch(:element_ids, [])).each.with_index(1) do |element, position|
-            element.update_columns(
+          params.fetch(:element_ids, []).each_with_index do |element_id, idx|
+            # Ensure to set page_id and parent_element_id to the current
+            # because of trashed elements could still have old values
+            Element.where(id: element_id).update_all(
+              page_id: params[:page_id],
               parent_element_id: params[:parent_element_id],
-              position: position
+              position: idx + 1,
             )
           end
-          @parent_element&.touch
+          @parent_element.try!(:touch)
         end
       end
 

--- a/spec/controllers/alchemy/admin/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/elements_controller_spec.rb
@@ -51,13 +51,15 @@ module Alchemy
       let(:page)        { element_1.page }
 
       it "sets new position for given element ids" do
-        post :order, params: { element_ids: element_ids }, xhr: true
+        post :order, params: {page_id: page.id, element_ids: element_ids}, xhr: true
         expect(Element.all.pluck(:id)).to eq(element_ids)
       end
 
       context "with missing [:element_ids] param" do
         it "does not raise any error and silently rejects to order" do
-          expect { post :order, xhr: true }.to_not raise_error
+          expect {
+            post :order, params: {page_id: page.id}, xhr: true
+          }.to_not raise_error
         end
       end
 
@@ -68,6 +70,7 @@ module Alchemy
           expect(Element).to receive(:find_by) { parent }
           expect(parent).to receive(:touch) { true }
           post :order, params: {
+            page_id: page.id,
             element_ids: element_ids,
             parent_element_id: parent.id,
           }, xhr: true
@@ -75,6 +78,7 @@ module Alchemy
 
         it "assigns parent element id to each element" do
           post :order, params: {
+            page_id: page.id,
             element_ids: element_ids,
             parent_element_id: parent.id,
           }, xhr: true

--- a/spec/controllers/alchemy/admin/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/elements_controller_spec.rb
@@ -44,22 +44,24 @@ module Alchemy
     end
 
     describe "#order" do
-      let(:element_1)   { create(:alchemy_element) }
-      let(:element_2)   { create(:alchemy_element, page: page) }
-      let(:element_3)   { create(:alchemy_element, page: page) }
+      let!(:element_1)   { create(:alchemy_element) }
+      let!(:element_2)   { create(:alchemy_element, page: page) }
+      let!(:element_3)   { create(:alchemy_element, page: page) }
       let(:element_ids) { [element_1.id, element_3.id, element_2.id] }
       let(:page)        { element_1.page }
 
       it "sets new position for given element ids" do
-        post :order, params: {page_id: page.id, element_ids: element_ids}, xhr: true
-        expect(Element.all.pluck(:id)).to eq(element_ids)
+        post :order, params: { element_ids: element_ids }, xhr: true
+        expect(Element.all.pluck(:id, :position)).to eq([
+          [element_1.id, 1],
+          [element_3.id, 2],
+          [element_2.id, 3],
+        ])
       end
 
       context "with missing [:element_ids] param" do
         it "does not raise any error and silently rejects to order" do
-          expect {
-            post :order, params: {page_id: page.id}, xhr: true
-          }.to_not raise_error
+          expect { post :order, xhr: true }.to_not raise_error
         end
       end
 
@@ -67,18 +69,17 @@ module Alchemy
         let(:parent) { create(:alchemy_element) }
 
         it "touches the cache key of parent element" do
-          expect(Element).to receive(:find_by) { parent }
-          expect(parent).to receive(:touch) { true }
-          post :order, params: {
-            page_id: page.id,
-            element_ids: element_ids,
-            parent_element_id: parent.id,
-          }, xhr: true
+          parent.update_column(:updated_at, 3.days.ago)
+          expect {
+            post :order, params: {
+              element_ids: element_ids,
+              parent_element_id: parent.id,
+            }, xhr: true
+          }.to change { parent.reload.updated_at }
         end
 
         it "assigns parent element id to each element" do
           post :order, params: {
-            page_id: page.id,
             element_ids: element_ids,
             parent_element_id: parent.id,
           }, xhr: true


### PR DESCRIPTION
## What is this pull request for?

Reverts c9b1c6857ad08016d0115e817df8fa324ad1e140 as this messed the element order by using the arbitary order
that the SQL query we initiated provides. 

Fixed by keeping with the order of element ids from the params. This is slightly slower, but keeps the order correct.

Refactored the test in that it now creates the elements upfront in the correct order and then explicitely compares the
position afterwards.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
