### PR TITLE
Allow to use dragonfly 1.4.0 security update with Alchemy 5.2.x

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'awesome_nested_set',               ['~> 3.1']
   gem.add_runtime_dependency 'cancancan',                        ['>= 2.1', '< 4.0']
   gem.add_runtime_dependency 'coffee-rails',                     ['>= 4.0', '< 6.0']
-  gem.add_runtime_dependency 'dragonfly',                        ['~> 1.0', '>= 1.0.7', '< 1.4']
+  gem.add_runtime_dependency 'dragonfly',                        ['~> 1.0', '>= 1.0.7']
   gem.add_runtime_dependency 'dragonfly_svg',                    ['~> 0.0.4']
   gem.add_runtime_dependency 'gutentag',                         ['~> 2.2', '>= 2.2.1']
   gem.add_runtime_dependency 'handlebars_assets',                ['~> 0.23']


### PR DESCRIPTION
Dragonfly released v1.4.0 that has a security update so we need to allow Alchemy 5.2.x version to use dragonfly v.1.4.0.
Currently, it locked to dragonfly v1.3.0
