### PR TITLE
Allow copying contents when they're not in the elements.yml

### DIFF
--- a/spec/models/alchemy/content_spec.rb
+++ b/spec/models/alchemy/content_spec.rb
@@ -163,6 +163,18 @@ module Alchemy
         expect(subject.essence).to be_instance_of(EssenceText)
         expect(subject.essence).to_not be_persisted
       end
+
+      context "when given an essence_type attribute that is not in the definition" do
+        let(:arguments) { { element: element, essence_type: "Alchemy::EssenceText", name: "not_in_elements_yml" } }
+
+        subject { Content.new(arguments) }
+
+        it "does not raise an error" do
+          expect { subject }.not_to raise_exception
+          expect(subject.name).to eq("not_in_elements_yml")
+          expect(subject.essence).to be_a(Alchemy::EssenceText)
+        end
+      end
     end
 
     describe ".create" do


### PR DESCRIPTION

## What is this pull request for?

When changing the elements.yml, we will often still have contents from
previous iterations of that file in the database. Copying must still
work.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
