### PR TITLE
Fix alchemy:generate:thumbnails task

### DIFF
--- a/lib/tasks/alchemy/thumbnails.rake
+++ b/lib/tasks/alchemy/thumbnails.rake
@@ -4,8 +4,8 @@ namespace :alchemy do
   namespace :generate do
     desc "Generates all thumbnails for Alchemy Pictures and EssencePictures."
     task thumbnails: [
-      "alchemy_dragonfly_s3:generate:picture_thumbnails",
-      "alchemy_dragonfly_s3:generate:essence_picture_thumbnails",
+      "alchemy:generate:picture_thumbnails",
+      "alchemy:generate:essence_picture_thumbnails",
     ]
 
     desc "Generates thumbnails for Alchemy Pictures."


### PR DESCRIPTION
## What is this pull request for?

If I try to run the `alchemy:generate:thumbnails` task, I get the following error:

```
rake aborted!
Don't know how to build task 'alchemy_dragonfly_s3:generate:picture_thumbnails' (See the list of available tasks with `rake --tasks`)
Did you mean?  alchemy:generate:picture_thumbnails

Tasks: TOP => alchemy:generate:thumbnails
(See full trace by running task with --trace)
```

- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
