### PR TITLE
Revert "Ajax: Send method override"

### DIFF
--- a/package/src/utils/__tests__/ajax.spec.js
+++ b/package/src/utils/__tests__/ajax.spec.js
@@ -95,7 +95,7 @@ describe("get", () => {
 
 describe("patch", () => {
   it("sends X-CSRF-TOKEN header", async () => {
-    xhrMock.post("http://localhost/users", (req, res) => {
+    xhrMock.patch("http://localhost/users", (req, res) => {
       expect(req.header("X-CSRF-TOKEN")).toEqual(token)
       return res.status(200).body('{"message":"Ok"}')
     })
@@ -103,7 +103,7 @@ describe("patch", () => {
   })
 
   it("sends Content-Type header", async () => {
-    xhrMock.post("http://localhost/users", (req, res) => {
+    xhrMock.patch("http://localhost/users", (req, res) => {
       expect(req.header("Content-Type")).toEqual(
         "application/json; charset=utf-8"
       )
@@ -113,26 +113,16 @@ describe("patch", () => {
   })
 
   it("sends Accept header", async () => {
-    xhrMock.post("http://localhost/users", (req, res) => {
+    xhrMock.patch("http://localhost/users", (req, res) => {
       expect(req.header("Accept")).toEqual("application/json")
       return res.status(200).body('{"message":"Ok"}')
     })
     await patch("/users")
   })
 
-  it("sends method override data", async () => {
-    xhrMock.post("http://localhost/users", (req, res) => {
-      expect(req.body()).toEqual('{"_method":"patch"}')
-      return res.status(200).body('{"message":"Ok"}')
-    })
-    await patch("/users")
-  })
-
   it("sends JSON data", async () => {
-    xhrMock.post("http://localhost/users", (req, res) => {
-      expect(req.body()).toEqual(
-        '{"email":"mail@example.com","_method":"patch"}'
-      )
+    xhrMock.patch("http://localhost/users", (req, res) => {
+      expect(req.body()).toEqual('{"email":"mail@example.com"}')
       return res.status(200).body('{"message":"Ok"}')
     })
     await patch("/users", { email: "mail@example.com" })

--- a/package/src/utils/ajax.js
+++ b/package/src/utils/ajax.js
@@ -33,8 +33,8 @@ export function get(url, params) {
   return ajax("GET", url, params)
 }
 
-export function patch(url, data = {}) {
-  return ajax("POST", url, { ...data, _method: "patch" })
+export function patch(url, data) {
+  return ajax("PATCH", url, data)
 }
 
 export function post(url, data) {


### PR DESCRIPTION
## What is this pull request for?

This reverts commit f183a5e3df4d83fdd977f49dcd3b9ac5361ef495.

The method override is not ending up in the Rails router as expected and leads to 404 errors (Route Not Found)

Relying on a properly configured Web-Server instead. Tested on several non-PaaS hosters as well as on PaaS Hosters
and it always works with the PATCH request. 

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
