### PR TITLE
Adjust tinymce skin assets urls again

### DIFF
--- a/app/assets/stylesheets/tinymce/skins/alchemy/content.min.css.scss
+++ b/app/assets/stylesheets/tinymce/skins/alchemy/content.min.css.scss
@@ -30,7 +30,7 @@ td,th {
 
 .mce-object {
   border: 1px dotted #3a3a3a;
-  background: #d5d5d5 url(img/object.gif) no-repeat center;
+  background: #d5d5d5 url('tinymce/skins/alchemy/fonts/img/object.gif') no-repeat center;
 }
 
 .mce-pagebreak {
@@ -55,7 +55,7 @@ td,th {
   width: 9px!important;
   height: 9px!important;
   border: 1px dotted #3a3a3a;
-  background: #d5d5d5 url(img/anchor.gif) no-repeat center;
+  background: #d5d5d5 url('tinymce/skins/alchemy/fonts/img/anchor.gif') no-repeat center;
 }
 
 .mce-nbsp {
@@ -77,7 +77,7 @@ hr {
 }
 
 .mce-spellchecker-word {
-  background: url(img/wline.gif) repeat-x bottom left;
+  background: url('tinymce/skins/alchemy/fonts/img/wline.gif') repeat-x bottom left;
   cursor: default;
 }
 

--- a/app/assets/stylesheets/tinymce/skins/alchemy/skin.min.css.scss
+++ b/app/assets/stylesheets/tinymce/skins/alchemy/skin.min.css.scss
@@ -1561,23 +1561,23 @@ i.mce-i-resize {
   opacity: 0.6;
   filter: alpha(opacity=60);
   zoom: 1;
-  background: #fff url('img/loader.gif') no-repeat center center;
+  background: #fff url('tinymce/skins/alchemy/fonts/img/loader.gif') no-repeat center center;
 }
 
 @font-face {
   font-family: 'tinymce';
-  src: url('./fonts/tinymce.woff') format('woff'),
-       url('./fonts/tinymce.ttf') format('truetype'),
-       url('./fonts/tinymce.svg#tinymce') format('svg');
+  src: url('tinymce/skins/alchemy/fonts/tinymce.woff') format('woff'),
+       url('tinymce/skins/alchemy/fonts/tinymce.ttf') format('truetype'),
+       url('tinymce/skins/alchemy/fonts/tinymce.svg#tinymce') format('svg');
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'tinymce-small';
-  src: url('./fonts/tinymce-small.woff') format('woff'),
-       url('./fonts/tinymce-small.ttf') format('truetype'),
-       url('./fonts/tinymce-small.svg#tinymce') format('svg');
+  src: url('tinymce/skins/alchemy/fonts/tinymce-small.woff') format('woff'),
+       url('tinymce/skins/alchemy/fonts/tinymce-small.ttf') format('truetype'),
+       url('tinymce/skins/alchemy/fonts/tinymce-small.svg#tinymce') format('svg');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
## What is this pull request for?

Thanks to another breaking release of sprockets-rails (3.4.0)
all urls are now assumed to be absolute, but without the leading
slash.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
