### PR TITLE
Fix updating the public_on date on persisted pages

### DIFF
--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -117,7 +117,7 @@ module Alchemy
     has_many :nodes, class_name: "Alchemy::Node", inverse_of: :page
     has_many :versions, class_name: "Alchemy::PageVersion", inverse_of: :page, dependent: :destroy
     has_one :draft_version, -> { drafts }, class_name: "Alchemy::PageVersion"
-    has_one :public_version, -> { published }, class_name: "Alchemy::PageVersion"
+    has_one :public_version, -> { published }, class_name: "Alchemy::PageVersion", autosave: -> { persisted? }
 
     before_validation :set_language,
       if: -> { language.nil? }

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1397,7 +1397,7 @@ module Alchemy
     end
 
     describe "#public_on=" do
-      let(:time) { Time.now }
+      let(:time) { 1.hour.ago }
 
       subject { page.public_on = time }
 
@@ -1407,6 +1407,15 @@ module Alchemy
         it "sets public_on on the public version" do
           subject
           expect(page.public_version.public_on).to be_within(1.second).of(time)
+        end
+
+        context "when the page is persisted" do
+          let(:page) { create(:alchemy_page, :public) }
+
+          it "sets public_on on the public version" do
+            page.update(public_on: time)
+            expect(page.reload.public_version.public_on).to be_within(1.second).of(time)
+          end
         end
 
         context "and the time is nil" do


### PR DESCRIPTION
When updating a page's `public_on` date, we need to save the associated
public page as well. This commit accomplishes that.

Prior to this commit, we would set the `public_on` date on the public
version, but not persist it.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
