### PR TITLE
Deprecate Alchemy::Element.available

### DIFF
--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -126,7 +126,7 @@ module Alchemy
     #
     # == Usage
     #
-    #   <%= render_element(Alchemy::Element.available.named(:headline).first) %>
+    #   <%= render_element(Alchemy::Element.published.named(:headline).first) %>
     #
     # @param [Alchemy::Element] element
     #   The element you want to render the view for

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -178,6 +178,8 @@ module Alchemy
 
         all_from_clipboard(clipboard).where(name: parent_element.definition["nestable_elements"])
       end
+
+      deprecate available: :published, deprecator: Alchemy::Deprecation
     end
 
     # Returns next public element from same page.

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -70,7 +70,7 @@ module Alchemy
       dependent: :destroy
 
     has_many :nested_elements,
-      -> { order(:position).available },
+      -> { order(:position).published },
       class_name: "Alchemy::Element",
       foreign_key: :parent_element_id,
       dependent: :destroy,

--- a/app/models/alchemy/ingredient_validator.rb
+++ b/app/models/alchemy/ingredient_validator.rb
@@ -88,7 +88,7 @@ module Alchemy
 
     def duplicates
       ingredient.class
-        .joins(:element).merge(Alchemy::Element.available)
+        .joins(:element).merge(Alchemy::Element.published)
         .where(Alchemy::Element.table_name => { name: ingredient.element.name })
         .where(value: ingredient.value)
         .where.not(id: ingredient.id)

--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -15,8 +15,8 @@ module Alchemy
           source: :elements,
         ) do
           has_many :all_elements
-          has_many :elements, -> { not_nested.unfixed.available }
-          has_many :fixed_elements, -> { fixed.available }
+          has_many :elements, -> { not_nested.unfixed.published }
+          has_many :fixed_elements, -> { fixed.published }
         end
 
         has_many :contents, through: :elements

--- a/lib/alchemy/essence.rb
+++ b/lib/alchemy/essence.rb
@@ -41,7 +41,7 @@ module Alchemy #:nodoc:
           has_one :element, through: :content, class_name: "Alchemy::Element"
           has_one :page,    through: :element, class_name: "Alchemy::Page"
 
-          scope :available,    -> { joins(:element).merge(Alchemy::Element.available) }
+          scope :available,    -> { joins(:element).merge(Alchemy::Element.published) }
           scope :from_element, ->(name) { joins(:element).where(Element.table_name => { name: name }) }
 
           delegate :restricted?, to: :page,    allow_nil: true

--- a/lib/alchemy/permissions.rb
+++ b/lib/alchemy/permissions.rb
@@ -41,7 +41,7 @@ module Alchemy
           c.public? && !c.restricted?
         end
 
-        can :read, Alchemy::Element, Alchemy::Element.available.not_restricted do |e|
+        can :read, Alchemy::Element, Alchemy::Element.published.not_restricted do |e|
           e.public? && !e.restricted?
         end
 
@@ -68,7 +68,7 @@ module Alchemy
           c.public?
         end
 
-        can :read, Alchemy::Element, Alchemy::Element.available do |e|
+        can :read, Alchemy::Element, Alchemy::Element.published do |e|
           e.public?
         end
 

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -1138,4 +1138,13 @@ module Alchemy
       element.reload.destroy!
     end
   end
+
+  describe ".available" do
+    subject { Alchemy::Element.available }
+
+    it "is deprecated" do
+      expect(Alchemy::Deprecation).to receive(:warn)
+      subject
+    end
+  end
 end


### PR DESCRIPTION
## What is this pull request for?

This removes a scope that is a synonym for another scope. I believe we should be using the `Enumerable` module much more often rather than using scopes, as that will make preloading easier. 

I could have also removed the `published` scope, but I like that it is close to the instance method `public`.

### Notable changes (remove if none)

Alchemy will issue a deprecation warning when `Alchemy::Element.available` is called. 


## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
