### PR TITLE
Refactor: Use page version's element repository rather than a new one

### DIFF
--- a/lib/alchemy/elements_finder.rb
+++ b/lib/alchemy/elements_finder.rb
@@ -54,8 +54,7 @@ module Alchemy
     def find_elements(page_version)
       return Alchemy::ElementsRepository.none unless page_version
 
-      elements = Alchemy::ElementsRepository.new(page_version.elements.available)
-      elements = elements.not_nested
+      elements = page_version.element_repository.visible.not_nested
       elements = options[:fixed] ? elements.fixed : elements.unfixed
 
       if options[:only]


### PR DESCRIPTION
The `PageVersion` model offers us a repository we can use, so let's go
with that. This will also avoid using a scope on a potentially already pre-loaded association.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
