### PR TITLE
Preview url fixes

### DIFF
--- a/lib/alchemy/admin/preview_url.rb
+++ b/lib/alchemy/admin/preview_url.rb
@@ -48,6 +48,7 @@ module Alchemy
             port: uri.port,
             path: page.url_path,
             userinfo: userinfo,
+            query: { alchemy_preview_mode: true }.to_param,
           ).to_s
         else
           routes.admin_page_path(page)

--- a/lib/alchemy/admin/preview_url.rb
+++ b/lib/alchemy/admin/preview_url.rb
@@ -45,6 +45,7 @@ module Alchemy
         if @preview_config && uri
           uri_class.build(
             host: uri.host,
+            port: uri.port,
             path: page.url_path,
             userinfo: userinfo,
           ).to_s

--- a/spec/libraries/admin/preview_url_spec.rb
+++ b/spec/libraries/admin/preview_url_spec.rb
@@ -71,6 +71,18 @@ RSpec.describe Alchemy::Admin::PreviewUrl do
         end
       end
 
+      context "with a port configured" do
+        before do
+          stub_alchemy_config(:preview, {
+            "host" => "https://www.example.com:8080",
+          })
+        end
+
+        it "returns the configured preview url with userinfo" do
+          is_expected.to eq "https://www.example.com:8080/#{page.urlname}"
+        end
+      end
+
       context "for a site" do
         before do
           stub_alchemy_config(:preview, config)

--- a/spec/libraries/admin/preview_url_spec.rb
+++ b/spec/libraries/admin/preview_url_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Alchemy::Admin::PreviewUrl do
         end
 
         it "returns the configured preview url" do
-          is_expected.to eq "http://www.example.com/#{page.urlname}"
+          is_expected.to eq "http://www.example.com/#{page.urlname}?alchemy_preview_mode=true"
         end
       end
 
@@ -51,7 +51,7 @@ RSpec.describe Alchemy::Admin::PreviewUrl do
         end
 
         it "returns the configured preview url with https" do
-          is_expected.to eq "https://www.example.com/#{page.urlname}"
+          is_expected.to eq "https://www.example.com/#{page.urlname}?alchemy_preview_mode=true"
         end
       end
 
@@ -67,7 +67,7 @@ RSpec.describe Alchemy::Admin::PreviewUrl do
         end
 
         it "returns the configured preview url with userinfo" do
-          is_expected.to eq "https://foo:baz@www.example.com/#{page.urlname}"
+          is_expected.to eq "https://foo:baz@www.example.com/#{page.urlname}?alchemy_preview_mode=true"
         end
       end
 
@@ -79,7 +79,7 @@ RSpec.describe Alchemy::Admin::PreviewUrl do
         end
 
         it "returns the configured preview url with userinfo" do
-          is_expected.to eq "https://www.example.com:8080/#{page.urlname}"
+          is_expected.to eq "https://www.example.com:8080/#{page.urlname}?alchemy_preview_mode=true"
         end
       end
 
@@ -98,7 +98,7 @@ RSpec.describe Alchemy::Admin::PreviewUrl do
           end
 
           it "returns the configured preview url for that site" do
-            is_expected.to eq "http://new.example.com/#{page.urlname}"
+            is_expected.to eq "http://new.example.com/#{page.urlname}?alchemy_preview_mode=true"
           end
         end
 
@@ -114,7 +114,7 @@ RSpec.describe Alchemy::Admin::PreviewUrl do
             end
 
             it "returns the default configured preview url" do
-              is_expected.to eq "http://www.example.com/#{page.urlname}"
+              is_expected.to eq "http://www.example.com/#{page.urlname}?alchemy_preview_mode=true"
             end
           end
 
@@ -144,7 +144,7 @@ RSpec.describe Alchemy::Admin::PreviewUrl do
         end
 
         it "returns the preview url without urlname" do
-          is_expected.to eq "https://www.example.com/"
+          is_expected.to eq "https://www.example.com/?alchemy_preview_mode=true"
         end
       end
     end


### PR DESCRIPTION
## What is this pull request for?

1. Pass port to preview url.

If the preview url has a port configured it uses that on the preview frame.

2. Add alchemy_preview_mode=true to preview url

In order to be able to treat a static site different if it's rendered
inside the preview frame we pass the
alchemy_preview_mode=true param.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
