### PR TITLE
Improve cache key defaults for menus #2138

### DIFF
--- a/lib/generators/alchemy/menus/templates/node.html.erb
+++ b/lib/generators/alchemy/menus/templates/node.html.erb
@@ -1,4 +1,4 @@
-<%% cache node do %>
+<%% cache [node, @page, @preview_mode] do %>
   <%%= content_tag :li, class: ['nav-item', node.children.any? ? 'dropdown' : nil].compact do %>
     <%%= link_to_if node.url,
       node.name,

--- a/lib/generators/alchemy/menus/templates/node.html.haml
+++ b/lib/generators/alchemy/menus/templates/node.html.haml
@@ -1,4 +1,4 @@
-- cache node do
+- cache [node, @page, @preview_mode] do
   = content_tag :li,
     class: ['nav-item', node.children.any? ? 'dropdown' : nil].compact do
     = link_to_if node.url,

--- a/lib/generators/alchemy/menus/templates/node.html.slim
+++ b/lib/generators/alchemy/menus/templates/node.html.slim
@@ -1,4 +1,4 @@
-- cache node do
+- cache [node, @page, @preview_mode] do
   = content_tag :li,
     class: ['nav-item', node.children.any? ? 'dropdown' : nil].compact do
     = link_to_if node.url,

--- a/lib/generators/alchemy/menus/templates/wrapper.html.erb
+++ b/lib/generators/alchemy/menus/templates/wrapper.html.erb
@@ -1,4 +1,4 @@
-<%% cache menu do %>
+<%% cache [menu, @page, @preview_mode] do %>
   <ul class="nav">
     <%%= render partial: menu.to_partial_path,
       collection: menu.children.includes(:page, :children),

--- a/lib/generators/alchemy/menus/templates/wrapper.html.haml
+++ b/lib/generators/alchemy/menus/templates/wrapper.html.haml
@@ -1,4 +1,4 @@
-- cache menu do
+- cache [menu, @page, @preview_mode] do
   %ul.nav
     = render partial: menu.to_partial_path,
       collection: menu.children.includes(:page, :children),

--- a/lib/generators/alchemy/menus/templates/wrapper.html.slim
+++ b/lib/generators/alchemy/menus/templates/wrapper.html.slim
@@ -1,4 +1,4 @@
-- cache menu do
+- cache [menu, @page, @preview_mode] do
   ul.nav
     = render partial: menu.to_partial_path,
       collection: menu.children.includes(:page, :children),


### PR DESCRIPTION
Following up on #2153 this is the very same change for 5.2-stable.

If you plan to release another point release for 5.2 before releasing version 6 this makes total sense to me. New projects will still use 5.2 until version 6 is available. And I expect menus to be generated relatively early on when setting up a new project.

With that being said, do you still think this should be ported even further back?

Will people still start new projects with 5.1 for example? Will people who have been on 5.1 for a long time and never made the jump to 5.2 upgrade to a new point release of 5.1 _and_ then generate new menus?