### PR TITLE
Fix rendering errors in page configure overlay

### DIFF
--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -133,7 +133,7 @@ module Alchemy
             @tree = serialized_page_tree
           end
         else
-          configure
+          render :configure
         end
       end
 


### PR DESCRIPTION
Somehow rendering a template by called it's method stopped working in current versions of Rails. It's better to explicitly render the template anyway.
