### PR TITLE
Fix ingredient form field DOM ids

### DIFF
--- a/app/assets/stylesheets/alchemy/_extends.scss
+++ b/app/assets/stylesheets/alchemy/_extends.scss
@@ -31,14 +31,27 @@
   line-height: $form-field-line-height;
   transition: $transition-duration;
 
-  &:focus {
+  &:focus:not(.readonly) {
     @include default-focus-style($box-shadow: 0 0 0 1px $focus-color);
   }
 
-  &[disabled], .disabled {
+  &[disabled],
+  &.disabled,
+  &[readonly],
+  &.readonly {
     color: $form-field-disabled-text-color;
     background-color: $form-field-disabled-bg-color;
+    cursor: default;
+  }
+
+  &[disabled],
+  &.disabled {
     cursor: not-allowed;
+  }
+
+  &[readonly],
+  &.readonly {
+    pointer-events: none;
   }
 }
 

--- a/app/decorators/alchemy/ingredient_editor.rb
+++ b/app/decorators/alchemy/ingredient_editor.rb
@@ -64,8 +64,12 @@ module Alchemy
       "element[ingredients_attributes][#{form_field_counter}][#{column}]"
     end
 
+    # Returns a unique string to be passed to a form field id.
+    #
+    # @param column [String] A Ingredient column_name. Default is 'value'
+    #
     def form_field_id(column = "value")
-      "element_ingredients_attributes_#{form_field_counter}_#{column}"
+      "element_#{element.id}_ingredient_#{id}_#{column}"
     end
 
     # Fixes Rails partial renderer calling to_model on the object

--- a/app/views/alchemy/ingredients/_boolean_editor.html.erb
+++ b/app/views/alchemy/ingredients/_boolean_editor.html.erb
@@ -3,7 +3,7 @@
   data: boolean_editor.data_attributes do %>
   <%= element_form.fields_for(:ingredients, boolean_editor.ingredient) do |f| %>
     <%= f.label :value, style: "display: inline-block" do %>
-      <%= f.check_box :value %>
+      <%= f.check_box :value, id: nil %>
       <%= render_ingredient_role(boolean_editor) %>
     <% end %>
     <%= render_hint_for(boolean_editor) %>

--- a/app/views/alchemy/ingredients/_file_editor.html.erb
+++ b/app/views/alchemy/ingredients/_file_editor.html.erb
@@ -44,7 +44,9 @@
           },
           title: Alchemy.t(:edit_file_properties) %>
       </div>
-      <%= f.hidden_field :attachment_id, value: file_editor.attachment&.id %>
+      <%= f.hidden_field :attachment_id,
+        value: file_editor.attachment&.id,
+        id: file_editor.form_field_id(:attachment_id) %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/alchemy/ingredients/_headline_editor.html.erb
+++ b/app/views/alchemy/ingredients/_headline_editor.html.erb
@@ -3,7 +3,7 @@
   data: headline_editor.data_attributes do %>
   <%= element_form.fields_for(:ingredients, headline_editor.ingredient) do |f| %>
     <%= ingredient_label(headline_editor) %>
-    <%= f.text_field :value %>
+    <%= f.text_field :value, id: nil %>
 
     <div class="input-row">
       <% if headline_editor.level_options.length > 1 %>

--- a/app/views/alchemy/ingredients/_html_editor.html.erb
+++ b/app/views/alchemy/ingredients/_html_editor.html.erb
@@ -3,6 +3,6 @@
   data: html_editor.data_attributes do %>
   <%= element_form.fields_for(:ingredients, html_editor.ingredient) do |f| %>
     <%= ingredient_label(html_editor) %>
-    <%= f.text_area :value %>
+    <%= f.text_area :value, id: nil %>
   <% end %>
 <% end %>

--- a/app/views/alchemy/ingredients/_link_editor.html.erb
+++ b/app/views/alchemy/ingredients/_link_editor.html.erb
@@ -4,12 +4,12 @@
   <%= element_form.fields_for(:ingredients, link_editor.ingredient) do |f| %>
     <%= ingredient_label(link_editor) %>
     <%= f.text_field :value,
-      class: "thin_border text_with_icon disabled",
-      name: nil,
+      class: "thin_border text_with_icon readonly",
       id: link_editor.form_field_id,
-      disabled: true
+      "data-link-value": true,
+      readonly: true,
+      tabindex: -1
     %>
-    <%= f.hidden_field :value, "data-link-value": true, id: nil %>
     <%= f.hidden_field :link_title, "data-link-title": true, id: nil %>
     <%= f.hidden_field :link_class_name, "data-link-class": true, id: nil %>
     <%= f.hidden_field :link_target, "data-link-target": true, id: nil %>

