### PR TITLE
Convert "Visit page" button to "Link to new tab"

### DIFF
--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -192,15 +192,6 @@ module Alchemy
         end
       end
 
-      def visit
-        @page.unlock!
-        redirect_to show_page_url(
-          urlname: @page.urlname,
-          locale: prefix_locale? ? @page.language_code : nil,
-          host: @page.site.host == "*" ? request.host : @page.site.host,
-        )
-      end
-
       # Sets the page public and updates the published_at attribute that is used as cache_key
       #
       def publish

--- a/app/views/alchemy/admin/pages/edit.html.erb
+++ b/app/views/alchemy/admin/pages/edit.html.erb
@@ -149,7 +149,7 @@
 <script type="text/javascript" charset="utf-8">
 
   $(function() {
-    $('#unlock_page_form, #visit_page_form, #publish_page_form').on('submit', function(event) {
+    $('#unlock_page_form, #publish_page_form').on('submit', function(event) {
       var not_dirty = Alchemy.checkPageDirtyness(this);
       if (!not_dirty) Alchemy.pleaseWaitOverlay(false);
       return not_dirty;

--- a/app/views/alchemy/admin/pages/edit.html.erb
+++ b/app/views/alchemy/admin/pages/edit.html.erb
@@ -74,17 +74,26 @@
   </div>
   <% unless @page.layoutpage? %>
     <div class="button_with_label">
-      <%= form_tag alchemy.visit_admin_page_path(@page), id: 'visit_page_form' do %>
-        <%= button_tag class: 'icon_button', disabled: !@page.public? do %>
+      <% if @page.public? %>
+        <%= link_to show_page_url(
+              urlname: @page.urlname,
+              locale: prefix_locale? ? @page.language_code : nil,
+              host: @page.site.host == "*" ? request.host : @page.site.host,
+            ),
+            title: Alchemy.t("Visit page"),
+            data: { turbolinks: false },
+            target: "_blank",
+            class: 'icon_button' do %>
           <%= render_icon('external-link-alt') %>
         <% end %>
-        <label>
-          <% if @page.public? %>
-            <%= Alchemy.t("Visit page") %>
-          <% else %>
-            <%= Alchemy.t(:cannot_visit_unpublic_page) %>
-          <% end %>
-        </label>
+        <label><%= Alchemy.t("Visit page") %></label>
+      <% else %>
+        <%= content_tag "a",
+            title: Alchemy.t(:cannot_visit_unpublic_page),
+            class: 'disabled icon_button' do %>
+          <%= render_icon('external-link-alt') %>
+        <% end %>
+        <label><%= Alchemy.t(:cannot_visit_unpublic_page) %></label>
       <% end %>
     </div>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,6 @@ Alchemy::Engine.routes.draw do
         post :unlock
         post :publish
         post :fold
-        post :visit
         get :configure
         get :preview
         get :info

--- a/spec/requests/alchemy/admin/pages_controller_spec.rb
+++ b/spec/requests/alchemy/admin/pages_controller_spec.rb
@@ -633,30 +633,6 @@ module Alchemy
         end
       end
 
-      describe "#visit" do
-        subject do
-          post visit_admin_page_path(page)
-        end
-
-        let(:page) { create(:alchemy_page, urlname: "home", site: site) }
-
-        context "when the pages site is a catch-all" do
-          let(:site) { create(:alchemy_site, host: "*") }
-
-          it "should redirect to the page path" do
-            is_expected.to redirect_to("/home")
-          end
-        end
-
-        context "when pages site is a real host" do
-          let(:site) { create(:alchemy_site, host: "reallygoodsite.com") }
-
-          it "should redirect to the page path on that host" do
-            is_expected.to redirect_to("http://reallygoodsite.com/home")
-          end
-        end
-      end
-
       describe "#fold" do
         let(:page) { create(:alchemy_page) }
 


### PR DESCRIPTION
## What is this pull request for?

In the admin edit page, editors can go and "visit" a page. I've always misunderstood this button as a link, and have very often tried to press shift while clicking on it in order to get it to display in a new tab - alas, to no avail. It was no link.

This makes it a link. It also removes the hidden functionality that the user's lock on the page would disappear silently. 

### Notable changes (remove if none)

See above. 


## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)

