### PR TITLE
Remove old unused root_page ivar

### DIFF
--- a/app/controllers/alchemy/messages_controller.rb
+++ b/app/controllers/alchemy/messages_controller.rb
@@ -62,7 +62,6 @@ module Alchemy
       end
 
       @page = @element.page
-      @root_page = @page.get_language_root
       if @message.valid?
         MessagesMailer.contact_form_mail(@message, mail_to, mail_from, subject).deliver
         redirect_to_success_page
@@ -122,8 +121,6 @@ module Alchemy
       if @page.blank?
         raise "Page for page_layout #{mailer_config["page_layout_name"]} not found"
       end
-
-      @root_page = @page.get_language_root
     end
 
     def message_params

--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -32,9 +32,6 @@ module Alchemy
       if: :locale_prefix_missing?,
       only: [:index, :show]
 
-    # We only need to set the +@root_page+ if we are sure that no more redirects happen.
-    before_action :set_root_page, only: [:index, :show]
-
     # Page layout callbacks need to run after all other callbacks
     before_action :run_on_page_layout_callbacks,
       if: :run_on_page_layout_callbacks?,
@@ -197,10 +194,6 @@ module Alchemy
       else
         expires_in @page.expiration_time, public: !@page.restricted, must_revalidate: true
       end
-    end
-
-    def set_root_page
-      @root_page ||= Language.current_root_page
     end
 
     def signup_required?

--- a/spec/controllers/alchemy/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/pages_controller_spec.rb
@@ -52,11 +52,6 @@ module Alchemy
             expect(assigns(:page)).to eq(default_language_root)
           end
 
-          it "sets @root_page to default language root" do
-            get :index
-            expect(assigns(:root_page)).to eq(default_language_root)
-          end
-
           context "and the root page is not public" do
             let(:default_language_root) do
               create(:alchemy_page, :language_root, public_on: nil, language: default_language, name: "Home")
@@ -103,11 +98,6 @@ module Alchemy
           it "loads the root page of that language" do
             get :index, params: { locale: "kl" }
             expect(assigns(:page)).to eq(start_page)
-          end
-
-          it "sets @root_page to root page of that language" do
-            get :index, params: { locale: "kl" }
-            expect(assigns(:root_page)).to eq(start_page)
           end
         end
       end

--- a/spec/helpers/alchemy/pages_helper_spec.rb
+++ b/spec/helpers/alchemy/pages_helper_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 module Alchemy
   describe PagesHelper do
-    let(:language_root) { create(:alchemy_page, :language_root) }
+    let!(:language_root) { create(:alchemy_page, :language_root) }
     let(:public_page) { create(:alchemy_page, :public) }
     let(:klingon) { create(:alchemy_language, :klingon) }
     let(:klingon_language_root) { create(:alchemy_page, :language_root, language: klingon) }
@@ -12,7 +12,6 @@ module Alchemy
 
     before do
       allow(helper).to receive(:prefix_locale?) { prefix_locale? }
-      @root_page = language_root # We need this instance variable in the helpers
     end
 
     describe "#render_page_layout" do
@@ -34,9 +33,8 @@ module Alchemy
       context "when block is given" do
         it "passes it on to the render method" do
           expect(helper).to receive(:current_alchemy_site).and_return(default_site)
-          expect(helper)
-            .to receive(:render)
-            .with(default_site) { |&block| expect(block).to be }
+          expect(helper).to receive(:render)
+              .with(default_site) { |&block| expect(block).to be }
 
           helper.render_site_layout { true }
         end


### PR DESCRIPTION
## What is this pull request for?

This ivar was necessary for the render_navigation helper,
which has been removed in 5.0

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
