### PR TITLE
Touch Elements only after update

### DIFF
--- a/app/models/concerns/alchemy/touch_elements.rb
+++ b/app/models/concerns/alchemy/touch_elements.rb
@@ -10,7 +10,7 @@ module Alchemy
   #
   module TouchElements
     def self.included(base)
-      base.after_save(:touch_elements)
+      base.after_update(:touch_elements)
     end
 
     private
@@ -18,7 +18,7 @@ module Alchemy
     def touch_elements
       return unless respond_to?(:elements)
 
-      elements.map(&:touch)
+      elements.touch_all
     end
   end
 end

--- a/spec/models/alchemy/attachment_spec.rb
+++ b/spec/models/alchemy/attachment_spec.rb
@@ -46,7 +46,7 @@ module Alchemy
         end
 
         it "touches elements" do
-          expect { attachment.save }.to change { attachment.elements.reload.first.updated_at }
+          expect { attachment.update(name: "image with spaces") }.to change { attachment.elements.reload.first.updated_at }
         end
       end
     end


### PR DESCRIPTION

## What is this pull request for?

When an essence has a related object, such as a picture or an
attachment, we need to break caches when that related object changes.
This reflects this desire - but stops touching the elements on first
creation. This results in a major speedup when publishing pages, as
publishing results in a lot of essence and element creation.


### Notable changes (remove if none)

None, I believe.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message

