### PR TITLE
Picture Abstraction

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.base.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.base.js.coffee
@@ -69,6 +69,14 @@ $.extend Alchemy,
       Alchemy.setElementDirty $element
     false
 
+  removeCommonPicture: (selector) ->
+    $form_field = $(selector)
+    $content = $form_field.closest(".picture_thumbnail")
+    if $form_field[0]
+      $form_field.val ""
+      $content.find(".thumbnail_background").html('<i class="icon far fa-image fa-fw"/>')
+    false
+
   # Initializes all select tag with .alchemy_selectbox class as select2 instance
   # Pass a jQuery scope to only init a subset of selectboxes.
   SelectBox: (scope) ->

--- a/app/controllers/alchemy/admin/pictures_controller.rb
+++ b/app/controllers/alchemy/admin/pictures_controller.rb
@@ -135,6 +135,12 @@ module Alchemy
         [per_page, per_page * 2, per_page * 4]
       end
 
+      def assign
+        @picture = Picture.find_by(id: params[:picture_id])
+        @book = Alchemy::Book.find_by(id: params[:book_id])
+        @book.cover_image = @picture
+      end
+
       private
 
       def set_size

--- a/app/controllers/alchemy/admin/pictures_controller.rb
+++ b/app/controllers/alchemy/admin/pictures_controller.rb
@@ -137,8 +137,9 @@ module Alchemy
 
       def assign
         @picture = Picture.find_by(id: params[:picture_id])
-        @book = Alchemy::Book.find_by(id: params[:book_id])
-        @book.cover_image = @picture
+        @record = params[:record_type].constantize.find_by(id: params[:record_id])
+        picture_attribute = @record.picture_assignment_field_name
+        @record.send("#{picture_attribute}=", @picture)
       end
 
       private

--- a/app/controllers/concerns/alchemy/admin/archive_overlay.rb
+++ b/app/controllers/concerns/alchemy/admin/archive_overlay.rb
@@ -5,12 +5,12 @@ module Alchemy
       private
 
       def in_overlay?
-        params[:content_id].present? || params[:use_assign_box]
+        params[:content_id].present? || params[:use_overlay]
       end
 
       def archive_overlay
         @content = Content.find_by(id: params[:content_id])
-        @book = Alchemy::Book.find_by(id: params[:book_id])
+        @record = params[:record_type]&.constantize&.find_by(id: params[:record_id])
 
         respond_to do |format|
           format.html { render partial: "archive_overlay" }

--- a/app/controllers/concerns/alchemy/admin/archive_overlay.rb
+++ b/app/controllers/concerns/alchemy/admin/archive_overlay.rb
@@ -5,11 +5,12 @@ module Alchemy
       private
 
       def in_overlay?
-        params[:content_id].present?
+        params[:content_id].present? || params[:use_assign_box]
       end
 
       def archive_overlay
         @content = Content.find_by(id: params[:content_id])
+        @book = Alchemy::Book.find_by(id: params[:book_id])
 
         respond_to do |format|
           format.html { render partial: "archive_overlay" }

--- a/app/helpers/alchemy/admin/pictures_helper.rb
+++ b/app/helpers/alchemy/admin/pictures_helper.rb
@@ -9,6 +9,19 @@ module Alchemy
           Alchemy::Picture::THUMBNAIL_SIZES[:medium]
         )
       end
+
+      def picture_thumbnail(image)
+        picture = image
+
+        return if picture.nil?
+
+        image_tag(
+          picture.url,
+          alt: picture.name,
+          class: "img_paddingtop",
+          title: Alchemy.t(:image_name) + ": #{picture.name}",
+        )
+      end
     end
   end
 end

--- a/app/helpers/alchemy/admin/pictures_helper.rb
+++ b/app/helpers/alchemy/admin/pictures_helper.rb
@@ -10,17 +10,19 @@ module Alchemy
         )
       end
 
