### PR TITLE
generate picture thumbnails only for pictures with convertible format

### DIFF
--- a/lib/tasks/alchemy/thumbnails.rake
+++ b/lib/tasks/alchemy/thumbnails.rake
@@ -14,6 +14,8 @@ namespace :alchemy do
       puts "Please wait..."
 
       Alchemy::Picture.find_each do |picture|
+        next unless picture.has_convertible_format?
+
         puts Alchemy::PictureThumb.generate_thumbs!(picture)
       end
 


### PR DESCRIPTION
## What is this pull request for?

It skips the generation of the thumbnails if the picture doesn't have a convertible format

Closes #2127 

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
