### PR TITLE
Fix Essence Picture View (#2083)

### DIFF
--- a/app/views/alchemy/essences/_essence_picture_view.html.erb
+++ b/app/views/alchemy/essences/_essence_picture_view.html.erb
@@ -1,6 +1,6 @@
 <% content = local_assigns[:content] || local_assigns[:essence_picture_view] %>
 <%= Alchemy::EssencePictureView.new(
   content,
-  local_assigns[:options],
-  local_assigns[:html_options]
+  local_assigns[:options] || {},
+  local_assigns[:html_options] || {}
 ).render %>

--- a/spec/views/essences/essence_picture_editor_spec.rb
+++ b/spec/views/essences/essence_picture_editor_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "essences/_essence_picture_editor" do
+describe "alchemy/essences/_essence_picture_editor" do
   let(:picture) { stub_model(Alchemy::Picture) }
 
   let(:essence_picture) do

--- a/spec/views/essences/essence_picture_view_spec.rb
+++ b/spec/views/essences/essence_picture_view_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "alchemy/essences/_essence_picture_view" do
+  let(:picture) { build_stubbed(:alchemy_picture) }
+  let(:essence) { build_stubbed(:alchemy_essence_picture, picture: picture) }
+  let(:content) { build_stubbed(:alchemy_content, essence: essence) }
+
+  it "renders when passing only the content" do
+    render content, content: content
+    expect(rendered).to have_selector("img")
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

Allow to render the essence picture view without options / html_options
Closes #2083

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
