### PR TITLE
[4.6] fix(CellsMigration): Do not autogenerate nested elements

### DIFF
--- a/lib/alchemy/upgrader/tasks/cells_migration.rb
+++ b/lib/alchemy/upgrader/tasks/cells_migration.rb
@@ -31,6 +31,7 @@ module Alchemy::Upgrader::Tasks
       elements = Alchemy::Element.where(cell_id: cell.id).order(position: :asc)
 
       if fixed_element.new_record?
+        fixed_element.autogenerate_nested_elements = false
         fixed_element.save!
         Alchemy::Element.acts_as_list_no_update do
           elements.update_all(parent_element_id: fixed_element.id)


### PR DESCRIPTION
Newly generated fixed elements should not autogenerate nested
elements during cells migration, because the elements already
exist and we just copy them over.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
