### PR TITLE
Ensure resource table ends before the filter/tag sidebar

### DIFF
--- a/app/assets/stylesheets/alchemy/archive.scss
+++ b/app/assets/stylesheets/alchemy/archive.scss
@@ -20,7 +20,8 @@
   padding-bottom: 60px;
 
   &.with_tag_filter {
-    padding-right: 242px;
+    width: calc(100% - 235px);
+    overflow-x: auto;
   }
 }
 


### PR DESCRIPTION
## What is this pull request for?

A wide resource table in combination with the sidebar for filter/tags made the table slip under the sidebar. As a consequence it would hide the edit/delete buttons and even some attributes.

This commit enforces the width of the resource-table-wrapper can always only be as wide as it doesn't slip under the library_sidebar.

## Screenshots

#### Before
<img width="817" alt="Screenshot 2021-08-07 at 21 41 27" src="https://user-images.githubusercontent.com/342977/128612196-545a7398-14fc-4b0d-beb7-d90f996402b5.png">

#### After
<img width="821" alt="Screenshot 2021-08-07 at 21 40 37" src="https://user-images.githubusercontent.com/342977/128612213-914cbf13-ae64-46c2-b5e3-fa94ea6d7782.png">
