### PR TITLE
Do not validate element during toggle fold and create

### DIFF
--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -32,14 +32,14 @@ module Alchemy
           if @paste_from_clipboard = params[:paste_from_clipboard].present?
             @element = paste_element_from_clipboard
           else
-            @element = Element.create(create_element_params)
+            @element = Element.new(create_element_params)
           end
           if @page.definition["insert_elements_at"] == "top"
             @insert_at_top = true
-            @element.move_to_top
+            @element.position = 1
           end
         end
-        if @element.valid?
+        if @element.save
           render :create
         else
           @element.page_version = @page_version

--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -91,10 +91,14 @@ module Alchemy
         end
       end
 
+      # Toggle fodls the element and persists the state in the db
+      #
+      # Ingredient validations might make the element invalid.
+      # In this case we are just toggling a UI state and do not care about the validations.
       def fold
         @page = @element.page
         @element.folded = !@element.folded
-        @element.save
+        @element.save(validate: false)
       end
 
       private

--- a/spec/controllers/alchemy/admin/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/elements_controller_spec.rb
@@ -189,6 +189,16 @@ module Alchemy
           expect(subject).to render_template(:new)
         end
       end
+
+      context "with ingredient validations" do
+        subject do
+          post :create, params: { element: { page_version_id: page_version.id, name: "all_you_can_eat_ingredients" } }, xhr: true
+        end
+
+        it "creates element without error" do
+          expect(subject).to render_template(:create)
+        end
+      end
     end
 
     describe "#update" do

--- a/spec/requests/alchemy/admin/elements_controller_spec.rb
+++ b/spec/requests/alchemy/admin/elements_controller_spec.rb
@@ -36,6 +36,15 @@ RSpec.describe Alchemy::Admin::ElementsController do
         post fold_admin_element_path(id: element.id, format: :js)
         expect(response.body).to include("Alchemy.Tinymce.init([#{element.ingredient_by_role(:text).id}]);")
       end
+
+      context "with validations" do
+        let(:element) { create(:alchemy_element, :with_ingredients, name: :all_you_can_eat_ingredients) }
+
+        it "saves without running validations" do
+          post fold_admin_element_path(id: element.id, format: :js)
+          expect(element.reload).to be_folded
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## What is this pull request for?

Elements with ingredient validations might get invalid on update. Since we do not care about the validations during toggling a UI state we skip them.

If an element has ingredient validations creating it first and calling `valid?` after that triggers the on update validation callback. Resulting in returning the new template instead.

Solved by only building the element and saving it later. This does not trigger the on update callback.
To spare an extra save we set the elements position instead of moving it down.
The only unnecessary ave we could not prevent is if we paste from clipboard.
But this is acceptable.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
