### PR TITLE
Ingredient by role block level helper

### DIFF
--- a/app/helpers/alchemy/elements_block_helper.rb
+++ b/app/helpers/alchemy/elements_block_helper.rb
@@ -77,6 +77,12 @@ module Alchemy
       end
 
       deprecate essence: "Use `ingredient_by_role` instead", deprecator: Alchemy::Deprecation
+
+      # Return's the ingredient record by given role.
+      #
+      def ingredient_by_role(role)
+        element.ingredient_by_role(role)
+      end
     end
 
     # Block-level helper for element views. Constructs a DOM element wrapping

--- a/spec/helpers/alchemy/elements_block_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_block_helper_spec.rb
@@ -171,6 +171,15 @@ module Alchemy
           end
         end
       end
+
+      describe "#ingredient_by_role" do
+        let(:element) { create(:alchemy_element, :with_ingredients) }
+        let(:ingredient) { element.ingredient_by_role(:headline) }
+
+        it "returns the ingredient record by role" do
+          expect(subject.ingredient_by_role(:headline)).to eq(ingredient)
+        end
+      end
     end
   end
 end

--- a/spec/helpers/alchemy/elements_block_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_block_helper_spec.rb
@@ -79,7 +79,9 @@ module Alchemy
               },
               html_options: {},
             })
-            subject.render(:headline, foo: "bar")
+            Alchemy::Deprecation.silence do
+              subject.render(:headline, foo: "bar")
+            end
           end
         end
 
@@ -102,7 +104,9 @@ module Alchemy
       describe "#content" do
         it "should delegate to the element's #content_by_name method" do
           expect(element).to receive(:content_by_name).with(:title)
-          subject.content :title
+          Alchemy::Deprecation.silence do
+            subject.content :title
+          end
         end
       end
 
@@ -162,7 +166,9 @@ module Alchemy
             mock_model("Content", essence: mock_model("EssenceText"))
           end
 
-          subject.essence :title
+          Alchemy::Deprecation.silence do
+            subject.essence :title
+          end
         end
       end
     end


### PR DESCRIPTION
## What is this pull request for?

Add `ingredient_by_role` element block helper

The ingredient equivalent to `el.essence` and `el.content`

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
