### PR TITLE
Add webpacker tasks to Alchemy upgrader

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'awesome_nested_set',               ['~> 3.1']
   gem.add_runtime_dependency 'cancancan',                        ['>= 2.1', '< 4.0']
   gem.add_runtime_dependency 'coffee-rails',                     ['>= 4.0', '< 6.0']
-  gem.add_runtime_dependency 'dragonfly',                        ['~> 1.0', '>= 1.0.7']
+  gem.add_runtime_dependency 'dragonfly',                        ['~> 1.0', '>= 1.0.7', '< 1.4']
   gem.add_runtime_dependency 'dragonfly_svg',                    ['~> 0.0.4']
   gem.add_runtime_dependency 'gutentag',                         ['~> 2.2', '>= 2.2.1']
   gem.add_runtime_dependency 'handlebars_assets',                ['~> 0.23']

--- a/lib/alchemy/upgrader/five_point_zero.rb
+++ b/lib/alchemy/upgrader/five_point_zero.rb
@@ -1,9 +1,18 @@
 # frozen_string_literal: true
 
 require_relative "tasks/harden_gutentag_migrations"
+require "rails/generators"
+require "thor"
+require "alchemy/install/tasks"
 
 module Alchemy
   class Upgrader::FivePointZero < Upgrader
+  	include Rails::Generators::Actions
+  	include Thor::Base
+  	include Thor::Actions
+
+  	source_root File.expand_path("../../generators/alchemy/install/files", __dir__)
+
     class << self
       def install_gutentag_migrations
         desc "Install Gutentag migrations"
@@ -35,6 +44,28 @@ module Alchemy
         else
           log "Root page not found.", :skip
         end
+      end
+
+      def run_webpacker_installer
+        # Webpacker does not create a package.json, but we need one
+        unless File.exist? app_root.join("package.json")
+          in_root { run "echo '{}' > package.json" }
+        end
+        new.rake("webpacker:install", abort_on_failure: true)
+      end
+
+      def add_npm_package
+        new.run "yarn add @alchemy_cms/admin"
+      end
+
+      def copy_alchemy_entry_point
+        webpack_config = YAML.load_file(app_root.join("config", "webpacker.yml"))[Rails.env]
+        new.copy_file "alchemy_admin.js",
+          app_root.join(webpack_config["source_path"], webpack_config["source_entry_path"], "alchemy/admin.js")
+      end
+
+      def app_root
+        @_app_root ||= Rails.root
       end
     end
   end

--- a/lib/tasks/alchemy/upgrade.rake
+++ b/lib/tasks/alchemy/upgrade.rake
@@ -42,6 +42,9 @@ namespace :alchemy do
         "alchemy:upgrade:5.0:install_gutentag_migrations",
         "alchemy:upgrade:5.0:remove_layout_roots",
         "alchemy:upgrade:5.0:remove_root_page",
+        "alchemy:upgrade:5.0:run_webpacker_installer",
+        "alchemy:upgrade:5.0:add_npm_package",
+        "alchemy:upgrade:5.0:copy_alchemy_entry_point",
       ]
 
       desc "Install Gutentag migrations"
@@ -57,6 +60,23 @@ namespace :alchemy do
       desc "Remove root page"
       task remove_root_page: [:environment] do
         Alchemy::Upgrader::FivePointZero.remove_root_page
+      end
+
+      desc "Run webpacker installer"
+      task run_webpacker_installer: [:environment] do
+        Alchemy::Upgrader::FivePointZero.run_webpacker_installer
+      end
+
+      desc "Add NPM package"
+      task add_npm_package: [:environment] do
+        puts "adding npm_package..."
+        Alchemy::Upgrader::FivePointZero.add_npm_package
+      end
+
+      desc "Copy alchemy entry point"
+      task copy_alchemy_entry_point: [:environment] do
+        puts "copying alchemy entry point"
+        Alchemy::Upgrader::FivePointZero.copy_alchemy_entry_point
       end
     end
   end


### PR DESCRIPTION
## What is this pull request for?

Adds Alchemy 5 upgrade tasks to complete required wepbacker setup, mirroring installer tasks, run webpacker installer, add alchemy's npm package, and copy alchemy's webpack entry point.

Closes #1937

## Checklist
- [x] I have followed [Pull Request guidelines]()
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
(I don't see any existing tests for the upgrader tasks, unless I'm missing them)
