### PR TITLE
Change Factory loading mechanism to FactoryBots supported mechanism

### DIFF
--- a/lib/alchemy/test_support.rb
+++ b/lib/alchemy/test_support.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Alchemy
+  module TestSupport
+    def self.factory_paths
+      Dir[
+        ::Alchemy::Engine.root.join("lib", "alchemy", "test_support", "factories", "*_factory.rb")
+      ].map { |path| path.sub(/.rb\z/, "") }
+    end
+  end
+end

--- a/lib/alchemy/test_support/essence_shared_examples.rb
+++ b/lib/alchemy/test_support/essence_shared_examples.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require "shoulda-matchers"
-require "alchemy/test_support/factories/page_factory"
-require "alchemy/test_support/factories/element_factory"
-require "alchemy/test_support/factories/content_factory"
 
 RSpec.shared_examples_for "an essence" do
   let(:element) { Alchemy::Element.new }

--- a/lib/alchemy/test_support/factories.rb
+++ b/lib/alchemy/test_support/factories.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+Alchemy::Deprecation.warn <<~MSG
+  Please require factories using FactoryBots preferred approach:
+
+      # spec/rails_helper.rb
+
+      require 'alchemy/test_support'
+
+      FactoryBot.definition_file_paths.concat(Alchemy::TestSupport.factory_paths)
+      FactoryBot.reload
+MSG
+
 Dir["#{File.dirname(__FILE__)}/factories/*.rb"].sort.each do |file|
   require file
 end

--- a/lib/alchemy/test_support/factories/attachment_factory.rb
+++ b/lib/alchemy/test_support/factories/attachment_factory.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "factory_bot"
-
 FactoryBot.define do
   factory :alchemy_attachment, class: "Alchemy::Attachment" do
     file do

--- a/lib/alchemy/test_support/factories/content_factory.rb
+++ b/lib/alchemy/test_support/factories/content_factory.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-require "factory_bot"
-require "alchemy/test_support/factories/element_factory"
-require "alchemy/test_support/factories/essence_file_factory"
-require "alchemy/test_support/factories/essence_picture_factory"
-require "alchemy/test_support/factories/essence_text_factory"
-
 FactoryBot.define do
   factory :alchemy_content, class: "Alchemy::Content" do
     name { "text" }

--- a/lib/alchemy/test_support/factories/dummy_user_factory.rb
+++ b/lib/alchemy/test_support/factories/dummy_user_factory.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "factory_bot"
-
 FactoryBot.define do
   factory :alchemy_dummy_user, class: "DummyUser" do
     sequence(:email) { |n| "john.#{n}@doe.com" }

--- a/lib/alchemy/test_support/factories/element_factory.rb
+++ b/lib/alchemy/test_support/factories/element_factory.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "factory_bot"
-require "alchemy/test_support/factories/page_factory"
-
 FactoryBot.define do
   factory :alchemy_element, class: "Alchemy::Element" do
     name { "article" }

--- a/lib/alchemy/test_support/factories/essence_file_factory.rb
+++ b/lib/alchemy/test_support/factories/essence_file_factory.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "factory_bot"
-require "alchemy/test_support/factories/attachment_factory"
-
 FactoryBot.define do
   factory :alchemy_essence_file, class: "Alchemy::EssenceFile" do
     attachment factory: :alchemy_attachment

--- a/lib/alchemy/test_support/factories/essence_page_factory.rb
+++ b/lib/alchemy/test_support/factories/essence_page_factory.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "factory_bot"
-require "alchemy/test_support/factories/page_factory"
-
 FactoryBot.define do
   factory :alchemy_essence_page, class: "Alchemy::EssencePage" do
     page factory: :alchemy_page

--- a/lib/alchemy/test_support/factories/essence_picture_factory.rb
+++ b/lib/alchemy/test_support/factories/essence_picture_factory.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require "factory_bot"
-require "alchemy/test_support/factories/content_factory"
-require "alchemy/test_support/factories/picture_factory"
-
 FactoryBot.define do
   factory :alchemy_essence_picture, class: "Alchemy::EssencePicture" do
     picture factory: :alchemy_picture

