### PR TITLE
Destroy public version if public checkbox is unset

### DIFF
--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -458,9 +458,14 @@ module Alchemy
     # Sets the public_on date on the published version
     #
     # Builds a new version if none exists yet.
+    # Destroys public version if empty time is set
     #
     def public_on=(time)
-      if public_version
+      if public_version && time.blank?
+        public_version.destroy!
+        # Need to reset the public version on the instance so we do not need to reload
+        self.public_version = nil
+      elsif public_version
         public_version.public_on = time
       else
         versions.build(public_on: time)

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1259,6 +1259,54 @@ module Alchemy
       end
     end
 
+    describe "#public_on=" do
+      let(:time) { Time.now }
+
+      subject { page.public_on = time }
+
+      context "when there is a public version" do
+        let(:page) { build(:alchemy_page, :public) }
+
+        it "sets public_on on the public version" do
+          expect {
+            subject
+          }.to change(page.public_version, :public_on).to(time)
+        end
+
+        context "and the time is nil" do
+          let(:page) { build(:alchemy_page, :public) }
+          let(:time) { nil }
+
+          it "destroys the public version" do
+            expect(page.public_version).to be
+            subject
+            expect(page.public_version).not_to be
+          end
+        end
+
+        context "and the time is empty string" do
+          let(:page) { build(:alchemy_page, :public) }
+          let(:time) { "" }
+
+          it "destroys the public version" do
+            expect(page.public_version).to be
+            subject
+            expect(page.public_version).not_to be
+          end
+        end
+      end
+
+      context "when there is no public version" do
+        let(:page) { build(:alchemy_page) }
+
+        it "builds a public version and sets public_on on it" do
+          subject
+          expect(page.versions.last).to be
+          expect(page.versions.last.public_on).to eq(time)
+        end
+      end
+    end
+
     describe "#public_on" do
       subject(:public_on) { page.public_on }
 

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1268,9 +1268,8 @@ module Alchemy
         let(:page) { build(:alchemy_page, :public) }
 
         it "sets public_on on the public version" do
-          expect {
-            subject
-          }.to change(page.public_version, :public_on).to(time)
+          subject
+          expect(page.public_version.public_on).to be_within(1.second).of(time)
         end
 
         context "and the time is nil" do
@@ -1302,7 +1301,7 @@ module Alchemy
         it "builds a public version and sets public_on on it" do
           subject
           expect(page.versions.last).to be
-          expect(page.versions.last.public_on).to eq(time)
+          expect(page.versions.last.public_on).to be_within(1.second).of(time)
         end
       end
     end


### PR DESCRIPTION
## What is this pull request for?

In order unpublish a page via the "Published" checkbox
in the page settings dialog we need to destroy it if
the value transmitted is en empty string (or nil).

If we would delegate the date to the public version we would
make that version to the current draft version. That is not
what we want, so we destroy the public version and keep the
current draft version.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
