### PR TITLE
Scope Node Trees by Language and Menu Type

### DIFF
--- a/app/models/alchemy/node.rb
+++ b/app/models/alchemy/node.rb
@@ -6,7 +6,7 @@ module Alchemy
 
     before_destroy :check_if_related_essence_nodes_present
 
-    acts_as_nested_set scope: "language_id", touch: true
+    acts_as_nested_set scope: ["language_id", "menu_type"], touch: true
     stampable stamper_class_name: Alchemy.user_class_name
 
     belongs_to :language, class_name: "Alchemy::Language"


### PR DESCRIPTION
## What is this pull request for?

We want to have separate node trees for each menu in a language.

Unfortunately, this piece of configuration is extremely hard to test,
because `awesome_nested_set` is very robust when it comes to wrong
configurations.

I would have to set up a rather contrived scenario where I create two
root nodes, give children to each of them, assign incorrect menu_type
columns, and then use some ANS method to find out something that's
wrong. This is extremely unlikely given normal use of our classes, so I
prefer to think of this as just maintenance.


## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] ~I have added tests to cover this change~
