### PR TITLE
Remove spec that tests default data store value

### DIFF
--- a/lib/alchemy/test_support/shared_ingredient_examples.rb
+++ b/lib/alchemy/test_support/shared_ingredient_examples.rb
@@ -16,7 +16,6 @@ RSpec.shared_examples_for "an alchemy ingredient" do
   it { is_expected.to belong_to(:related_object).optional }
   it { is_expected.to validate_presence_of(:role) }
   it { is_expected.to validate_presence_of(:type) }
-  it { expect(subject.data).to eq({}) }
 
   describe "#settings" do
     subject { ingredient.settings }


### PR DESCRIPTION
Do not expect that an ingredient data is an empty Hash

In MySQL/MariaDB and sqlite you cannot set an default value
to a json column. Since we use Rails' data store feature
and this works without the default db value we can simply
remove that spec.

Follow up to #2183 