### PR TITLE
Add custom gutentag tag validations class

### DIFF
--- a/app/services/alchemy/tag_validations.rb
+++ b/app/services/alchemy/tag_validations.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Alchemy
+  class TagValidations
+    def self.call(klass)
+      new(klass).call
+    end
+
+    def initialize(klass)
+      @klass = klass
+    end
+
+    def call
+      klass.validates :name, presence: true, uniqueness: { case_sensitive: true }
+    end
+
+    private
+
+    attr_reader :klass
+  end
+end

--- a/lib/alchemy/engine.rb
+++ b/lib/alchemy/engine.rb
@@ -19,11 +19,12 @@ module Alchemy
       NonStupidDigestAssets.whitelist += [/^tinymce\//]
     end
 
-    # Gutentag downcases all tgas before save.
-    # We support having tags with uppercase characters.
-    # The Gutentag search is case insensitive.
-    initializer "alchemy.gutentag_normalizer" do
+    # Gutentag downcases all tags before save
+    # and Gutentag validations are not case sensitive.
+    # But we support having tags with uppercase characters.
+    config.to_prepare do
       Gutentag.normaliser = ->(value) { value.to_s }
+      Gutentag.tag_validations = Alchemy::TagValidations
     end
 
     # Custom Ransack sort arrows

--- a/spec/models/gutentag/tag_spec.rb
+++ b/spec/models/gutentag/tag_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Gutentag::Tag do
+  describe "validations" do
+    let!(:tag_1) { described_class.create(name: "red") }
+    let(:tag_2) { described_class.new(name: "Red") }
+
+    it "should allow tags with different case" do
+      expect(tag_2).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

We support having tags with different casing to exist
side-by-side because of historical reasons (we used acts-as-taggable-on
back in the days). We already have a custom `Gutentag.normaliser`,
but never a custom validation. That leads to "already taken" errors
trying to save an element or page with tags having different casing.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
