### PR TITLE
Default Link Format matcher: Allow tel: protocol

### DIFF
--- a/config/alchemy/config.yml
+++ b/config/alchemy/config.yml
@@ -200,7 +200,7 @@ link_target_options: [blank]
 format_matchers:
   email: !ruby/regexp '/\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/'
   url: !ruby/regexp '/\A[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?\z/ix'
-  link_url: !ruby/regexp '/^(mailto:|\/|[a-z]+:\/\/)/'
+  link_url: !ruby/regexp '/^(tel:|mailto:|\/|[a-z]+:\/\/)/'
 
 # The layout used for rendering the +alchemy/admin/pages#show+ action.
 admin_page_preview_layout: application


### PR DESCRIPTION
## What is this pull request for?

In the age of mobile phones, it's nice to be able to link to a phone
number. The format for that is `<a href="tel:1234567890">Call us</a>`,
but the default link format matcher won't allow that. This allows the
`tel` protocol to be entered without slashes.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
