### PR TITLE
Fix copying page with descendants to a different language

### DIFF
--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -448,6 +448,7 @@ module Alchemy
         next if child == new_parent
 
         new_child = Page.copy(child, {
+          parent_id: new_parent.id,
           language_id: new_parent.language_id,
           language_code: new_parent.language_code,
         })

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1119,7 +1119,7 @@ module Alchemy
           :public,
           children: [
             build(:alchemy_page),
-            build(:alchemy_page, name: 'child with children', children: [build(:alchemy_page)])
+            build(:alchemy_page, name: "child with children", children: [build(:alchemy_page)]),
           ]
         )
       end
@@ -1133,8 +1133,8 @@ module Alchemy
           expect(new_parent.children.where(title: child.title).count).to eq 1
         end
 
-        source_page_grandchildren = source_page.children.find_by_title('child with children').children
-        new_parent_grandchildren = new_parent.children.find_by_title('child with children').children
+        source_page_grandchildren = source_page.children.find_by_title("child with children").children
+        new_parent_grandchildren = new_parent.children.find_by_title("child with children").children
 
         source_page_grandchildren.each do |grandchild|
           expect(new_parent_grandchildren.where(title: grandchild.title).count).to eq 1
@@ -1151,8 +1151,8 @@ module Alchemy
             expect(new_parent.children.where(title: child.title).count).to eq 1
           end
 
-          source_page_grandchildren = source_page.children.find_by_title('child with children').children
-          new_parent_grandchildren = new_parent.children.find_by_title('child with children').children
+          source_page_grandchildren = source_page.children.find_by_title("child with children").children
+          new_parent_grandchildren = new_parent.children.find_by_title("child with children").children
 
           source_page_grandchildren.each do |grandchild|
             expect(new_parent_grandchildren.where(title: grandchild.title).count).to eq 1


### PR DESCRIPTION
## What is this pull request for?

When copying a page with children from one language to another, an `ActiveRecord::RecordNotFound` exception occurs.
If I understand this correctly, it's because the nested_set is scoped to the language [here](https://github.com/AlchemyCMS/alchemy_cms/blob/main/app/models/alchemy/page.rb#L89).

Closes #2101

### Notable changes (remove if none)

Explicitly set the new `parent_id` on copied children.  This allows nested set to operate in the scope of the new parent's language.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
