### PR TITLE
Delete nested elements quickly

### DIFF
--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -968,4 +968,18 @@ module Alchemy
       end
     end
   end
+
+  describe "destroy callbacks" do
+    let(:element) { create(:alchemy_element) }
+    let!(:nested_element_1) { create(:alchemy_element, parent_element: element) }
+    let!(:nested_element_2) { create(:alchemy_element, parent_element: nested_element_1) }
+    let!(:nested_element_3) { create(:alchemy_element, parent_element: nested_element_2) }
+
+    it "destroys all the nested elements quickly" do
+      expect(Alchemy::DeleteElements).to receive(:new).with(
+        [nested_element_1, nested_element_2, nested_element_3]
+      ).and_call_original
+      element.reload.destroy!
+    end
+  end
 end


### PR DESCRIPTION
## What is this pull request for?

This adds a before_destroy callback to elements that builds an array 
of all the descendent elements from this element,
and then calls the DeleteElements service class on them. Afterwards it
resets the two associations, so that no callbacks run on in-memory
deleted objects.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
