### PR TITLE
Use symbols in polymorphic routes for resources

### DIFF
--- a/lib/alchemy/resource.rb
+++ b/lib/alchemy/resource.rb
@@ -132,7 +132,9 @@ module Alchemy
     end
 
     def namespaced_resource_name
-      @_namespaced_resource_name ||= namespaced_resources_name.singularize
+      @_namespaced_resource_name ||= begin
+        namespaced_resources_name.to_s.singularize
+      end.to_sym # Rails >= 6.0.3.7 needs symbols in polymorphic routes
     end
 
     def namespaced_resources_name
@@ -140,13 +142,13 @@ module Alchemy
         resource_name_array = resource_array.dup
         resource_name_array.delete(engine_name) if in_engine?
         resource_name_array.join("_")
-      end
+      end.to_sym # Rails >= 6.0.3.7 needs symbols in polymorphic routes
     end
 
     def namespace_for_scope
       namespace_array = namespace_diff
       namespace_array.delete(engine_name) if in_engine?
-      namespace_array
+      namespace_array.map(&:to_sym) # Rails >= 6.0.3.7 needs symbols in polymorphic routes
     end
 
     # Returns an array of underscored association names

--- a/spec/libraries/resource_spec.rb
+++ b/spec/libraries/resource_spec.rb
@@ -143,19 +143,19 @@ module Alchemy
     end
 
     describe "#namespaced_resource_name" do
-      it "returns resource_name with namespace (namespace_party for Namespace::Party), i.e. for use in forms" do
+      it "returns resource_name symbol with namespace (namespace_party for Namespace::Party), i.e. for use in forms" do
         namespaced_resource = Resource.new("admin/namespace/parties")
-        expect(namespaced_resource.namespaced_resource_name).to eq("namespace_party")
+        expect(namespaced_resource.namespaced_resource_name).to eq(:namespace_party)
       end
 
-      it "equals resource_name if resource not namespaced" do
+      it "equals resource_name symbol if resource not namespaced" do
         namespaced_resource = Resource.new("admin/parties")
-        expect(namespaced_resource.namespaced_resource_name).to eq("party")
+        expect(namespaced_resource.namespaced_resource_name).to eq(:party)
       end
 
       it "doesn't include the engine's name" do
         namespaced_resource = Resource.new("admin/party_engine/namespace/parties", module_definition)
-        expect(namespaced_resource.namespaced_resource_name).to eq("namespace_party")
+        expect(namespaced_resource.namespaced_resource_name).to eq(:namespace_party)
       end
     end
 
@@ -168,7 +168,7 @@ module Alchemy
 
     describe "#namespace_for_scope" do
       it "returns a scope for use in url_for based path helpers" do
-        expect(resource.namespace_for_scope).to eq(%w(admin))
+        expect(resource.namespace_for_scope).to eq(%i(admin))
       end
     end
 

--- a/spec/libraries/resources_helper_spec.rb
+++ b/spec/libraries/resources_helper_spec.rb
@@ -33,7 +33,7 @@ describe Alchemy::ResourcesHelper do
   let(:resource_item) { double("resource-item") }
 
   before {
-    allow(controller).to receive(:main_app).and_return "main_app_proxy"
+    allow(controller).to receive(:main_app).and_return :main_app_proxy
     controller.instance_variable_set("@my_resource", resource_item)
     controller.instance_variable_set("@my_resources", [resource_item])
   }
@@ -41,7 +41,7 @@ describe Alchemy::ResourcesHelper do
   describe "path-helpers" do
     describe "#resource_url_proxy" do
       it "returns the current proxy for url-helper-methods" do
-        expect(controller.resource_url_proxy).to eq("main_app_proxy")
+        expect(controller.resource_url_proxy).to eq(:main_app_proxy)
       end
 
       context "when resource is in engine" do
@@ -56,33 +56,33 @@ describe Alchemy::ResourcesHelper do
 
     describe "#resource_scope" do
       it "returns an array containing a proxy and namespaces for url_for-based helper-methods" do
-        expect(controller.resource_scope).to eq(%w[main_app_proxy admin])
+        expect(controller.resource_scope).to eq(%i[main_app_proxy admin])
       end
     end
 
     describe "#resource_path" do
       it "invokes polymorphic-path with correct scope and object" do
         my_resource_item = double
-        expect(controller).to receive(:polymorphic_path).with(["main_app_proxy", "admin", my_resource_item], {})
+        expect(controller).to receive(:polymorphic_path).with([:main_app_proxy, :admin, my_resource_item], {})
         controller.resource_path(my_resource_item)
       end
 
       it "uses resource_name when no object is given" do
-        expect(controller).to receive(:polymorphic_path).with(["main_app_proxy", "admin", "namespace_my_resource"], {})
+        expect(controller).to receive(:polymorphic_path).with([:main_app_proxy, :admin, :namespace_my_resource], {})
         controller.resource_path
       end
     end
 
     describe "#resources_path" do
       it "invokes polymorphic-path with correct scope and resources_name" do
-        expect(controller).to receive(:polymorphic_path).with(["main_app_proxy", "admin", "namespace_my_resources"], {})
+        expect(controller).to receive(:polymorphic_path).with([:main_app_proxy, :admin, :namespace_my_resources], {})
         controller.resources_path
       end
     end
 
     describe "#new_resource_path" do
       it "invokes new_polymorphic_path with correct scope and resource_name" do
-        expect(controller).to receive(:new_polymorphic_path).with(["main_app_proxy", "admin", "namespace_my_resource"], {})
+        expect(controller).to receive(:new_polymorphic_path).with([:main_app_proxy, :admin, :namespace_my_resource], {})
         controller.new_resource_path
       end
     end
@@ -90,7 +90,7 @@ describe Alchemy::ResourcesHelper do
     describe "#edit_resource_path" do
       it "invokes edit_polymorphic_path with correct scope and resource_name" do
         my_resource_item = double
-        expect(controller).to receive(:edit_polymorphic_path).with(["main_app_proxy", "admin", my_resource_item], {})
+        expect(controller).to receive(:edit_polymorphic_path).with([:main_app_proxy, :admin, my_resource_item], {})
         controller.edit_resource_path(my_resource_item)
       end
     end


### PR DESCRIPTION
Rails 6.0.3.7 includes a security fix that forces us to use Symbols in polymorphic routes.
