### PR TITLE
Use self_and_ancestors in page_active? helper

### DIFF
--- a/app/helpers/alchemy/pages_helper.rb
+++ b/app/helpers/alchemy/pages_helper.rb
@@ -100,7 +100,7 @@ module Alchemy
 
     # Returns true if page is in the active branch
     def page_active?(page)
-      @_page_ancestors ||= Page.ancestors_for(@page)
+      @_page_ancestors ||= @page.self_and_ancestors.contentpages
       @_page_ancestors.include?(page)
     end
 

--- a/spec/helpers/alchemy/pages_helper_spec.rb
+++ b/spec/helpers/alchemy/pages_helper_spec.rb
@@ -357,5 +357,36 @@ module Alchemy
         expect(helper.picture_essence_caption(content)).to eq "my caption"
       end
     end
+
+    describe "#page_active?" do
+      let(:child_page) { create(:alchemy_page, parent: public_page) }
+
+      before do
+        @page = current_page
+      end
+
+      subject { helper.page_active?(passed_page) }
+
+      context "passed page is the current page" do
+        let(:passed_page) { public_page }
+        let(:current_page) { public_page }
+
+        it { is_expected.to be true }
+      end
+
+      context "passed page is an ancestor of the current page" do
+        let(:current_page) { child_page }
+        let(:passed_page) { public_page }
+
+        it { is_expected.to be true }
+      end
+
+      context "passed page is in another branch of the page tree" do
+        let(:passed_page) { create(:alchemy_page, parent: language_root) }
+        let(:current_page) { public_page }
+
+        it { is_expected.to be false }
+      end
+    end
   end
 end


### PR DESCRIPTION
This helper used a method that has been removed in #1813.
I'm also adding some specs.
