### PR TITLE
Add Elements repository

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -100,9 +100,6 @@ Layout/MultilineMethodCallBraceLayout:
 Layout/MultilineMethodCallIndentation:
   Enabled: false
 
-Layout/MultilineOperationIndentation:
-  EnforcedStyle: indented
-
 Layout/SpaceBeforeBlockBraces:
   Enabled: false
   StyleGuide: http://relaxed.ruby.style/#stylespacebeforeblockbraces

--- a/app/models/alchemy/elements_repository.rb
+++ b/app/models/alchemy/elements_repository.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module Alchemy
+  # Mimics ActiveRecord query interface
+  # but does this on the preloaded elements
+  class ElementsRepository
+    include Enumerable
+
+    # @param [ActiveRecord::Relation]
+    def initialize(elements)
+      @elements = elements.to_a
+    end
+
+    # All visible elements
+    # @return [Array]
+    def visible
+      select(&:public)
+    end
+
+    # All not fixed elements
+    # @return [Array]
+    def hidden
+      reject(&:public)
+    end
+
+    # All elements with given name(s)
+    # @param [Array<String|Symbol>|String|Symbol]
+    # @return [Array]
+    def named(*names)
+      names.flatten!
+      select { |e| e.name.in?(names.map!(&:to_s)) }
+    end
+
+    # Filter elements by given attribute and value
+    # @param [Array|Hash]
+    # @return [Array]
+    def where(attrs)
+      select do |element|
+        attrs.all? do |attr, value|
+          element.public_send(attr) == value
+        end
+      end
+    end
+
+    # All elements excluding those wth given name(s)
+    # @param [Array<String|Symbol>|String|Symbol]
+    # @return [Array]
+    def excluded(*names)
+      names.flatten!
+      reject { |e| e.name.in?(names.map!(&:to_s)) }
+    end
+
+    # All fixed elements
+    # @return [Array]
+    def fixed
+      select(&:fixed)
+    end
+
+    # All not fixed elements
+    # @return [Array]
+    def unfixed
+      reject(&:fixed)
+    end
+
+    # All folded elements
+    # @return [Array]
+    def folded
+      select(&:folded)
+    end
+
+    # All expanded elements
+    # @return [Array]
+    def expanded
+      reject(&:folded)
+    end
+
+    def each(&blk)
+      elements.each(&blk)
+    end
+
+    private
+
+    attr_reader :elements
+  end
+end

--- a/app/models/alchemy/elements_repository.rb
+++ b/app/models/alchemy/elements_repository.rb
@@ -6,6 +6,11 @@ module Alchemy
   class ElementsRepository
     include Enumerable
 
+    # An empty set of elements
+    def self.none
+      new([])
+    end
+
     # @param [ActiveRecord::Relation]
     def initialize(elements)
       @elements = elements.to_a
@@ -74,6 +79,36 @@ module Alchemy
     # @return [Alchemy::ElementRepository]
     def expanded
       self.class.new reject(&:folded)
+    end
+
+    # All not nested top level elements
+    # @return [Alchemy::ElementRepository]
+    def not_nested
+      self.class.new(select { |e| e.parent_element_id.nil? })
+    end
+
+    # Elements in reversed order
+    # @return [Alchemy::ElementRepository]
+    def reverse
+      self.class.new elements.reverse
+    end
+
+    # Elements in random order
+    # @return [Alchemy::ElementRepository]
+    def random
+      self.class.new Array(elements).shuffle
+    end
+
+    # Elements off setted by
+    # @return [Alchemy::ElementRepository]
+    def offset(offset)
+      self.class.new elements[offset.to_i..-1]
+    end
+
+    # Elements limitted by
+    # @return [Alchemy::ElementRepository]
+    def limit(limit)
+      self.class.new elements[0..(limit.to_i - 1)]
     end
 
     def each(&blk)

--- a/app/models/alchemy/elements_repository.rb
+++ b/app/models/alchemy/elements_repository.rb
@@ -12,66 +12,68 @@ module Alchemy
     end
 
     # All visible elements
-    # @return [Array]
+    # @return [Alchemy::ElementRepository]
     def visible
