### PR TITLE
Fix element with ingredients preview text

### DIFF
--- a/app/models/alchemy/element/presenters.rb
+++ b/app/models/alchemy/element/presenters.rb
@@ -99,12 +99,12 @@ module Alchemy
       # The ingredient that's used for element's preview text.
       #
       # It tries to find one of element's ingredients that is defined +as_element_title+.
-      # Takes element's first ingredient if no ingredient is defined +as_element_title+.
+      # Takes element's first defined ingredient if no ingredient is defined +as_element_title+.
       #
       # @return (Alchemy::Ingredient)
       #
       def preview_ingredient
-        @_preview_ingredient ||= ingredients.detect(&:preview_ingredient?) || ingredients.first
+        @_preview_ingredient ||= ingredients.detect(&:preview_ingredient?) || first_ingredient_by_definition
       end
 
       private
@@ -121,6 +121,13 @@ module Alchemy
 
       def preview_text_from_preview_ingredient(maxlength)
         preview_ingredient&.preview_text(maxlength)
+      end
+
+      def first_ingredient_by_definition
+        return if ingredient_definitions.empty?
+
+        role = ingredient_definitions.first["role"]
+        ingredients.detect { |ingredient| ingredient.role == role }
       end
     end
   end

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -519,18 +519,20 @@ module Alchemy
       let(:element) { build_stubbed(:alchemy_element) }
 
       context "with element having ingredients" do
+        let(:element) { build_stubbed(:alchemy_element, :with_ingredients) }
+
         let(:ingredient) do
-          mock_model(Ingredients::Text, preview_text: "Ingredient 1", preview_ingredient?: false)
+          mock_model(Ingredients::Text, role: "foo", preview_text: "Ingredient 1", preview_ingredient?: false)
         end
 
         let(:ingredient_2) do
-          mock_model(Ingredients::Text, preview_text: "Ingredient 2", preview_ingredient?: false)
+          mock_model(Ingredients::Text, role: "headline", preview_text: "Ingredient 2", preview_ingredient?: false)
         end
 
         let(:ingredients) { [] }
 
         let(:preview_ingredient) do
-          mock_model(Ingredients::Text, preview_text: "Preview Ingredient", preview_ingredient?: true)
+          mock_model(Ingredients::Text, role: "bar", preview_text: "Preview Ingredient", preview_ingredient?: true)
         end
 
         before do
@@ -541,7 +543,7 @@ module Alchemy
           let(:ingredients) { [ingredient, ingredient_2] }
 
           it "returns the preview text of first ingredient found" do
-            expect(ingredient).to receive(:preview_text).with(60)
+            expect(ingredient_2).to receive(:preview_text).with(60)
             element.preview_text
           end
         end
@@ -615,14 +617,24 @@ module Alchemy
           build_stubbed(:alchemy_element, name: "slide")
         end
 
+        let(:content_2) do
+          mock_model(Content, preview_text: "Content 2", preview_content?: false)
+        end
+
         before do
           allow(nested_element).to receive(:contents) { [content_2] }
           allow(element).to receive(:all_nested_elements) { [nested_element] }
         end
 
         context "when parent element has ingredients" do
+          let(:element) { build_stubbed(:alchemy_element, :with_ingredients) }
+
+          let(:nested_element) do
+            build_stubbed(:alchemy_element, :with_ingredients, name: "slide")
+          end
+
           let(:ingredient) do
-            mock_model(Ingredients::Text, preview_text: "Ingredient 1", preview_ingredient?: false)
+            mock_model(Ingredients::Text, role: "headline", preview_text: "Ingredient 1", preview_ingredient?: false)
           end
 
           before do
@@ -636,8 +648,11 @@ module Alchemy
         end
 
         context "when parent element has no ingredients but nestable element has" do
+          let(:element) { build_stubbed(:alchemy_element, :with_ingredients) }
+          let(:nested_element) { build_stubbed(:alchemy_element, :with_ingredients) }
+
           let(:ingredient) do
-            mock_model(Ingredients::Text, preview_text: "Ingredient 1", preview_ingredient?: false)
+            mock_model(Ingredients::Text, role: "headline", preview_text: "Ingredient 1", preview_ingredient?: false)
           end
 
           before do


### PR DESCRIPTION
## What is this pull request for?

Since we do not have a position column the order of elements ingredients is arbitrary.

Because of that the first ingredient is not always the first one defined.
Leading to the preview text sometimes not displaying if no explicit
`as_element_title` ingredient is defined.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
