### PR TITLE
Add thumbnail processor to support resizing on animated GIFs

### DIFF
--- a/app/models/alchemy/picture/transformations.rb
+++ b/app/models/alchemy/picture/transformations.rb
@@ -67,7 +67,7 @@ module Alchemy
     # Returns the rendered resized image using imagemagick directly.
     #
     def resize(size, upsample = false)
-      image_file.thumb(upsample ? size : "#{size}>")
+      image_file.thumbnail(upsample ? size : "#{size}>")
     end
 
     # Returns true if picture's width is greater than it's height
@@ -191,7 +191,7 @@ module Alchemy
       if is_smaller_than?(dimensions) && upsample == false
         dimensions = reduce_to_image(dimensions)
       end
-      image_file.thumb("#{dimensions_to_string(dimensions)}#")
+      image_file.thumbnail("#{dimensions_to_string(dimensions)}#")
     end
 
     # Use imagemagick to custom crop an image. Uses -thumbnail for better performance when resizing.

--- a/config/initializers/dragonfly.rb
+++ b/config/initializers/dragonfly.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "dragonfly_svg"
 require "alchemy/dragonfly/processors/crop_resize"
+require "alchemy/dragonfly/processors/thumbnail"
 
 # Logger
 Dragonfly.logger = Rails.logger
@@ -16,4 +17,5 @@ Dragonfly::ImageMagick::Processors::Encode::WHITELISTED_ARGS << "flatten"
 
 Rails.application.config.after_initialize do
   Dragonfly.app(:alchemy_pictures).add_processor(:crop_resize, Alchemy::Dragonfly::Processors::CropResize.new)
+  Dragonfly.app(:alchemy_pictures).add_processor(:thumbnail, Alchemy::Dragonfly::Processors::Thumbnail.new)
 end

--- a/lib/alchemy/dragonfly/processors/thumbnail.rb
+++ b/lib/alchemy/dragonfly/processors/thumbnail.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "dragonfly/image_magick/processors/thumb"
+
+module Alchemy
+  module Dragonfly
+    module Processors
+      class Thumbnail < ::Dragonfly::ImageMagick::Processors::Thumb
+        def call(content, geometry, opts = {})
+          # store content into an instance variable to use it in args_for_geometry - method
+          @content = content
+          super
+        end
+
+        ##
+        # due to a missing ImageMagick parameter animated GIFs were broken with the default
+        # Dragonfly Thumb processor
+        def args_for_geometry(geometry)
+          # resize all frames in a GIF
+          # @link https://imagemagick.org/script/command-line-options.php#coalesce
+          # @link https://imagemagick.org/script/command-line-options.php#deconstruct
+          @content&.mime_type == "image/gif" ? "-coalesce #{super} -deconstruct" : super
+        end
+      end
+    end
+  end
+end

--- a/spec/libraries/dragonfly/processors/thumbnail_spec.rb
+++ b/spec/libraries/dragonfly/processors/thumbnail_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../../../support/dragonfly_test_app"
+
+RSpec.describe Alchemy::Dragonfly::Processors::Thumbnail do
+  let(:app) { dragonfly_test_app }
+  let(:file) { Pathname.new(File.expand_path("../../../fixtures/80x60.png", __dir__)) }
+  let(:image) { Dragonfly::Content.new(app, file) }
+  let(:processor) { described_class.new }
+  let(:geometry) { "40x30#" }
+
+  describe "validation" do
+    it "works with a valid argument" do
+      expect {
+        processor.call(image, geometry)
+      }.to_not raise_error
+    end
+
+    it "validates with invalid argument" do
+      expect {
+        processor.call(image, "foo")
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "args_for_geometry" do
+    before do
+      processor.call(image, geometry)
+    end
+
+    context "PNG" do
+      it "should not have the coalesce and deconstruct argument" do
+        expect(processor.args_for_geometry(geometry)).not_to include("coalesce", "deconstruct")
+      end
+    end
+
+    context "GIF" do
+      let(:file) { Pathname.new(File.expand_path("../../../fixtures/animated.gif", __dir__)) }
+
+      it "should have the coalesce and deconstruct argument" do
+        expect(processor.args_for_geometry(geometry)).to include("coalesce", "deconstruct")
+      end
+    end
+  end
+end


### PR DESCRIPTION
With the default thumb - method the GIFs have artifacts  after the second frame. To prevent this an additional processor was added.

## What is this pull request for?

A thumbnail processor for dragonfly to handling resizing on animated GIFs. 

### Notable changes

The thumbnail generation now runs with the new thumbnail processor and not with the default Dragonfly processor.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
