### PR TITLE
fix(Sitemap): Use response data

### DIFF
--- a/package/src/page_sorter.js
+++ b/package/src/page_sorter.js
@@ -11,7 +11,7 @@ function onFinishDragging(evt) {
 
   patch(url, data)
     .then(async (response) => {
-      const pageData = await response.json()
+      const pageData = await response.data
       const pageEl = document.getElementById(`page_${pageId}`)
       const urlPathEl = pageEl.querySelector(".sitemap_url")
 

--- a/package/src/sitemap.js
+++ b/package/src/sitemap.js
@@ -1,7 +1,7 @@
 // The admin sitemap Alchemy class
 import PageSorter from "./page_sorter"
 import { on } from "./utils/events"
-import { patch } from "./utils/ajax"
+import { get, patch } from "./utils/ajax"
 import { createSortables, displayPageFolders } from "./page_sorter"
 
 export default class Sitemap {
@@ -31,9 +31,9 @@ export default class Sitemap {
     const spinTarget = this.sitemap_wrapper
     spinTarget.innerHTML = ""
     spinner.spin(spinTarget)
-    fetch(`${this.options.url}?id=${pageId}`)
+    get(this.options.url, { id: pageId })
       .then(async (response) => {
-        this.render(await response.json())
+        this.render(await response.data)
         this.handlePageFolders()
         spinner.stop()
       })
@@ -55,7 +55,7 @@ export default class Sitemap {
 
         patch(Alchemy.routes.fold_admin_page_path(pageId))
           .then(async (response) => {
-            this.reRender(pageId, await response.json())
+            this.reRender(pageId, await response.data)
             spinner.stop()
           })
           .catch(this.errorHandler)

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   config.action_dispatch.show_exceptions = false
 
   # Disable request forgery protection in test environment.
-  config.action_controller.allow_forgery_protection = false
+  config.action_controller.allow_forgery_protection = true
 
   config.action_mailer.perform_caching = false
 

--- a/spec/features/admin/legacy_page_url_management_spec.rb
+++ b/spec/features/admin/legacy_page_url_management_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe "Legacy page url management", type: :system, js: true do
 
   def open_page_properties
     visit admin_pages_path
-    page.find("a[href='#{configure_admin_page_path(a_page)}']").click
+    expect(page).to have_no_css(".spinner")
+    page.find("a[href='#{configure_admin_page_path(a_page)}']", wait: 10).click
   end
 
   it "lets a user add a page link" do


### PR DESCRIPTION
## What is this pull request for?

Our ajax library returns the parsed json as response.data. The former was part of the fetch() api that we used before.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message

