### PR TITLE
Handle copying/pasting global pages

### DIFF
--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -245,8 +245,8 @@ module Alchemy
 
       def copy_and_paste(source, new_parent, new_name)
         page = copy(source, {
-          parent_id: new_parent.id,
-          language: new_parent.language,
+          parent: new_parent,
+          language: new_parent&.language,
           name: new_name,
           title: new_name,
         })

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1163,7 +1163,7 @@ module Alchemy
 
       it "should copy the source page with the given name to the new parent" do
         expect(Page).to receive(:copy).with(source, {
-                          parent_id: new_parent.id,
+                          parent: new_parent,
                           language: new_parent.language,
                           name: page_name,
                           title: page_name,
@@ -1181,6 +1181,21 @@ module Alchemy
           allow(Page).to receive(:copy).and_return(copied_page)
           allow(source).to receive(:children).and_return([mock_model("Page")])
           expect(source).to receive(:copy_children_to).with(copied_page)
+          subject
+        end
+      end
+
+      context "if the source page has no parent (global page)" do
+        let(:source) { build_stubbed(:alchemy_page, layoutpage: true, parent_id: nil) }
+        let(:new_parent) { nil }
+
+        it "copies the source page with the given name" do
+          expect(Page).to receive(:copy).with(source, {
+                          parent: nil,
+                          language: nil,
+                          name: page_name,
+                          title: page_name,
+                        })
           subject
         end
       end


### PR DESCRIPTION
## What is this pull request for?

Copying and then pasting a global page results in an exception because there is no `parent` `Alchemy::Page`.

### Notable changes (remove if none)

Handle the possibility of the new `parent_page` being `nil`.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
