### PR TITLE
Return only pages from current site in api

### DIFF
--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -7,11 +7,10 @@ module Alchemy
     # Returns all pages as json object
     #
     def index
+      @pages = Language.current&.pages.presence || Alchemy::Page.none
       # Fix for cancancan not able to merge multiple AR scopes for logged in users
-      if can? :edit_content, Alchemy::Page
-        @pages = Page.all
-      else
-        @pages = Page.accessible_by(current_ability, :index)
+      if cannot? :edit_content, Alchemy::Page
+        @pages = @pages.accessible_by(current_ability, :index)
       end
       @pages = @pages.includes(*page_includes)
       @pages = @pages.ransack(params[:q]).result

--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -7,10 +7,12 @@ module Alchemy
     # Returns all pages as json object
     #
     def index
-      @pages = Language.current&.pages.presence || Alchemy::Page.none
       # Fix for cancancan not able to merge multiple AR scopes for logged in users
       if cannot? :edit_content, Alchemy::Page
-        @pages = @pages.accessible_by(current_ability, :index)
+        @pages = Alchemy::Page.accessible_by(current_ability, :index)
+        @pages = @pages.where(language: Language.current)
+      else
+        @pages = Language.current&.pages.presence || Alchemy::Page.none
       end
       @pages = @pages.includes(*page_includes)
       @pages = @pages.ransack(params[:q]).result

--- a/spec/controllers/alchemy/api/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/api/pages_controller_spec.rb
@@ -80,6 +80,18 @@ module Alchemy
             expect(result["pages"].size).to eq(1)
           end
         end
+
+        context "with multiple sites" do
+          let(:site_2) { create(:alchemy_site) }
+          let(:language_2) { create(:alchemy_language, site: site_2) }
+          let!(:site_2_page) { create(:alchemy_page, :public, language: language_2) }
+
+          it "only returns pages for current site" do
+            get :index, format: :json
+
+            expect(result["pages"].map { |r| r["id"] }).to_not include(site_2_page.id)
+          end
+        end
       end
 
       describe "#nested" do


### PR DESCRIPTION
## What is this pull request for?

If we search the internal page to be linked when we create a node in the menu, the results span all the websites.
This is for me not necessary and it gives troubles if many pages have the same name and paths.

### Notable changes (remove if none)

This PR filter the pages to be the ones available only in the current alchemy site.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
