### PR TITLE
Stick with Dragonfly 1.3 for now

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "awesome_nested_set", ["~> 3.1"]
   gem.add_runtime_dependency "cancancan", [">= 2.1", "< 4.0"]
   gem.add_runtime_dependency "coffee-rails", [">= 4.0", "< 6.0"]
-  gem.add_runtime_dependency "dragonfly", ["~> 1.0", ">= 1.0.7"]
+  gem.add_runtime_dependency "dragonfly", ["~> 1.3.0"]
   gem.add_runtime_dependency "dragonfly_svg", ["~> 0.0.4"]
   gem.add_runtime_dependency "gutentag", ["~> 2.2", ">= 2.2.1"]
   gem.add_runtime_dependency "handlebars_assets", ["~> 0.23"]

--- a/config/initializers/dragonfly.rb
+++ b/config/initializers/dragonfly.rb
@@ -9,6 +9,3 @@ if defined?(ActiveRecord::Base)
   ActiveRecord::Base.extend Dragonfly::Model
   ActiveRecord::Base.extend Dragonfly::Model::Validations
 end
-
-# Dragonfly 1.4.0 only allows `quality` as argument to `encode`
-Dragonfly::ImageMagick::Processors::Encode::WHITELISTED_ARGS << "flatten"


### PR DESCRIPTION
With Dragonfly 1.4 we cannot use `image_file.convert`
anymore, since this raises an exception telling us to use
`Dragonfly::ImageMagick::Commands#convert` instead,
but this turns does not work as expected:

1. We will have multiple conversion per image for the same arguments
2. The thumbnails do not get cropped anymore

We only use `convert` because Dragonfly does not support cropping and resizing in one covert command like we do for performance and image quality reasons.

One possible solution would be to create our own processor that we then can make use of.

Let's stick to 1.3 for now.
