### PR TITLE
Tidy Rake task to remove duplicate legacy URLs

### DIFF
--- a/lib/alchemy/tasks/tidy.rb
+++ b/lib/alchemy/tasks/tidy.rb
@@ -98,6 +98,18 @@ module Alchemy
         end
       end
 
+      def remove_duplicate_legacy_urls
+        puts "\n## Removing duplicate legacy URLs"
+        sql = <<~SQL
+          DELETE FROM alchemy_legacy_page_urls A USING alchemy_legacy_page_urls B
+          WHERE A.page_id = B.page_id
+            AND A.urlname = B.urlname
+            AND A.id < B.id
+        SQL
+        count = ActiveRecord::Base.connection.exec_delete(sql)
+        log "Deleted #{count} duplicate legacy URLs"
+      end
+
       private
 
       def destroy_orphaned_records(records, class_name)

--- a/lib/tasks/alchemy/tidy.rake
+++ b/lib/tasks/alchemy/tidy.rake
@@ -9,6 +9,7 @@ namespace :alchemy do
       Rake::Task["alchemy:tidy:content_positions"].invoke
       Rake::Task["alchemy:tidy:remove_orphaned_records"].invoke
       Rake::Task["alchemy:tidy:remove_trashed_elements"].invoke
+      Rake::Task["alchemy:tidy:remove_duplicate_legacy_urls"].invoke
     end
 
     desc "Fixes element positions."
@@ -40,6 +41,11 @@ namespace :alchemy do
     desc "Remove trashed elements."
     task remove_trashed_elements: [:environment] do
       Alchemy::Tidy.remove_trashed_elements
+    end
+
+    desc "Remove duplicate legacy URLs"
+    task remove_duplicate_legacy_urls: [:environment] do
+      Alchemy::Tidy.remove_duplicate_legacy_urls
     end
 
     desc "List Alchemy elements usage"


### PR DESCRIPTION
## What is this pull request for?

Adds a new tidy Rake task to remove duplicate legacy URLs from pages.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
