### PR TITLE
Touch parent node on move

### DIFF
--- a/app/models/alchemy/node.rb
+++ b/app/models/alchemy/node.rb
@@ -7,6 +7,7 @@ module Alchemy
     before_destroy :check_if_related_essence_nodes_present
 
     acts_as_nested_set scope: "language_id", touch: true
+    after_move :touch_parent
     stampable stamper_class_name: Alchemy.user_class_name
 
     belongs_to :language, class_name: "Alchemy::Language"
@@ -90,6 +91,10 @@ module Alchemy
 
     def set_menu_type_from_root
       self.menu_type = root.menu_type
+    end
+
+    def touch_parent
+      parent.touch
     end
   end
 end

--- a/spec/requests/alchemy/api/nodes_controller_spec.rb
+++ b/spec/requests/alchemy/api/nodes_controller_spec.rb
@@ -78,6 +78,7 @@ module Alchemy
         end
 
         it "returns JSON and moves the node" do
+          expect(page_node).to receive(:touch)
           expect(page_node.children).to be_empty
           expect(url_node.lft).to eq(6)
           patch alchemy.move_api_node_path(url_node, format: :json), params: {


### PR DESCRIPTION
## What is this pull request for?

If we move the nodes in the menu there is no way to invalidate the cache.
In this way we touch the parent (and this will touch the parent of the parent, till the root node), invalidating the wrapper fragment cache for the menu.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
