### PR TITLE
Set stampable user_class_name without root identifier

### DIFF
--- a/app/models/alchemy/attachment.rb
+++ b/app/models/alchemy/attachment.rb
@@ -28,7 +28,7 @@ module Alchemy
       after_assign { |f| write_attribute(:file_mime_type, f.mime_type) }
     end
 
-    stampable stamper_class_name: Alchemy.user_class_name
+    stampable stamper_class_name: Alchemy.user_class.name
 
     has_many :essence_files, class_name: 'Alchemy::EssenceFile', foreign_key: 'attachment_id'
     has_many :contents, through: :essence_files

--- a/app/models/alchemy/content.rb
+++ b/app/models/alchemy/content.rb
@@ -28,7 +28,7 @@ module Alchemy
     belongs_to :element, touch: true, inverse_of: :contents
     has_one :page, through: :element
 
-    stampable stamper_class_name: Alchemy.user_class_name
+    stampable stamper_class_name: Alchemy.user_class.name
 
     acts_as_list scope: [:element_id]
 

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -58,7 +58,7 @@ module Alchemy
     #
     acts_as_list scope: [:page_id, :fixed, :parent_element_id]
 
-    stampable stamper_class_name: Alchemy.user_class_name
+    stampable stamper_class_name: Alchemy.user_class.name
 
     has_many :contents, -> { order(:position) }, dependent: :destroy, inverse_of: :element
 

--- a/app/models/alchemy/node.rb
+++ b/app/models/alchemy/node.rb
@@ -5,7 +5,7 @@ module Alchemy
     VALID_URL_REGEX = /\A(\/|\D[a-z\+\d\.\-]+:)/
 
     acts_as_nested_set scope: 'language_id', touch: true
-    stampable stamper_class_name: Alchemy.user_class_name
+    stampable stamper_class_name: Alchemy.user_class.name
 
     belongs_to :site, class_name: 'Alchemy::Site'
     belongs_to :language, class_name: 'Alchemy::Language'

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -85,7 +85,7 @@ module Alchemy
 
     acts_as_nested_set(dependent: :destroy)
 
-    stampable stamper_class_name: Alchemy.user_class_name
+    stampable stamper_class_name: Alchemy.user_class.name
 
     belongs_to :language, optional: true
 

--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -74,7 +74,7 @@ module Alchemy
       case_sensitive: false,
       message: Alchemy.t("not a valid image")
 
-    stampable stamper_class_name: Alchemy.user_class_name
+    stampable stamper_class_name: Alchemy.user_class.name
 
     scope :named, ->(name) {
       where("#{table_name}.name LIKE ?", "%#{name}%")

--- a/lib/alchemy/essence.rb
+++ b/lib/alchemy/essence.rb
@@ -48,7 +48,7 @@ module Alchemy #:nodoc:
         class_eval <<-RUBY, __FILE__, __LINE__ + 1
           attr_writer :validation_errors
           include Alchemy::Essence::InstanceMethods
-          stampable stamper_class_name: Alchemy.user_class_name
+          stampable stamper_class_name: Alchemy.user_class.name
           validate :validate_ingredient, on: :update, if: -> { validations.any? }
 
           has_one :content, as: :essence, class_name: "Alchemy::Content", inverse_of: :essence

--- a/lib/alchemy/userstamp.rb
+++ b/lib/alchemy/userstamp.rb
@@ -7,6 +7,6 @@
 if Alchemy.user_class < ActiveRecord::Base
   Alchemy.user_class.class_eval do
     model_stamper
-    stampable stamper_class_name: Alchemy.user_class_name
+    stampable stamper_class_name: Alchemy.user_class.name
   end
 end


### PR DESCRIPTION
Since Alchemy always prepends a root constant identifier to
the user_class_name getter and userstamp (the originator gem)
does the same this can lead to wrong constant names under
some circumstances.

Making sure we never set a root constant identifier by using class.name
