### PR TITLE
Do not load factories twice in FactoryBot.find_definitions

### DIFF
--- a/lib/alchemy/test_support/factories.rb
+++ b/lib/alchemy/test_support/factories.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+return if caller.find do |line|
+  line.include?("/factory_bot/find_definitions.rb")
+end
+
 Alchemy::Deprecation.warn <<~MSG
   Please require factories using FactoryBots preferred approach:
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,7 +44,7 @@ Rails.logger.level = 4
 Capybara.default_selector = :css
 Capybara.ignore_hidden_elements = false
 
-FactoryBot.definition_file_paths.concat(Alchemy::TestSupport.factory_paths)
+FactoryBot.definition_file_paths.prepend(Alchemy::TestSupport.factories_path)
 FactoryBot.find_definitions
 
 Capybara.register_driver :selenium_chrome_headless do |app|


### PR DESCRIPTION
FactoryBot's `find_definitions` helper will take Alchemy's
`TestSupport.factories_path` and load both files and directories with
that basename. Because `lib/alchemy/test_support/factories.rb` has the
same basename as the directory `lib/alchemy/test_support/factories/`,
and `factories.rb` will use require the factories as well, this leads to
duplicate definition errors.

What this does is it returns from loading the file if called through
`FactoryBot.find_definitions`.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message

