### PR TITLE
Add Ruby 3.1 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
           - "2.6"
           - "2.7"
           - "3.0"
+          - "3.1"
         database:
           - mysql
           - postgresql

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,12 @@ jobs:
           - mysql
           - postgresql
         exclude:
+          - rails: "6.0"
+            ruby: "3.1"
+            database: mysql
+          - rails: "6.0"
+            ruby: "3.1"
+            database: postgresql
           - rails: "7.0"
             ruby: "2.6"
             database: mysql

--- a/Gemfile
+++ b/Gemfile
@@ -48,3 +48,10 @@ group :development, :test do
     gem "brakeman", require: false
   end
 end
+
+# Ruby 3.1 split out the net-smtp gem
+# Necessary until https://github.com/mikel/mail/pull/1439
+# got merged and released.
+if Gem.ruby_version >= Gem::Version.new("3.1.0")
+  gem "net-smtp", "~> 0.3.0", require: false
+end

--- a/Gemfile
+++ b/Gemfile
@@ -53,5 +53,10 @@ end
 # Necessary until https://github.com/mikel/mail/pull/1439
 # got merged and released.
 if Gem.ruby_version >= Gem::Version.new("3.1.0")
+  if rails_version.to_s.match?(/6.1/)
+    # Rails 6.1 needs this as well
+    gem "net-pop", "~> 0.1.0", require: false
+    gem "net-imap", "~> 0.2.0", require: false
+  end
   gem "net-smtp", "~> 0.3.0", require: false
 end

--- a/lib/alchemy.rb
+++ b/lib/alchemy.rb
@@ -3,7 +3,7 @@
 require "alchemy/admin/preview_url"
 
 module Alchemy
-  YAML_PERMITTED_CLASSES = %w(Symbol Date Regexp)
+  YAML_PERMITTED_CLASSES = %w[Symbol Date Regexp]
 
   # Define page preview sources
   #
@@ -35,9 +35,7 @@ module Alchemy
   #           acme/preview_source: Acme Vorschau
   #
   def self.preview_sources
-    @_preview_sources ||= begin
-        Set.new << Alchemy::Admin::PreviewUrl
-      end
+    @_preview_sources ||= Set.new << Alchemy::Admin::PreviewUrl
   end
 
   # Define page publish targets

--- a/lib/alchemy.rb
+++ b/lib/alchemy.rb
@@ -3,7 +3,7 @@
 require "alchemy/admin/preview_url"
 
 module Alchemy
-  YAML_WHITELIST_CLASSES = %w(Symbol Date Regexp)
+  YAML_PERMITTED_CLASSES = %w(Symbol Date Regexp)
 
   # Define page preview sources
   #
@@ -36,8 +36,8 @@ module Alchemy
   #
   def self.preview_sources
     @_preview_sources ||= begin
-      Set.new << Alchemy::Admin::PreviewUrl
-    end
+        Set.new << Alchemy::Admin::PreviewUrl
+      end
   end
 
   # Define page publish targets

--- a/lib/alchemy/config.rb
+++ b/lib/alchemy/config.rb
@@ -55,7 +55,11 @@ module Alchemy
       # If it does not exist, or its empty, it returns an empty Hash.
       #
       def read_file(file)
-        YAML.safe_load(ERB.new(File.read(file)).result, YAML_WHITELIST_CLASSES, [], true) || {}
+        YAML.safe_load(
+          ERB.new(File.read(file)).result,
+          permitted_classes: YAML_WHITELIST_CLASSES,
+          aliases: true,
+        ) || {}
       rescue Errno::ENOENT
         {}
       end

--- a/lib/alchemy/config.rb
+++ b/lib/alchemy/config.rb
@@ -57,7 +57,7 @@ module Alchemy
       def read_file(file)
         YAML.safe_load(
           ERB.new(File.read(file)).result,
-          permitted_classes: YAML_WHITELIST_CLASSES,
+          permitted_classes: YAML_PERMITTED_CLASSES,
           aliases: true,
         ) || {}
       rescue Errno::ENOENT

--- a/lib/alchemy/element_definition.rb
+++ b/lib/alchemy/element_definition.rb
@@ -50,9 +50,8 @@ module Alchemy
         if File.exist?(definitions_file_path)
           YAML.safe_load(
             ERB.new(File.read(definitions_file_path)).result,
-            YAML_WHITELIST_CLASSES,
-            [],
-            true
+            permitted_classes: YAML_WHITELIST_CLASSES,
+            aliases: true,
           ) || []
         else
           raise LoadError,

