### PR TITLE
(Re)-init Tinymce for elements with ingredients

### DIFF
--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -65,6 +65,7 @@ module Alchemy
       end
 
       def destroy
+        @richtext_ids = @element.richtext_contents_ids + @element.richtext_ingredients_ids
         @element.destroy
         @notice = Alchemy.t("Successfully deleted element") % { element: @element.display_name }
       end

--- a/app/views/alchemy/admin/elements/create.js.erb
+++ b/app/views/alchemy/admin/elements/create.js.erb
@@ -34,7 +34,7 @@
 
   Alchemy.growl('<%= Alchemy.t(:successfully_added_element) %>');
   Alchemy.closeCurrentDialog();
-  Alchemy.Tinymce.init(<%= @element.richtext_contents_ids.to_json %>);
+  Alchemy.Tinymce.init(<%= (@element.richtext_contents_ids + @element.richtext_ingredients_ids).to_json %>);
   Alchemy.PreviewWindow.refresh(function() {
     Alchemy.ElementEditors.focusElementPreview(<%= @element.id %>);
   });

--- a/app/views/alchemy/admin/elements/destroy.js.erb
+++ b/app/views/alchemy/admin/elements/destroy.js.erb
@@ -3,9 +3,7 @@ $('#element_<%= @element.id %>').hide(200, function() {
   Alchemy.growl('<%= j @notice %>');
   $('#element_area .sortable-elements').sortable('refresh');
   Alchemy.PreviewWindow.refresh();
-  <% @element.richtext_contents_ids.each do |id| %>
-  tinymce.get('tinymce_<%= id %>').remove();
-  <% end %>
+  Alchemy.Tinymce.remove(<%= @richtext_ids.to_json %>);
   <% if @element.fixed? %>
   Alchemy.FixedElements.removeTab(<%= @element.id %>);
   <% end %>

--- a/app/views/alchemy/admin/elements/fold.js.erb
+++ b/app/views/alchemy/admin/elements/fold.js.erb
@@ -14,12 +14,12 @@
 
   <% if @element.folded? -%>
 
-  Alchemy.Tinymce.remove(<%= @element.richtext_contents_ids.to_json %>);
+  Alchemy.Tinymce.remove(<%= (@element.richtext_contents_ids + @element.richtext_ingredients_ids).to_json %>);
 
   <% else -%>
 
   $el.trigger('FocusElementEditor.Alchemy');
-  Alchemy.Tinymce.init(<%= @element.richtext_contents_ids.to_json %>);
+  Alchemy.Tinymce.init(<%= (@element.richtext_contents_ids + @element.richtext_ingredients_ids).to_json %>);
   Alchemy.GUI.initElement($el);
   Alchemy.SortableElements(
     <%= @page.id %>,

--- a/spec/requests/alchemy/admin/elements_controller_spec.rb
+++ b/spec/requests/alchemy/admin/elements_controller_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::Admin::ElementsController do
+  before do
+    authorize_user(:as_admin)
+  end
+
+  describe "#create" do
+    let(:page_version) { create(:alchemy_page_version) }
+
+    context "element with ingredients" do
+      it "inits Tinymce for richtext ingredients" do
+        post admin_elements_path(element: { page_version_id: page_version.id, name: "element_with_ingredients" }, format: :js)
+        element = Alchemy::Element.last
+        expect(response.body).to include("Alchemy.Tinymce.init([#{element.ingredient_by_role(:text).id}]);")
+      end
+    end
+  end
+
+  describe "#fold" do
+    context "expanded element with ingredients" do
+      let(:element) { create(:alchemy_element, :with_ingredients) }
+
+      it "removes Tinymce for richtext ingredients" do
+        post fold_admin_element_path(id: element.id, format: :js)
+        expect(response.body).to include("Alchemy.Tinymce.remove([#{element.ingredient_by_role(:text).id}]);")
+      end
+    end
+
+    context "folded element with ingredients" do
+      let(:element) { create(:alchemy_element, :with_ingredients, folded: true) }
+
+      it "inits Tinymce for richtext ingredients" do
+        post fold_admin_element_path(id: element.id, format: :js)
+        expect(response.body).to include("Alchemy.Tinymce.init([#{element.ingredient_by_role(:text).id}]);")
+      end
+    end
+  end
+
+  describe "#destroy" do
+    context "element with ingredients" do
+      let(:element) { create(:alchemy_element, :with_ingredients) }
+
+      it "removes Tinymce for richtext ingredients" do
+        delete admin_element_path(id: element.id, format: :js)
+        expect(response.body).to include("Alchemy.Tinymce.remove([#{element.ingredient_by_role(:text).id}]);")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

If an element has ingredients we need to take those into
account as well if we create, delete or fold an element with
ingredients.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
