### PR TITLE
Restrict Node select to the site/language of the page being edited

### DIFF
--- a/app/controllers/alchemy/api/nodes_controller.rb
+++ b/app/controllers/alchemy/api/nodes_controller.rb
@@ -8,6 +8,7 @@ module Alchemy
     def index
       @nodes = Node.all
       @nodes = @nodes.includes(:parent)
+      @nodes = @nodes.where(language_id: params[:language_id]) if params[:language_id]
       @nodes = @nodes.ransack(params[:filter]).result
 
       if params[:page]

--- a/app/views/alchemy/essences/_essence_node_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_node_editor.html.erb
@@ -17,7 +17,7 @@
   }) %>
   $('#<%= essence_node_editor.form_field_id %>').alchemyNodeSelect({
     placeholder: "<%= Alchemy.t(:search_node) %>",
-    url: "<%= alchemy.api_nodes_path %>",
+    url: "<%= alchemy.api_nodes_path(language_id: essence_node_editor.page&.language_id) %>",
     query_params: <%== query_params.to_json %>,
     <% if essence_node_editor.essence.node %>
     <% serialized_node = ActiveModelSerializers::SerializableResource.new(essence_node_editor.essence.node, include: :ancestors) %>

--- a/spec/features/admin/node_select_feature_spec.rb
+++ b/spec/features/admin/node_select_feature_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Node select", type: :system, js: true do
+  before do
+    authorize_user(:as_admin)
+  end
+
+  let(:english_element) { create(:alchemy_element, name: :menu, page: create(:alchemy_page)) }
+  let!(:english_node) { create(:alchemy_node, name: "test") }
+
+  let!(:klingon) { create(:alchemy_language, :klingon) }
+  let(:klingon_element) { create(:alchemy_element, name: :menu, page: create(:alchemy_page, language: klingon)) }
+  let!(:klingon_node) { create(:alchemy_node, name: "test", language: klingon) }
+
+  %w(english klingon).each do |language|
+    context language do
+      let(:element) { send "#{language}_element" }
+      let(:node) { send "#{language}_node" }
+
+      it "restricts to the site/language of the page the element is on" do
+        visit alchemy.admin_elements_path(page_version_id: element.page_version_id)
+        select2_search("test", element_id: element.id, content_name: "menu")
+        within "#element_#{element.id}" do
+          click_on("Save")
+        end
+
+        expect(page).to have_content("Saved", wait: 5)
+        expect(element.reload.ingredient(:menu)).to eq(node)
+      end
+    end
+  end
+end

--- a/spec/requests/alchemy/api/nodes_controller_spec.rb
+++ b/spec/requests/alchemy/api/nodes_controller_spec.rb
@@ -63,6 +63,18 @@ module Alchemy
             expect(result["data"].size).to eq(1)
           end
         end
+
+        context "with a language_id given" do
+          let(:klingon) { create(:alchemy_language, :klingon) }
+          let!(:klingon_node) { create(:alchemy_node, name: "yup", language: klingon) }
+
+          it "returns only nodes for that language" do
+            get alchemy.api_nodes_path(params: {format: :json, language_id: klingon.id})
+
+            expect(result["data"].size).to eq(1)
+            expect(result["data"].first["id"]).to eq klingon_node.id
+          end
+        end
       end
     end
 

--- a/spec/support/capybara_helpers.rb
+++ b/spec/support/capybara_helpers.rb
@@ -22,10 +22,15 @@ module CapybaraSelect2
   end
 
   def select2_search(value, options)
-    label = find_label_by_text(options[:from])
-
-    within label.first(:xpath, ".//..") do
-      options[:from] = "##{find(".select2-container")["id"]}"
+    if options[:from]
+      label = find_label_by_text(options[:from])
+      within label.first(:xpath, ".//..") do
+        options[:from] = "##{find(".select2-container")["id"]}"
+      end
+    elsif options[:element_id] && options[:content_name]
+      container_id = find("#element_#{options[:element_id]} [data-content-name='#{options[:content_name]}'] .select2-container"
+      )["id"]
+      options[:from] = "##{container_id}"
     end
 
     find("#{options[:from]}:not(.select2-container-disabled):not(.select2-offscreen)").click


### PR DESCRIPTION
## What is this pull request for?

Restrict Node results to the current Site/Language in the EssenceNode editor.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
