### PR TITLE
Auto-orient images based on their EXIF data

### DIFF
--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -86,7 +86,9 @@ module Alchemy
     dragonfly_accessor :image_file, app: :alchemy_pictures do
       # Preprocess after uploading the picture
       after_assign do |image|
-        self.class.preprocessor_class.new(image).call
+        if has_convertible_format?
+          self.class.preprocessor_class.new(image).call
+        end
       end
     end
 

--- a/app/models/alchemy/picture/preprocessor.rb
+++ b/app/models/alchemy/picture/preprocessor.rb
@@ -16,6 +16,8 @@ module Alchemy
       def call
         max_image_size = Alchemy::Config.get(:preprocess_image_resize)
         image_file.thumb!(max_image_size) if max_image_size.present?
+        # Auto orient the image so EXIF orientation data is taken into account
+        image_file.auto_orient!
       end
 
       private

--- a/config/initializers/dragonfly.rb
+++ b/config/initializers/dragonfly.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "dragonfly_svg"
 require "alchemy/dragonfly/processors/crop_resize"
+require "alchemy/dragonfly/processors/auto_orient"
 
 # Logger
 Dragonfly.logger = Rails.logger
@@ -16,4 +17,5 @@ Dragonfly::ImageMagick::Processors::Encode::WHITELISTED_ARGS << "flatten"
 
 Rails.application.config.after_initialize do
   Dragonfly.app(:alchemy_pictures).add_processor(:crop_resize, Alchemy::Dragonfly::Processors::CropResize.new)
+  Dragonfly.app(:alchemy_pictures).add_processor(:auto_orient, Alchemy::Dragonfly::Processors::AutoOrient.new)
 end

--- a/lib/alchemy/dragonfly/processors/auto_orient.rb
+++ b/lib/alchemy/dragonfly/processors/auto_orient.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "dragonfly/image_magick/commands"
+
+module Alchemy
+  module Dragonfly
+    module Processors
+      class AutoOrient
+        def call(content)
+          ::Dragonfly::ImageMagick::Commands.convert(
+            content,
+            "-auto-orient"
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/libraries/dragonfly/processors/auto_orient_spec.rb
+++ b/spec/libraries/dragonfly/processors/auto_orient_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../../../support/dragonfly_test_app"
+
+RSpec.describe Alchemy::Dragonfly::Processors::AutoOrient do
+  let(:app) { dragonfly_test_app }
+  let(:file) { Pathname.new(File.expand_path("../../../fixtures/80x60.png", __dir__)) }
+  let(:image) { Dragonfly::Content.new(app, file) }
+  let(:processor) { described_class.new }
+
+  it "works" do
+    expect {
+      processor.call(image)
+    }.to_not raise_error
+  end
+end


### PR DESCRIPTION
Includes #2109 

## What is this pull request for?

When uploading images, turn them based on their EXIF data so that Dragonfly knows how they are oriented.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
