### PR TITLE
fix(ImageCropper): Add dom ids to picture crop fields

### DIFF
--- a/app/views/alchemy/ingredients/_picture_editor.html.erb
+++ b/app/views/alchemy/ingredients/_picture_editor.html.erb
@@ -54,7 +54,7 @@
     <%= f.hidden_field :link_title, data: { link_title: true }, id: nil %>
     <%= f.hidden_field :link_class_name, data: { link_class: true }, id: nil %>
     <%= f.hidden_field :link_target, data: { link_target: true }, id: nil %>
-    <%= f.hidden_field :crop_from, data: { crop_from: true }, id: nil %>
-    <%= f.hidden_field :crop_size, data: { crop_size: true }, id: nil %>
+    <%= f.hidden_field :crop_from, data: { crop_from: true }, id: picture_editor.form_field_id(:crop_from) %>
+    <%= f.hidden_field :crop_size, data: { crop_size: true }, id: picture_editor.form_field_id(:crop_size) %>
   <% end %>
 <% end %>

--- a/spec/views/alchemy/ingredients/picture_editor_spec.rb
+++ b/spec/views/alchemy/ingredients/picture_editor_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "alchemy/ingredients/_picture_editor" do
   let(:picture) { stub_model(Alchemy::Picture) }
   let(:element) { build_stubbed(:alchemy_element, name: "all_you_can_eat_ingredients") }
   let(:element_editor) { Alchemy::ElementEditor.new(element) }
+  let(:ingredient_editor) { Alchemy::IngredientEditor.new(ingredient) }
 
   let(:ingredient) do
     stub_model(
@@ -22,7 +23,7 @@ RSpec.describe "alchemy/ingredients/_picture_editor" do
   it_behaves_like "an alchemy ingredient editor"
 
   before do
-    allow(element_editor).to receive(:ingredients) { [Alchemy::IngredientEditor.new(ingredient)] }
+    allow(element_editor).to receive(:ingredients) { [ingredient_editor] }
     allow(ingredient).to receive(:settings) { settings }
     view.class.send :include, Alchemy::Admin::BaseHelper
     view.class.send :include, Alchemy::Admin::IngredientsHelper
@@ -65,6 +66,14 @@ RSpec.describe "alchemy/ingredients/_picture_editor" do
 
     it "shows cropping link" do
       is_expected.to have_selector('a[href*="crop"]')
+    end
+
+    it "has crop_from hidden field" do
+      is_expected.to have_selector("input[type=\"hidden\"][id=\"#{ingredient_editor.form_field_id(:crop_from)}\"]")
+    end
+
+    it "has crop_size hidden field" do
+      is_expected.to have_selector("input[type=\"hidden\"][id=\"#{ingredient_editor.form_field_id(:crop_size)}\"]")
     end
   end
 


### PR DESCRIPTION
## What is this pull request for?

These DOM ids have been removed in cb49ce8a02162fe27a492b6a87e872e0fb111bac to remove duplicated DOM ids.

But we need DOM ids for the image cropper to work.

Fixed by adding unique DOM ids for these fields.

Closes #2216

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