-      def picture_thumbnail(image)
-        picture = image
-
-        return if picture.nil?
-
-        image_tag(
-          picture.url,
-          alt: picture.name,
-          class: "img_paddingtop",
-          title: Alchemy.t(:image_name) + ": #{picture.name}",
-        )
+      def picture_assignment_redirect_url(picture_to_assign, record, content)
+        if content.present?
+          alchemy.assign_admin_essence_pictures_path(
+            picture_id: picture_to_assign.id,
+            content_id: content
+          )
+        else
+          alchemy.assign_admin_pictures_path(
+            picture_id: picture_to_assign.id,
+            record_id: record.id,
+            record_type: record.class.name
+          )
+        end
       end
     end
   end

--- a/app/helpers/alchemy/base_helper.rb
+++ b/app/helpers/alchemy/base_helper.rb
@@ -100,5 +100,12 @@ module Alchemy
         message_type
       end
     end
+
+    def render_picture_assignment_box(record)
+      render partial: "alchemy/admin/pictures/picture_assignment", 
+            locals: { record: record,
+                      image: record.send(record.picture_assignment_field_name)
+                    }
+    end
   end
 end

--- a/app/models/alchemy/picture_assignment.rb
+++ b/app/models/alchemy/picture_assignment.rb
@@ -1,0 +1,6 @@
+module Alchemy
+  class PictureAssignment < ApplicationRecord
+    belongs_to :picture
+    belongs_to :assignee, polymorphic: true, dependent: :destroy
+  end
+end

--- a/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
+++ b/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
@@ -8,8 +8,10 @@
       redirect_url: alchemy.admin_pictures_path(
         size: search_filter_params[:size],
         filter: 'last_upload',
-        content_id: @content.try(:id),
-        element_id: @element.try(:id)
+        book_id: @book.id,
+        use_assign_box: true,
+        # content_id: @content.try(:id),
+        # element_id: @element.try(:id)
       ) %>
     <div class="toolbar_spacer"></div>
   <% end %>

--- a/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
+++ b/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
@@ -8,10 +8,11 @@
       redirect_url: alchemy.admin_pictures_path(
         size: search_filter_params[:size],
         filter: 'last_upload',
-        book_id: @book.id,
-        use_assign_box: true,
-        # content_id: @content.try(:id),
-        # element_id: @element.try(:id)
+        record_id: @record&.id,
+        record_type: @record&.class&.name,
+        use_overlay: true,
+        content_id: @content.try(:id),
+        element_id: @element.try(:id)
       ) %>
     <div class="toolbar_spacer"></div>
   <% end %>
@@ -25,7 +26,10 @@
           element_id: @element,
           q: search_filter_params[:q],
           filter: search_filter_params[:filter],
-          tagged_with: search_filter_params[:tagged_with]
+          tagged_with: search_filter_params[:tagged_with],
+          record_id: @record&.id,
+          record_type: @record&.class&.name,
+          use_overlay: true,
         }),
         remote: true,
         title: Alchemy.t(:small_thumbnails),
@@ -41,7 +45,10 @@
           element_id: @element,
           q: search_filter_params[:q],
           filter: search_filter_params[:filter],
-          tagged_with: search_filter_params[:tagged_with]
+          tagged_with: search_filter_params[:tagged_with],
+          use_overlay: true,
+          record_id: @record&.id,
+          record_type: @record&.class&.name,
         }),
         remote: true,
         title: Alchemy.t(:medium_thumbnails),
@@ -57,7 +64,10 @@
           element_id: @element,
           q: search_filter_params[:q],
           filter: search_filter_params[:filter],
-          tagged_with: search_filter_params[:tagged_with]
+          tagged_with: search_filter_params[:tagged_with],
+          use_overlay: true,
+          record_id: @record&.id,
+          record_type: @record&.class&.name,
         }),
         remote: true,
         title: Alchemy.t(:big_thumbnails),

