### PR TITLE
fix: call paging on jquery tabs only after initializing them

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.fixed_elements.js
+++ b/app/assets/javascripts/alchemy/alchemy.fixed_elements.js
@@ -10,7 +10,7 @@ Alchemy.FixedElements = {
         $tabs = $(this.TABS.replace(/{{label}}/, label));
 
     $('#main-content-elements').wrap($wrapper);
-    $('#fixed-elements').prepend($tabs).tabs('paging', {
+    $('#fixed-elements').prepend($tabs).tabs().tabs('paging', {
       follow: true,
       followOnSelect: true
     });


### PR DESCRIPTION
## What is this pull request for?

When creating the first fixed element on a Page (using the admin UI), a javascript error was thrown (see screenshot).

The js console does no show the origin of the error, but debugging a little showed it was actually happening inside `Alchemy.FixedElements.buildTabs()` when `paging` was called on the tabs and they weren't yet initialised.

### Screenshots

<img width="572" alt="Screenshot 2021-07-02 at 14 54 32" src="https://user-images.githubusercontent.com/342977/124279180-7bbbd380-db47-11eb-9243-7b654a2ba438.png">

<img width="598" alt="Screenshot 2021-07-02 at 13 20 27" src="https://user-images.githubusercontent.com/342977/124279218-870eff00-db47-11eb-8fc7-6a1b5a9c4c12.png">

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