--- a/app/views/alchemy/ingredients/_link_editor.html.erb
+++ b/app/views/alchemy/ingredients/_link_editor.html.erb
@@ -9,10 +9,10 @@
       id: link_editor.form_field_id,
       disabled: true
     %>
-    <%= f.hidden_field :value, "data-link-value": true %>
-    <%= f.hidden_field :link_title, "data-link-title": true %>
-    <%= f.hidden_field :link_class_name, "data-link-class": true %>
-    <%= f.hidden_field :link_target, "data-link-target": true %>
+    <%= f.hidden_field :value, "data-link-value": true, id: nil %>
+    <%= f.hidden_field :link_title, "data-link-title": true, id: nil %>
+    <%= f.hidden_field :link_class_name, "data-link-class": true, id: nil %>
+    <%= f.hidden_field :link_target, "data-link-target": true, id: nil %>
   <% end %>
   <%= render "alchemy/ingredients/shared/link_tools", ingredient_editor: link_editor %>
 <% end %>

--- a/app/views/alchemy/ingredients/_link_editor.html.erb
+++ b/app/views/alchemy/ingredients/_link_editor.html.erb
@@ -6,7 +6,7 @@
     <%= f.text_field :value,
       class: "thin_border text_with_icon disabled",
       name: nil,
-      id: nil,
+      id: link_editor.form_field_id,
       disabled: true
     %>
     <%= f.hidden_field :value, "data-link-value": true %>

--- a/app/views/alchemy/ingredients/_node_editor.html.erb
+++ b/app/views/alchemy/ingredients/_node_editor.html.erb
@@ -5,6 +5,7 @@
     <%= ingredient_label(node_editor, :node_id) %>
     <%= f.text_field :node_id,
       value: node_editor.node&.id,
+      id: node_editor.form_field_id(:node_id),
       class: 'alchemy_selectbox full_width' %>
   <% end %>
 <% end %>

--- a/app/views/alchemy/ingredients/_page_editor.html.erb
+++ b/app/views/alchemy/ingredients/_page_editor.html.erb
@@ -5,6 +5,7 @@
     <%= ingredient_label(page_editor, :page_id) %>
     <%= f.text_field :page_id,
       value: page_editor.page&.id,
+      id: page_editor.form_field_id(:page_id),
       class: 'alchemy_selectbox full_width' %>
   <% end %>
 <% end %>

--- a/app/views/alchemy/ingredients/_picture_editor.html.erb
+++ b/app/views/alchemy/ingredients/_picture_editor.html.erb
@@ -44,6 +44,7 @@
       </div>
     <% end %>
     <%= f.hidden_field :picture_id, value: picture_editor.picture&.id,
+      id: picture_editor.form_field_id(:picture_id),
       data: {
         picture_id: true,
         image_file_width: picture_editor.image_file_width,

--- a/app/views/alchemy/ingredients/_picture_editor.html.erb
+++ b/app/views/alchemy/ingredients/_picture_editor.html.erb
@@ -50,11 +50,11 @@
         image_file_width: picture_editor.image_file_width,
         image_file_height: picture_editor.image_file_height
       } %>
-    <%= f.hidden_field :link, data: { link_value: true } %>
-    <%= f.hidden_field :link_title, data: { link_title: true } %>
-    <%= f.hidden_field :link_class_name, data: { link_class: true } %>
-    <%= f.hidden_field :link_target, data: { link_target: true } %>
-    <%= f.hidden_field :crop_from, data: { crop_from: true } %>
-    <%= f.hidden_field :crop_size, data: { crop_size: true } %>
+    <%= f.hidden_field :link, data: { link_value: true }, id: nil %>
+    <%= f.hidden_field :link_title, data: { link_title: true }, id: nil %>
+    <%= f.hidden_field :link_class_name, data: { link_class: true }, id: nil %>
+    <%= f.hidden_field :link_target, data: { link_target: true }, id: nil %>
+    <%= f.hidden_field :crop_from, data: { crop_from: true }, id: nil %>
+    <%= f.hidden_field :crop_size, data: { crop_size: true }, id: nil %>
   <% end %>
 <% end %>

--- a/app/views/alchemy/ingredients/_select_editor.html.erb
+++ b/app/views/alchemy/ingredients/_select_editor.html.erb
@@ -22,6 +22,7 @@
         options_tags = options_for_select(select_values, select_editor.value)
       end %>
       <%= f.select :value, options_tags, {}, {
+        id: nil,
         class: ["alchemy_selectbox", "ingredient-editor-select"]
       } %>
     <% end %>

