### PR TITLE
Allow all pages in API again

### DIFF
--- a/app/assets/javascripts/alchemy/templates/page.hbs
+++ b/app/assets/javascripts/alchemy/templates/page.hbs
@@ -1,9 +1,19 @@
 <div class="page-select--page">
-  <i class="icon far fa-file fa-lg"></i>
-  <span class="page-select--page-name">
-    {{ page.name }}
-  </span>
-  <span class="page-select--page-urlname">
-    {{ page.url_path }}
-  </span>
+  <div class="page-select--top">
+    <i class="icon far fa-file fa-lg"></i>
+    <span class="page-select--page-name">
+      {{ page.name }}
+    </span>
+    <span class="page-select--page-urlname">
+      {{ page.url_path }}
+    </span>
+  </div>
+  <div class="page-select--bottom">
+    <span class="page-select--site-name">
+      {{ page.site.name }}
+    </span>
+    <span class="page-select--language-code">
+      {{ page.language.name }}
+    </span>
+  </div>
 </div>

--- a/app/assets/stylesheets/alchemy/page-select.scss
+++ b/app/assets/stylesheets/alchemy/page-select.scss
@@ -8,24 +8,49 @@
 
 .page-select--page {
   display: flex;
-  align-items: center;
+  flex-direction: column;
 
   .icon {
     margin: 0 8px 0 4px;
 
     .select2-highlighted & {
-      color: $white
+      color: $white;
     }
+  }
+}
+
+.page-select--top,
+.page-select--bottom {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.page-select--bottom {
+  font-size: $small-font-size;
+  padding-left: 6 * $default-padding;
+}
+
+.page-select--language-code {
+  display: inline-block;
+  background-color: $medium-gray;
+  margin-left: auto;
+  border-radius: $default-border-radius;
+  padding: $default-padding / 2 $default-padding;
+
+  .select2-highlighted & {
+    color: $select-hover-bg-color;
+    background-color: white;
   }
 }
 
 .page-select--page-urlname {
   margin-left: auto;
-  padding: $default-padding 2*$default-padding;
+  padding: $default-padding 2 * $default-padding;
   color: $dark-gray;
   font-size: $small-font-size;
 
   .select2-highlighted & {
-    color: $white
+    color: $white;
   }
 }

--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -7,14 +7,13 @@ module Alchemy
     # Returns all pages as json object
     #
     def index
-      language = Alchemy::Language.find_by(id: params[:language_id]) || Alchemy::Language.current
-
       # Fix for cancancan not able to merge multiple AR scopes for logged in users
-      if cannot? :edit_content, Alchemy::Page
+      if can? :edit_content, Alchemy::Page
+        @pages = Alchemy::Page.all
+      else
+        language = Alchemy::Language.find_by(id: params[:language_id]) || Alchemy::Language.current
         @pages = Alchemy::Page.accessible_by(current_ability, :index)
         @pages = @pages.where(language: language)
-      else
-        @pages = language&.pages.presence || Alchemy::Page.none
       end
       @pages = @pages.includes(*page_includes)
       @pages = @pages.ransack(params[:q]).result

--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -2,6 +2,7 @@
 
 module Alchemy
   class Api::PagesController < Api::BaseController
+    serialization_scope :current_ability
     before_action :load_page, only: [:show]
 
     # Returns all pages as json object

--- a/app/serializers/alchemy/page_serializer.rb
+++ b/app/serializers/alchemy/page_serializer.rb
@@ -18,5 +18,10 @@ module Alchemy
       :parent_id
 
     has_many :elements
+
+    with_options if: -> { scope.can?(:edit_content, object) } do
+      belongs_to :site
+      belongs_to :language
+    end
   end
 end

--- a/spec/serializers/alchemy/page_serializer_spec.rb
+++ b/spec/serializers/alchemy/page_serializer_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::PageSerializer do
+  subject do
+    described_class.new(page, scope: Alchemy::Permissions.new(user)).to_json
+  end
+
+  let(:page) { build_stubbed(:alchemy_page) }
+
+  context "for guest user" do
+    let(:user) { nil }
+
+    it "includes public attributes" do
+      json = JSON.parse(subject)
+      expect(json).to match(
+        "id" => page.id,
+        "name" => page.name,
+        "urlname" => page.urlname,
+        "page_layout" => page.page_layout,
+        "title" => page.title,
+        "language_code" => page.language_code,
+        "meta_keywords" => page.meta_keywords,
+        "meta_description" => page.meta_description,
+        "tag_list" => page.tag_list,
+        "created_at" => an_instance_of(String),
+        "updated_at" => an_instance_of(String),
+        "status" => page.status.transform_keys(&:to_s),
+        "url_path" => page.url_path,
+        "parent_id" => page.parent_id,
+        "elements" => [],
+      )
+    end
+  end
+
+  context "for admin user" do
+    let(:user) { build_stubbed(:alchemy_dummy_user, :as_author) }
+
+    it "includes all attributes" do
+      json = JSON.parse(subject)
+      expect(json).to match(
+        "id" => page.id,
+        "name" => page.name,
+        "urlname" => page.urlname,
+        "page_layout" => page.page_layout,
+        "title" => page.title,
+        "language_code" => page.language_code,
+        "meta_keywords" => page.meta_keywords,
+        "meta_description" => page.meta_description,
+        "tag_list" => page.tag_list,
+        "created_at" => an_instance_of(String),
+        "updated_at" => an_instance_of(String),
+        "status" => page.status.transform_keys(&:to_s),
+        "url_path" => page.url_path,
+        "parent_id" => page.parent_id,
+        "elements" => [],
+        "site" => {
+          "id" => page.site.id,
+          "aliases" => nil,
+          "created_at" => an_instance_of(String),
+          "host" => "*",
+          "name" => "Default Site",
+          "public" => true,
+          "redirect_to_primary_host" => false,
+          "updated_at" => an_instance_of(String),
+        },
+        "language" => {
+          "country_code" => "",
+          "created_at" => an_instance_of(String),
+          "creator_id" => nil,
+          "default" => true,
+          "frontpage_name" => "Intro",
+          "id" => page.language_id,
+          "language_code" => "en",
+          "locale" => "en",
+          "name" => "Your Language",
+          "page_layout" => "index",
+          "public" => true,
+          "site_id" => page.site.id,
+          "updated_at" => an_instance_of(String),
+          "updater_id" => nil,
+        },
+      )
+    end
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

This reverts the changes made in https://github.com/AlchemyCMS/alchemy_cms/commit/59467e811247ebb0a01ffd2069460005e3b92b3b and https://github.com/AlchemyCMS/alchemy_cms/commit/5c3f912090164ab03f34c4c19a538d3bc1b65f52

We need to be able to list all pages from the admin API, because admin users need to be able to link pages from other sites and languages. Since we do not have a way right now to restrict pages, languages and sites to certain admin users we need to return all.

References #2207

### Notable changes

Change the admin page select UI so that it shows the site/domain and language a page is on, so that admin users can distinguish pages visually.

### Screenshots

<img alt="Alchemy CMS - Contact 2022-03-10 11-21-14" src="https://user-images.githubusercontent.com/42868/157648408-6a4439ee-ae37-4f85-96f9-30e812893007.png">

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
