### PR TITLE
Do not leak all records for guest users in API controllers

### DIFF
--- a/app/controllers/alchemy/api/elements_controller.rb
+++ b/app/controllers/alchemy/api/elements_controller.rb
@@ -19,13 +19,15 @@ module Alchemy
       @elements = @elements.not_nested.joins(:page_version).merge(PageVersion.published)
 
       if params[:page_id].present?
-        @elements = @elements.where(alchemy_pages: { id: params[:page_id] })
+        @elements = @elements.includes(:page).where(alchemy_pages: { id: params[:page_id] })
+      else
+        @elements = @elements.includes(*element_includes)
       end
 
       if params[:named].present?
         @elements = @elements.named(params[:named])
       end
-      @elements = @elements.includes(*element_includes).order(:position)
+      @elements = @elements.order(:position)
 
       render json: @elements, adapter: :json, root: "elements"
     end

--- a/app/controllers/alchemy/api/elements_controller.rb
+++ b/app/controllers/alchemy/api/elements_controller.rb
@@ -9,17 +9,19 @@ module Alchemy
     # If you want to only load a specific type of element pass ?named=an_element_name
     #
     def index
-      if params[:page_id].present?
-        @page = Page.find(params[:page_id])
-        @elements = @page.elements.not_nested
-      else
-        @elements = Element.not_nested.joins(:page_version).merge(PageVersion.published)
-      end
-
       # Fix for cancancan not able to merge multiple AR scopes for logged in users
       if cannot? :manage, Alchemy::Element
-        @elements = @elements.accessible_by(current_ability, :index)
+        @elements = Alchemy::Element.accessible_by(current_ability, :index)
+      else
+        @elements = Alchemy::Element.all
       end
+
+      @elements = @elements.not_nested.joins(:page_version).merge(PageVersion.published)
+
+      if params[:page_id].present?
+        @elements = @elements.where(alchemy_pages: { id: params[:page_id] })
+      end
+
       if params[:named].present?
         @elements = @elements.named(params[:named])
       end

--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -7,10 +7,12 @@ module Alchemy
     # Returns all pages as json object
     #
     def index
-      @pages = Language.current&.pages.presence || Alchemy::Page.none
       # Fix for cancancan not able to merge multiple AR scopes for logged in users
       if cannot? :edit_content, Alchemy::Page
-        @pages = @pages.accessible_by(current_ability, :index)
+        @pages = Alchemy::Page.accessible_by(current_ability, :index)
+        @pages = @pages.where(language: Language.current)
+      else
+        @pages = Language.current&.pages.presence || Alchemy::Page.none
       end
       @pages = @pages.includes(*page_includes)
       @pages = @pages.ransack(params[:q]).result

--- a/spec/features/admin/link_overlay_spec.rb
+++ b/spec/features/admin/link_overlay_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe "Link overlay", type: :system do
     let!(:article) do
       create(:alchemy_element,
         name: "article",
-        page: page1,
         page_version: page1.draft_version,
         autogenerate_contents: true)
     end
@@ -60,29 +59,22 @@ RSpec.describe "Link overlay", type: :system do
         click_link "Link text"
       end
 
-      begin
-        within "#overlay_tab_internal_link" do
-          expect(page).to have_selector("#s2id_page_urlname")
-          select2_search(page2.name, from: "Page")
-          click_link "apply"
-        end
+      within "#overlay_tab_internal_link" do
+        expect(page).to have_selector("#s2id_page_urlname")
+        select2_search(page2.name, from: "Page")
+        click_button "apply"
+      end
 
-        within "#element_#{article.id}" do
-          click_button "Save"
-        end
+      within "#element_#{article.id}" do
+        click_button "Save"
+      end
 
-        within "#flash_notices" do
-          expect(page).to have_content "Saved element."
-        end
+      within "#flash_notices" do
+        expect(page).to have_content "Saved element."
+      end
 
-        click_button_with_label "Publish page"
-
-        visit "/#{page1.urlname}"
-
+      within_frame "alchemy_preview_window" do
         expect(page).to have_link("Link me", href: "/#{page2.urlname}")
-      rescue Capybara::ElementNotFound => e
-        pending e.message
-        raise e
       end
     end
   end


### PR DESCRIPTION
## What is this pull request for?

CanCanCan does not respect any scope set before `accessible_by`.
We need to make sure the additional scopes get called afterwards.

Thanks @mamhoff for finding this during working on https://github.com/CanCanCommunity/cancancan/pull/717

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
