### PR TITLE
Wrap the result of rendering into an ActiveSupport::SafeBuffer

### DIFF
--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -87,11 +87,13 @@ module Alchemy
       elements = finder.elements(page_version: page_version)
 
       default_rendering = ->(element, i) { render_element(element, options, i + 1) }
-      if block_given?
-        elements.map.with_index(&blk)
-      else
-        elements.map.with_index(&default_rendering)
-      end.join(options[:separator]).html_safe
+      capture do
+        if block_given?
+          elements.map.with_index(&blk)
+        else
+          elements.map.with_index(&default_rendering)
+        end.join(options[:separator]).html_safe
+      end
     end
 
     # This helper renders a {Alchemy::Element} view partial.

--- a/spec/helpers/alchemy/elements_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_helper_spec.rb
@@ -108,6 +108,7 @@ module Alchemy
         end
 
         it "renders the block" do
+          is_expected.to be_a(ActiveSupport::SafeBuffer)
           is_expected.to eq("headline, article")
         end
       end


### PR DESCRIPTION
## What is this pull request for?

This allows the use of loud ERB on the `render_elements` helper without
the last ERB line being used a return value and rendered out in the
output buffer.

### Notable changes (remove if none)

The new usage of `render_elements` with a block can and must now be used in loud ERB.

Good: 
```
<%= render_elements do |element| %>
  <%= render_element element %>
<% end %>
```

Bad: 
```
<% render_elements do |element| %>
  <%= render_element element %>
<% end %>
```

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
