### PR TITLE
Add namespace for Tree related routes

### DIFF
--- a/app/assets/javascripts/alchemy/templates/node_folder.hbs
+++ b/app/assets/javascripts/alchemy/templates/node_folder.hbs
@@ -1,3 +1,3 @@
-<a class="node_folder" data-node-id="{{ node.id }}" data-record-type="{{ node.type }}">
+<a class="node_folder" data-record-id="{{ node.id }}" data-record-type="{{ node.type }}">
   <i class="far fa-{{#if node.folded }}plus{{else}}minus{{/if}}-square fa-fw"></i>
 </a>

--- a/app/assets/javascripts/alchemy/templates/node_folder.hbs
+++ b/app/assets/javascripts/alchemy/templates/node_folder.hbs
@@ -1,3 +1,3 @@
-<a class="node_folder" data-node-id="{{ node.id }}">
+<a class="node_folder" data-node-id="{{ node.id }}" data-record-type="{{ node.type }}>
   <i class="far fa-{{#if node.folded }}plus{{else}}minus{{/if}}-square fa-fw"></i>
 </a>

--- a/app/assets/javascripts/alchemy/templates/node_folder.hbs
+++ b/app/assets/javascripts/alchemy/templates/node_folder.hbs
@@ -1,3 +1,3 @@
-<a class="node_folder" data-node-id="{{ node.id }}" data-record-type="{{ node.type }}>
+<a class="node_folder" data-node-id="{{ node.id }}" data-record-type="{{ node.type }}">
   <i class="far fa-{{#if node.folded }}plus{{else}}minus{{/if}}-square fa-fw"></i>
 </a>

--- a/app/views/alchemy/admin/nodes/_node.html.erb
+++ b/app/views/alchemy/admin/nodes/_node.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag :li, class: 'menu-item', data: { id: node.id, parent_id: node.parent_id, folded: node.folded? } do %>
+<%= content_tag :li, class: 'menu-item', data: { id: node.id, parent_id: node.parent_id, folded: node.folded?, type: "node" } do %>
   <%= content_tag :div, class: [
     'sitemap_node',
     node.external? ? 'external' : 'internal',

--- a/app/views/alchemy/admin/nodes/_node.html.erb
+++ b/app/views/alchemy/admin/nodes/_node.html.erb
@@ -67,7 +67,7 @@
       <% end %>
     </div>
   <% end %>
-  <%= content_tag :ul, class: "children #{' folded' if node.folded?}", data: { node_id: node.id } do %>
+  <%= content_tag :ul, class: "children #{' folded' if node.folded?}", data: { record_id: node.id } do %>
     <%= render partial: 'node', collection: node.children.includes(:page, :children) %>
   <% end %>
 <% end %>

--- a/app/views/alchemy/admin/partials/_routes.html.erb
+++ b/app/views/alchemy/admin/partials/_routes.html.erb
@@ -9,12 +9,14 @@
       return '<%= alchemy.fold_admin_element_path(id: 1) %>'.replace(/1/, id);
     },
 
-    toggle_folded_api_node_path: function(id) {
-      return '<%= alchemy.toggle_folded_api_node_path(id: 1) %>'.replace(/1/, id);
-    },
+    node: {
+      toggle_folded_api_path: function(id) {
+        return '<%= alchemy.toggle_folded_api_node_path(id: 1) %>'.replace(/1/, id);
+      },
 
-    move_api_node_path: function(id) {
-      return '<%= alchemy.move_api_node_path(id: 1) %>'.replace(/1/, id);
+      move_api_path: function(id) {
+        return '<%= alchemy.move_api_node_path(id: 1) %>'.replace(/1/, id);
+      },
     },
 
     order_admin_elements_path: '<%= alchemy.order_admin_elements_path %>',

--- a/package/src/node_tree.js
+++ b/package/src/node_tree.js
@@ -6,7 +6,7 @@ function displayNodeFolders() {
   document.querySelectorAll("li.menu-item").forEach((el) => {
     const leftIconArea = el.querySelector(".nodes_tree-left_images")
     const list = el.querySelector(".children")
-    const node = { folded: el.dataset.folded === "true", id: el.dataset.id }
+    const node = { folded: el.dataset.folded === "true", id: el.dataset.id, type: el.dataset.type }
 
     if (list.children.length > 0 || node.folded) {
       leftIconArea.innerHTML = HandlebarsTemplates.node_folder({ node: node })
@@ -17,9 +17,9 @@ function displayNodeFolders() {
 }
 
 function onFinishDragging(evt) {
-  const url = Alchemy.routes.move_api_node_path(evt.item.dataset.id)
+  const url = Alchemy.routes[evt.item.dataset.type].move_api_path(evt.item.dataset.id)
   const data = {
-    target_parent_id: evt.to.dataset.nodeId,
+    target_parent_id: evt.to.dataset.recordId,
     new_position: evt.newIndex
   }
 
@@ -36,9 +36,9 @@ function onFinishDragging(evt) {
 
 function handleNodeFolders() {
   on("click", ".nodes_tree", ".node_folder", function () {
-    const nodeId = this.dataset.nodeId
+    const nodeId = this.dataset.recordId
     const menu_item = this.closest("li.menu-item")
-    const url = Alchemy.routes.toggle_folded_api_node_path(nodeId)
+    const url = Alchemy.routes[this.dataset.recordType].toggle_folded_api_path(nodeId)
     const list = menu_item.querySelector(".children")
 
     ajax("PATCH", url)


### PR DESCRIPTION
## What is this pull request for?

NodeTree is being used for rendering the Menu in tree
structure. This Tree could be made generic so that it could be
used at other places too. All that will be required is the fields
similar to what we are using for Node, and the API endpoints.
The API endpoints needs to be similar to what we have for Node.
To differentiate and use the existing NodeTree.js, a namespace could
be added so that it could be extended and new routes could be added
it someone needs to make a similar Tree structure anywhere else too.



This PR adds a namespace for existing Alchemy.routes for node type
objects. 
Similarly, in future if it is required to use the currently implemented
NodeTree, all that will be required is to extend and add the routes
to the API with namespace, update the model similar to the Node model
attributes and use Alchemy.NodeTree().


### Notable changes
The type is added as "node"  at NodeTree.js, node_folder.hbs and
_node.html.erb since these are the places from where the type data
could be sent out and the current NodeTree works as expected.

## Checklist
- [ ] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
