### PR TITLE
Explicitly validate uniqueness without case sensitivity

### DIFF
--- a/app/models/alchemy/language.rb
+++ b/app/models/alchemy/language.rb
@@ -38,7 +38,7 @@ module Alchemy
 
     validates :language_code,
       presence: true,
-      uniqueness: { scope: [:site_id, :country_code] },
+      uniqueness: { scope: [:site_id, :country_code], case_sensitive: false },
       format: { with: /\A[a-z]{2}\z/, if: -> { language_code.present? } }
 
     validates :country_code,

--- a/app/models/alchemy/page/page_naming.rb
+++ b/app/models/alchemy/page/page_naming.rb
@@ -15,7 +15,7 @@ module Alchemy
         validates :name,
           presence: true
         validates :urlname,
-          uniqueness: { scope: [:language_id, :layoutpage], if: -> { urlname.present? } },
+          uniqueness: { scope: [:language_id, :layoutpage], if: -> { urlname.present? }, case_sensitive: false },
           exclusion: { in: RESERVED_URLNAMES },
           length: { minimum: 3, if: -> { urlname.present? } }
 

--- a/app/models/alchemy/site.rb
+++ b/app/models/alchemy/site.rb
@@ -18,7 +18,7 @@ module Alchemy
   class Site < BaseRecord
     # validations
     validates_presence_of :host
-    validates_uniqueness_of :host
+    validates_uniqueness_of :host, case_sensitive: false
 
     # associations
     has_many :languages


### PR DESCRIPTION
In Rails 6.1, the default behavior of the uniqueness validator changed
from case-sensitive to case-insensitive. The Rails folk have made a
beautiful deprecation warning for this behavior, which we now see in all
our Rails 6 builds.

This PR explicitly specifies that we don't want case sensitivity on
URLs, host names, and language codes. This is in line with browser
behavior and implicit behavior on newer Rails versions.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
