### PR TITLE
Extract element ingredient migrator

### DIFF
--- a/lib/alchemy/upgrader/tasks/ingredients_migrator.rb
+++ b/lib/alchemy/upgrader/tasks/ingredients_migrator.rb
@@ -24,36 +24,42 @@ module Alchemy::Upgrader::Tasks
             if elements.any?
               puts "-- Creating ingredients for #{elements.count} #{element_definition[:name]}(s)"
               elements.each do |element|
-                Alchemy::Element.transaction do
-                  element_definition[:ingredients].each do |ingredient_definition|
-                    content = element.content_by_name(ingredient_definition[:role])
-                    next unless content
-
-                    essence = content.essence
-                    ingredient = element.ingredients.build(
-                      role: ingredient_definition[:role],
-                      type: Alchemy::Ingredient.normalize_type(ingredient_definition[:type]),
-                    )
-                    belongs_to_associations = essence.class.reflect_on_all_associations(:belongs_to)
-                    if belongs_to_associations.any?
-                      ingredient.related_object = essence.public_send(belongs_to_associations.first.name)
-                    else
-                      ingredient.value = content.ingredient
-                    end
-                    data = ingredient.class.stored_attributes.fetch(:data, []).each_with_object({}) do |attr, d|
-                      d[attr] = essence.public_send(attr)
-                    end
-                    ingredient.data = data
-                    print "."
-                    ingredient.save!
-                    content.destroy!
-                  end
-                end
+                MigrateElementIngredients.call(element)
+                print "."
               end
               puts "\n"
             else
               puts "-- No #{element_definition[:name]} elements found for migration."
             end
+          end
+        end
+      end
+    end
+
+    class MigrateElementIngredients
+      def self.call(element)
+        Alchemy::Element.transaction do
+          element.definition[:ingredients].each do |ingredient_definition|
+            content = element.content_by_name(ingredient_definition[:role])
+            next unless content
+
+            essence = content.essence
+            ingredient = element.ingredients.build(
+              role: ingredient_definition[:role],
+              type: Alchemy::Ingredient.normalize_type(ingredient_definition[:type]),
+            )
+            belongs_to_associations = essence.class.reflect_on_all_associations(:belongs_to)
+            if belongs_to_associations.any?
+              ingredient.related_object = essence.public_send(belongs_to_associations.first.name)
+            else
+              ingredient.value = content.ingredient
+            end
+            data = ingredient.class.stored_attributes.fetch(:data, []).each_with_object({}) do |attr, d|
+              d[attr] = essence.public_send(attr)
+            end
+            ingredient.data = data
+            ingredient.save!
+            content.destroy!
           end
         end
       end


### PR DESCRIPTION
## What is this pull request for?

Then we are able to call this from a data migration or rake task from apps.

Also ensure all ingredients get created during migration.

It might be the case that ingredients are defined on an element
that does not have a equivalent content.

We want to make sure that the element is exaclty is how it is defined in the elements.yml after the migration.

If the content could not be found, we just skip copying the data.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
