### PR TITLE
Override Alchemy::Page.ransackable_scopes

### DIFF
--- a/app/models/alchemy/page/page_scopes.rb
+++ b/app/models/alchemy/page/page_scopes.rb
@@ -122,6 +122,10 @@ module Alchemy
             )
           SQL
         end
+
+        def ransackable_scopes(_auth_object)
+          [:published, :from_current_site, :searchables, :layoutpages]
+        end
       end
     end
   end

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -695,6 +695,14 @@ module Alchemy
           expect(subject.collect { |e| e["name"] }).not_to include("unique_headline")
         end
       end
+
+      describe ".ransackable_scopes" do
+        let(:auth_object) { double }
+
+        subject { described_class.ransackable_scopes(auth_object) }
+
+        it { is_expected.to match_array([:published, :from_current_site, :layoutpages, :searchables]) }
+      end
     end
 
     describe "#available_elements_within_current_scope" do


### PR DESCRIPTION
Ransack has a feature by which one can pass the name of a scope to a
ransack query as the key of a query param with a value of true, like so:

```
GET http://localhost.localdomain:3000/api/pages?q[published]=true
```

This feature can be used very nicely in the page select for an
`Alchemy::Ingredients::Page` to restrict that e.g. only public pages are
available:

```
[elements.yml]
- name: featured_page
  ingredients:
  - role: page
    type: Page
    settings:
      query_params:
        page_layout_start: "new_"
        published: true
```

However, for that to work, `:published` must be in the
`Alchemy::Pages.ransackable_scopes` array. By default this method
returns an empty array.
See https://github.com/activerecord-hackery/ransack/blob/be8c4642f927e8aa41204009c46c269158201cc7/lib/ransack/adapters/active_record/base.rb#L61-L68

for the origin of the method.

I've added a few more scopes that I think are fine to safelist here.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
