### PR TITLE
Sanitized richtext body

### DIFF
--- a/app/models/alchemy/essence_richtext.rb
+++ b/app/models/alchemy/essence_richtext.rb
@@ -17,6 +17,7 @@ module Alchemy
     acts_as_essence preview_text_column: "stripped_body"
 
     before_save :strip_content
+    before_save :sanitize_content
 
     def has_tinymce?
       true
@@ -26,6 +27,17 @@ module Alchemy
 
     def strip_content
       self.stripped_body = Rails::Html::FullSanitizer.new.sanitize(body)
+    end
+
+    def sanitize_content
+      self.sanitized_body = Rails::Html::SafeListSanitizer.new.sanitize(
+        body,
+        content_sanitizer_settings
+      )
+    end
+
+    def content_sanitizer_settings
+      content&.settings&.fetch(:sanitizer, {})
     end
   end
 end

--- a/db/migrate/20210326105046_add_sanitized_body_to_alchemy_essence_richtexts.rb
+++ b/db/migrate/20210326105046_add_sanitized_body_to_alchemy_essence_richtexts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSanitizedBodyToAlchemyEssenceRichtexts < ActiveRecord::Migration[6.0]
+  def change
+    add_column :alchemy_essence_richtexts, :sanitized_body, :text
+  end
+end

--- a/spec/dummy/config/alchemy/elements.yml
+++ b/spec/dummy/config/alchemy/elements.yml
@@ -31,6 +31,11 @@
   contents:
   - name: text
     type: EssenceRichtext
+    settings:
+      sanitizer:
+        attributes: [href, target]
+        tags: [p, ol, ul, ul, li, em, strong]
+
 
 - name: search
   contents: []

--- a/spec/dummy/db/migrate/20210326105046_add_sanitized_body_to_alchemy_essence_richtexts.rb
+++ b/spec/dummy/db/migrate/20210326105046_add_sanitized_body_to_alchemy_essence_richtexts.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20210326105046_add_sanitized_body_to_alchemy_essence_richtexts.rb

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_05_143548) do
+ActiveRecord::Schema.define(version: 2021_03_26_105046) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string "name"
@@ -123,6 +123,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_143548) do
     t.text "body"
     t.text "stripped_body"
     t.boolean "public", default: false, null: false
+    t.text "sanitized_body"
   end
 
   create_table "alchemy_essence_selects", force: :cascade do |t|

--- a/spec/models/alchemy/essence_richtext_spec.rb
+++ b/spec/models/alchemy/essence_richtext_spec.rb
@@ -4,13 +4,38 @@ require "rails_helper"
 
 module Alchemy
   describe EssenceRichtext do
+    let(:element) { create(:alchemy_element, name: "article") }
+    let(:content) { Alchemy::Content.new(name: "text", element: element) }
     let(:essence) do
-      EssenceRichtext.new(body: "<h1>Hello!</h1><p>Welcome to Peters Petshop.</p>")
+      Alchemy::EssenceRichtext.new(
+        content: content,
+        body: "<h1 style=\"color: red;\">Hello!</h1><p class=\"green\">Welcome to Peters Petshop.</p>"
+      )
     end
 
     it_behaves_like "an essence" do
-      let(:essence) { EssenceRichtext.new }
-      let(:ingredient_value) { "<h1>Hello!</h1><p>Welcome to Peters Petshop.</p>" }
+      let(:essence) { EssenceRichtext.new(content: content) }
+      let(:ingredient_value) { "<h1 style=\"color: red;\">Hello!</h1><p class=\"green\">Welcome to Peters Petshop.</p>" }
+    end
+
+    it "should save a HTML tag free version of body column" do
+      essence.save
+      expect(essence.stripped_body).to eq("Hello!Welcome to Peters Petshop.")
+    end
+
+    it "should save a sanitized version of body column" do
+      essence.save
+      expect(essence.sanitized_body).to eq("<h1>Hello!</h1><p class=\"green\">Welcome to Peters Petshop.</p>")
+    end
+
+    context "when class is not part of the allowed attributes" do
+      let(:element) { create(:alchemy_element, name: "text") }
+      let(:content) { Alchemy::Content.new(name: "text", element: element) }
+
+      it "should save a sanitized version of body column" do
+        essence.save
+        expect(essence.sanitized_body).to eq("Hello!<p>Welcome to Peters Petshop.</p>")
+      end
     end
 
     it "should save a HTML tag free version of body column" do


### PR DESCRIPTION
## What is this pull request for?

This adds a new column on the `alchemy_essence_richtexts` table, `sanitized_body`. This column will contain the sanitized content of the body. The sanitization options, such as which tags and attributes are allowed and which will be stripped out, can be configured either globally, through: 

```rb
# config/initializers/sanitizer.rb
Rails::Html::SafeListSanitizer.allowed_tags = ["a", "p", "h"]
Rails::Html::SafeListSanitizer.allowed_attributes = ["href", "target"]
```

or on a per-element level through the `settings` hash on the content: 
```yml
# config/alchemy/elements.yml
- name: text
  contents:
  - name: text
    type: EssenceRichtext
    settings:
      sanitizer:
        attributes: [href, target]
        tags: [p, ol, ul, ul, li, em, strong]
```
The sanitized body is populated whenever the element in question is saved.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
