### PR TITLE
Background page publishing

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
     actionmailer
     actionpack
     actionview
+    activejob
     activemodel
     activerecord
     activesupport

--- a/app/jobs/alchemy/base_job.rb
+++ b/app/jobs/alchemy/base_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Alchemy
+  class BaseJob < ActiveJob::Base
+    # Automatically retry jobs that encountered a deadlock
+    # retry_on ActiveRecord::Deadlocked
+
+    # Most jobs are safe to ignore if the underlying records are no longer available
+    # discard_on ActiveJob::DeserializationError
+  end
+end

--- a/app/jobs/alchemy/publish_page_job.rb
+++ b/app/jobs/alchemy/publish_page_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Alchemy
+  class PublishPageJob < BaseJob
+    queue_as :default
+
+    def perform(page, public_on:)
+      Alchemy::Page::Publisher.new(page).publish!(public_on: public_on)
+    end
+  end
+end

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -451,8 +451,8 @@ module Alchemy
     # The +published_at+ attribute is used as +cache_key+.
     #
     def publish!(current_time = Time.current)
-      update_columns(published_at: current_time)
-      Publisher.new(self).publish!(public_on: current_time)
+      update(published_at: current_time)
+      PublishPageJob.perform_later(self, public_on: current_time)
     end
 
     # Sets the public_on date on the published version

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'boot'
+require_relative "boot"
 
 require "rails"
 # Pick the frameworks you want:
@@ -9,7 +9,7 @@ require "active_record/railtie"
 require "action_controller/railtie"
 require "action_mailer/railtie"
 require "action_view/railtie"
-# require "active_job/railtie"
+require "active_job/railtie"
 # require "action_cable/engine"
 # require "rails/test_unit/railtie"
 require "sprockets/railtie"
@@ -23,7 +23,7 @@ module Dummy
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     if config.respond_to?(:load_defaults)
-      config.load_defaults ENV['RAILS_VERSION'] || 6.0
+      config.load_defaults ENV["RAILS_VERSION"] || 6.0
     end
 
     # Settings in config/environments/* take precedence over those specified here.

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -5,7 +5,7 @@
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
-  
+
   config.cache_classes = true
 
   # Do not eager load code on boot. This avoids loading your whole application
@@ -16,11 +16,11 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
+    "Cache-Control" => "public, max-age=#{1.hour.to_i}",
   }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 
@@ -42,4 +42,6 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+
+  config.active_job.queue_adapter = :test
 end

--- a/spec/jobs/alchemy/publish_page_job_spec.rb
+++ b/spec/jobs/alchemy/publish_page_job_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::PublishPageJob, type: :job do
+  describe "#perfom_later" do
+    let(:page) { build_stubbed(:alchemy_page) }
+    let(:public_on) { Time.current }
+
+    it "enqueues job" do
+      expect {
+        described_class.perform_later(page, public_on: public_on)
+      }.to have_enqueued_job
+    end
+
+    it "calls the page publisher" do
+      expect_any_instance_of(Alchemy::Page::Publisher).to receive(:publish!).with(
+        public_on: public_on,
+      )
+      described_class.new.perform(page, public_on: public_on)
+    end
+  end
+end

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1413,9 +1413,10 @@ module Alchemy
         allow(Time).to receive(:current).and_return(current_time)
       end
 
-      it "calls the page publisher" do
-        expect_any_instance_of(Alchemy::Page::Publisher).to receive(:publish!).with(public_on: current_time)
-        page.publish!
+      it "enqueues publish page job" do
+        expect {
+          page.publish!
+        }.to have_enqueued_job(Alchemy::PublishPageJob)
       end
 
       it "sets published_at" do


### PR DESCRIPTION
## What is this pull request for?

This will allow to background page publishing.
It will run in parallel if no background job processor
has been defined in the host app.

Apps using sidekiq or delayed job will benefit from
running this in the background, making large pages
publish in the pbackground.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
