### PR TITLE
Set preview mode earlier

### DIFF
--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -25,10 +25,6 @@ module Alchemy
 
       before_action :set_preview_mode, only: [:show]
 
-      before_action :run_on_page_layout_callbacks,
-        if: :run_on_page_layout_callbacks?,
-        only: [:show]
-
       before_action :load_languages_and_layouts,
         unless: -> { @page_root },
         only: [:index]
@@ -36,6 +32,10 @@ module Alchemy
       before_action :set_view, only: [:index]
 
       before_action :set_page_version, only: [:show, :edit]
+
+      before_action :run_on_page_layout_callbacks,
+        if: :run_on_page_layout_callbacks?,
+        only: [:show]
 
       def index
         @query = @current_language.pages.contentpages.ransack(search_filter_params[:q])

--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -23,6 +23,8 @@ module Alchemy
       before_action :set_root_page,
         only: [:index, :show, :order]
 
+      before_action :set_preview_mode, only: [:show]
+
       before_action :run_on_page_layout_callbacks,
         if: :run_on_page_layout_callbacks?,
         only: [:show]
@@ -64,7 +66,6 @@ module Alchemy
       # Used by page preview iframe in Page#edit view.
       #
       def show
-        @preview_mode = true
         Page.current_preview = @page
         # Setting the locale to pages language, so the page content has it's correct translations.
         ::I18n.locale = @page.language.locale
@@ -396,6 +397,10 @@ module Alchemy
         @language = @current_language
         @languages_with_page_tree = Language.on_current_site.with_root_page
         @page_layouts = PageLayout.layouts_for_select(@language.id)
+      end
+
+      def set_preview_mode
+        @preview_mode = true
       end
     end
   end


### PR DESCRIPTION
## What is this pull request for?

This sets `@preview_mode` before executing any `OnPageLayout` callbacks, so that the callbacks can identify whether they are in in preview mode or not. 

### Notable changes (remove if none)

This just changes the order of callbacks.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message

