### PR TITLE
Fix ingredient editor selector in element update callback

### DIFF
--- a/app/views/alchemy/admin/elements/update.js.erb
+++ b/app/views/alchemy/admin/elements/update.js.erb
@@ -1,7 +1,7 @@
 (function() {
   var $el = $('#element_<%= @element.id %>');
   var $errors = $('#element_<%= @element.id %>_errors');
-  $('> .element-content .content_editor, > .element-content .ingredient_editor', $el).removeClass('validation_failed');
+  $('> .element-content .content_editor, > .element-content .ingredient-editor', $el).removeClass('validation_failed');
 
 <%- if @element_validated -%>
 


### PR DESCRIPTION
## What is this pull request for?

The ingredient editor class name has a hyphen. Fixes a bug
where an element with failed ingredient validation did not
updated the UI accordingly after an element updated.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
