### PR TITLE
Allow render_elements to take a block

### DIFF
--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -70,7 +70,7 @@ module Alchemy
     #   A class instance that will return elements that get rendered.
     #   Use this for your custom element loading logic in views.
     #
-    def render_elements(options = {})
+    def render_elements(options = {}, &blk)
       options = {
         from_page: @page,
         render_format: "html",
@@ -86,11 +86,12 @@ module Alchemy
 
       elements = finder.elements(page_version: page_version)
 
-      buff = []
-      elements.each_with_index do |element, i|
-        buff << render_element(element, options, i + 1)
-      end
-      buff.join(options[:separator]).html_safe
+      default_rendering = ->(element, i) { render_element(element, options, i + 1) }
+      if block_given?
+        elements.map.with_index(&blk)
+      else
+        elements.map.with_index(&default_rendering)
+      end.join(options[:separator]).html_safe
     end
 
     # This helper renders a {Alchemy::Element} view partial.

--- a/spec/helpers/alchemy/elements_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_helper_spec.rb
@@ -92,6 +92,18 @@ module Alchemy
         end
       end
 
+      context "with a block" do
+        subject do
+          helper.render_elements(separator: ", ") do |element|
+            element.name
+          end
+        end
+
+        it "renders the block" do
+          is_expected.to eq("headline, article")
+        end
+      end
+
       context "with from_page option" do
         context "is a page object" do
           let(:another_page) { create(:alchemy_page, :public) }


### PR DESCRIPTION
In this block you can call

```
render_element(element, options, i)
```

It's quite convenient!

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
