### PR TITLE
Compatibility with Shakapacker

### DIFF
--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -36,7 +36,7 @@
     </script>
     <%= render 'alchemy/admin/partials/routes' %>
     <%= javascript_include_tag('alchemy/admin/all', 'data-turbolinks-track' => true) %>
-    <%= javascript_pack_tag('alchemy/admin') %>
+    <%= javascript_pack_tag('alchemy_admin') %>
     <%= yield :javascript_includes %>
   </head>
   <%= content_tag :body, id: 'alchemy', class: alchemy_body_class do %>

--- a/lib/generators/alchemy/install/install_generator.rb
+++ b/lib/generators/alchemy/install/install_generator.rb
@@ -95,7 +95,7 @@ module Alchemy
       def copy_alchemy_entry_point
         webpack_config = YAML.load_file(app_root.join("config", "webpacker.yml"))[Rails.env]
         copy_file "alchemy_admin.js",
-          app_root.join(webpack_config["source_path"], webpack_config["source_entry_path"], "alchemy/admin.js")
+          app_root.join(webpack_config["source_path"], webpack_config["source_entry_path"], "alchemy_admin.js")
       end
 
       def set_primary_language


### PR DESCRIPTION
## What is this pull request for?

This PR is just a first attempt to make AlchemyCMS at least compatible with the successor of webpacker: https://github.com/shakacode/shakapacker. This is the minimum change required to let AlchemyCMS work again after the update to the new gem.

Other changes are needed inside AlchemyCMS (eg. peer dependencies, change from `bin/wepack` to `bin/webpacker`, ...), but since I was not sure how to handle the breaking changes, I haven't changed too much yet.
Is it possible (and worth...) to check which one is installed between webpacker and shakapacker and react on that?
Maybe there is a way to be more "agnostic" regarding the way to include the admin js package that would allow to use whatever system to pack the assets (see this discussion [here](https://github.com/AlchemyCMS/alchemy_cms/discussions/2234)).

### Notable changes

This is a **breaking change**, because the user should actively move the js from `alchemy/admin.js` to `alchemy_admin.js` inside his entrypoints directory of webpack.
Anyway, an upgrade task could be created to do it automatically.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
