### PR TITLE
Require alchemy/version

### DIFF
--- a/lib/alchemy_cms.rb
+++ b/lib/alchemy_cms.rb
@@ -54,6 +54,7 @@ require_relative "alchemy/permissions"
 require_relative "alchemy/resource"
 require_relative "alchemy/tinymce"
 require_relative "alchemy/taggable"
+require_relative "alchemy/version"
 
 # Require hacks
 require_relative "kaminari/scoped_pagination_url_helper"


### PR DESCRIPTION
## What is this pull request for?

Projects and gems want to know the version without needing
to require 'alchemy/version'

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message

