### PR TITLE
Add Support for MariaDB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         database:
           - mysql
           - postgresql
+          - mariadb
         exclude:
           - rails: "6.0"
             ruby: "3.1"
@@ -27,12 +28,18 @@ jobs:
           - rails: "6.0"
             ruby: "3.1"
             database: postgresql
+          - rails: "6.0"
+            ruby: "3.1"
+            database: mariadb
           - rails: "7.0"
             ruby: "2.6"
             database: mysql
           - rails: "7.0"
             ruby: "2.6"
             database: postgresql
+          - rails: "7.0"
+            ruby: "2.6"
+            database: mariadb
     env:
       DB: ${{ matrix.database }}
       DB_USER: alchemy_user
@@ -58,6 +65,15 @@ jobs:
           MYSQL_DATABASE: alchemy_cms_dummy_test
           MYSQL_ROOT_PASSWORD: password
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
+      mariadb:
+        image: mariadb:latest
+        ports: ["3307:3306"]
+        env:
+          MARIADB_USER: alchemy_user
+          MARIADB_PASSWORD: password
+          MARIADB_DATABASE: alchemy_cms_dummy_test
+          MARIADB_ROOT_PASSWORD: password
+        options: --health-cmd="mariadb-admin ping" --health-interval=10s --health-timeout=5s --health-retries=5
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Set up Ruby
@@ -81,7 +97,7 @@ jobs:
           sudo apt install -qq --fix-missing libpq-dev -o dir::cache::archives="/home/runner/apt/cache"
           sudo chown -R runner /home/runner/apt/cache
       - name: Install MySQL headers
-        if: matrix.database == 'mysql'
+        if: matrix.database == 'mysql' || matrix.database == 'mariadb'
         run: |
           mkdir -p /home/runner/apt/cache
           sudo apt update -qq

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,9 @@ end
 if ENV["DB"].nil? || ENV["DB"] == "sqlite"
   gem "sqlite3", "~> 1.4.1"
 end
-gem "mysql2", "~> 0.5.1" if ENV["DB"] == "mysql"
+if ENV["DB"] == "mysql" || ENV["DB"] == "mariadb"
+  gem "mysql2", "~> 0.5.1"
+end
 gem "pg", "~> 1.0" if ENV["DB"] == "postgresql"
 
 group :development, :test do

--- a/app/models/alchemy/ingredient.rb
+++ b/app/models/alchemy/ingredient.rb
@@ -8,6 +8,8 @@ module Alchemy
 
     self.table_name = "alchemy_ingredients"
 
+    attribute :data, :json
+
     belongs_to :element, touch: true, class_name: "Alchemy::Element", inverse_of: :ingredients
     belongs_to :related_object, polymorphic: true, optional: true
 

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -9,6 +9,14 @@ mysql: &mysql
   password: <%= ENV['DB_PASSWORD'] %>
   database: alchemy_cms_dummy_<%= Rails.env %>
 
+mariadb: &mariadb
+  adapter: mysql2
+  encoding: utf8mb4
+  port: 3307
+  username: <%= ENV['DB_USER'] %>
+  password: <%= ENV['DB_PASSWORD'] %>
+  database: alchemy_cms_dummy_<%= Rails.env %>
+
 postgresql: &postgresql
   adapter: postgresql
   <% if ENV['DB_USER'] %>


### PR DESCRIPTION
## What is this pull request for?

This adds support for MariaDB to Alchemy. MariaDB is not fully compatible to Alchemy right now as they do not support a native JSON type. What we do here is we override Rails' automatic guessing of attribute types for the `alchemy_ingredients.data` column and make it `:json` by default. This is what Rails does automatically for MySQL and SQLite, and it changes no functionality with Postgres.

### Notable changes (remove if none)

Stops the app from breaking on MariaDB, and adds MariaDB to the CI matrix.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
