### PR TITLE
Allow creating an EssenceRichtext without a content

### DIFF
--- a/app/models/alchemy/essence_richtext.rb
+++ b/app/models/alchemy/essence_richtext.rb
@@ -37,7 +37,7 @@ module Alchemy
     end
 
     def content_sanitizer_settings
-      content&.settings&.fetch(:sanitizer, {})
+      content&.settings&.fetch(:sanitizer, {}) || {}
     end
   end
 end

--- a/spec/models/alchemy/essence_richtext_spec.rb
+++ b/spec/models/alchemy/essence_richtext_spec.rb
@@ -13,6 +13,18 @@ module Alchemy
       )
     end
 
+    context "without a content" do
+      let(:essence) do
+        Alchemy::EssenceRichtext.new(
+          body: "<h1 style=\"color: red;\">Hello!</h1><p class=\"green\">Welcome to Peters Petshop.</p>"
+        )
+      end
+
+      it "can still be created with no odd error" do
+        expect { essence.save! }.not_to raise_exception
+      end
+    end
+
     it_behaves_like "an essence" do
       let(:essence) { EssenceRichtext.new(content: content) }
       let(:ingredient_value) { "<h1 style=\"color: red;\">Hello!</h1><p class=\"green\">Welcome to Peters Petshop.</p>" }


### PR DESCRIPTION
## What is this pull request for?

This worked before adding the sanitization. The problem is that if there
is no content, we pass `nil` into the sanitizer as options, and that
breaks the sanitizer.

This commit adds a fallback to a Hash for all cases.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
