### PR TITLE
Make element preview text work with ingredients

### DIFF
--- a/app/models/alchemy/element/presenters.rb
+++ b/app/models/alchemy/element/presenters.rb
@@ -46,7 +46,9 @@ module Alchemy
       #   Length of characters after the text will be cut off.
       #
       def preview_text(maxlength = 60)
-        preview_text_from_preview_content(maxlength) || preview_text_from_nested_elements(maxlength)
+        preview_text_from_preview_ingredient(maxlength) ||
+          preview_text_from_preview_content(maxlength) ||
+          preview_text_from_nested_elements(maxlength)
       end
 
       # Generates a preview text containing Element#display_name and Element#preview_text.
@@ -94,6 +96,17 @@ module Alchemy
         @_preview_content ||= contents.detect(&:preview_content?) || contents.first
       end
 
+      # The ingredient that's used for element's preview text.
+      #
+      # It tries to find one of element's ingredients that is defined +as_element_title+.
+      # Takes element's first ingredient if no ingredient is defined +as_element_title+.
+      #
+      # @return (Alchemy::Ingredient)
+      #
+      def preview_ingredient
+        @_preview_ingredient ||= ingredients.detect(&:preview_ingredient?) || ingredients.first
+      end
+
       private
 
       def preview_text_from_nested_elements(maxlength)
@@ -104,6 +117,10 @@ module Alchemy
 
       def preview_text_from_preview_content(maxlength)
         preview_content.try!(:preview_text, maxlength)
+      end
+
+      def preview_text_from_preview_ingredient(maxlength)
+        preview_ingredient&.preview_text(maxlength)
       end
     end
   end

--- a/app/models/alchemy/ingredient.rb
+++ b/app/models/alchemy/ingredient.rb
@@ -210,6 +210,11 @@ module Alchemy
       false
     end
 
+    # @return [Boolean]
+    def preview_ingredient?
+      !!definition[:as_element_title]
+    end
+
     private
 
     def hint_translation_attribute

--- a/spec/models/alchemy/ingredient_spec.rb
+++ b/spec/models/alchemy/ingredient_spec.rb
@@ -269,6 +269,26 @@ RSpec.describe Alchemy::Ingredient do
     end
   end
 
+  describe "#preview_ingredient?" do
+    let(:ingredient) { Alchemy::Ingredients::Text.build(role: "headline", element: element) }
+
+    subject { ingredient.preview_ingredient? }
+
+    context "not defined as as_element_title" do
+      it { is_expected.to be false }
+    end
+
+    context "defined as as_element_title" do
+      before do
+        expect(ingredient).to receive(:definition).at_least(:once).and_return({
+          as_element_title: true,
+        })
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+
   describe "#has_tinymce?" do
     subject { ingredient.has_tinymce? }
 


### PR DESCRIPTION
## What is this pull request for?

If an element has ingredients the Preview Text should be read from
the ingredients not contents.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
