### PR TITLE
Ensure I18n can find the translation key for boolean ingredients

### DIFF
--- a/app/models/alchemy/ingredients/boolean.rb
+++ b/app/models/alchemy/ingredients/boolean.rb
@@ -14,7 +14,7 @@ module Alchemy
       # Used by the Element#preview_text method.
       #
       def preview_text(_max_length = nil)
-        Alchemy.t(value, scope: "ingredient_values.boolean")
+        Alchemy.t(value.to_s, scope: "ingredient_values.boolean")
       end
     end
   end


### PR DESCRIPTION
Before this change we were passing a boolean type in to `I18n.t` which failed to find the according translation. This bubbled up to even raise an error when rendering the `admin/elements/_header` view partial when the boolean ingredient is used for the preview text.

Solution: Passing a `String` instead of `Boolean` to `I18n.t` fixes the issue.

Fixes #2175
