### PR TITLE
Fix setting default value of ingredients

### DIFF
--- a/app/models/alchemy/ingredient.rb
+++ b/app/models/alchemy/ingredient.rb
@@ -11,7 +11,8 @@ module Alchemy
     belongs_to :element, touch: true, class_name: "Alchemy::Element", inverse_of: :ingredients
     belongs_to :related_object, polymorphic: true, optional: true
 
-    before_validation(on: :create) { self.value ||= default_value }
+    after_initialize :set_default_value,
+      if: -> { definition.key?(:default) && value.nil? }
 
     validates :type, presence: true
     validates :role, presence: true
@@ -159,6 +160,10 @@ module Alchemy
 
     def hint_translation_attribute
       role
+    end
+
+    def set_default_value
+      self.value = default_value
     end
 
     # Returns the default value from ingredient definition

--- a/lib/alchemy/test_support/shared_ingredient_examples.rb
+++ b/lib/alchemy/test_support/shared_ingredient_examples.rb
@@ -28,7 +28,7 @@ RSpec.shared_examples_for "an alchemy ingredient" do
 
     context "with element" do
       before do
-        expect(element).to receive(:ingredient_definition_for) do
+        expect(element).to receive(:ingredient_definition_for).at_least(:once) do
           {
             settings: {
               linkable: true,
@@ -63,7 +63,9 @@ RSpec.shared_examples_for "an alchemy ingredient" do
       end
 
       before do
-        expect(element).to receive(:ingredient_definition_for) { definition }
+        expect(element).to receive(:ingredient_definition_for).at_least(:once) do
+          definition
+        end
       end
 
       it "returns ingredient definition" do

--- a/spec/dummy/config/alchemy/elements.yml
+++ b/spec/dummy/config/alchemy/elements.yml
@@ -160,6 +160,7 @@
     - role: boolean
       type: Boolean
       hint: true
+      default: true
     - role: datetime
       type: Datetime
       hint: true

--- a/spec/models/alchemy/element_ingredients_spec.rb
+++ b/spec/models/alchemy/element_ingredients_spec.rb
@@ -97,7 +97,9 @@ RSpec.describe Alchemy::Element do
   end
 
   describe "#has_value_for?" do
-    let!(:element) { create(:alchemy_element, :with_ingredients) }
+    let!(:element) do
+      create(:alchemy_element, :with_ingredients, name: "all_you_can_eat_ingredients")
+    end
 
     context "with role existing" do
       let(:ingredient) { element.ingredient_by_role(:headline) }

--- a/spec/views/alchemy/ingredients/boolean_editor_spec.rb
+++ b/spec/views/alchemy/ingredients/boolean_editor_spec.rb
@@ -28,21 +28,14 @@ RSpec.describe "alchemy/ingredients/_boolean_editor" do
   end
 
   context "with default value given in ingredient settings" do
-    let(:element) { create(:alchemy_element, name: "all_you_can_eat_ingredients") }
-
-    let(:ingredient) do
-      allow_any_instance_of(Alchemy::Ingredients::Boolean).to receive(:definition) do
-        {
-          role: "boolean",
-          type: "Boolean",
-          default: true,
-        }.with_indifferent_access
-      end
-      Alchemy::Ingredients::Boolean.create!(role: "boolean", element: element)
+    let(:element) do
+      create(:alchemy_element, :with_ingredients, name: "all_you_can_eat_ingredients")
     end
 
     it "checks the checkbox" do
-      is_expected.to have_selector('input[type="checkbox"][checked="checked"]')
+      within ".ingredient-editor boolean" do
+        is_expected.to have_selector('input[type="checkbox"][checked="checked"]')
+      end
     end
   end
 end


### PR DESCRIPTION
## What is this pull request for?

Somehow before_validation is not called ever during creating an element and its ingredients.

Using after_initialize fixes this.

Closes #2189

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
