### PR TITLE
Load custom Tinymce config for ingredients

### DIFF
--- a/app/views/alchemy/admin/pages/edit.html.erb
+++ b/app/views/alchemy/admin/pages/edit.html.erb
@@ -138,7 +138,7 @@
 <% end %>
 
 <% content_for :javascripts do %>
-<% if Alchemy::Tinymce.custom_config_contents(@page).present? %>
+<% if Alchemy::Tinymce.custom_configs_present?(@page) %>
   <%= render 'tinymce_custom_config' %>
 <% end %>
 

--- a/lib/alchemy/tinymce.rb
+++ b/lib/alchemy/tinymce.rb
@@ -34,6 +34,10 @@ module Alchemy
         @@init
       end
 
+      def custom_configs_present?(page)
+        custom_config_contents(page).any? || custom_config_ingredients(page).any?
+      end
+
       def custom_config_contents(page)
         content_definitions_from_elements(page.descendent_element_definitions)
       end

--- a/spec/libraries/tinymce_spec.rb
+++ b/spec/libraries/tinymce_spec.rb
@@ -40,6 +40,42 @@ module Alchemy
         }
       end
 
+      describe ".custom_configs_present?" do
+        let(:page) { build_stubbed(:alchemy_page) }
+
+        subject { described_class.custom_configs_present?(page) }
+
+        context "if custom_config_contents are present" do
+          before do
+            expect(described_class).to receive(:custom_config_contents) { [:foo] }
+          end
+
+          it { is_expected.to be(true) }
+        end
+
+        context "if no custom_config_contents are present" do
+          before do
+            expect(described_class).to receive(:custom_config_contents) { [] }
+          end
+
+          context "but custom_config_ingredients are present" do
+            before do
+              expect(described_class).to receive(:custom_config_ingredients) { [:foo] }
+            end
+
+            it { is_expected.to be(true) }
+          end
+
+          context "and no custom_config_ingredients are present" do
+            before do
+              expect(described_class).to receive(:custom_config_ingredients) { [] }
+            end
+
+            it { is_expected.to be(false) }
+          end
+        end
+      end
+
       describe ".custom_config_contents" do
         let(:page) { build_stubbed(:alchemy_page) }
 

--- a/spec/requests/alchemy/admin/pages_controller_spec.rb
+++ b/spec/requests/alchemy/admin/pages_controller_spec.rb
@@ -578,6 +578,14 @@ module Alchemy
             expect_any_instance_of(Page).to receive(:lock_to!)
             get edit_admin_page_path(page)
           end
+
+          context "if custom tinymce configs are present" do
+            it "adds the custom config to the head" do
+              expect(Alchemy::Tinymce).to receive(:custom_configs_present?).with(page) { true }
+              get edit_admin_page_path(page)
+              expect(response.body).to match(/Populate custom tinymce configurations/)
+            end
+          end
         end
 
         context "if page is scoped" do


### PR DESCRIPTION
## What is this pull request for?

The custom tinymce config setup script was not loaded for elements with ingredients.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
