### PR TITLE
Allow to update element without tags

### DIFF
--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -151,7 +151,7 @@ module Alchemy
       end
 
       def element_params
-        params.fetch(:element).permit(:tag_list, ingredients_attributes: {})
+        params.fetch(:element, {}).permit(:tag_list, ingredients_attributes: {})
       end
 
       def create_element_params

--- a/spec/controllers/alchemy/admin/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/elements_controller_spec.rb
@@ -198,7 +198,7 @@ module Alchemy
 
       context "with element having contents" do
         subject do
-          put :update, params: { id: element.id, element: element_params, contents: contents_params }, xhr: true
+          put :update, params: { id: element.id, element: element_params, contents: contents_params }.compact, xhr: true
         end
 
         let(:element) { create(:alchemy_element, :with_contents) }
@@ -219,6 +219,14 @@ module Alchemy
             expect(element).to receive(:update_contents).and_return(false)
             subject
             expect(assigns(:element_validated)).to be_falsey
+          end
+        end
+
+        context "with element not taggable" do
+          let(:element_params) { nil }
+
+          it "updates the element" do
+            expect { subject }.to_not raise_error
           end
         end
       end


### PR DESCRIPTION
## What is this pull request for?

Elements not having tags do not send any element params.
The strong params code needs to fallback to an empty Hash.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
