### PR TITLE
Remove old page layout change code from update action

### DIFF
--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -123,8 +123,6 @@ module Alchemy
       # * fetches page via before filter
       #
       def update
-        # stores old page_layout value, because unfurtunally rails @page.changes does not work here.
-        @old_page_layout = @page.page_layout
         if @page.update(page_params)
           @notice = Alchemy.t("Page saved", name: @page.name)
           @while_page_edit = request.referer.include?("edit")

--- a/app/views/alchemy/admin/pages/update.js.erb
+++ b/app/views/alchemy/admin/pages/update.js.erb
@@ -1,11 +1,6 @@
 (function() {
   var page = document.querySelector('#page_<%= @page.id %>');
 
-<% if @old_page_layout != @page.page_layout -%>
-  Alchemy.ElementsWindow.reload();
-  Alchemy.growl('<%= j Alchemy.t(:page_layout_changed_notice) %>');
-<% end -%>
-
 <% if @while_page_edit -%>
 
   Alchemy.reloadPreview();

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -534,7 +534,6 @@ en:
     or_replace_it_with_an_existing_tag: 'Or replace it with an existing tag'
     "Page created": "Page: '%{name}' created."
     page_infos: 'Page info'
-    page_layout_changed_notice: "Page type was changed. Elements not usable anymore have been hided."
     page_properties: "Page properties"
     page_public: "published"
     page_published: "Published page"


### PR DESCRIPTION
This feature has been removed in https://github.com/AlchemyCMS/alchemy_cms/pull/1991

This code is not called anymore.
