### PR TITLE
don't use existing element names when migrating from cells

### DIFF
--- a/lib/alchemy/upgrader/four_point_two.rb
+++ b/lib/alchemy/upgrader/four_point_two.rb
@@ -1,5 +1,6 @@
 require_relative 'tasks/picture_gallery_upgrader'
 require_relative 'tasks/picture_gallery_migration'
+require_relative 'tasks/cell_name_migrator'
 require_relative 'tasks/cells_upgrader'
 require_relative 'tasks/cells_migration'
 require_relative 'tasks/element_partial_name_variable_updater'

--- a/lib/alchemy/upgrader/tasks/cell_name_migrator.rb
+++ b/lib/alchemy/upgrader/tasks/cell_name_migrator.rb
@@ -1,0 +1,19 @@
+module Alchemy::Upgrader::Tasks
+  class CellNameMigrator
+    class << self
+      def call(cell_name)
+        element_name_exists = existing_element_names.find { |name| name == cell_name }
+        element_name_exists ? "#{cell_name}_elements" : cell_name
+      end
+
+      private
+
+      def existing_element_names
+        @_existing_element_names ||= begin
+          elements_file_path = Rails.root.join('config', 'alchemy', 'elements.yml')
+          YAML.load_file(elements_file_path).map { |element| element['name'] }
+        end
+      end  
+    end
+  end
+end

--- a/lib/alchemy/upgrader/tasks/cells_migration.rb
+++ b/lib/alchemy/upgrader/tasks/cells_migration.rb
@@ -26,7 +26,7 @@ module Alchemy::Upgrader::Tasks
     def migrate_cell!(cell)
       # bust element definitions insta cache
       Alchemy::Element.instance_variable_set('@definitions', nil)
-      fixed_element = Alchemy::Element.find_or_initialize_by(fixed: true, name: cell.name, page: cell.page)
+      fixed_element = Alchemy::Element.find_or_initialize_by(fixed: true, name: CellNameMigrator.call(cell.name), page: cell.page)
       elements = Alchemy::Element.where(cell_id: cell.id).order(position: :asc)
 
       if fixed_element.new_record?


### PR DESCRIPTION
## What is this pull request for?

The upgrader writes new fixed elements to the elements.yml for each
cell definition it finds in the cells.yml file. If there is an element
with the same name as the cell, we get two elements with the same name:
the original one and the new fixed one. This leads to problems when you
are searching for specific elements by name in your code.

Now the upgrader checks if the name already  exists before we add a
new fixed element and add `_elements` if we find an existing elements
name.

Most of the time the cells with the same name as existing elements
are used as a vehicle to group multiple elements to get a more
complex element.

### Notable changes

The upgrader adds `_elements` to a cell name to prevent having multiple elements with the same name. That means that the name of the new fixed element may not be the same as the old cell name it was generated from.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