--- a/app/views/alchemy/admin/pictures/_picture_assignment.html.erb
+++ b/app/views/alchemy/admin/pictures/_picture_assignment.html.erb
@@ -1,0 +1,38 @@
+<div id="cover_image">
+  <div class="picture_thumbnail">
+    <span class="picture_tool delete">
+      <%= link_to render_icon(:times), '#',
+        onclick: "return Alchemy.removeCommonPicture('#book_picture_id');"%>
+      <%= link_to_dialog render_icon('edit', style: 'regular'),
+        alchemy.admin_pictures_path(
+          swap: true,
+          record_id: record.id,
+          record_type: record.class.name,
+          use_overlay: true
+        ),
+        {
+          title: (Alchemy.t(:insert_image)),
+          size: '790x590',
+          padding: false
+        },
+        title: (Alchemy.t(:swap_image)) %>
+    </span>
+    <div class="picture_image">
+      <div class="thumbnail_background">
+        <%- if image.present? -%>
+          <%= image_tag(
+            image.url,
+            id: "#{record.id}-cover-image",
+            alt: image.name,
+            class: "img_paddingtop",
+            title: Alchemy.t(:image_name) + ": #{image.name}",
+            )
+          %>
+        <% else %>
+          <%= render_icon(:image, style: 'regular') %>
+        <% end %>
+      </div>
+    </div>
+    <%= hidden_field_tag "book[picture_id]", image.try!(:id) %>
+  </div>
+</div>

--- a/app/views/alchemy/admin/pictures/_picture_to_assign.html.erb
+++ b/app/views/alchemy/admin/pictures/_picture_to_assign.html.erb
@@ -4,9 +4,9 @@
       picture_to_assign.url(size: preview_size(size), flatten: true) || "alchemy/missing-image.svg",
       alt: picture_to_assign.name
     ),
-    alchemy.assign_admin_essence_pictures_path(
+    alchemy.assign_admin_pictures_path(
       picture_id: picture_to_assign.id,
-      content_id: @content
+      book_id: @book.id
     ),
     remote: true,
     onclick: '$(self).attr("href", "#").off("click"); return false',

--- a/app/views/alchemy/admin/pictures/_picture_to_assign.html.erb
+++ b/app/views/alchemy/admin/pictures/_picture_to_assign.html.erb
@@ -4,10 +4,7 @@
       picture_to_assign.url(size: preview_size(size), flatten: true) || "alchemy/missing-image.svg",
       alt: picture_to_assign.name
     ),
-    alchemy.assign_admin_pictures_path(
-      picture_id: picture_to_assign.id,
-      book_id: @book.id
-    ),
+    picture_assignment_redirect_url(picture_to_assign, @record, @content),
     remote: true,
     onclick: '$(self).attr("href", "#").off("click"); return false',
     method: 'put',

--- a/app/views/alchemy/admin/pictures/assign.js.erb
+++ b/app/views/alchemy/admin/pictures/assign.js.erb
@@ -1,0 +1,3 @@
+$('#picture_to_assign_<%= @picture.id %> a').attr('href', '#').off('click');
+$('#cover_image').replaceWith('<%= j render(partial: "alchemy/admin/books/cover_image") %>');
+Alchemy.closeCurrentDialog();

--- a/app/views/alchemy/admin/pictures/assign.js.erb
+++ b/app/views/alchemy/admin/pictures/assign.js.erb
@@ -1,3 +1,3 @@
 $('#picture_to_assign_<%= @picture.id %> a').attr('href', '#').off('click');
-$('#cover_image').replaceWith('<%= j render(partial: "alchemy/admin/books/cover_image") %>');
+$('#cover_image').replaceWith('<%= j render(partial: "alchemy/admin/pictures/picture_assignment", locals: { record: @record, image: @picture }) %>');
 Alchemy.closeCurrentDialog();

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,7 @@ Alchemy::Engine.routes.draw do
 
     resources :pictures, except: [:new] do
       collection do
+        put :assign
         post :update_multiple
         delete :delete_multiple
         get :edit_multiple

