### PR TITLE
Alchemy essence headline

### DIFF
--- a/app/models/alchemy/content/factory.rb
+++ b/app/models/alchemy/content/factory.rb
@@ -117,7 +117,7 @@ module Alchemy
     #
     def build_essence(attributes = {})
       self.essence = essence_class(essence_type).new(
-        { ingredient: default_value }.merge(attributes)
+        { content: self, ingredient: default_value }.merge(attributes)
       )
     end
 

--- a/app/models/alchemy/essence_headline.rb
+++ b/app/models/alchemy/essence_headline.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Alchemy
+  class EssenceHeadline < BaseRecord
+    acts_as_essence
+
+    after_initialize :set_level_and_size
+
+    def preview_text(maxlength = 30)
+      "H#{level}: #{body}"[0..maxlength - 1]
+    end
+
+    def level_options
+      levels.map { |level| ["H#{level}", level] }
+    end
+
+    def size_options
+      sizes.map { |size| ["H#{size}", size] }
+    end
+
+    private
+
+    def content_settings
+      content&.settings || {}
+    end
+
+    def levels
+      content_settings.fetch(:levels, (1..6))
+    end
+
+    def sizes
+      content_settings.fetch(:sizes, [])
+    end
+
+    def set_level_and_size
+      self.level ||= levels.first
+      self.size ||= sizes.first
+    end
+  end
+end

--- a/app/views/alchemy/essences/_essence_headline_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_headline_editor.html.erb
@@ -1,0 +1,36 @@
+<%= content_tag :div,
+  id: essence_headline_editor.dom_id,
+  class: essence_headline_editor.css_classes,
+  data: essence_headline_editor.data_attributes do %>
+  <%= content_label(essence_headline_editor) %>
+  <%= text_field_tag(
+    essence_headline_editor.form_field_name,
+    essence_headline_editor.essence.body,
+    id: essence_headline_editor.form_field_id
+  ) %>
+
+  <div class="input-row">
+    <% essence = essence_headline_editor.essence %>
+    <% if essence.level_options.length > 1 %>
+      <div class="input-column">
+        <%= label_tag Alchemy::EssenceHeadline.human_attribute_name(:level) %>
+        <%= select_tag(
+          essence_headline_editor.form_field_name(:level),
+          options_for_select(essence_headline_editor.essence.level_options, essence_headline_editor.essence.level),
+          class: "alchemy_selectbox full_width"
+        ) %>
+      </div>
+    <% end %>
+
+    <% if essence.size_options.length > 1 %>
+      <div class="input-column">
+        <%= label_tag Alchemy::EssenceHeadline.human_attribute_name(:size) %>
+        <%= select_tag(
+          essence_headline_editor.form_field_name(:size),
+          options_for_select(essence_headline_editor.essence.size_options, essence_headline_editor.essence.size),
+          class: "alchemy_selectbox full_width"
+        ) %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/alchemy/essences/_essence_headline_view.html.erb
+++ b/app/views/alchemy/essences/_essence_headline_view.html.erb
@@ -1,0 +1,9 @@
+<%- html_options = local_assigns.fetch(:html_options, {}) -%>
+
+<%= content_tag "h#{content.essence.level}",
+    content.essence.ingredient,
+    class: [
+      content.essence.size ? "h#{content.essence.size}" : nil,
+      html_options[:class]
+    ]
+%>

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -701,11 +701,18 @@ en:
   # Translations for Alchemy models
   activemodel:
     models:
+      alchemy/essence_headline:
+        one: Headline
+        other: Headline
       alchemy/message:
         one: Message
         other: Messages
       alchemy/admin/preview_url: Internal
     attributes:
+      alchemy/essence_headline:
+        body: Headline
+        level: Level
+        size: Size
       alchemy/message:
         salutation: 'Salutation'
         firstname: 'Firstname'

--- a/db/migrate/20210406093436_add_alchemy_essence_headlines.rb
+++ b/db/migrate/20210406093436_add_alchemy_essence_headlines.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddAlchemyEssenceHeadlines < ActiveRecord::Migration[6.0]
+  def change
+    create_table :alchemy_essence_headlines do |t|
+      t.text :body
+      t.integer :level
+      t.integer :size
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/config/alchemy/elements.yml
+++ b/spec/dummy/config/alchemy/elements.yml
@@ -7,7 +7,7 @@
 - name: headline
   contents:
   - name: headline
-    type: EssenceText
+    type: EssenceHeadline
 
 - name: article
   taggable: true

