### PR TITLE
Eager load in PageTree serializer

### DIFF
--- a/app/serializers/alchemy/page_tree_serializer.rb
+++ b/app/serializers/alchemy/page_tree_serializer.rb
@@ -3,13 +3,13 @@
 module Alchemy
   class PageTreeSerializer < BaseSerializer
     def attributes
-      {"pages" => nil}
+      { "pages" => nil }
     end
 
     def pages
       tree = []
-      path = [{id: object.parent_id, children: tree}]
-      page_list = object.self_and_descendants
+      path = [{ id: object.parent_id, children: tree }]
+      page_list = object.self_and_descendants.includes(:public_version, { language: :site })
       base_level = object.level - 1
       # Load folded pages in advance
       folded_user_pages = FoldedPage.folded_for_user(opts[:user]).pluck(:page_id)


### PR DESCRIPTION
Eager load pages public version, language and its site.

## Before

A 100 pages, 10 levels sitemap

```
[active_model_serializers] Rendered ActiveModel::Serializer::Null with Alchemy::PageTreeSerializer (5427.42ms)
Completed 200 OK in 5445ms (Views: 5338.8ms | ActiveRecord: 91.6ms | Allocations: 10999091)
```

## After

```
[active_model_serializers] Rendered ActiveModel::Serializer::Null with Alchemy::PageTreeSerializer (413.06ms)
Completed 200 OK in 445ms (Views: 409.2ms | ActiveRecord: 8.2ms | Allocations: 918201)
```

This speeds up the page tree by 10!!

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
