### PR TITLE
Allow parent page change

### DIFF
--- a/app/assets/javascripts/alchemy/page_select.js
+++ b/app/assets/javascripts/alchemy/page_select.js
@@ -1,9 +1,11 @@
-$.fn.alchemyPageSelect = function(options) {
+$.fn.alchemyPageSelect = function (options) {
   var pageTemplate = HandlebarsTemplates.page
 
   return this.select2({
     placeholder: options.placeholder,
-    allowClear: true,
+    allowClear: options.hasOwnProperty("allowClear")
+      ? options.allowClear
+      : true,
     minimumInputLength: 3,
     initSelection: function (_$el, callback) {
       if (options.initialSelection) {
@@ -12,13 +14,16 @@ $.fn.alchemyPageSelect = function(options) {
     },
     ajax: {
       url: options.url,
-      datatype: 'json',
+      datatype: "json",
       quietMillis: 300,
       data: function (term, page) {
         return {
-          q: $.extend({
-            name_cont: term
-          }, options.query_params),
+          q: $.extend(
+            {
+              name_cont: term
+            },
+            options.query_params
+          ),
           page: page
         }
       },
@@ -34,8 +39,8 @@ $.fn.alchemyPageSelect = function(options) {
     formatSelection: function (page) {
       return page.text || page.name
     },
-    formatResult: function(page) {
-      return pageTemplate({page: page})
+    formatResult: function (page) {
+      return pageTemplate({ page: page })
     }
   })
 }

--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -123,6 +123,7 @@ module Alchemy
       # * fetches page via before filter
       #
       def update
+        @old_parent_id = @page.parent_id
         if @page.update(page_params)
           @notice = Alchemy.t("Page saved", name: @page.name)
           @while_page_edit = request.referer.include?("edit")

--- a/app/views/alchemy/admin/pages/_form.html.erb
+++ b/app/views/alchemy/admin/pages/_form.html.erb
@@ -1,4 +1,8 @@
 <%= alchemy_form_for [:admin, @page], class: 'edit_page' do |f| %>
+  <% unless @page.language_root? || @page.layoutpage %>
+    <%= f.input :parent_id, required: true, input_html: { class: 'alchemy_selectbox' } %>
+  <% end %>
+
   <div class="input check_boxes">
     <label class="control-label"><%= Alchemy.t(:page_status) %></label>
     <div class="control_group">
@@ -37,3 +41,18 @@
 
   <%= f.submit Alchemy.t(:save) %>
 <% end %>
+
+<script>
+  $('#page_parent_id').alchemyPageSelect({
+    placeholder: "<%= Alchemy.t(:search_page) %>",
+    url: "<%= alchemy.api_pages_path %>",
+    allowClear: false,
+    <% if @page.parent %>
+    initialSelection: {
+      id: <%= @page.parent.id %>,
+      text: "<%= @page.parent.name %>",
+      url_path: "<%= @page.parent.url_path %>"
+    }
+    <% end %>
+  })
+</script>

--- a/app/views/alchemy/admin/pages/_new_page_form.html.erb
+++ b/app/views/alchemy/admin/pages/_new_page_form.html.erb
@@ -22,6 +22,7 @@
   $('input[type="text"]#page_parent_id').alchemyPageSelect({
     placeholder: "<%= Alchemy.t(:search_page) %>",
     url: "<%= alchemy.api_pages_path %>",
+    allowClear: false,
     <% if @page.parent %>
     initialSelection: {
       id: <%= @page.parent.id %>,

--- a/app/views/alchemy/admin/pages/_new_page_form.html.erb
+++ b/app/views/alchemy/admin/pages/_new_page_form.html.erb
@@ -3,11 +3,7 @@
     <%= f.hidden_field(:parent_id) %>
   <% else %>
     <% @page.parent = @current_language.root_page %>
-    <%= f.input :parent_id,
-      collection: @current_language.pages.contentpages,
-      label_method: :name,
-      value_method: :id,
-      input_html: { class: "alchemy_selectbox" } %>
+    <%= f.input :parent_id, as: :string, input_html: { class: 'alchemy_selectbox' } %>
   <% end %>
   <%= f.hidden_field(:language_id) %>
   <%= f.hidden_field(:layoutpage) %>
@@ -21,3 +17,17 @@
   <%= f.input :name %>
   <%= f.submit Alchemy.t(:create) %>
 <% end %>
+
+<script>
+  $('input[type="text"]#page_parent_id').alchemyPageSelect({
+    placeholder: "<%= Alchemy.t(:search_page) %>",
+    url: "<%= alchemy.api_pages_path %>",
+    <% if @page.parent %>
+    initialSelection: {
+      id: <%= @page.parent.id %>,
+      text: "<%= @page.parent.name %>",
+      url_path: "<%= @page.parent.url_path %>"
+    }
+    <% end %>
+  })
+</script>

--- a/app/views/alchemy/admin/pages/update.js.erb
+++ b/app/views/alchemy/admin/pages/update.js.erb
@@ -8,6 +8,13 @@
   Alchemy.growl("<%= j @notice %>");
   Alchemy.closeCurrentDialog();
 
+<% elsif @page.parent_id != @old_parent_id -%>
+
+  Alchemy.closeCurrentDialog(function() {
+    Alchemy.growl("<%= j @notice %>");
+    Alchemy.currentSitemap.load(<%= @page.get_language_root.id %>);
+  });
+
 <% else -%>
 
   if (page) {

--- a/spec/features/admin/page_creation_feature_spec.rb
+++ b/spec/features/admin/page_creation_feature_spec.rb
@@ -5,13 +5,13 @@ require "rails_helper"
 RSpec.describe "Page creation", type: :system do
   before { authorize_user(:as_admin) }
 
-  describe "parent selection" do
+  describe "parent selection", :js do
     let!(:homepage) { create(:alchemy_page, :language_root) }
 
     context "without having a parent id in the params" do
       it "contains a parent select" do
         visit new_admin_page_path
-        expect(page).to have_select("Parent", selected: homepage.name)
+        expect(page).to have_css("#s2id_page_parent_id")
       end
     end
 
@@ -19,6 +19,7 @@ RSpec.describe "Page creation", type: :system do
       it "contains a hidden parent_id field" do
         visit new_admin_page_path(parent_id: homepage)
         expect(page).to have_field("page_parent_id", type: "hidden")
+        expect(page).to_not have_css("#s2id_page_parent_id")
       end
     end
   end

--- a/spec/features/admin/page_editing_feature_spec.rb
+++ b/spec/features/admin/page_editing_feature_spec.rb
@@ -189,17 +189,34 @@ RSpec.describe "Page editing feature", type: :system do
     before { authorize_user(:as_admin) }
     let!(:a_page) { create(:alchemy_page) }
 
+    before do
+      visit alchemy.admin_pages_path
+      find(".sitemap_page[name='#{a_page.name}'] .icon.fa-cog").click
+      expect(page).to have_selector(".alchemy-dialog-overlay.open")
+    end
+
     context "when updating the name" do
       it "saves the name" do
-        visit alchemy.admin_pages_path
-        find(".sitemap_page[name='#{a_page.name}'] .icon.fa-cog").click
-        expect(page).to have_selector(".alchemy-dialog-overlay.open")
         within(".alchemy-dialog.modal") do
           find("input#page_name").set("name with some %!x^)'([@!{}]|/?\:# characters")
           find(".submit button").click
         end
         expect(page).to_not have_selector(".alchemy-dialog-overlay.open")
         expect(page).to have_selector("#sitemap a.sitemap_pagename_link", text: "name with some %!x^)'([@!{}]|/?\:# characters")
+      end
+    end
+
+    describe "changing parent" do
+      let!(:new_parent) { create(:alchemy_page) }
+
+      it "can change page parent" do
+        within(".alchemy-dialog.modal") do
+          expect(page).to have_css("#s2id_page_parent_id")
+          select2_search(new_parent.name, from: "Parent")
+          find(".submit button").click
+        end
+        expect(page).to_not have_selector(".alchemy-dialog-overlay.open")
+        expect(page).to have_selector("#sitemap .sitemap_url", text: "/#{new_parent.urlname}/#{a_page.urlname}")
       end
     end
   end


### PR DESCRIPTION
## What is this pull request for?

Unless the page is the current language root or a layoutpage, we allow to change the parent.

This is much more efficient than using the dragndrop interface, especially in large trees.

### Notable changes

The new page form now uses the `alchemyPageSelect`. This is useful for large sites with many pages.

### Screenshots

Remove if no visual changes have been made.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message

## TODO

- [x] Reload page tree if parent has changed