-      select(&:public)
+      self.class.new select(&:public)
     end
 
     # All not fixed elements
-    # @return [Array]
+    # @return [Alchemy::ElementRepository]
     def hidden
-      reject(&:public)
+      self.class.new reject(&:public)
     end
 
     # All elements with given name(s)
     # @param [Array<String|Symbol>|String|Symbol]
-    # @return [Array]
+    # @return [Alchemy::ElementRepository]
     def named(*names)
       names.flatten!
-      select { |e| e.name.in?(names.map!(&:to_s)) }
+      self.class.new(select { |e| e.name.in?(names.map!(&:to_s)) })
     end
 
     # Filter elements by given attribute and value
     # @param [Array|Hash]
-    # @return [Array]
+    # @return [Alchemy::ElementRepository]
     def where(attrs)
-      select do |element|
-        attrs.all? do |attr, value|
-          element.public_send(attr) == value
+      self.class.new(
+        select do |element|
+          attrs.all? do |attr, value|
+            element.public_send(attr) == value
+          end
         end
-      end
+      )
     end
 
     # All elements excluding those wth given name(s)
     # @param [Array<String|Symbol>|String|Symbol]
-    # @return [Array]
+    # @return [Alchemy::ElementRepository]
     def excluded(*names)
       names.flatten!
-      reject { |e| e.name.in?(names.map!(&:to_s)) }
+      self.class.new(reject { |e| e.name.in?(names.map!(&:to_s)) })
     end
 
     # All fixed elements
-    # @return [Array]
+    # @return [Alchemy::ElementRepository]
     def fixed
-      select(&:fixed)
+      self.class.new select(&:fixed)
     end
 
     # All not fixed elements
-    # @return [Array]
+    # @return [Alchemy::ElementRepository]
     def unfixed
-      reject(&:fixed)
+      self.class.new reject(&:fixed)
     end
 
     # All folded elements
-    # @return [Array]
+    # @return [Alchemy::ElementRepository]
     def folded
-      select(&:folded)
+      self.class.new select(&:folded)
     end
 
     # All expanded elements
-    # @return [Array]
+    # @return [Alchemy::ElementRepository]
     def expanded
-      reject(&:folded)
+      self.class.new reject(&:folded)
     end
 
     def each(&blk)

--- a/spec/libraries/elements_finder_spec.rb
+++ b/spec/libraries/elements_finder_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Alchemy::ElementsFinder do
     end
 
     context "with page_version object given" do
-      subject { finder.elements(page_version: page_version) }
+      subject { finder.elements(page_version: page_version).to_a }
 
       it "returns all public elements from page_version" do
         is_expected.to eq([visible_element])
@@ -132,18 +132,9 @@ RSpec.describe Alchemy::ElementsFinder do
           { random: true }
         end
 
-        let(:random_function) do
-          case ActiveRecord::Base.connection_config[:adapter]
-          when "postgresql", "sqlite3"
-            "RANDOM()"
-          else
-            "RAND()"
-          end
-        end
-
         it "returns elements in random order" do
-          expect_any_instance_of(ActiveRecord::Relation).to \
-            receive(:reorder).with(random_function).and_call_original
+          expect_any_instance_of(Alchemy::ElementsRepository).to \
+            receive(:random).and_call_original
           subject
         end
       end

