### PR TITLE
Allow all possible args in tagged_with method

### DIFF
--- a/lib/alchemy/taggable.rb
+++ b/lib/alchemy/taggable.rb
@@ -22,13 +22,20 @@ module Alchemy
     end
 
     module ClassMethods
-      # Find all records matching all of the given tags.
-      # Separate multiple tags by comma.
-      def tagged_with(names)
+      def tagged_with(names = [], **args)
         if names.is_a? String
           names = names.split(/,\s*/)
         end
-        super(names: names, match: :all)
+
+        unless args[:match]
+          args.merge!(match: :all)
+        end
+
+        if names.any?
+          args.merge!(names: names)
+        end
+
+        super(args)
       end
 
       # Returns all unique tags


### PR DESCRIPTION
Previously, we only allowed tag names to be passed into the `tagged_with` method. This commit allows to take advantage of the interface gutentag has to offer, while being backwards compatible.

Closes #2208 

If we agree on this proposed implementation I can add a couple of specs to cover the change.