### PR TITLE
Eagerload at the controller or job layer

### DIFF
--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -324,7 +324,7 @@ module Alchemy
       end
 
       def load_resource
-        @page = Page.find(params[:id])
+        @page = Page.includes(page_includes).find(params[:id])
       end
 
       def pages_from_raw_request
@@ -401,6 +401,23 @@ module Alchemy
 
       def set_preview_mode
         @preview_mode = true
+      end
+
+      def page_includes
+        {
+          :tags,
+          language: :site,
+          draft_version: {
+            elements: [
+              :page,
+              :touchable_pages,
+              {
+                ingredients: :related_object,
+                contents: :essence,
+              },
+            ],
+          },
+        }
       end
     end
   end

--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -404,20 +404,7 @@ module Alchemy
       end
 
       def page_includes
-        {
-          :tags,
-          language: :site,
-          draft_version: {
-            elements: [
-              :page,
-              :touchable_pages,
-              {
-                ingredients: :related_object,
-                contents: :essence,
-              },
-            ],
-          },
-        }
+        Alchemy::EagerLoading.page_includes(version: :draft_version)
       end
     end
   end

--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -246,20 +246,7 @@ module Alchemy
     end
 
     def page_includes
-      {
-        :tags,
-        language: :site,
-        public_version: {
-          elements: [
-            :page,
-            :touchable_pages,
-            {
-              ingredients: :related_object,
-              contents: :essence,
-            },
-          ],
-        },
-      }
+      Alchemy::EagerLoading.page_includes(version: :public_version)
     end
   end
 end

--- a/app/jobs/alchemy/publish_page_job.rb
+++ b/app/jobs/alchemy/publish_page_job.rb
@@ -5,6 +5,20 @@ module Alchemy
     queue_as :default
 
     def perform(page, public_on:)
+      page = Alchemy::Page.includes(
+        :tags,
+        language: :site,
+        draft_version: {
+          elements: [
+            :page,
+            :touchable_pages,
+            {
+              ingredients: :related_object,
+              contents: :essence,
+            },
+          ],
+        },
+      ).find(page.id)
       Alchemy::Page::Publisher.new(page).publish!(public_on: public_on)
     end
   end

--- a/app/jobs/alchemy/publish_page_job.rb
+++ b/app/jobs/alchemy/publish_page_job.rb
@@ -6,18 +6,7 @@ module Alchemy
 
     def perform(page_id, public_on:)
       page = Alchemy::Page.includes(
-        :tags,
-        language: :site,
-        draft_version: {
-          elements: [
-            :page,
-            :touchable_pages,
-            {
-              ingredients: :related_object,
-              contents: :essence,
-            },
-          ],
-        },
+        Alchemy::EagerLoading.page_includes(version: :draft_version)
       ).find(page_id)
       Alchemy::Page::Publisher.new(page).publish!(public_on: public_on)
     end

--- a/app/jobs/alchemy/publish_page_job.rb
+++ b/app/jobs/alchemy/publish_page_job.rb
@@ -4,7 +4,7 @@ module Alchemy
   class PublishPageJob < BaseJob
     queue_as :default
 
-    def perform(page, public_on:)
+    def perform(page_id, public_on:)
       page = Alchemy::Page.includes(
         :tags,
         language: :site,
@@ -18,7 +18,7 @@ module Alchemy
             },
           ],
         },
-      ).find(page.id)
+      ).find(page_id)
       Alchemy::Page::Publisher.new(page).publish!(public_on: public_on)
     end
   end

--- a/app/models/alchemy/eager_loading.rb
+++ b/app/models/alchemy/eager_loading.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Alchemy
+  # Eager loading parameters for loading pages
+  class EagerLoading
+    PAGE_VERSIONS = %i[draft_version public_version]
+
+    class << self
+      # Eager loading parameters for {ActiveRecord::Base.includes}
+      #
+      # Pass this to +includes+ whereever you load an {Alchemy::Page}
+      #
+      #     Alchemy::Page.includes(Alchemy::EagerLoading.page_includes).find_by(urlname: "my-page")
+      #
+      # @param version [Symbol] Type of page version to eager load
+      # @return [Array]
+      def page_includes(version: :public_version)
+        raise UnsupportedPageVersion unless version.in? PAGE_VERSIONS
+
+        [
+          :tags,
+          {
+            language: :site,
+            version => {
+              elements: [
+                :page,
+                :touchable_pages,
+                {
+                  ingredients: :related_object,
+                  contents: :essence,
+                },
+              ],
+            },
+          },
+        ]
+      end
+    end
+  end
+end

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -465,7 +465,7 @@ module Alchemy
     #
     def publish!(current_time = Time.current)
       update(published_at: current_time)
