### PR TITLE
Update rubocop config and stick version

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,6 +1,6 @@
 rubocop:
   config_file: .rubocop.yml
-  version: 0.80.0
+  version: 1.5.2
 scss:
   enabled: false
 coffeescript:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -309,3 +309,48 @@ Naming/PredicateName:
 
 Naming/VariableNumber:
   Enabled: false
+
+Lint/DuplicateBranch: # (new in 1.3)
+  Enabled: false
+
+Lint/DuplicateRegexpCharacterClassElement: # (new in 1.1)
+  Enabled: false
+
+Lint/EmptyBlock: # (new in 1.1)
+  Enabled: false
+
+Lint/EmptyClass: # (new in 1.3)
+  Enabled: false
+
+Lint/NoReturnInBeginEndBlocks: # (new in 1.2)
+  Enabled: false
+
+Lint/ToEnumArguments: # (new in 1.1)
+  Enabled: false
+
+Lint/UnexpectedBlockArity: # (new in 1.5)
+  Enabled: false
+
+Lint/UnmodifiedReduceAccumulator: # (new in 1.1)
+  Enabled: false
+
+Style/ArgumentsForwarding: # (new in 1.1)
+  Enabled: false
+
+Style/CollectionCompact: # (new in 1.2)
+  Enabled: false
+
+Style/DocumentDynamicEvalDefinition: # (new in 1.1)
+  Enabled: false
+
+Style/NegatedIfElseCondition: # (new in 1.2)
+  Enabled: false
+
+Style/NilLambda: # (new in 1.3)
+  Enabled: false
+
+Style/RedundantArgument: # (new in 1.4)
+  Enabled: false
+
+Style/SwapValues: # (new in 1.1)
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 # Relaxed.Ruby.Style
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   Exclude:
     - 'bin/rspec'
     - 'vendor/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :development, :test do
     gem "yard"
     gem "redcarpet"
     gem "pry-byebug"
-    gem "rubocop", "~> 1.9.0", require: false
+    gem "rubocop", "1.5.2", require: false
     gem "listen"
     gem "localeapp", "~> 3.0", require: false
     gem "dotenv", "~> 2.2"


### PR DESCRIPTION
## What is this pull request for?

Use the same rubocop version as hound. We use hound ci to run linting. They only support some versions of rubocop.

http://help.houndci.com/en/articles/2461415-supported-linters

Lets stick with the exact same version for now.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