--- a/db/migrate/20210310074251_create_alchemy_picture_assignments.rb
+++ b/db/migrate/20210310074251_create_alchemy_picture_assignments.rb
@@ -1,0 +1,12 @@
+class CreateAlchemyPictureAssignments < ActiveRecord::Migration[6.0]
+  def change
+    unless table_exists?("alchemy_picture_assignments")
+      create_table :alchemy_picture_assignments, force: :cascade do |t|
+        t.references "assignee", null: false, polymorphic: true, index: false
+        t.references "picture", null: false
+        t.timestamps
+        t.index ["assignee_id", "assigne_type", "picture_id"], name: "index_assignee_picture_uniqueness"
+      end
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20210310080333_create_alchemy_picture_assignments.alchemy.rb
+++ b/spec/dummy/db/migrate/20210310080333_create_alchemy_picture_assignments.alchemy.rb
@@ -1,0 +1,14 @@
+# This migration comes from alchemy (originally 20210310074251)
+class CreateAlchemyPictureAssignments < ActiveRecord::Migration[6.0]
+  def change
+    unless table_exists?("alchemy_picture_assignments")
+      create_table :alchemy_picture_assignments, force: :cascade do |t|
+        t.references "assignee", null: false, polymorphic: true, index: false
+        t.references "picture", null: false
+        t.timestamps
+
+        t.index ["assignee_id", "assigne_type", "picture_id"], name: "index_assignee_picture_uniqueness"
+      end
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_05_143548) do
+ActiveRecord::Schema.define(version: 2021_03_10_080333) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string "name"
@@ -248,6 +248,16 @@ ActiveRecord::Schema.define(version: 2021_02_05_143548) do
     t.index ["rgt"], name: "index_alchemy_pages_on_rgt"
     t.index ["updater_id"], name: "index_alchemy_pages_on_updater_id"
     t.index ["urlname"], name: "index_pages_on_urlname"
+  end
+
+  create_table "alchemy_picture_assignments", force: :cascade do |t|
+    t.string "assignee_type", null: false
+    t.integer "assignee_id", null: false
+    t.integer "picture_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index "\"assignee_id\", \"assigne_type\", \"picture_id\"", name: "index_assignee_picture_uniqueness"
+    t.index ["picture_id"], name: "index_alchemy_picture_assignments_on_picture_id"
   end
 
   create_table "alchemy_picture_thumbs", force: :cascade do |t|

--- a/test/fixtures/alchemy/picture_assignments.yml
+++ b/test/fixtures/alchemy/picture_assignments.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/alchemy/picture_assignment_test.rb
+++ b/test/models/alchemy/picture_assignment_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+module Alchemy
+  class PictureAssignmentTest < ActiveSupport::TestCase
+    # test "the truth" do
+    #   assert true
+    # end
+  end
+end


### PR DESCRIPTION
## What is this pull request for?
Images can be uploaded to AlchemyCMS using Image library or when adding image to page using essence_picture.
When uploading image to pages, the CMS provides a really nice interface as on overlay to select the image to be
added/edit and also upload the image if required. This overlay is now used only for EssencePicture module. 
To make this reusable, so that whenever there is a image attribute required to be added to any model, using the 
image overlay to use the existing images/upload a new one, rather than adding a new image attribute altogether
to the model, this PR adds a helper which helps us upload the image very similar to what is done for EssencePicture.

```
**render_picture_assignment_box(object)**
```
This helper takes the object which is needs the image attribute to be added and renders the image_overlay modal.

### Notable changes
A new model called PictureAssignment(tentative- could be renamed) is added which is a polymorphic one. 
This model has picture_id which references the picture to be used.
Also, the model which needs the attribute needs to define a has_one/has_many through relation.
Eg: If a Book model requires a cover_image attribute, then following change needs to be done to app/model/book.rb
```
    has_one :picture_assignment, as: :assignee
    has_one :cover_image,
            source: :picture,
            through: :picture_assignment
```
Similarly, we have to define **picture_assignment_field** method to notify the fields being used for adding image.
```
    def picture_assignment_field
      "cover_image"
    end
```
The model changes can be abstracted into a concern similar to `act_as_essence` . This is being worked on.

## Checklist
- [ ] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [ ] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
