### PR TITLE
Fix page re-publishing for page with nested elements

### DIFF
--- a/app/models/alchemy/page/publisher.rb
+++ b/app/models/alchemy/page/publisher.rb
@@ -17,7 +17,7 @@ module Alchemy
       def publish!(public_on:)
         Page.transaction do
           version = public_version(public_on)
-          version.elements.destroy_all
+          version.elements.not_nested.destroy_all
 
           # We must not use .find_each here to not mess up the order of elements
           page.draft_version.elements.not_nested.available.each do |element|

--- a/spec/models/alchemy/page/publisher_spec.rb
+++ b/spec/models/alchemy/page/publisher_spec.rb
@@ -51,6 +51,10 @@ RSpec.describe Alchemy::Page::Publisher do
         create(:alchemy_page_version, :with_elements, element_count: 3, public_on: Date.yesterday.to_time, page: page)
       end
 
+      let!(:nested_element) do
+        create(:alchemy_element, page_version: public_version, parent_element: public_version.elements.first)
+      end
+
       it "does not change current public versions public on date" do
         expect { publish }.to_not change(page.public_version, :public_on)
       end


### PR DESCRIPTION
## What is this pull request for?

If a page has a published page version with nested elements
the nested elements got deleted before the parent has been deleted.

Using the not_nested scope here to cascade from top to bottom.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
