### PR TITLE
expose translations in global Alchemy js object, #2113

### DIFF
--- a/package/admin.js
+++ b/package/admin.js
@@ -1,4 +1,5 @@
 import translate from "./src/i18n"
+import translationData from "./src/translations"
 import NodeTree from "./src/node_tree"
 import fileEditors from "./src/file_editors"
 import pictureEditors from "./src/picture_editors"
@@ -14,6 +15,7 @@ if (typeof window.Alchemy === "undefined") {
 Object.assign(Alchemy, {
   // Global utility method for translating a given string
   t: translate,
+  translations: Object.assign(Alchemy.translations || {}, translationData),
   NodeTree,
   fileEditors,
   pictureEditors,

--- a/package/src/i18n.js
+++ b/package/src/i18n.js
@@ -1,5 +1,3 @@
-import translationData from "./translations"
-
 const KEY_SEPARATOR = /\./
 
 function currentLocale() {
@@ -11,7 +9,7 @@ function currentLocale() {
 
 function getTranslations() {
   const locale = currentLocale()
-  const translations = translationData[locale]
+  const translations = Alchemy.translations[locale]
 
   if (translations) {
     return translations


### PR DESCRIPTION
## What is this pull request for?

Closes #2113 and it's a prerequisite for https://github.com/AlchemyCMS/alchemy_i18n/pull/34
It needs to be backported to all v5.x versions of Alchemy, because since Webpacker was added, the gem is broken.

### Notable changes (remove if none)

The global JS object Alchemy now contains the key `translations` like in Alchemy v4, in order to use it to add other translations using [the alchemy_i18n gem](https://github.com/AlchemyCMS/alchemy_i18n).

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
