### PR TITLE
Set stampable user_class_name without root identifier

### DIFF
--- a/app/models/alchemy/attachment.rb
+++ b/app/models/alchemy/attachment.rb
@@ -28,7 +28,7 @@ module Alchemy
       after_assign { |f| write_attribute(:file_mime_type, f.mime_type) }
     end
 
-    stampable stamper_class_name: Alchemy.user_class_name
+    stampable stamper_class_name: Alchemy.user_class.name
 
     has_many :essence_files, class_name: "Alchemy::EssenceFile", foreign_key: "attachment_id"
     has_many :contents, through: :essence_files

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -57,7 +57,7 @@ module Alchemy
     #
     acts_as_list scope: [:page_version_id, :fixed, :parent_element_id]
 
-    stampable stamper_class_name: Alchemy.user_class_name
+    stampable stamper_class_name: Alchemy.user_class.name
 
     has_many :contents, dependent: :destroy, inverse_of: :element
 

--- a/app/models/alchemy/node.rb
+++ b/app/models/alchemy/node.rb
@@ -7,7 +7,7 @@ module Alchemy
     before_destroy :check_if_related_essence_nodes_present
 
     acts_as_nested_set scope: "language_id", touch: true
-    stampable stamper_class_name: Alchemy.user_class_name
+    stampable stamper_class_name: Alchemy.user_class.name
 
     belongs_to :language, class_name: "Alchemy::Language"
     belongs_to :page, class_name: "Alchemy::Page", optional: true, inverse_of: :nodes

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -88,7 +88,7 @@ module Alchemy
 
     acts_as_nested_set(dependent: :destroy, scope: [:layoutpage, :language_id])
 
-    stampable stamper_class_name: Alchemy.user_class_name
+    stampable stamper_class_name: Alchemy.user_class.name
 
     belongs_to :language
 

--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -110,7 +110,7 @@ module Alchemy
       case_sensitive: false,
       message: Alchemy.t("not a valid image")
 
-    stampable stamper_class_name: Alchemy.user_class_name
+    stampable stamper_class_name: Alchemy.user_class.name
 
     scope :named, ->(name) { where("#{table_name}.name LIKE ?", "%#{name}%") }
     scope :recent, -> { where("#{table_name}.created_at > ?", Time.current - 24.hours).order(:created_at) }

--- a/lib/alchemy/engine.rb
+++ b/lib/alchemy/engine.rb
@@ -40,7 +40,7 @@ module Alchemy
       if Alchemy.user_class
         ActiveSupport.on_load(:active_record) do
           Alchemy.user_class.model_stamper
-          Alchemy.user_class.stampable(stamper_class_name: Alchemy.user_class_name)
+          Alchemy.user_class.stampable(stamper_class_name: Alchemy.user_class.name)
         end
       end
     end

--- a/spec/libraries/userstamp_spec.rb
+++ b/spec/libraries/userstamp_spec.rb
@@ -6,7 +6,7 @@ describe "Alchemy::AuthAccessors" do
   describe ".user_class" do
     it "injects userstamp class methods" do
       expect(Alchemy.user_class).to respond_to(:stamper_class_name)
-      expect(Alchemy.user_class.stamper_class_name).to eq(:"::DummyUser")
+      expect(Alchemy.user_class.stamper_class_name).to eq(:DummyUser)
     end
   end
 end


### PR DESCRIPTION
## What is this pull request for?

Since Alchemy [always prepends a root constant identifier](https://github.com/AlchemyCMS/alchemy_cms/blob/main/lib/alchemy/auth_accessors.rb#L82) to the `user_class_name` getter and [userstamp (the originator gem) does the same](https://github.com/AlchemyCMS/originator/blob/master/lib/stampable.rb#L92) this can lead to wrong constant names under some circumstances.

Making sure we never set a root constant identifier by using `class.name`

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