--- a/spec/dummy/db/migrate/20210406093436_add_alchemy_essence_headlines.rb
+++ b/spec/dummy/db/migrate/20210406093436_add_alchemy_essence_headlines.rb
@@ -1,0 +1,1 @@
+../../../../db/migrate/20210406093436_add_alchemy_essence_headlines.rb

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_26_105046) do
+ActiveRecord::Schema.define(version: 2021_04_06_093436) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string "name"
@@ -78,6 +78,14 @@ ActiveRecord::Schema.define(version: 2021_03_26_105046) do
     t.string "css_class"
     t.string "link_text"
     t.index ["attachment_id"], name: "index_alchemy_essence_files_on_attachment_id"
+  end
+
+  create_table "alchemy_essence_headlines", force: :cascade do |t|
+    t.text "body"
+    t.integer "level"
+    t.integer "size"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "alchemy_essence_htmls", force: :cascade do |t|

--- a/spec/models/alchemy/content_spec.rb
+++ b/spec/models/alchemy/content_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 module Alchemy
   describe Content do
     let(:element) { create(:alchemy_element, :with_contents, name: "headline") }
-    let(:content) { element.contents.find_by(essence_type: "Alchemy::EssenceText") }
+    let(:content) { element.contents.find_by(name: "headline") }
 
     it "should return the ingredient from its essence" do
       content.essence.update_columns(body: "Hello")

--- a/spec/models/alchemy/essence_headline_spec.rb
+++ b/spec/models/alchemy/essence_headline_spec.rb
@@ -66,4 +66,25 @@ RSpec.describe Alchemy::EssenceHeadline do
       end
     end
   end
+
+  describe "creating from a content" do
+    it "should have the size and level fields filled with correct defaults" do
+      element = create(:alchemy_element)
+
+      allow(element).to receive(:content_definition_for) do
+        {
+          "name" => "headline",
+          "type" => "EssenceHeadline",
+          "settings" => {
+            "sizes" => [3],
+            "levels" => [2, 3],
+          },
+        }.with_indifferent_access
+      end
+
+      content = Alchemy::Content.create(element: element, name: "headline")
+      expect(content.essence.size).to eq(3)
+      expect(content.essence.level).to eq(2)
+    end
+  end
 end

--- a/spec/models/alchemy/essence_headline_spec.rb
+++ b/spec/models/alchemy/essence_headline_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::EssenceHeadline do
+  subject(:essence) do
+    Alchemy::EssenceHeadline.new(
+      body: ingredient_value,
+      level: 2,
+      size: 3
+    )
+  end
+
+  let(:ingredient_value) { "A headline" }
+
+  it_behaves_like "an essence"
+
+  describe "#level_options" do
+    subject { essence.level_options }
+
+    it { is_expected.to eq([["H1", 1], ["H2", 2], ["H3", 3], ["H4", 4], ["H5", 5], ["H6", 6]]) }
+
+    context "when restricted through the essence settings" do
+      before do
+        expect(essence).to receive_message_chain(:content, :settings).and_return(levels: [2, 3])
+      end
+
+      it { is_expected.to eq([["H2", 2], ["H3", 3]]) }
+    end
+  end
+
+  describe "#size_options" do
+    subject { essence.size_options }
+
+    it { is_expected.to eq([]) }
+
+    context "when enabled through the essence settings" do
+      before do
+        expect(essence).to receive_message_chain(:content, :settings).and_return(sizes: [3, 4])
+      end
+
+      it { is_expected.to eq([["H3", 3], ["H4", 4]]) }
+    end
+  end
+
+  describe "initialization" do
+    describe "level" do
+      subject { Alchemy::EssenceHeadline.new.level }
+
+      it { is_expected.to eq(1) }
+    end
+
+    describe "size" do
+      let(:content) { build(:alchemy_content) }
+      let(:essence) { Alchemy::EssenceHeadline.new(content: content) }
+      subject { essence.size }
+
+      it { is_expected.to be_nil }
+
+      context "when enabled through the essence settings" do
+        before do
+          expect(content).to receive(:settings).and_return(sizes: [3, 4]).twice
+        end
+
+        it { is_expected.to eq(3) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

 This introduces an `Alchemy::EssenceHeadline`. It has the following features:
    When used as a preview text, it will show the level of the headline so
    that content editors can see what levels they are using. There are is
    also an optional `level` element.
    
 Headlines can be configured through their content settings. One can
    restrict the sizes and levels available to an element, by specifying them
    like follows:
    
```yml
    - name: MyComponent
      contents:
         - name: my_headline
           type: EssenceHeadline
           settings:
              levels: [3, 4]
              sizes: [3]
```
    
 If, as in the previous example, `sizes` only has one option, the select
    input in the element editor will not be displayed.
    
 If `sizes` is unconfigured, the default will be an empty array, and the
    essence will have no size class.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
