### PR TITLE
Fix frozen string error when mixing template engines

### DIFF
--- a/lib/generators/alchemy/base.rb
+++ b/lib/generators/alchemy/base.rb
@@ -17,8 +17,8 @@ module Alchemy
           # source and destination file names to use that engine.
           if ext != template_engine.to_s
             say_status :warning, "View uses unexpected template engine '#{ext}'.", :cyan
-            destination.gsub!(/#{template_engine}$/, ext)
-            source.gsub!(/#{template_engine}$/, ext)
+            destination = destination.gsub(/#{template_engine}$/, ext)
+            source = source.gsub(/#{template_engine}$/, ext)
           end
         end
 


### PR DESCRIPTION
## What is this pull request for?

Situation:
There's already an _article.html.erb which was created when first installing alchemy.

Now, after adding elements and page layouts, calling `rails g alchemy:elements --skip -e slim` gives the following warning:
>  warning  View uses unexpected template engine 'erb'.

followed by the this error:

`/usr/local/rvm/gems/ruby-2.7.5/gems/alchemy_cms-6.0.0/lib/generators/alchemy/base.rb:20:in `gsub!': can't modify frozen String: "app/views/alchemy/elements/_article.html.slim" (FrozenError)`

This PR fixes this.

## Checklist
- [ ] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [ ] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
