### PR TITLE
Explicitly set "store" for MariaDB

### DIFF
--- a/app/models/alchemy/ingredient.rb
+++ b/app/models/alchemy/ingredient.rb
@@ -6,6 +6,10 @@ module Alchemy
 
     include Hints
 
+    # MariaDB needs to be told explicitly to use `data` as a JSON store. All other databases
+    # can do this natively.
+    store :data, coder: JSON
+
     self.table_name = "alchemy_ingredients"
 
     belongs_to :element, touch: true, class_name: "Alchemy::Element", inverse_of: :ingredients


### PR DESCRIPTION

## What is this pull request for?

MariaDB does not have a native "JSON(B)" type, and thus rails does not
know that the `alchemy_ingredients.data` column needs to be serialized
as JSON.

I'm running this as a test; if it doesn't produce errors or warnings this should fix https://github.com/AlchemyCMS/alchemy_cms/discussions/2304


## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message

