### PR TITLE
Make ingredient examples usable without elements.yml

### DIFF
--- a/lib/alchemy/test_support/shared_ingredient_examples.rb
+++ b/lib/alchemy/test_support/shared_ingredient_examples.rb
@@ -28,6 +28,16 @@ RSpec.shared_examples_for "an alchemy ingredient" do
     end
 
     context "with element" do
+      before do
+        expect(element).to receive(:ingredient_definition_for) do
+          {
+            settings: {
+              linkable: true,
+            },
+          }.with_indifferent_access
+        end
+      end
+
       it { is_expected.to eq({ linkable: true }.with_indifferent_access) }
     end
   end
@@ -42,15 +52,23 @@ RSpec.shared_examples_for "an alchemy ingredient" do
     end
 
     context "with element" do
-      it do
-        is_expected.to eq({
+      let(:definition) do
+        {
           role: "headline",
           type: "Text",
           default: "Hello World",
           settings: {
             linkable: true,
           },
-        }.with_indifferent_access)
+        }.with_indifferent_access
+      end
+
+      before do
+        expect(element).to receive(:ingredient_definition_for) { definition }
+      end
+
+      it "returns ingredient definition" do
+        is_expected.to eq(definition)
       end
     end
   end


### PR DESCRIPTION
## What is this pull request for?

If you want to use the ingredient examples in another project or gem
we do not have the elements.yml from alchemys dummy.

We need to stub the definition instead.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
