### PR TITLE
Allow opting out of Turbolinks in non-Alchemy controllers

### DIFF
--- a/app/controllers/alchemy/base_controller.rb
+++ b/app/controllers/alchemy/base_controller.rb
@@ -9,6 +9,13 @@ module Alchemy
     include Alchemy::ControllerActions
     include Alchemy::Modules
 
+    # Include Turbolinks explicitly in case Alchemy is embedded into a
+    # larger application that doesn't work with Turbolinks. The app
+    # can then set config.turbolinks.auto_include = false so that
+    # Turbolinks is not included in the app controllers.
+    include Turbolinks::Controller
+    ::ActionDispatch::Assertions.include ::Turbolinks::Assertions
+
     protect_from_forgery
 
     before_action :mailer_set_url_options


### PR DESCRIPTION
## What is this pull request for?

Closes #2295.

## Notable changes

No breaking changes, see code comment for exact details.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
