### PR TITLE
Fix ingredient migrator (again)

### DIFF
--- a/lib/alchemy/upgrader/tasks/ingredients_migrator.rb
+++ b/lib/alchemy/upgrader/tasks/ingredients_migrator.rb
@@ -37,10 +37,10 @@ module Alchemy::Upgrader::Tasks
                     else
                       ingredient.value = content.ingredient
                     end
-                    ingredient.class.stored_attributes.fetch(:data, []).each do |attr|
-                      value = essence.public_send(attr)
-                      ingredient.public_send("#{attr}=", value)
+                    data = ingredient.class.stored_attributes.fetch(:data, []).each_with_object({}) do |attr, d|
+                      d[attr] = essence.public_send(attr)
                     end
+                    ingredient.data = data
                     print "."
                     ingredient.save!
                     content.destroy!


### PR DESCRIPTION
## What is this pull request for?

It turns out that Rails does not persist the data column
unless you replace the Hash. Just setting the attributes
does not seem to set the data Hash dirty.

*slow clap*

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
