### PR TITLE
Allow pasting into parent element with only one nested element type

### DIFF
--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -12,6 +12,7 @@ module Alchemy
         elements = @page_version.elements.order(:position).includes(*element_includes)
         @elements = elements.not_nested.unfixed
         @fixed_elements = elements.not_nested.fixed
+        load_clipboard_items
       end
 
       def new
@@ -20,8 +21,7 @@ module Alchemy
         @parent_element = Element.find_by(id: params[:parent_element_id])
         @elements = @page.available_elements_within_current_scope(@parent_element)
         @element = @page_version.elements.build
-        @clipboard = get_clipboard("elements")
-        @clipboard_items = Element.all_from_clipboard_for_page(@clipboard, @page)
+        load_clipboard_items
       end
 
       # Creates a element as discribed in config/alchemy/elements.yml on page via AJAX.
@@ -44,8 +44,7 @@ module Alchemy
         else
           @element.page_version = @page_version
           @elements = @page.available_element_definitions
-          @clipboard = get_clipboard("elements")
-          @clipboard_items = Element.all_from_clipboard_for_page(@clipboard, @page)
+          load_clipboard_items
           render :new
         end
       end
@@ -126,19 +125,27 @@ module Alchemy
         @element = Element.find(params[:id])
       end
 
+      def load_clipboard_items
+        @clipboard = get_clipboard("elements")
+        @clipboard_items = Element.all_from_clipboard_for_page(@clipboard, @page)
+      end
+
       def element_from_clipboard
         @element_from_clipboard ||= begin
-            @clipboard = get_clipboard("elements")
-            @clipboard.detect { |item| item["id"].to_i == params[:paste_from_clipboard].to_i }
-          end
+          @clipboard = get_clipboard("elements")
+          @clipboard.detect { |item| item["id"].to_i == params[:paste_from_clipboard].to_i }
+        end
       end
 
       def paste_element_from_clipboard
         @source_element = Element.find(element_from_clipboard["id"])
-        element = Element.copy(@source_element, {
-          parent_element_id: create_element_params[:parent_element_id],
-          page_version_id: @page_version.id,
-        })
+        element = Element.copy(
+          @source_element,
+          {
+            parent_element_id: create_element_params[:parent_element_id],
+            page_version_id: @page_version.id,
+          }
+        )
         if element_from_clipboard["action"] == "cut"
           @cut_element_id = @source_element.id
           @clipboard.delete_if { |item| item["id"] == @source_element.id.to_s }

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -159,7 +159,7 @@ module Alchemy
       end
 
       def all_from_clipboard(clipboard)
-        return [] if clipboard.nil?
+        return none if clipboard.nil?
 
         where(id: clipboard.collect { |e| e["id"] })
       end
@@ -167,11 +167,16 @@ module Alchemy
       # All elements in clipboard that could be placed on page
       #
       def all_from_clipboard_for_page(clipboard, page)
-        return [] if clipboard.nil? || page.nil?
+        return none if clipboard.nil? || page.nil?
 
-        all_from_clipboard(clipboard).select { |ce|
-          page.available_element_names.include?(ce.name)
-        }
+        all_from_clipboard(clipboard).where(name: page.available_element_names)
+      end
+
+      # All elements in clipboard that could be placed as a child of `parent_element`
+      def all_from_clipboard_for_parent_element(clipboard, parent_element)
+        return none if clipboard.nil? || parent_element.nil?
+
+        all_from_clipboard(clipboard).where(name: parent_element.definition["nestable_elements"])
       end
     end
 

--- a/app/views/alchemy/admin/clipboard/insert.js.erb
+++ b/app/views/alchemy/admin/clipboard/insert.js.erb
@@ -14,3 +14,14 @@
   Alchemy.growl('<%= j Alchemy.t("item copied to clipboard", name: @item.class.name == "Alchemy::Element" ? @item.display_name_with_preview_text : @item.name) %>')
 <% end -%>
 $('#clipboard_button .icon').removeClass('fa-clipboard').addClass('fa-paste');
+
+if (window.location.pathname == "<%= edit_admin_page_path(@item.page.id) %>") {
+  <%# Update add nested element forms for any elements that accept ONLY this as a nested element %>
+  <% if @item.class == Alchemy::Element %>
+    <% @item.page.draft_version.elements.expanded.each do |element| %>
+      <% if element.definition["nestable_elements"] == [@item.name] %>
+        $(".add-nested-element[data-element-id='<%= element.id %>']").replaceWith('<%= j render "alchemy/admin/elements/add_nested_element_form", element: element %>')
+      <% end %>
+    <% end %>
+  <% end %>
+}

--- a/app/views/alchemy/admin/clipboard/insert.js.erb
+++ b/app/views/alchemy/admin/clipboard/insert.js.erb
@@ -15,13 +15,15 @@
 <% end -%>
 $('#clipboard_button .icon').removeClass('fa-clipboard').addClass('fa-paste');
 
