### PR TITLE
Do not flatten gifs if converted to webp

### DIFF
--- a/app/models/alchemy/picture_variant.rb
+++ b/app/models/alchemy/picture_variant.rb
@@ -13,6 +13,8 @@ module Alchemy
     include Alchemy::Logger
     include Alchemy::Picture::Transformations
 
+    ANIMATED_IMAGE_FORMATS = %w[gif webp]
+
     attr_reader :picture, :render_format
 
     def_delegators :@picture,
@@ -86,7 +88,7 @@ module Alchemy
       end
 
       options = {
-        flatten: render_format != "gif" && picture.image_file_format == "gif",
+        flatten: !render_format.in?(ANIMATED_IMAGE_FORMATS) && picture.image_file_format == "gif",
       }.with_indifferent_access.merge(options)
 
       encoding_options = []

--- a/spec/models/alchemy/picture_variant_spec.rb
+++ b/spec/models/alchemy/picture_variant_spec.rb
@@ -171,6 +171,25 @@ RSpec.describe Alchemy::PictureVariant do
         expect(step.name).to eq(:encode)
         expect(step.arguments).to eq(["png", "-flatten"])
       end
+
+      context "converted to webp" do
+        let(:options) do
+          { format: "webp" }
+        end
+
+        let(:image_file) do
+          fixture_file_upload(
+            File.expand_path("../../fixtures/animated.gif", __dir__),
+            "image/gif",
+          )
+        end
+
+        it "does not flatten the image." do
+          step = subject.steps[0]
+          expect(step.name).to eq(:encode)
+          expect(step.arguments).to eq(["webp", ""])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## What is this pull request for?

WebP can also be animated. So, we should not flatten GIFs,
if we convert them to WebP.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
