### PR TITLE
Create new contents on demand

### DIFF
--- a/app/decorators/alchemy/element_editor.rb
+++ b/app/decorators/alchemy/element_editor.rb
@@ -8,9 +8,14 @@ module Alchemy
       "alchemy/admin/elements/element"
     end
 
+    # Returns content editor instances for defined contents
+    #
+    # Creates contents on demand if the content is not yet present on the element
+    #
+    # @return Array<Alchemy::ContentEditor>
     def contents
-      element.contents.map do |content|
-        Alchemy::ContentEditor.new(content)
+      element.definition.fetch(:contents, []).map do |content|
+        Alchemy::ContentEditor.new(find_or_create_content(content[:name]))
       end
     end
 
@@ -83,6 +88,20 @@ module Alchemy
                   scope: :element_deprecation_notices,
                   default: Alchemy.t(:element_deprecated))
       end
+    end
+
+    private
+
+    def find_or_create_content(name)
+      find_content(name) || create_content(name)
+    end
+
+    def find_content(name)
+      element.contents.find { |content| content.name == name }
+    end
+
+    def create_content(name)
+      Alchemy::Content.create(element: element, name: name)
     end
   end
 end

--- a/app/decorators/alchemy/element_editor.rb
+++ b/app/decorators/alchemy/element_editor.rb
@@ -8,6 +8,12 @@ module Alchemy
       "alchemy/admin/elements/element"
     end
 
+    def contents
+      element.contents.map do |content|
+        Alchemy::ContentEditor.new(content)
+      end
+    end
+
     # CSS classes for the element editor partial.
     def css_classes
       [

--- a/app/views/alchemy/admin/elements/_element.html.erb
+++ b/app/views/alchemy/admin/elements/_element.html.erb
@@ -25,7 +25,7 @@
         <div id="element_<%= element.id %>_errors" class="element_errors"></div>
 
         <div id="element_<%= element.id %>_content" class="element-content-editors">
-          <%= render element.contents.map { |content| Alchemy::ContentEditor.new(content) } %>
+          <%= render element.contents %>
         </div>
 
         <% if element.taggable? %>

--- a/spec/decorators/alchemy/element_editor_spec.rb
+++ b/spec/decorators/alchemy/element_editor_spec.rb
@@ -12,6 +12,20 @@ RSpec.describe Alchemy::ElementEditor do
     end
   end
 
+  describe "#contents" do
+    let(:element) { create(:alchemy_element, :with_contents) }
+
+    subject(:contents) { element_editor.contents }
+
+    it "returns a ContentEditor instance for each content defined" do
+      aggregate_failures do
+        contents.each do |content|
+          expect(content).to be_an(Alchemy::ContentEditor)
+        end
+      end
+    end
+  end
+
   describe "#to_partial_path" do
     subject { element_editor.to_partial_path }
 

--- a/spec/decorators/alchemy/element_editor_spec.rb
+++ b/spec/decorators/alchemy/element_editor_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Alchemy::ElementEditor do
   end
 
   describe "#contents" do
-    let(:element) { create(:alchemy_element, :with_contents) }
+    let(:element) { create(:alchemy_element, :with_contents, name: "headline") }
 
     subject(:contents) { element_editor.contents }
 
@@ -22,6 +22,30 @@ RSpec.describe Alchemy::ElementEditor do
         contents.each do |content|
           expect(content).to be_an(Alchemy::ContentEditor)
         end
+      end
+    end
+
+    context "with a content defined but not existing yet" do
+      before do
+        expect(element).to receive(:definition).at_least(:once) do
+          {
+            name: "headline",
+            contents: [
+              {
+                name: "headline",
+                type: "EssenceText",
+              },
+              {
+                name: "foo",
+                type: "EssenceText",
+              },
+            ],
+          }.with_indifferent_access
+        end
+      end
+
+      it "creates the missing content" do
+        expect { subject }.to change { element.contents.count }.by(1)
       end
     end
   end


### PR DESCRIPTION
## What is this pull request for?

If new contents have been defined on the elements definition, but they are not existing yet we create them on demand.

This happens during rendering (speak loading) elements in the elements window during page edit. Ideally we would only instantiate them, but since the content editors expect a persisted content we cannot do that.

Thanks @mamhoff for that smart idea.

This also closes #2031

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