--- a/lib/alchemy/test_support/factories/essence_text_factory.rb
+++ b/lib/alchemy/test_support/factories/essence_text_factory.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "factory_bot"
-
 FactoryBot.define do
   factory :alchemy_essence_text, class: "Alchemy::EssenceText" do
     body { "This is a headline" }

--- a/lib/alchemy/test_support/factories/language_factory.rb
+++ b/lib/alchemy/test_support/factories/language_factory.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "factory_bot"
-require "alchemy/test_support/factories/site_factory"
-
 FactoryBot.define do
   factory :alchemy_language, class: "Alchemy::Language" do
     name { "Your Language" }

--- a/lib/alchemy/test_support/factories/node_factory.rb
+++ b/lib/alchemy/test_support/factories/node_factory.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require "factory_bot"
-require "alchemy/test_support/factories/language_factory"
-require "alchemy/test_support/factories/page_factory"
-
 FactoryBot.define do
   factory :alchemy_node, class: "Alchemy::Node" do
     language { Alchemy::Language.default || create(:alchemy_language) }

--- a/lib/alchemy/test_support/factories/page_factory.rb
+++ b/lib/alchemy/test_support/factories/page_factory.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "factory_bot"
-require "alchemy/test_support/factories/language_factory"
-
 FactoryBot.define do
   factory :alchemy_page, class: "Alchemy::Page" do
     language do

--- a/lib/alchemy/test_support/factories/picture_factory.rb
+++ b/lib/alchemy/test_support/factories/picture_factory.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "factory_bot"
-
 FactoryBot.define do
   factory :alchemy_picture, class: "Alchemy::Picture" do
     image_file do

--- a/lib/alchemy/test_support/factories/picture_thumb_factory.rb
+++ b/lib/alchemy/test_support/factories/picture_thumb_factory.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "factory_bot"
-require "securerandom"
-
 FactoryBot.define do
   factory :alchemy_picture_thumb, class: "Alchemy::PictureThumb" do
     picture { create(:alchemy_picture) }

--- a/lib/alchemy/test_support/factories/site_factory.rb
+++ b/lib/alchemy/test_support/factories/site_factory.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "factory_bot"
-
 FactoryBot.define do
   factory :alchemy_site, class: "Alchemy::Site" do
     name { "A Site" }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,16 +14,16 @@ require "rspec-activemodel-mocks"
 require "rspec/rails"
 require "webdrivers/chromedriver"
 require "shoulda-matchers"
+require "factory_bot"
 
 require "alchemy/seeder"
+require "alchemy/test_support"
 require "alchemy/test_support/config_stubbing"
 require "alchemy/test_support/essence_shared_examples"
 require "alchemy/test_support/integration_helpers"
-require "alchemy/test_support/factories"
 require "alchemy/test_support/shared_contexts"
 require "alchemy/test_support/shared_uploader_examples"
 
-require_relative "factories"
 require_relative "support/calculation_examples.rb"
 require_relative "support/hint_examples.rb"
 require_relative "support/transformation_examples.rb"
@@ -43,6 +43,9 @@ Rails.logger.level = 4
 # Configure capybara for integration testing
 Capybara.default_selector = :css
 Capybara.ignore_hidden_elements = false
+
+FactoryBot.definition_file_paths.concat(Alchemy::TestSupport.factory_paths)
+FactoryBot.reload
 
 Capybara.register_driver :selenium_chrome_headless do |app|
   Capybara::Selenium::Driver.load_selenium


### PR DESCRIPTION
We build these factories such that they could be independently loaded.
However, FactoryBot is built with the assumption in mind that it gets a
number of folder names and loads the factories when loading itself (via
FactoryBot.find_definitions).

The old behaviour is partially still supported, but deprecated.
