### PR TITLE
Don't delete locals in render_element so they can be used by all elements in render_elements

### DIFF
--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -149,8 +149,8 @@ module Alchemy
       render element, {
         element: element,
         counter: counter,
-        options: options,
-      }.merge(options.delete(:locals) || {})
+        options: options.except(:locals),
+      }.merge(options[:locals] || {})
     rescue ActionView::MissingTemplate => e
       warning(%(
         Element view partial not found for #{element.name}.\n

--- a/spec/helpers/alchemy/elements_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_helper_spec.rb
@@ -147,6 +147,25 @@ module Alchemy
           is_expected.to have_selector("#news_1001")
         end
       end
+
+      context "with locals option" do
+        let(:options) do
+          { locals: { foo: :bar} }
+        end
+
+        it "sends locals with every #render_element call" do
+          expect(helper).to receive(:render).with(
+            element,
+            {element: element, counter: 1, options: { from_page: page, render_format: "html" }, foo: :bar}
+          )
+          expect(helper).to receive(:render).with(
+            another_element,
+            {element: another_element, counter: 2, options: { from_page: page, render_format: "html" }, foo: :bar}
+          )
+
+          subject
+        end
+      end
     end
 
     describe "#element_preview_code_attributes" do


### PR DESCRIPTION
## What is this pull request for?

Fix a bug which was preventing the `locals` option passed to `Alchemy::ElementsHelper#render_elements` from being passed to more than the first element, due to `delete` being called on the `options` hash.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
