### PR TITLE
Return fully namespaced ingredient constant

### DIFF
--- a/app/models/alchemy/ingredient.rb
+++ b/app/models/alchemy/ingredient.rb
@@ -80,7 +80,7 @@ module Alchemy
 
       # Returns an ingredient class by type
       #
-      # Raises ArgumentError if there is no such class in the
+      # Raises NameError if there is no such class in the
       # +Alchemy::Ingredients+ module namespace.
       #
       # If you add custom ingredient class,
@@ -89,7 +89,7 @@ module Alchemy
       # @param [String] The ingredient class name to constantize
       # @return [Class]
       def ingredient_class_by_type(ingredient_type)
-        Alchemy::Ingredients.const_get(ingredient_type.to_s.classify.demodulize)
+        normalize_type(ingredient_type).constantize
       end
 
       # Modulize ingredient type

--- a/spec/models/alchemy/ingredient_spec.rb
+++ b/spec/models/alchemy/ingredient_spec.rb
@@ -105,6 +105,34 @@ RSpec.describe Alchemy::Ingredient do
     end
   end
 
+  describe ".ingredient_class_by_type" do
+    subject { described_class.ingredient_class_by_type(ingredient_type) }
+
+    context "with a known ingredient class" do
+      let(:ingredient_type) { "Text" }
+
+      it "returns full ingredient constant" do
+        expect(subject).to eq(Alchemy::Ingredients::Text)
+      end
+    end
+
+    context "with unkown ingredient class" do
+      let(:ingredient_type) { "Foo" }
+
+      it do
+        expect { subject }.to raise_error(NameError)
+      end
+    end
+  end
+
+  describe ".normalize_type" do
+    subject { described_class.normalize_type("Text") }
+
+    it "returns full ingredient constant name" do
+      is_expected.to eq("Alchemy::Ingredients::Text")
+    end
+  end
+
   describe "#settings" do
     let(:ingredient) { Alchemy::Ingredients::Text.build(role: "headline", element: element) }
 


### PR DESCRIPTION
## What is this pull request for?
Using `const_get` returns the constant from within the `Alchemy::Ingredients`
module, not the full constant. This can lead to errors with ingredients
that have a reserved constant name (like the `File` ingredient)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
