### PR TITLE
Use lodash-es instead of lodash

### DIFF
--- a/package/src/picture_editors.js
+++ b/package/src/picture_editors.js
@@ -1,5 +1,5 @@
-import debounce from "lodash/debounce"
-import max from "lodash/max"
+import debounce from "lodash-es/debounce"
+import max from "lodash-es/max"
 import { get } from "./utils/ajax"
 import ImageLoader from "./image_loader"
 


### PR DESCRIPTION
## What is this pull request for?

Change to use `lodash-es` package instead of `lodash`.

Closes #2264

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