--- a/lib/alchemy/element_definition.rb
+++ b/lib/alchemy/element_definition.rb
@@ -50,7 +50,7 @@ module Alchemy
         if File.exist?(definitions_file_path)
           YAML.safe_load(
             ERB.new(File.read(definitions_file_path)).result,
-            permitted_classes: YAML_WHITELIST_CLASSES,
+            permitted_classes: YAML_PERMITTED_CLASSES,
             aliases: true,
           ) || []
         else

--- a/lib/alchemy/page_layout.rb
+++ b/lib/alchemy/page_layout.rb
@@ -151,7 +151,11 @@ module Alchemy
       #
       def read_definitions_file
         if File.exist?(layouts_file_path)
-          YAML.safe_load(ERB.new(File.read(layouts_file_path)).result, YAML_WHITELIST_CLASSES, [], true) || []
+          YAML.safe_load(
+            ERB.new(File.read(layouts_file_path)).result,
+            permitted_classes: YAML_WHITELIST_CLASSES,
+            aliases: true,
+          ) || []
         else
           raise LoadError, "Could not find page_layouts.yml file! Please run `rails generate alchemy:install`"
         end

--- a/lib/alchemy/page_layout.rb
+++ b/lib/alchemy/page_layout.rb
@@ -153,7 +153,7 @@ module Alchemy
         if File.exist?(layouts_file_path)
           YAML.safe_load(
             ERB.new(File.read(layouts_file_path)).result,
-            permitted_classes: YAML_WHITELIST_CLASSES,
+            permitted_classes: YAML_PERMITTED_CLASSES,
             aliases: true,
           ) || []
         else

--- a/lib/generators/alchemy/base.rb
+++ b/lib/generators/alchemy/base.rb
@@ -35,7 +35,7 @@ module Alchemy
       def load_alchemy_yaml(name)
         YAML.safe_load(
           ERB.new(File.read(Rails.root.join("config", "alchemy", name))).result,
-          permitted_classes: YAML_WHITELIST_CLASSES,
+          permitted_classes: YAML_PERMITTED_CLASSES,
           aliases: true,
         )
       rescue Errno::ENOENT

--- a/lib/generators/alchemy/base.rb
+++ b/lib/generators/alchemy/base.rb
@@ -33,7 +33,11 @@ module Alchemy
       end
 
       def load_alchemy_yaml(name)
-        YAML.safe_load(ERB.new(File.read("#{Rails.root}/config/alchemy/#{name}")).result, YAML_WHITELIST_CLASSES, [], true)
+        YAML.safe_load(
+          ERB.new(File.read(Rails.root.join("config", "alchemy", name))).result,
+          permitted_classes: YAML_WHITELIST_CLASSES,
+          aliases: true,
+        )
       rescue Errno::ENOENT
         puts "\nERROR: Could not read config/alchemy/#{name} file. Please run: `rails generate alchemy:install`"
       end

--- a/lib/generators/alchemy/install/install_generator.rb
+++ b/lib/generators/alchemy/install/install_generator.rb
@@ -98,7 +98,10 @@ module Alchemy
       end
 
       def copy_alchemy_entry_point
-        webpack_config = YAML.load_file(app_root.join("config", "webpacker.yml"))[Rails.env]
+        webpack_config = YAML.safe_load(
+          File.read(app_root.join("config", "webpacker.yml")),
+          aliases: true
+        )[Rails.env]
         copy_file "alchemy_admin.js",
           app_root.join(webpack_config["source_path"], webpack_config["source_entry_path"], "alchemy/admin.js")
       end


### PR DESCRIPTION
## What is this pull request for?

Adds support for Ruby 3.1

### Notable changes

Until https://github.com/mikel/mail/pull/1439 got merged and released you need to manually add

```rb
gem "net-smtp", "~> 0.3.0", require: false
```

#### For Rails 6.1 you need to additionally add

```rb
gem "net-pop", "~> 0.1.0", require: false
```

to your Apps `Gemfile`

### Breaking Changes

- Renamed `Alchemy::YAML_WHITELIST_CLASSES` into `Alchemy::YAML_PERMITTED_CLASSES`

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
