### PR TITLE
Render site layout with block

### DIFF
--- a/app/helpers/alchemy/pages_helper.rb
+++ b/app/helpers/alchemy/pages_helper.rb
@@ -66,8 +66,8 @@ module Alchemy
     #
     # renders +app/views/alchemy/site_layouts/_default_site.html.erb+ for the site named "Default Site".
     #
-    def render_site_layout
-      render current_alchemy_site
+    def render_site_layout(&block)
+      render current_alchemy_site, &block
     rescue ActionView::MissingTemplate
       warning("Site layout for #{current_alchemy_site.try(:name)} not found. Please run `rails g alchemy:site_layouts`")
       ""

--- a/spec/helpers/alchemy/pages_helper_spec.rb
+++ b/spec/helpers/alchemy/pages_helper_spec.rb
@@ -30,6 +30,17 @@ module Alchemy
         helper.render_site_layout
       end
 
+      context "when block is given" do
+        it "passes it on to the render method" do
+          expect(helper).to receive(:current_alchemy_site).and_return(default_site)
+          expect(helper)
+            .to receive(:render)
+            .with(default_site) { |&block| expect(block).to be }
+
+          helper.render_site_layout { true }
+        end
+      end
+
       context "with missing partial" do
         it "returns empty string and logges warning" do
           expect(helper).to receive(:current_alchemy_site).twice.and_return(default_site)


### PR DESCRIPTION
## What is this pull request for?

This pull request adds the ability to pass a block to the `render_site_layout` method inside the `PagesHelper`.

I stumbled across this issue when I tried to do this inside a page layout:
``` ruby
<%= render_site_layout do %>
  <%= render_elements %>
  ...
<% end %>
```

I think it _should_ work because the generated partial (`rails g alchemy:site_layouts`) contains a `yield`. Therefore I would expect a block argument to work. But it did not work because of the missing changes I added in this PR.


### Explain any changes (maybe breaking?) that have been made.

The `render_site_layout` method can now receive a block and passes it on to the `render` method.
I've also written a small spec that failed before and is now passing.

## Checklist
- [X] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [X] I have added a detailed description into each commit message
- [X] I have added tests to cover this change
