### PR TITLE
Deprecate image format methods

### DIFF
--- a/app/models/alchemy/picture/transformations.rb
+++ b/app/models/alchemy/picture/transformations.rb
@@ -75,21 +75,30 @@ module Alchemy
     def landscape_format?
       image_file.landscape?
     end
+
     alias_method :landscape?, :landscape_format?
+    deprecate landscape_format?: "Use image_file.landscape? instead", deprecator: Alchemy::Deprecation
+    deprecate landscape?: "Use image_file.landscape? instead", deprecator: Alchemy::Deprecation
 
     # Returns true if picture's width is smaller than it's height
     #
     def portrait_format?
       image_file.portrait?
     end
+
     alias_method :portrait?, :portrait_format?
+    deprecate portrait_format?: "Use image_file.portrait? instead", deprecator: Alchemy::Deprecation
+    deprecate portrait?: "Use image_file.portrait? instead", deprecator: Alchemy::Deprecation
 
     # Returns true if picture's width and height is equal
     #
     def square_format?
       image_file.aspect_ratio == 1.0
     end
+
     alias_method :square?, :square_format?
+    deprecate square_format?: "Use image_file.aspect_ratio instead", deprecator: Alchemy::Deprecation
+    deprecate square?: "Use image_file.aspect_ratio instead", deprecator: Alchemy::Deprecation
 
     # Returns true if the class we're included in has a meaningful render_size attribute
     #

--- a/lib/alchemy/deprecation.rb
+++ b/lib/alchemy/deprecation.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Alchemy
-  Deprecation = ActiveSupport::Deprecation.new("7.0", "Alchemy")
+  Deprecation = ActiveSupport::Deprecation.new("6.1", "Alchemy")
 end


### PR DESCRIPTION
## What is this pull request for?

This deprecates `landscape_format?`, `portrait_format?` and
`square_format` as well as their aliases `landscape?`, `portrait?`
and `square?` in favor of the same methods on the `image_file`
object Dragonfly provides us.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