--- a/spec/models/alchemy/elements_repository_spec.rb
+++ b/spec/models/alchemy/elements_repository_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::ElementsRepository do
+  let(:repo) { described_class.new(elements) }
+  let(:visible_element) { create(:alchemy_element, name: "headline") }
+  let(:hidden_element) { create(:alchemy_element, public: false) }
+  let(:fixed_element) { create(:alchemy_element, fixed: true) }
+  let(:folded_element) { create(:alchemy_element, folded: true) }
+  let(:elements) { [visible_element, hidden_element, fixed_element, folded_element] }
+
+  it { expect(repo).to be_an(Enumerable) }
+
+  describe "#visible" do
+    subject { repo.visible }
+
+    it "returns only visible elements" do
+      is_expected.to match_array([visible_element, fixed_element, folded_element])
+    end
+  end
+
+  describe "#hidden" do
+    subject { repo.hidden }
+
+    it "returns only hidden elements" do
+      is_expected.to match_array([hidden_element])
+    end
+  end
+
+  describe "#named" do
+    let(:names) { [] }
+
+    subject { repo.named(names) }
+
+    context "with a single string" do
+      let(:names) { "headline" }
+
+      it "returns only elements with given name" do
+        is_expected.to match_array([visible_element])
+      end
+    end
+
+    context "with a single symbol" do
+      let(:names) { :headline }
+
+      it "returns only elements with given name" do
+        is_expected.to match_array([visible_element])
+      end
+    end
+
+    context "with an array of strings" do
+      let(:names) { %w[headline] }
+
+      it "returns only elements with given name" do
+        is_expected.to match_array([visible_element])
+      end
+    end
+
+    context "with an array of symbols" do
+      let(:names) { %i[headline] }
+
+      it "returns only elements with given name" do
+        is_expected.to match_array([visible_element])
+      end
+    end
+  end
+
+  describe "#where" do
+    subject { repo.where(attrs) }
+
+    context "with a single key hash" do
+      let(:attrs) { { name: "headline" } }
+
+      it "returns only elements matching attribute and value" do
+        is_expected.to match_array([visible_element])
+      end
+    end
+
+    context "with a multi key hash" do
+      let(:attrs) { { name: "headline", public: false } }
+
+      it "returns only elements matching all attributes and values" do
+        is_expected.to match_array([])
+      end
+    end
+  end
+
+  describe "#excluded" do
+    subject { repo.excluded(names) }
+
+    context "with a single string" do
+      let(:names) { "headline" }
+
+      it "returns only elements without given name" do
+        is_expected.to match_array([hidden_element, fixed_element, folded_element])
+      end
+    end
+
+    context "with a single symbol" do
+      let(:names) { :headline }
+
+      it "returns only elements without given name" do
+        is_expected.to match_array([hidden_element, fixed_element, folded_element])
+      end
+    end
+
+    context "with an array of strings" do
+      let(:names) { %w[headline] }
+
+      it "returns only elements without given name" do
+        is_expected.to match_array([hidden_element, fixed_element, folded_element])
+      end
+    end
+
+    context "with an array of symbols" do
+      let(:names) { %i[headline] }
+
+      it "returns only elements without given name" do
+        is_expected.to match_array([hidden_element, fixed_element, folded_element])
+      end
+    end
+  end
+
+  describe "#fixed" do
+    subject { repo.fixed }
+
+    it "returns only fixed elements" do
+      is_expected.to match_array([fixed_element])
+    end
+  end
+
+  describe "#unfixed" do
+    subject { repo.unfixed }
+
+    it "returns only not fixed elements" do
+      is_expected.to match_array([visible_element, hidden_element, folded_element])
+    end
+  end
+
+  describe "#folded" do
+    subject { repo.folded }
+
+    it "returns only folded elements" do
+      is_expected.to match_array([folded_element])
+    end
+  end
+
+  describe "#expanded" do
+    subject { repo.expanded }
+
+    it "returns only expanded elements" do
+      is_expected.to match_array([visible_element, hidden_element, fixed_element])
+    end
+  end
+end

--- a/spec/models/alchemy/elements_repository_spec.rb
+++ b/spec/models/alchemy/elements_repository_spec.rb
@@ -12,12 +12,20 @@ RSpec.describe Alchemy::ElementsRepository do
 
   it { expect(repo).to be_an(Enumerable) }
 
+  shared_examples "being chainable" do
+    it "is chainable" do
+      expect(subject).to be_an(described_class)
+    end
+  end
+
   describe "#visible" do
     subject { repo.visible }
 
     it "returns only visible elements" do
       is_expected.to match_array([visible_element, fixed_element, folded_element])
     end
+
+    it_behaves_like "being chainable"
   end
 
   describe "#hidden" do
@@ -26,12 +34,16 @@ RSpec.describe Alchemy::ElementsRepository do
     it "returns only hidden elements" do
       is_expected.to match_array([hidden_element])
     end
+
+    it_behaves_like "being chainable"
   end
 
   describe "#named" do
     let(:names) { [] }
 
     subject { repo.named(names) }