--- a/app/views/alchemy/ingredients/_text_editor.html.erb
+++ b/app/views/alchemy/ingredients/_text_editor.html.erb
@@ -7,12 +7,13 @@
     <%= ingredient_label(text_editor) %>
     <%= f.text_field :value,
       class: text_editor.settings[:linkable] ? "text_with_icon" : "",
+      id: nil,
       type: text_editor.settings[:input_type] || "text" %>
     <% if text_editor.settings[:linkable] %>
-      <%= f.hidden_field :link, "data-link-value": true %>
-      <%= f.hidden_field :link_title, "data-link-title": true %>
-      <%= f.hidden_field :link_class_name, "data-link-class": true%>
-      <%= f.hidden_field :link_target, "data-link-target": true %>
+      <%= f.hidden_field :link, "data-link-value": true, id: nil %>
+      <%= f.hidden_field :link_title, "data-link-title": true, id: nil %>
+      <%= f.hidden_field :link_class_name, "data-link-class": true, id: nil %>
+      <%= f.hidden_field :link_target, "data-link-target": true, id: nil %>
       <%= render "alchemy/ingredients/shared/link_tools", ingredient_editor: text_editor %>
     <% end %>
   <% end %>

--- a/spec/decorators/alchemy/ingredient_editor_spec.rb
+++ b/spec/decorators/alchemy/ingredient_editor_spec.rb
@@ -67,12 +67,12 @@ RSpec.describe Alchemy::IngredientEditor do
 
   describe "#form_field_id" do
     it "returns a id value for form fields with ingredient as default" do
-      expect(ingredient_editor.form_field_id).to eq("element_ingredients_attributes_0_value")
+      expect(ingredient_editor.form_field_id).to eq("element_#{element.id}_ingredient_#{ingredient.id}_value")
     end
 
     context "with a value given" do
       it "returns a id value for form fields for that column" do
-        expect(ingredient_editor.form_field_id(:link_title)).to eq("element_ingredients_attributes_0_link_title")
+        expect(ingredient_editor.form_field_id(:link_title)).to eq("element_#{element.id}_ingredient_#{ingredient.id}_link_title")
       end
     end
   end

--- a/spec/helpers/alchemy/admin/ingredients_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/ingredients_helper_spec.rb
@@ -11,14 +11,14 @@ describe Alchemy::Admin::IngredientsHelper do
     subject { helper.ingredient_label(ingredient_editor) }
 
     it "has for attribute set to ingredient form field id" do
-      is_expected.to have_selector('label[for="element_ingredients_attributes_0_value"]')
+      is_expected.to have_selector("label[for='element_#{element.id}_ingredient_#{ingredient.id}_value']")
     end
 
     context "with another column given" do
       subject { helper.ingredient_label(ingredient_editor, :picture_id) }
 
       it "has for attribute set to ingredient form field id for that column" do
-        is_expected.to have_selector('label[for="element_ingredients_attributes_0_picture_id"]')
+        is_expected.to have_selector("label[for='element_#{element.id}_ingredient_#{ingredient.id}_picture_id']")
       end
     end
 

--- a/spec/views/alchemy/ingredients/link_editor_spec.rb
+++ b/spec/views/alchemy/ingredients/link_editor_spec.rb
@@ -26,12 +26,11 @@ RSpec.describe "alchemy/ingredients/_link_editor" do
 
   it_behaves_like "an alchemy ingredient editor"
 
-  it "renders a disabled text input field" do
-    is_expected.to have_selector('input[type="text"][disabled]')
+  it "renders a readonly text input field" do
+    is_expected.to have_selector('input[type="text"][readonly]')
   end
 
   it "renders link buttons" do
-    is_expected.to have_selector('input[type="hidden"][name="element[ingredients_attributes][0][value]"]')
     is_expected.to have_selector('input[type="hidden"][name="element[ingredients_attributes][0][link_title]"]')
     is_expected.to have_selector('input[type="hidden"][name="element[ingredients_attributes][0][link_class_name]"]')
     is_expected.to have_selector('input[type="hidden"][name="element[ingredients_attributes][0][link_target]"]')


### PR DESCRIPTION
## What is this pull request for?

Before the IDs where not unique; producing duplicated DOM ids for multiple instances of the same element type on the same page.

Since we want to be able to access the input via JS we need to have a unique DOM ID.

Also removes a lot of superfluous DOM ids that Rails generates to reduce DOM warnings. 

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
