### PR TITLE
Link dialog changes can be submitted by enter

### DIFF
--- a/app/views/alchemy/admin/pages/_anchor_link.html.erb
+++ b/app/views/alchemy/admin/pages/_anchor_link.html.erb
@@ -17,6 +17,6 @@
     <%= text_field_tag "anchor_link_title", '', class: 'link_title' %>
   </div>
   <div class="submit">
-    <%= link_to Alchemy.t(:apply), '', class: 'create-link button', 'data-link-type' => 'anchor' %>
+    <%= button_tag Alchemy.t(:apply), class: 'create-link button', data: { link_type: 'anchor' } %>
   </div>
 <% end %>

--- a/app/views/alchemy/admin/pages/_external_link.html.erb
+++ b/app/views/alchemy/admin/pages/_external_link.html.erb
@@ -26,6 +26,6 @@
       class: 'alchemy_selectbox link_target' %>
   </div>
   <div class="submit">
-    <%= link_to Alchemy.t(:apply), '#', class: 'create-link button', 'data-link-type' => 'external' %>
+    <%= button_tag Alchemy.t(:apply), class: 'create-link button', data: { link_type: 'external' } %>
   </div>
 <% end %>

--- a/app/views/alchemy/admin/pages/_file_link.html.erb
+++ b/app/views/alchemy/admin/pages/_file_link.html.erb
@@ -26,6 +26,6 @@
       class: 'alchemy_selectbox link_target' %>
   </div>
   <div class="submit">
-    <%= link_to Alchemy.t(:apply), '#', class: 'create-link button', 'data-link-type' => 'file' %>
+    <%= button_tag Alchemy.t(:apply), class: 'create-link button', data: { link_type: 'file' } %>
   </div>
 <% end %>

--- a/app/views/alchemy/admin/pages/_internal_link.html.erb
+++ b/app/views/alchemy/admin/pages/_internal_link.html.erb
@@ -30,6 +30,6 @@
       class: 'alchemy_selectbox link_target' %>
   </div>
   <div class="submit">
-    <%= link_to Alchemy.t(:apply), '', class: 'create-link button', 'data-link-type' => 'internal' %>
+    <%= button_tag Alchemy.t(:apply), class: 'create-link button', data: { link_type: 'internal' } %>
   </div>
 <% end %>


### PR DESCRIPTION
## What is this pull request for?

A small but impactful PR that makes Alchemy even more accessible.

The link dialog forms can now be submitted by pressing the Enter key as well.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
