### PR TITLE
Allow flatten as argument for Dragonfly encode

### DIFF
--- a/config/initializers/dragonfly.rb
+++ b/config/initializers/dragonfly.rb
@@ -9,3 +9,6 @@ if defined?(ActiveRecord::Base)
   ActiveRecord::Base.extend Dragonfly::Model
   ActiveRecord::Base.extend Dragonfly::Model::Validations
 end
+
+# Dragonfly 1.4.0 only allows `quality` as argument to `encode`
+Dragonfly::ImageMagick::Processors::Encode::WHITELISTED_ARGS << "flatten"


### PR DESCRIPTION
Dragonfly 1.4.0 does not allow flatten as argument to encode.
