### PR TITLE
Add support for Rails' recycable cache keys

### DIFF
--- a/app/models/alchemy/page/page_natures.rb
+++ b/app/models/alchemy/page/page_natures.rb
@@ -103,17 +103,17 @@ module Alchemy
         page_layout.parameterize.underscore
       end
 
-      # Returns the key that's taken for cache path.
+      # Returns the version that's taken for Rails' recycable cache key.
       #
       # Uses the +published_at+ value that's updated when the user publishes the page.
       #
-      # If the page is the current preview it uses the updated_at value as cache key.
+      # If the page is the current preview it uses the +updated_at+ value as cache key.
       #
-      def cache_key
+      def cache_version
         if Page.current_preview == id
-          "alchemy/pages/#{id}-#{updated_at}"
+          updated_at.to_s
         else
-          "alchemy/pages/#{id}-#{published_at}"
+          published_at.to_s
         end
       end
 

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -735,7 +735,7 @@ module Alchemy
       end
     end
 
-    describe "#cache_key" do
+    describe "#cache_version" do
       let(:now) { Time.current }
       let(:last_week) { Time.current - 1.week }
 
@@ -743,7 +743,7 @@ module Alchemy
         build_stubbed(:alchemy_page, updated_at: now, published_at: last_week)
       end
 
-      subject { page.cache_key }
+      subject { page.cache_version }
 
       before do
         expect(Page).to receive(:current_preview).and_return(preview)
@@ -753,7 +753,7 @@ module Alchemy
         let(:preview) { page.id }
 
         it "uses updated_at" do
-          is_expected.to eq("alchemy/pages/#{page.id}-#{now}")
+          is_expected.to eq(now.to_s)
         end
       end
 
@@ -761,7 +761,7 @@ module Alchemy
         let(:preview) { nil }
 
         it "uses published_at" do
-          is_expected.to eq("alchemy/pages/#{page.id}-#{last_week}")
+          is_expected.to eq(last_week.to_s)
         end
       end
     end


### PR DESCRIPTION
## What is this pull request for?

This has been a feature from Rails 5.2 and is enabled by default
from Rails 6.0 and above.

### Notable changes

`Page#cache_key` now simply returns `"alchemy/page/<id>"` (the Rails default). 

Since Rails 6.0 has turned on `Rails.application.config.active_record.cache_versioning` by default and then uses `cache_key_with_version` (that then calls `cache_version`) we can safely make this change.

In the unlikely case that someone had turned off `Rails.application.config.active_record.cache_versioning` in a Rails 6 application this will "break" the cache, but I think we can take the risk.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
