### PR TITLE
Improve cache key defaults for menus

### DIFF
--- a/lib/generators/alchemy/menus/templates/node.html.erb
+++ b/lib/generators/alchemy/menus/templates/node.html.erb
@@ -1,4 +1,4 @@
-<%% cache node do %>
+<%% cache [node, @page, @preview_mode] do %>
   <%%= content_tag :li, class: ['nav-item', node.children.any? ? 'dropdown' : nil].compact do %>
     <%%= link_to_if node.url,
       node.name,

--- a/lib/generators/alchemy/menus/templates/node.html.haml
+++ b/lib/generators/alchemy/menus/templates/node.html.haml
@@ -1,4 +1,4 @@
-- cache node do
+- cache [node, @page, @preview_mode] do
   = content_tag :li,
     class: ['nav-item', node.children.any? ? 'dropdown' : nil].compact do
     = link_to_if node.url,

--- a/lib/generators/alchemy/menus/templates/node.html.slim
+++ b/lib/generators/alchemy/menus/templates/node.html.slim
@@ -1,4 +1,4 @@
-- cache node do
+- cache [node, @page, @preview_mode] do
   = content_tag :li,
     class: ['nav-item', node.children.any? ? 'dropdown' : nil].compact do
     = link_to_if node.url,

--- a/lib/generators/alchemy/menus/templates/wrapper.html.erb
+++ b/lib/generators/alchemy/menus/templates/wrapper.html.erb
@@ -1,4 +1,4 @@
-<%% cache menu do %>
+<%% cache [menu, @page, @preview_mode] do %>
   <ul class="nav">
     <%%= render partial: menu.to_partial_path,
       collection: menu.children.includes(:page, :children),

--- a/lib/generators/alchemy/menus/templates/wrapper.html.haml
+++ b/lib/generators/alchemy/menus/templates/wrapper.html.haml
@@ -1,4 +1,4 @@
-- cache menu do
+- cache [menu, @page, @preview_mode] do
   %ul.nav
     = render partial: menu.to_partial_path,
       collection: menu.children.includes(:page, :children),

--- a/lib/generators/alchemy/menus/templates/wrapper.html.slim
+++ b/lib/generators/alchemy/menus/templates/wrapper.html.slim
@@ -1,4 +1,4 @@
-- cache menu do
+- cache [menu, @page, @preview_mode] do
   ul.nav
     = render partial: menu.to_partial_path,
       collection: menu.children.includes(:page, :children),


### PR DESCRIPTION
## What is this pull request for?

With the currently generated templates the way menus are being displayed depends on the (current) page and whether one is in preview mode or not.

This PR adds both facts to the cache key used in the generator's templates.

Closes #2138

### Notable changes (remove if none)

This only affects newly generated menu templates.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change

Sorry, I have no idea if this even needs test and if yes, how this could be tested. If you have suggestions, please let me know and I will gladly add something.