+
+    it_behaves_like "being chainable"
 
     context "with a single string" do
       let(:names) { "headline" }
@@ -67,7 +79,11 @@ RSpec.describe Alchemy::ElementsRepository do
   end
 
   describe "#where" do
+    let(:attrs) { {} }
+
     subject { repo.where(attrs) }
+
+    it_behaves_like "being chainable"
 
     context "with a single key hash" do
       let(:attrs) { { name: "headline" } }
@@ -87,7 +103,11 @@ RSpec.describe Alchemy::ElementsRepository do
   end
 
   describe "#excluded" do
+    let(:names) { [] }
+
     subject { repo.excluded(names) }
+
+    it_behaves_like "being chainable"
 
     context "with a single string" do
       let(:names) { "headline" }
@@ -128,6 +148,8 @@ RSpec.describe Alchemy::ElementsRepository do
     it "returns only fixed elements" do
       is_expected.to match_array([fixed_element])
     end
+
+    it_behaves_like "being chainable"
   end
 
   describe "#unfixed" do
@@ -136,6 +158,8 @@ RSpec.describe Alchemy::ElementsRepository do
     it "returns only not fixed elements" do
       is_expected.to match_array([visible_element, hidden_element, folded_element])
     end
+
+    it_behaves_like "being chainable"
   end
 
   describe "#folded" do
@@ -144,6 +168,8 @@ RSpec.describe Alchemy::ElementsRepository do
     it "returns only folded elements" do
       is_expected.to match_array([folded_element])
     end
+
+    it_behaves_like "being chainable"
   end
 
   describe "#expanded" do
@@ -152,5 +178,7 @@ RSpec.describe Alchemy::ElementsRepository do
     it "returns only expanded elements" do
       is_expected.to match_array([visible_element, hidden_element, fixed_element])
     end
+
+    it_behaves_like "being chainable"
   end
 end

--- a/spec/models/alchemy/elements_repository_spec.rb
+++ b/spec/models/alchemy/elements_repository_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Alchemy::ElementsRepository do
   let(:hidden_element) { create(:alchemy_element, public: false) }
   let(:fixed_element) { create(:alchemy_element, fixed: true) }
   let(:folded_element) { create(:alchemy_element, folded: true) }
-  let(:elements) { [visible_element, hidden_element, fixed_element, folded_element] }
+  let(:nested_element) { create(:alchemy_element, parent_element: visible_element) }
+  let(:elements) { [visible_element, hidden_element, fixed_element, folded_element, nested_element] }
 
   it { expect(repo).to be_an(Enumerable) }
 
@@ -18,11 +19,21 @@ RSpec.describe Alchemy::ElementsRepository do
     end
   end
 
+  describe ".none" do
+    subject { described_class.none }
+
+    it "returns empty set of elements" do
+      expect(subject.to_a).to eq([])
+    end
+
+    it_behaves_like "being chainable"
+  end
+
   describe "#visible" do
     subject { repo.visible }
 
     it "returns only visible elements" do
-      is_expected.to match_array([visible_element, fixed_element, folded_element])
+      is_expected.to match_array([visible_element, fixed_element, folded_element, nested_element])
     end
 
     it_behaves_like "being chainable"
@@ -113,7 +124,7 @@ RSpec.describe Alchemy::ElementsRepository do
       let(:names) { "headline" }
 
       it "returns only elements without given name" do
-        is_expected.to match_array([hidden_element, fixed_element, folded_element])
+        is_expected.to match_array([hidden_element, fixed_element, folded_element, nested_element])
       end
     end
 
@@ -121,7 +132,7 @@ RSpec.describe Alchemy::ElementsRepository do
       let(:names) { :headline }
 
       it "returns only elements without given name" do
-        is_expected.to match_array([hidden_element, fixed_element, folded_element])
+        is_expected.to match_array([hidden_element, fixed_element, folded_element, nested_element])
       end
     end
 
@@ -129,7 +140,7 @@ RSpec.describe Alchemy::ElementsRepository do
       let(:names) { %w[headline] }
 
       it "returns only elements without given name" do
