### PR TITLE
[main] Fix execjs to 2.7.0 for developers and CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,11 @@ gem "mysql2", "~> 0.5.1" if ENV["DB"] == "mysql"
 gem "pg", "~> 1.0" if ENV["DB"] == "postgresql"
 
 group :development, :test do
+  # execjs 2.8 removes deprecation warnings but also breaks a number of dependent projects.
+  # in our case the culprit is `handlebars-assets`. The changes between 2.7.0 and 2.8.0 are
+  # minimal, but breaking.
+  gem "execjs", "= 2.7.0"
+
   if ENV["GITHUB_ACTIONS"]
     # Necessary because GH Actions gem cache does not have this "Bundled with Ruby" gem installed
     gem "rexml", "~> 3.2.4"


### PR DESCRIPTION
There's an ecosystem bug in the new release of `execjs`, where the new
version (after five years of stability) breaks a few libraries. In our
case, it's `handlebars-assets`.

I'm opting not to include this fix in the .gemspec file, as I expect
this to be rectified pretty soon, and it's not our responsibility to
version control transient dependencies.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
