### PR TITLE
hotfix and deprecate page_active? helper

### DIFF
--- a/app/helpers/alchemy/pages_helper.rb
+++ b/app/helpers/alchemy/pages_helper.rb
@@ -100,7 +100,9 @@ module Alchemy
 
     # Returns true if page is in the active branch
     def page_active?(page)
-      @_page_ancestors ||= Page.ancestors_for(@page)
+      Alchemy::Deprecation.warn("page_active? helper is deprecated and will be removed from Alchemy 6.0")
+
+      @_page_ancestors ||= @page.self_and_ancestors.contentpages
       @_page_ancestors.include?(page)
     end
 

--- a/spec/helpers/alchemy/pages_helper_spec.rb
+++ b/spec/helpers/alchemy/pages_helper_spec.rb
@@ -14,6 +14,14 @@ module Alchemy
       @root_page = language_root # We need this instance variable in the helpers
     end
 
+    describe "page_active?" do
+      it "shows a deprecation warning" do
+        @page = public_page
+        expect(Alchemy::Deprecation).to receive(:warn).with /will be removed from Alchemy 6/
+        helper.page_active?(public_page)
+      end
+    end
+
     describe "#render_page_layout" do
       it "should render the current page layout" do
         @page = public_page


### PR DESCRIPTION
The `page_active?` helper used to depend on `Page.ancestors_for` which got removed with https://github.com/AlchemyCMS/alchemy_cms/pull/1813. This PR hotfixes `page_active?`, but since menus got introduced with https://github.com/AlchemyCMS/alchemy_cms/pull/1667 the helper is obsolete and is now marked for deletion.

Due to the removal of `Page.ancestors_for` in Alchemy 5.0 this commit should be cherry-picked for Alchemy 5.0, 5.1, 5.2