### PR TITLE
Fix add nested element with multiple nestable elements

### DIFF
--- a/app/views/alchemy/admin/elements/_element.html.erb
+++ b/app/views/alchemy/admin/elements/_element.html.erb
@@ -67,7 +67,7 @@
           <%= link_to_dialog Alchemy.t("New Element"),
             alchemy.new_admin_element_path(
               parent_element_id: element.id,
-              page_id: element.page.id
+              page_version_id: element.page_version_id
             ), {
               size: "320x125",
               title: Alchemy.t("New Element")

--- a/spec/features/admin/edit_elements_feature_spec.rb
+++ b/spec/features/admin/edit_elements_feature_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "The edit elements feature", type: :system do
              page_version: a_page.draft_version)
     end
 
-    pending "the add element button opens add element form.", :js do
+    scenario "the add element button opens add element form.", :js do
       visit alchemy.admin_elements_path(page_version_id: element.page_version_id)
       button = page.find(".add-nestable-element-button")
       expect(button).to have_content "New element"

--- a/spec/features/admin/edit_elements_feature_spec.rb
+++ b/spec/features/admin/edit_elements_feature_spec.rb
@@ -48,14 +48,39 @@ RSpec.describe "The edit elements feature", type: :system do
     end
   end
 
-  context "With an element having nestable elements defined" do
+  context "With an element having one nestable element defined" do
     let!(:element) do
       create(:alchemy_element, :with_nestable_elements, page_version: a_page.draft_version)
     end
 
-    scenario "a button to add an nestable element appears." do
+    scenario "the add element button immediately creates the nested element.", :js do
       visit alchemy.admin_elements_path(page_version_id: element.page_version_id)
-      expect(page).to have_selector(".add-nestable-element-button")
+      button = page.find(".add-nestable-element-button")
+      expect(button).to have_content "Add slide"
+      button.click
+      expect(page).to have_selector(".element-editor[data-element-name='slide']")
+    end
+  end
+
+  context "With an element having multiple nestable element defined" do
+    let!(:element) do
+      create(:alchemy_element,
+             :with_nestable_elements,
+             name: :right_column,
+             page_version: a_page.draft_version)
+    end
+
+    pending "the add element button opens add element form.", :js do
+      visit alchemy.admin_elements_path(page_version_id: element.page_version_id)
+      button = page.find(".add-nestable-element-button")
+      expect(button).to have_content "New element"
+      button.click
+      expect(page).to have_select("Element")
+      within ".alchemy-dialog" do
+        select2("Text", from: "Element")
+        click_button("Add")
+      end
+      expect(page).to have_selector(".element-editor[data-element-name='text']")
     end
   end
 


### PR DESCRIPTION
## What is this pull request for?

If an element allows multiple nestable elements the element select dialog appears. That form was missing the `page_version`.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
