### PR TITLE
Fix image loader

### DIFF
--- a/app/assets/stylesheets/alchemy/archive.scss
+++ b/app/assets/stylesheets/alchemy/archive.scss
@@ -65,6 +65,11 @@ div#image_assign_filter_and_image_sizing {
     width: 100%;
     height: 100%;
     object-fit: contain;
+
+    &[src$=".svg"] {
+      width: auto;
+      height: auto;
+    }
   }
 
   .picture_name {

--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -545,6 +545,10 @@
     font-size: 4em;
     color: $medium-gray;
     vertical-align: top;
+
+    &.error {
+      font-size: 1.2em;
+    }
   }
 
   .essence_picture_css_class {

--- a/package/src/image_loader.js
+++ b/package/src/image_loader.js
@@ -40,9 +40,9 @@ export default class ImageLoader {
   }
 
   onError(evt) {
-    const message = `Could not load ${this.image.src}`
+    const message = `Could not load "${this.image.src}"`
     this.removeSpinner()
-    this.parent.innerHTML = `<span class="icon fas fa-exclamation-triangle" title="${message}" />`
+    this.parent.innerHTML = `<span class="icon error fas fa-exclamation-triangle" title="${message}" />`
     console.error(message, evt)
     this.unbind()
   }

--- a/package/src/picture_editors.js
+++ b/package/src/picture_editors.js
@@ -5,7 +5,6 @@ import ImageLoader from "./image_loader"
 
 const UPDATE_DELAY = 125
 const IMAGE_PLACEHOLDER = '<i class="icon far fa-image fa-fw"></i>'
-const EMPTY_IMAGE = '<img src="" class="img_paddingtop" />'
 const THUMBNAIL_SIZE = "160x120"
 
 class PictureEditor {
@@ -83,9 +82,10 @@ class PictureEditor {
   ensureImage() {
     if (this.image) return
 
-    this.thumbnailBackground.innerHTML = EMPTY_IMAGE
-    this.image = this.container.querySelector("img")
-    this.imageLoader = new ImageLoader(this.image)
+    const img = new Image()
+    this.thumbnailBackground.replaceChildren(img)
+    this.image = img
+    this.imageLoader = new ImageLoader(img)
   }
 
   removeImage() {


### PR DESCRIPTION
## What is this pull request for?

The image loader stopped working in recent versions of Firefox and Safari.
Fixed by using an actual `Image` element instead of a DOM String.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
