### PR TITLE
Fix factory loading

### DIFF
--- a/lib/alchemy/test_support.rb
+++ b/lib/alchemy/test_support.rb
@@ -2,10 +2,8 @@
 
 module Alchemy
   module TestSupport
-    def self.factory_paths
-      Dir[
-        ::Alchemy::Engine.root.join("lib", "alchemy", "test_support", "factories", "*_factory.rb")
-      ].map { |path| path.sub(/.rb\z/, "") }
+    def self.factories_path
+      ::Alchemy::Engine.root.join("lib", "alchemy", "test_support", "factories")
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,8 +44,8 @@ Rails.logger.level = 4
 Capybara.default_selector = :css
 Capybara.ignore_hidden_elements = false
 
-FactoryBot.definition_file_paths.concat(Alchemy::TestSupport.factory_paths)
-FactoryBot.reload
+FactoryBot.definition_file_paths.append(Alchemy::TestSupport.factories_path)
+FactoryBot.find_definitions
 
 Capybara.register_driver :selenium_chrome_headless do |app|
   Capybara::Selenium::Driver.load_selenium


### PR DESCRIPTION
## What is this pull request for?

Before the method returned a list of individual file paths. FactoryBot is able to load files from a directory. By changing this to `factories_path` and return a single directory path it is easier to prepend and append the path to the list of factory bots factory definitions.

Also `FactoryBot.reload` is wrong as it resets the internal configs of factory bot.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
