### PR TITLE
Add collection option for resource relations

### DIFF
--- a/app/views/alchemy/admin/resources/_form.html.erb
+++ b/app/views/alchemy/admin/resources/_form.html.erb
@@ -2,6 +2,7 @@
   <% resource_handler.editable_attributes.each do |attribute| %>
     <% if relation = attribute[:relation] %>
       <%= f.association relation[:name].to_sym,
+        collection: relation[:collection],
         label_method: relation[:attr_method],
         include_blank: Alchemy.t(:blank, scope: 'resources.relation_select'),
         input_html: {class: 'alchemy_selectbox'} %>

--- a/spec/libraries/resource_spec.rb
+++ b/spec/libraries/resource_spec.rb
@@ -359,6 +359,26 @@ module Alchemy
           expect(relation.keys).to include(:name)
           expect(relation[:name]).to eq("location")
         end
+
+        it "stores an ActiveRecord::Relation scope for all records in a collection key" do
+          expect(Location).to receive(:all).and_call_original
+          expect(resource.resource_relations[:location_id][:collection]).to be_a(ActiveRecord::Relation)
+        end
+
+        context "when collection gets passed with a specific ActiveRecord::Relation" do
+          before do
+            allow(Event).to receive(:alchemy_resource_relations) do
+              {
+                location: {attr_method: "name", attr_type: :string, collection: Location.where(name: "foo")},
+              }
+            end
+          end
+
+          it "stores the given ActiveRecord::Relation scope in a collection key" do
+            expect(resource.resource_relations[:location_id][:collection].where_values_hash).to eq({"name" => "foo"})
+            expect(resource.resource_relations[:location_id][:collection]).to be_a(ActiveRecord::Relation)
+          end
+        end
       end
 
       describe "#model_associations" do


### PR DESCRIPTION
This addition allows to provide a scoped collection of records when defining a resource relation.

Example:

```
class Event < ApplicationRecord
  belongs_to :location

  def self.alchemy_resource_relations
    {
      location: {
        attr_method: "name",
        attr_type: "string",
        collection: Location.where(...)
      },
    }
  end
end
```

In the view the user will see the scoped collection of locations in the select box.

In case `collection` is not passed

  * `Location.all` will be used
  * `class_name` on the association is used if it's defined

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
