### PR TITLE
Respect additional essence attributes during ingredients migration

### DIFF
--- a/lib/alchemy/upgrader/tasks/ingredients_migrator.rb
+++ b/lib/alchemy/upgrader/tasks/ingredients_migrator.rb
@@ -10,6 +10,9 @@ module Alchemy::Upgrader::Tasks
       def create_ingredients
         Alchemy::Deprecation.silence do
           elements_with_ingredients = Alchemy::ElementDefinition.all.select { |d| d.key?(:ingredients) }
+          if ENV["ONLY"]
+            elements_with_ingredients = elements_with_ingredients.select { |d| d[:name].in? ENV["ONLY"].split(",") }
+          end
           # eager load all elements that have ingredients defined but no ingredient records yet.
           all_elements = Alchemy::Element
             .named(elements_with_ingredients.map { |d| d[:name] })

--- a/lib/alchemy/upgrader/tasks/ingredients_migrator.rb
+++ b/lib/alchemy/upgrader/tasks/ingredients_migrator.rb
@@ -22,21 +22,26 @@ module Alchemy::Upgrader::Tasks
               puts "-- Creating ingredients for #{elements.count} #{element_definition[:name]}(s)"
               elements.each do |element|
                 Alchemy::Element.transaction do
-                  element.ingredients = element_definition[:ingredients].map do |ingredient_definition|
+                  element_definition[:ingredients].each do |ingredient_definition|
                     content = element.content_by_name(ingredient_definition[:role])
                     next unless content
 
+                    essence = content.essence
                     ingredient = Alchemy::Ingredient.build(role: ingredient_definition[:role], element: element)
-                    belongs_to_associations = content.essence.class.reflect_on_all_associations(:belongs_to)
+                    belongs_to_associations = essence.class.reflect_on_all_associations(:belongs_to)
                     if belongs_to_associations.any?
-                      ingredient.related_object = content.essence.public_send(belongs_to_associations.first.name)
+                      ingredient.related_object = essence.public_send(belongs_to_associations.first.name)
                     else
                       ingredient.value = content.ingredient
                     end
-                    content.destroy!
+                    ingredient.class.stored_attributes.fetch(:data, []).each do |attr|
+                      value = essence.public_send(attr)
+                      ingredient.public_send("#{attr}=", value)
+                    end
                     print "."
-                    ingredient
-                  end.compact
+                    ingredient.save!
+                    content.destroy!
+                  end
                 end
               end
               puts "\n"


### PR DESCRIPTION
## What is this pull request for?

Essences might have additional attributes that we store in the data JSON column on the ingredients table.
The ingredients migrator task needs to copy those values as well.

Also you can now migrate only a subset of elements by passing a comma separated list with `ONLY=element1,element2` while running the rake task

```
bin/rake alchemy:upgrade:6.0:create_ingredients ONLY=product_slide
```

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
