### PR TITLE
Support AR enums in resource models

### DIFF
--- a/app/views/alchemy/admin/resources/_form.html.erb
+++ b/app/views/alchemy/admin/resources/_form.html.erb
@@ -8,6 +8,11 @@
         input_html: {class: 'alchemy_selectbox'} %>
     <% elsif attribute[:type].in? %i[date time datetime] %>
       <%= f.datepicker attribute[:name], resource_attribute_field_options(attribute) %>
+    <% elsif attribute[:enum].present? %>
+      <%= f.input attribute[:name],
+        collection: attribute[:enum],
+        include_blank: Alchemy.t(:blank, scope: 'resources.relation_select'),
+        input_html: {class: 'alchemy_selectbox'} %>
     <% else %>
       <%= f.input attribute[:name], resource_attribute_field_options(attribute) %>
     <% end %>

--- a/lib/alchemy/resource.rb
+++ b/lib/alchemy/resource.rb
@@ -169,8 +169,23 @@ module Alchemy
           name: col.name,
           type: resource_column_type(col),
           relation: resource_relation(col.name),
-        }.delete_if { |_k, v| v.nil? }
+          enum: enum_values_collection_for_select(col.name),
+        }.delete_if { |_k, v| v.blank? }
       end.compact
+    end
+
+    def enum_values_collection_for_select(column_name)
+      enum = model.defined_enums[column_name]
+      return if enum.blank?
+
+      enum.keys.map do |key|
+        [
+          ::I18n.t(key, scope: [
+            :activerecord, :attributes, model.model_name.i18n_key, "#{column_name}_values"
+          ], default: key.humanize),
+          key,
+        ]
+      end
     end
 
     def sorted_attributes

--- a/spec/dummy/app/models/event.rb
+++ b/spec/dummy/app/models/event.rb
@@ -5,6 +5,12 @@ class Event < ActiveRecord::Base
 
   validates_presence_of :name
   belongs_to :location
+
+  enum event_type: {
+    expo: 0,
+    workshop: 1,
+  }
+
   before_destroy :abort_if_name_is_undestructible
 
   scope :starting_today, -> { where(starts_at: Time.current.at_midnight..Date.tomorrow.at_midnight) }

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -10,5 +10,9 @@ en:
     attributes:
       event:
         tag_names: Tags
+        event_type: Type
+        event_type_values:
+          expo: exposition
+          workshop: workshop
       location:
         tag_names: Tags

--- a/spec/dummy/db/migrate/20211105175532_add_event_type_to_events.rb
+++ b/spec/dummy/db/migrate/20211105175532_add_event_type_to_events.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEventTypeToEvents < ActiveRecord::Migration[5.2]
+  def change
+    add_column :events, :event_type, :integer, null: false, default: 0
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_08_091432) do
+ActiveRecord::Schema.define(version: 2021_11_05_175532) do
 
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string "name"
@@ -364,6 +364,7 @@ ActiveRecord::Schema.define(version: 2021_05_08_091432) do
     t.integer "location_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "event_type", default: 0, null: false
   end
 
   create_table "gutentag_taggings", force: :cascade do |t|

--- a/spec/features/admin/resources_integration_spec.rb
+++ b/spec/features/admin/resources_integration_spec.rb
@@ -187,7 +187,15 @@ RSpec.describe "Resources", type: :system do
     it "should have a select box for associated models" do
       visit "/admin/events/new"
       within("form") do
-        expect(page).to have_selector("select")
+        expect(page).to have_selector("select#event_location_id")
+      end
+    end
+
+    it "should have a select box for enums values" do
+      visit "/admin/events/new"
+
+      within("form") do
+        expect(page).to have_selector("select#event_event_type")
       end
     end
 


### PR DESCRIPTION
This PR adds support for ActiveRecord enums, in the context of Alchemy resource models.
If a resource model has enum values defined they'll be rendered in a select box within the resource form.

Example view
<img width="496" alt="Screenshot 2021-11-05 at 16 55 58" src="https://user-images.githubusercontent.com/342977/140544148-68f6ef14-8603-47ae-90a7-aa7a3d41236c.png">


If we agree on this proposal I can add a test as well. I think adding a spec shouldn't be a big deal.