### PR TITLE
Eager load elements and contents in pages controller

### DIFF
--- a/app/controllers/alchemy/base_controller.rb
+++ b/app/controllers/alchemy/base_controller.rb
@@ -8,6 +8,7 @@ module Alchemy
     include Alchemy::AbilityHelper
     include Alchemy::ControllerActions
     include Alchemy::Modules
+    include Alchemy::EagerLoading
 
     protect_from_forgery
 

--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -107,7 +107,9 @@ module Alchemy
     # If no index page and no admin users are present we show the "Welcome to Alchemy" page.
     #
     def load_index_page
-      @page ||= Language.current_root_page
+      page_not_found! unless Language.current
+
+      @page ||= Language.current.pages.language_roots.includes(*alchemy_page_loading_includes).first
       render template: "alchemy/welcome", layout: false if signup_required?
     end
 
@@ -123,7 +125,7 @@ module Alchemy
     def load_page
       page_not_found! unless Language.current
 
-      @page ||= Language.current.pages.contentpages.find_by(
+      @page ||= Language.current.pages.contentpages.includes(*alchemy_page_loading_includes).find_by(
         urlname: params[:urlname],
         language_code: params[:locale] || Language.current.code,
       )

--- a/app/controllers/concerns/alchemy/eager_loading.rb
+++ b/app/controllers/concerns/alchemy/eager_loading.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Alchemy
+  module EagerLoading
+    extend ActiveSupport::Concern
+
+    included do
+      helper_method :alchemy_page_loading_includes
+    end
+
+    private
+
+    # Eager load includes for loading alchemy pages
+    def alchemy_page_loading_includes
+      [{ public_version: { elements: alchemy_element_loading_includes } }]
+    end
+
+    # Eager load includes for loading alchemy elements
+    def alchemy_element_loading_includes
+      [
+        { nested_elements: { contents: alchemy_content_loading_includes } },
+        { contents: alchemy_content_loading_includes },
+      ]
+    end
+
+    # Eager load includes for loading alchemy contents
+    def alchemy_content_loading_includes
+      [{ essence: :ingredient_association }]
+    end
+  end
+end

--- a/lib/alchemy/elements_finder.rb
+++ b/lib/alchemy/elements_finder.rb
@@ -54,8 +54,8 @@ module Alchemy
     def find_elements(page_version)
       return Alchemy::ElementsRepository.none unless page_version
 
-      elements = Alchemy::ElementsRepository.new(page_version.elements.available)
-      elements = elements.not_nested
+      elements = Alchemy::ElementsRepository.new(page_version.elements)
+      elements = elements.not_nested.visible
       elements = options[:fixed] ? elements.fixed : elements.unfixed
 
       if options[:only]


### PR DESCRIPTION
## What is this pull request for?

Exposes a helper method `alchemy_page_loading_includes` that
is used in the pages controller to eager load the public page
version and all its elements, their contents, their essences and
their associations.

You can use this helper method to load a page for the render_elements
helper and eager load all those elements as well.

    footer_page ||= Alchemy::Page.where(
        name: "Footer"
      ).includes(*alchemy_page_loading_includes).first

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