-      PublishPageJob.perform_later(self, public_on: current_time)
+      PublishPageJob.perform_later(id, public_on: current_time)
     end
 
     # Sets the public_on date on the published version

--- a/app/models/alchemy/page_version.rb
+++ b/app/models/alchemy/page_version.rb
@@ -46,7 +46,7 @@ module Alchemy
     end
 
     def element_repository
-      ElementsRepository.new(elements.includes({ contents: :essence }, :tags))
+      ElementsRepository.new(elements)
     end
 
     private

--- a/lib/alchemy/errors.rb
+++ b/lib/alchemy/errors.rb
@@ -11,7 +11,7 @@ module Alchemy
     # Raised if no default language configuration can be found.
     def message
       "No default language configuration found!" \
-        " Please ensure that you have a 'default_language' defined in Alchemy configuration file."
+      " Please ensure that you have a 'default_language' defined in Alchemy configuration file."
     end
   end
 
@@ -19,7 +19,7 @@ module Alchemy
     # Raised if no default site configuration can be found.
     def message
       "No default site configuration found!" \
-        " Please ensure that you have a 'default_site' defined in Alchemy configuration file."
+      " Please ensure that you have a 'default_site' defined in Alchemy configuration file."
     end
   end
 
@@ -88,6 +88,12 @@ module Alchemy
     # Raised if no current_user is found to authorize against.
     def message
       "You need to provide a current_user method in your ApplicationController that returns the current authenticated user."
+    end
+  end
+
+  class UnsupportedPageVersion < StandardError
+    def message
+      "Unknown Version! Please use one of #{Alchemy::EagerLoading::PAGE_VERSIONS.join(", ")}"
     end
   end
 end

--- a/spec/jobs/alchemy/publish_page_job_spec.rb
+++ b/spec/jobs/alchemy/publish_page_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Alchemy::PublishPageJob, type: :job do
 
     it "enqueues job" do
       expect {
-        described_class.perform_later(page, public_on: public_on)
+        described_class.perform_later(page.id, public_on: public_on)
       }.to have_enqueued_job
     end
 
@@ -17,7 +17,7 @@ RSpec.describe Alchemy::PublishPageJob, type: :job do
       expect_any_instance_of(Alchemy::Page::Publisher).to receive(:publish!).with(
         public_on: public_on,
       )
-      described_class.new.perform(page, public_on: public_on)
+      described_class.new.perform(page.id, public_on: public_on)
     end
   end
 end

--- a/spec/jobs/alchemy/publish_page_job_spec.rb
+++ b/spec/jobs/alchemy/publish_page_job_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe Alchemy::PublishPageJob, type: :job do
   describe "#perfom_later" do
-    let(:page) { build_stubbed(:alchemy_page) }
+    let(:page) { create(:alchemy_page) }
     let(:public_on) { Time.current }
 
     it "enqueues job" do

--- a/spec/models/alchemy/eager_loading_spec.rb
+++ b/spec/models/alchemy/eager_loading_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::EagerLoading do
+  describe ".page_includes" do
+    context "with no version param given" do
+      subject { described_class.page_includes }
+
+      it "returns public version includes" do
+        is_expected.to match_array([
+          :tags,
+          {
+            language: :site,
+            public_version: {
+              elements: [
+                :page,
+                :touchable_pages,
+                {
+                  ingredients: :related_object,
+                  contents: :essence,
+                },
+              ],
+            },
+          },
+        ])
+      end
+    end
+
+    context "with version param given" do
+      subject { described_class.page_includes(version: :draft_version) }
+
+      it "returns version includes" do
+        is_expected.to match_array([
+          :tags,
+          {
+            language: :site,
+            draft_version: {
+              elements: [
+                :page,
+                :touchable_pages,
+                {
+                  ingredients: :related_object,
+                  contents: :essence,
+                },
+              ],
+            },
+          },
+        ])
+      end
+    end
+
+    context "with unknown version param given" do
+      subject { described_class.page_includes(version: :foo_baz) }
+
+      it "returns version includes" do
+        expect { subject }.to raise_error(Alchemy::UnsupportedPageVersion)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

(Extracted from #2309)

This moves preloading of stuff to the Job layer rather than do it at the controller layer. Two advantages: We don't preload anything we don't need, and the element repository of the page version can be used in other contexts as well (I had a case where I wanted to load multiple pages and preload their ingredients, and using the previous element repository would break that).

### Notable changes (remove if none)

We now also preload ingredients. We do that explicitly at the controller level, which means we can use the `PageVersion#element_repository` in contexts like the following: 

```rb
@page.children.where(page_layout: "blog_post).includes(public_version: :elements).each { |p| p.public_version.elements } 
```

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
