### PR TITLE
Do not attempt to generate thumbs for svg files (fixes upload of svg files)

### DIFF
--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -91,7 +91,7 @@ module Alchemy
     end
 
     # Create important thumbnails upfront
-    after_create -> { PictureThumb.generate_thumbs!(self) }
+    after_create -> { PictureThumb.generate_thumbs!(self) if has_convertible_format? }
 
     # We need to define this method here to have it available in the validations below.
     class << self

--- a/spec/models/alchemy/picture_spec.rb
+++ b/spec/models/alchemy/picture_spec.rb
@@ -14,10 +14,24 @@ module Alchemy
 
     it { is_expected.to have_many(:thumbs).class_name("Alchemy::PictureThumb") }
 
-    it "generates thumbnails after create" do
-      expect {
-        create(:alchemy_picture)
-      }.to change { Alchemy::PictureThumb.count }.by(3)
+    context "with a png file" do
+      it "generates thumbnails after create" do
+        expect {
+          create(:alchemy_picture)
+        }.to change { Alchemy::PictureThumb.count }.by(3)
+      end
+    end
+
+    context "with a svg file" do
+      let :image_file do
+        File.new(File.expand_path("../../fixtures/icon.svg", __dir__))
+      end
+
+      it "does not generate any thumbnails" do
+        expect {
+          create(:alchemy_picture, image_file: image_file)
+        }.to_not change { Alchemy::PictureThumb.count }
+      end
     end
 
     it "is valid with valid attributes" do


### PR DESCRIPTION
Hi everyone. First of all let me thank you for this fantastic project.

## What is this pull request for?

While trying to set up a new alchemy based project a colleague of mine discovered a small problem: He was not able to upload any `.svg` files. I could reproduce this with current `main` branch. The exception we hit was:

```
NoMethodError undefined method `steps' for #<#<Class:0x00007fa2316963f8>:0x00007fa2316d4630> in /app/models/alchemy/picture_thumb/signature.rb:12:in `call'
/app/models/alchemy/picture_thumb.rb:47:in `block in generate_thumbs!'
/app/models/alchemy/picture_thumb.rb:42:in `each'
/app/models/alchemy/picture_thumb.rb:42:in `generate_thumbs!'
/app/models/alchemy/picture.rb:94:in `block in <class:Picture>'
```

I did a little digging and found that the missing `#steps` method is called on `Alchemy::PictureVariant#image`. The documentation of that method explicitly says that it can either return a `Dragonfly::Attachment` or a `Dragonfly::Job`. Only the latter seems to have this `#steps` method.

In this case I think a `Dragonfly::Job` is only returned for raster image formats for which an actual thumbnail is being generated. For other formats, any conversions are skipped and a `Dragonfly::Attachment` is being returned.

### Notable changes

I was not 100% how to fix this. So please find my first clumsy attempt attached. I decided that the whole thumbnail (pre-)generation probably only makes sense for those formats that can actually be converted this way. So I tried to shut this off as early as possible.

Feel free to discard this if it does not make sense. Also, please let me know if I can improve on this in any way.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
