### PR TITLE
Remove data store accessor from ingredient base class

### DIFF
--- a/app/models/alchemy/ingredient.rb
+++ b/app/models/alchemy/ingredient.rb
@@ -118,11 +118,6 @@ module Alchemy
       value.to_s[0..maxlength - 1]
     end
 
-    # Cross DB adapter data accessor that works
-    def data
-      @_data ||= (self[:data] || {}).with_indifferent_access
-    end
-
     # The path to the view partial of the ingredient
     # @return [String]
     def to_partial_path


### PR DESCRIPTION
## What is this pull request for?

Remove data store accessor from ingredient base class

This was necessary before we started to use Rails' data store feature in
https://github.com/AlchemyCMS/alchemy_cms/pull/2171

This currently leads to weird bugs around active record dirty falsy thinking
the attribute set is not dirty, leading
to the data store not being saved.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
