### PR TITLE
Remove unused route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,7 +124,6 @@ Alchemy::Engine.routes.draw do
 
   resources :messages, only: [:index, :new, :create]
   resources :elements, only: :show
-  resources :contents, only: :show
 
   namespace :api, defaults: { format: "json" } do
     resources :contents, only: [:index, :show]


### PR DESCRIPTION
There is no Alchemy::ContentsController to handle any requests to this
route. It was likely added by accident as part of https://github.com/AlchemyCMS/alchemy_cms/commit/871e77eca5bdb014339be153f4adffd21ec36344

Given this route only produces errors, it makes most sense to remove it
here

## What is this pull request for?

Closes #2237 

### Notable changes (remove if none)

Removes the unused `/contents/:id` route from the Alchemy engine routes list

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change (N/A ?)