-        is_expected.to match_array([hidden_element, fixed_element, folded_element])
+        is_expected.to match_array([hidden_element, fixed_element, folded_element, nested_element])
       end
     end
 
@@ -137,7 +148,7 @@ RSpec.describe Alchemy::ElementsRepository do
       let(:names) { %i[headline] }
 
       it "returns only elements without given name" do
-        is_expected.to match_array([hidden_element, fixed_element, folded_element])
+        is_expected.to match_array([hidden_element, fixed_element, folded_element, nested_element])
       end
     end
   end
@@ -156,7 +167,7 @@ RSpec.describe Alchemy::ElementsRepository do
     subject { repo.unfixed }
 
     it "returns only not fixed elements" do
-      is_expected.to match_array([visible_element, hidden_element, folded_element])
+      is_expected.to match_array([visible_element, hidden_element, folded_element, nested_element])
     end
 
     it_behaves_like "being chainable"
@@ -176,7 +187,58 @@ RSpec.describe Alchemy::ElementsRepository do
     subject { repo.expanded }
 
     it "returns only expanded elements" do
-      is_expected.to match_array([visible_element, hidden_element, fixed_element])
+      is_expected.to match_array([visible_element, hidden_element, fixed_element, nested_element])
+    end
+
+    it_behaves_like "being chainable"
+  end
+
+  describe "#not_nested" do
+    subject { repo.not_nested }
+
+    it "returns only top level not nested elements" do
+      is_expected.to match_array([visible_element, hidden_element, fixed_element, folded_element])
+    end
+
+    it_behaves_like "being chainable"
+  end
+
+  describe "#reverse" do
+    subject { repo.reverse }
+
+    it "returns elements in reverse order" do
+      expect(subject.to_a).to eq([nested_element, folded_element, fixed_element, hidden_element, visible_element])
+    end
+
+    it_behaves_like "being chainable"
+  end
+
+  describe "#random" do
+    subject { repo.random }
+
+    it "returns elements in random order" do
+      expect_any_instance_of(Array).to receive(:shuffle).and_call_original
+      subject
+    end
+
+    it_behaves_like "being chainable"
+  end
+
+  describe "#offset" do
+    subject { repo.offset(2) }
+
+    it "returns elements offsetted" do
+      is_expected.to match_array([fixed_element, folded_element, nested_element])
+    end
+
+    it_behaves_like "being chainable"
+  end
+
+  describe "#limit" do
+    subject { repo.limit(2) }
+
+    it "returns elements limitted" do
+      is_expected.to match_array([visible_element, hidden_element])
     end
 
     it_behaves_like "being chainable"

--- a/spec/models/alchemy/elements_repository_spec.rb
+++ b/spec/models/alchemy/elements_repository_spec.rb
@@ -4,11 +4,11 @@ require "rails_helper"
 
 RSpec.describe Alchemy::ElementsRepository do
   let(:repo) { described_class.new(elements) }
-  let(:visible_element) { create(:alchemy_element, name: "headline") }
-  let(:hidden_element) { create(:alchemy_element, public: false) }
-  let(:fixed_element) { create(:alchemy_element, fixed: true) }
-  let(:folded_element) { create(:alchemy_element, folded: true) }
-  let(:nested_element) { create(:alchemy_element, parent_element: visible_element) }
+  let(:visible_element) { build_stubbed(:alchemy_element, name: "headline") }
+  let(:hidden_element) { build_stubbed(:alchemy_element, public: false) }
+  let(:fixed_element) { build_stubbed(:alchemy_element, fixed: true) }
+  let(:folded_element) { build_stubbed(:alchemy_element, folded: true) }
+  let(:nested_element) { build_stubbed(:alchemy_element, parent_element: visible_element) }
   let(:elements) { [visible_element, hidden_element, fixed_element, folded_element, nested_element] }
 
   it { expect(repo).to be_an(Enumerable) }


### PR DESCRIPTION
## What is this pull request for?

Adds a repository class that mimics the ActiveRecord interface of elements, but uses the eager loaded elements and POR methods to filter the collection.

With that we filter the elements in the elements finder (used in the `render_elements` helper) on a eager loaded elements collection.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
