### PR TITLE
Quickly delete elements when deleting a page version

### DIFF
--- a/app/models/alchemy/page_version.rb
+++ b/app/models/alchemy/page_version.rb
@@ -17,6 +17,8 @@ module Alchemy
             "OR #{table_name}.public_until >= :time)", time: time)
     end
 
+    before_destroy :delete_elements
+
     # Determines if this version is public
     #
     # Takes the two timestamps +public_on+ and +public_until+
@@ -41,6 +43,12 @@ module Alchemy
     # @returns Boolean
     def still_public_for?(time = Time.current)
       public_until.nil? || public_until >= time
+    end
+
+    private
+
+    def delete_elements
+      DeleteElements.new(elements).call
     end
   end
 end

--- a/spec/models/alchemy/page_version_spec.rb
+++ b/spec/models/alchemy/page_version_spec.rb
@@ -116,5 +116,26 @@ describe Alchemy::PageVersion do
 
       it { is_expected.to be(false) }
     end
+
+    describe "dependent element destruction" do
+      let!(:parent_element) { create(:alchemy_element, :with_nestable_elements, :with_contents) }
+      let!(:nested_element) { parent_element.nested_elements.first }
+      let!(:normal_element) { create(:alchemy_element, :with_contents) }
+
+      let(:page_version) { create(:alchemy_page_version) }
+
+      before do
+        Alchemy::Element.update_all(page_version_id: page_version.id)
+      end
+
+      it "deletes all elements along with the page version" do
+        page_version.destroy!
+        expect(Alchemy::Element.count).to be_zero
+        expect(Alchemy::Content.count).to be_zero
+        expect(Alchemy::EssenceText.count).to be_zero
+        expect(Alchemy::EssencePicture.count).to be_zero
+        expect(Alchemy::EssenceRichtext.count).to be_zero
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds a `before_destroy` callback to page versions that makes sure that elements are deleted quickly when deleting a page version. 

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