-if (window.location.pathname == "<%= edit_admin_page_path(@item.page.id) %>") {
-  <%# Update add nested element forms for any elements that accept ONLY this as a nested element %>
-  <% if @item.class == Alchemy::Element %>
-    <% @item.page.draft_version.elements.expanded.each do |element| %>
-      <% if element.definition["nestable_elements"] == [@item.name] %>
-        $(".add-nested-element[data-element-id='<%= element.id %>']").replaceWith('<%= j render "alchemy/admin/elements/add_nested_element_form", element: element %>')
-      <% end %>
+<%# Update add nested element forms for any elements that accept ONLY this as a nested element %>
+<% if @item.class == Alchemy::Element %>
+  if (window.location.pathname == "<%= edit_admin_page_path(@item.page.id) %>") {
+    <%
+      @item.page.draft_version.elements.expanded.select do |element|
+        element.definition["nestable_elements"] == [@item.name]
+      end.each do |element|
+    %>
+      $(".add-nested-element[data-element-id='<%= element.id %>']").replaceWith('<%= j render "alchemy/admin/elements/add_nested_element_form", element: element %>')
     <% end %>
-  <% end %>
-}
+  }
+<% end %>

--- a/app/views/alchemy/admin/elements/_add_nested_element_form.html.erb
+++ b/app/views/alchemy/admin/elements/_add_nested_element_form.html.erb
@@ -1,0 +1,27 @@
+<%= content_tag :div, class: 'add-nested-element', data: { element_id: element.id } do %>
+  <% if element.expanded? || element.fixed? %>
+    <% if element.nestable_elements.length == 1 && 
+      (nestable_element = element.nestable_elements.first) && 
+      Alchemy::Element.all_from_clipboard_for_parent_element(get_clipboard("elements"), element).none?
+    %>
+      <%= form_for [:admin, Alchemy::Element.new(name: nestable_element)],
+        remote: true, html: { class: 'add-nested-element-form', id: nil } do |f| %>
+        <%= f.hidden_field :name %>
+        <%= f.hidden_field :page_version_id, value: element.page_version_id %>
+        <%= f.hidden_field :parent_element_id, value: element.id %>
+        <button class="button add-nestable-element-button" data-alchemy-button>
+          <%= Alchemy.t(:add_nested_element, name: Alchemy.t(nestable_element, scope: 'element_names')) %>
+        </button>
+      <% end %>
+    <% else %>
+      <%= link_to_dialog (nestable_element ? Alchemy.t(:add_nested_element, name: Alchemy.t(nestable_element, scope: 'element_names')) : Alchemy.t("New Element")),
+        alchemy.new_admin_element_path(
+          parent_element_id: element.id,
+          page_version_id: element.page_version_id
+        ), {
+          size: "320x125",
+          title: Alchemy.t("New Element")
+        }, class: "button add-nestable-element-button" %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/alchemy/admin/elements/_element.html.erb
+++ b/app/views/alchemy/admin/elements/_element.html.erb
@@ -55,29 +55,7 @@
         } %>
       <% end %>
 
-      <% if element.expanded? || element.fixed? %>
-        <% if element.nestable_elements.length == 1 %>
-          <% nestable_element = element.nestable_elements.first %>
-          <%= form_for [:admin, Alchemy::Element.new(name: nestable_element)],
-            remote: true, html: { class: 'add-nested-element-form', id: nil } do |f| %>
-            <%= f.hidden_field :name %>
-            <%= f.hidden_field :page_version_id, value: element.page_version_id %>
-            <%= f.hidden_field :parent_element_id, value: element.id %>
-            <button class="button add-nestable-element-button" data-alchemy-button>
-              <%= Alchemy.t(:add_nested_element) % { name: Alchemy.t(nestable_element, scope: 'element_names') } %>
-            </button>
-          <% end %>
-        <% else %>
-          <%= link_to_dialog Alchemy.t("New Element"),
-            alchemy.new_admin_element_path(
-              parent_element_id: element.id,
-              page_version_id: element.page_version_id
-            ), {
-              size: "320x125",
-              title: Alchemy.t("New Element")
-            }, class: "button add-nestable-element-button" %>
-        <% end %>
-      <% end %>
+      <%= render "alchemy/admin/elements/add_nested_element_form", element: element %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/alchemy/admin/elements/_form.html.erb
+++ b/app/views/alchemy/admin/elements/_form.html.erb
@@ -9,7 +9,11 @@
       label: Alchemy.t(:element_of_type),
       collection: elements_for_select(@elements),
       prompt: Alchemy.t(:select_element),
-      input_html: {class: 'alchemy_selectbox', autofocus: true} %>
+      selected: (@elements.first if @elements.count == 1),
+      input_html: {class: 'alchemy_selectbox', autofocus: true, disabled: @elements.count == 1} %>
+    <% if @elements.count == 1 %>
+      <%= form.hidden_field :name, value: @elements.first[:name] %>
+    <% end %>
     <%= form.hidden_field :parent_element_id, value: @parent_element.try(:id) %>
     <%= form.submit Alchemy.t(:add) %>
   <%- end -%>

--- a/spec/controllers/alchemy/admin/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/elements_controller_spec.rb
@@ -91,7 +91,7 @@ module Alchemy
       let(:page_version) { create(:alchemy_page_version) }
 
       it "assign variable for all available element definitions" do
-        expect_any_instance_of(Alchemy::Page).to receive(:available_element_definitions)
+        expect_any_instance_of(Alchemy::Page).to receive(:available_element_definitions).twice { [] }
         get :new, params: { page_version_id: page_version.id }
       end
 


### PR DESCRIPTION
## What is this pull request for?

Before this change, the new element dialog (including the option to paste) is not shown when adding a nested element when the parent element only has a one nestable element type.
This change shows the dialog in this case **only** if the clipboard contains an element with the name of the nestable element type.  In this case, the element select is disabled (and shows the only option).

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
