### PR TITLE
Touch nodes and all ancestors on page update

### DIFF
--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -144,7 +144,7 @@ module Alchemy
     after_update :create_legacy_url,
       if: :saved_change_to_urlname?
 
-    after_update -> { nodes.update_all(updated_at: Time.current) }
+    after_update :touch_nodes
 
     # Concerns
     include PageScopes
@@ -602,6 +602,11 @@ module Alchemy
     # Stores the old urlname in a LegacyPageUrl
     def create_legacy_url
       legacy_urls.find_or_create_by(urlname: urlname_before_last_save)
+    end
+
+    def touch_nodes
+      ids = node_ids + nodes.flat_map { |n| n.ancestors.pluck(:id) }
+      Node.where(id: ids).touch_all
     end
   end
 end

--- a/spec/dummy/app/views/alchemy/menus/main_menu/_node.html.erb
+++ b/spec/dummy/app/views/alchemy/menus/main_menu/_node.html.erb
@@ -1,14 +1,16 @@
-<%= content_tag :li, class: ['nav-item', node.children.any? ? 'dropdown' : nil].compact do %>
-  <%= link_to_if node.url,
-    node.name,
-    @preview_mode ? 'javascript: void(0)' : node.url,
-    class: ['nav-link', current_page?(node.url) ? 'active' : nil].compact,
-    title: node.title,
-    target: node.external? ? '_blank' : nil,
-    rel: node.nofollow? ? 'nofollow' : nil %>
-  <% if node.children.any? %>
-    <ul class="dropdown-menu">
-      <%= render node.children.includes(:page, :children), as: 'node' %>
-    </ul>
+<% cache [node, @page, @preview_mode] do %>
+  <%= content_tag :li, class: ['nav-item', node.children.any? ? 'dropdown' : nil].compact do %>
+    <%= link_to_if node.url,
+      node.name,
+      @preview_mode ? 'javascript: void(0)' : node.url,
+      class: ['nav-link', current_page?(node.url) ? 'active' : nil].compact,
+      title: node.title,
+      target: node.external? ? '_blank' : nil,
+      rel: node.nofollow? ? 'nofollow' : nil %>
+    <% if node.children.any? %>
+      <ul class="dropdown-menu">
+        <%= render node.children.includes(:page, :children), as: 'node' %>
+      </ul>
+    <% end %>
   <% end %>
 <% end %>

--- a/spec/dummy/app/views/alchemy/menus/main_menu/_wrapper.html.erb
+++ b/spec/dummy/app/views/alchemy/menus/main_menu/_wrapper.html.erb
@@ -1,6 +1,8 @@
-<ul class="nav">
-  <%= render partial: menu.to_partial_path,
-    collection: menu.children.includes(:page, :children),
-    locals: { options: options },
-    as: "node" %>
-</ul>
+<% cache [menu, @page, @preview_mode] do %>
+  <ul class="nav">
+    <%= render partial: menu.to_partial_path,
+      collection: menu.children.includes(:page, :children),
+      locals: { options: options },
+      as: "node" %>
+  </ul>
+<% end %>

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -2050,17 +2050,18 @@ module Alchemy
 
     describe "#nodes" do
       let(:page) { create(:alchemy_page) }
-      let(:node) { create(:alchemy_node, page: page, updated_at: 1.hour.ago) }
+      let(:parent) { create(:alchemy_node, updated_at: 1.hour.ago) }
+      let(:node) { create(:alchemy_node, page: page, parent: parent, updated_at: 1.hour.ago) }
 
       it "returns all nodes the page is attached to" do
         expect(page.nodes).to include(node)
       end
 
       describe "after page updates" do
-        it "touches all nodes" do
-          expect {
-            page.update(name: "foo")
-          }.to change { node.reload.updated_at }
+        subject { page.update(name: "foo") }
+
+        it "touches all nodes and all their ancestors" do
+          expect { subject }.to change { node.reload.updated_at }.and change { parent.reload.updated_at }
         end
       end
     end


### PR DESCRIPTION
## What is this pull request for?

Menu partials might be cached.

So we need to make sure the menu node a page might be attached to and all their ancestors get touched as well.

Closes #2080 

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
