### PR TITLE
Link dialog UI fixes

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.link_dialog.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.link_dialog.js.coffee
@@ -228,7 +228,7 @@ class window.Alchemy.LinkDialog extends Alchemy.Dialog
   # Populates the internal anchors select
   initAnchorLinks: ->
     frame = document.getElementById('alchemy_preview_window')
-    elements = frame.contentDocument.getElementsByTagName('*')
+    elements = frame.contentDocument?.getElementsByTagName('*') || []
     if elements.length > 0
       for element in elements
         if element.id

--- a/app/assets/stylesheets/alchemy/page-select.scss
+++ b/app/assets/stylesheets/alchemy/page-select.scss
@@ -1,4 +1,5 @@
 .page-select--page,
+.page-select--page-name,
 .page-select--page-urlname {
   text-overflow: ellipsis;
   overflow: hidden;

--- a/app/assets/stylesheets/alchemy/selects.scss
+++ b/app/assets/stylesheets/alchemy/selects.scss
@@ -41,7 +41,6 @@ select {
       display: block;
       font-weight: normal;
       text-align: left;
-      line-height: 21px;
 
       .select2-chosen {
         overflow: visible;


### PR DESCRIPTION
## What is this pull request for?

In the link overlay we read the iframes body to generate
anchor links for the existing content. This is not allowed
for preview targets on a different domain.

Add a text-overflow to long page names so that the urlpath can
still be read in the select result list.

And fixes a ugly line height issue

### Screenshots

![Screenshot from 2021-06-02 18-50-45](https://user-images.githubusercontent.com/42868/120539894-5c1a7980-c3e8-11eb-955c-cc3a41930d4c.png)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message

