### PR TITLE
Show site and language name on page select in Link dialog

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.link_dialog.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.link_dialog.js.coffee
@@ -87,6 +87,8 @@ class window.Alchemy.LinkDialog extends Alchemy.Dialog
               name: page.name
               url_path: page.url_path
               page_id: page.id
+              language: page.language
+              site: page.site
           more: meta.page * meta.per_page < meta.total_count
       initSelection: ($element, callback) =>
         urlname = $element.val()


### PR DESCRIPTION
## What is this pull request for?

The Link Dialog wasn't including the Site and Language in the results passed to the handlebars template, resulting in them being missing from displayed results.  This fixes that.

### Screenshots
![image](https://user-images.githubusercontent.com/339991/160951192-3a78b326-a3c0-474b-8295-5d3671682134.png)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
