### PR TITLE
Image cropper destroy

### DIFF
--- a/app/views/alchemy/admin/essence_pictures/update.js.erb
+++ b/app/views/alchemy/admin/essence_pictures/update.js.erb
@@ -1,5 +1,4 @@
 (function($) {
-  Alchemy.ImageCropper.destroy();
   Alchemy.closeCurrentDialog();
   Alchemy.setElementDirty('#element_<%= @content.element.id %>');
 <% if @content.ingredient %>

--- a/package/src/image_cropper.js
+++ b/package/src/image_cropper.js
@@ -17,6 +17,7 @@ export default class ImageCropper {
     this.cropSizeField = document.getElementById(formFieldIds[1])
     this.elementId = elementId
     this.dialog = Alchemy.currentDialog()
+    this.dialog.options.closed = this.destroy
 
     this.init()
     this.bind()


### PR DESCRIPTION
## What is this pull request for?

Makes sure to destroy the image cropper instance on dialog close. Also removes old Image Cropper destroy from essence picture update callback.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
