### PR TITLE
Allow to skip db:create during install task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -48,7 +48,7 @@ namespace :alchemy do
           bin/rake db:create && \
           bin/rake db:environment:set && \
           bin/rake db:migrate:reset && \
-          bin/rails g alchemy:install --skip --skip-demo-files --auto-accept && \
+          bin/rails g alchemy:install --skip --skip-demo-files --auto-accept --skip-db-create && \
           yarn link @alchemy_cms/admin && \
           RAILS_ENV=test bin/webpack && \
           cd -

--- a/lib/generators/alchemy/install/install_generator.rb
+++ b/lib/generators/alchemy/install/install_generator.rb
@@ -23,6 +23,11 @@ module Alchemy
         default: false,
         desc: "Skip running the webpacker installer."
 
+      class_option :skip_db_create,
+        type: :boolean,
+        default: false,
+        desc: "Skip creting the database during install."
+
       source_root File.expand_path("files", __dir__)
 
       def setup
@@ -104,7 +109,7 @@ module Alchemy
       end
 
       def setup_database
-        rake("db:create", abort_on_failure: true)
+        rake("db:create", abort_on_failure: true) unless options[:skip_db_create]
         # We can't invoke this rake task, because Rails will use wrong engine names otherwise
         rake("railties:install:migrations", abort_on_failure: true)
         rake("db:migrate", abort_on_failure: true)


### PR DESCRIPTION
## What is this pull request for?

Pass `--skip-db-create` while running `rails g alchemy:install` to skip database creation.

Useful on CIs where a database is already present or if you do not have the privilege to create databases in your env.

Closes #2265

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
