### PR TITLE
Disallow deleting pages if still attached to menu node

### DIFF
--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -145,6 +145,8 @@ module Alchemy
           # Remove page from clipboard
           clipboard = get_clipboard("pages")
           clipboard.delete_if { |item| item["id"] == @page.id.to_s }
+        else
+          flash[:warning] = @page.errors.full_messages.to_sentence
         end
 
         respond_to do |format|

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -129,6 +129,11 @@ module Alchemy
     before_create -> { versions.build },
       if: -> { versions.none? }
 
+    before_destroy if: -> { nodes.any? } do
+      errors.add(:nodes, :still_present)
+      throw(:abort)
+    end
+
     before_save :set_language_code,
       if: -> { language.present? }
 

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -777,6 +777,10 @@ en:
           attributes:
             pages:
               still_present: "are still attached to this language. Please remove them first."
+        alchemy/page:
+          attributes:
+            nodes:
+              still_present: "are still attached to this page. Please remove them first."
     models:
       gutentag/tag:
         one: Tag

--- a/db/migrate/20220514072456_restrict_on_delete_page_id_foreign_key_from_alchemy_nodes.rb
+++ b/db/migrate/20220514072456_restrict_on_delete_page_id_foreign_key_from_alchemy_nodes.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class RestrictOnDeletePageIdForeignKeyFromAlchemyNodes < ActiveRecord::Migration[6.1]
+  def up
+    remove_foreign_key :alchemy_nodes, :alchemy_pages
+    add_foreign_key :alchemy_nodes, :alchemy_pages, column: :page_id, on_delete: :restrict
+  end
+
+  def down
+    remove_foreign_key :alchemy_nodes, :alchemy_pages
+    add_foreign_key :alchemy_nodes, :alchemy_pages, column: :page_id, on_delete: :cascade
+  end
+end

--- a/db/migrate/20220514072456_restrict_on_delete_page_id_foreign_key_from_alchemy_nodes.rb
+++ b/db/migrate/20220514072456_restrict_on_delete_page_id_foreign_key_from_alchemy_nodes.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RestrictOnDeletePageIdForeignKeyFromAlchemyNodes < ActiveRecord::Migration[6.1]
+class RestrictOnDeletePageIdForeignKeyFromAlchemyNodes < ActiveRecord::Migration[6.0]
   def up
     remove_foreign_key :alchemy_nodes, :alchemy_pages
     add_foreign_key :alchemy_nodes, :alchemy_pages, column: :page_id, on_delete: :restrict

--- a/spec/controllers/alchemy/admin/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/pages_controller_spec.rb
@@ -46,6 +46,29 @@ RSpec.describe Alchemy::Admin::PagesController do
     end
   end
 
+  describe "#destroy" do
+    let(:page) { create(:alchemy_page) }
+
+    context "with nodes attached" do
+      let!(:node) { create(:alchemy_node, page: page) }
+
+      it "returns with error message" do
+        delete :destroy, params: { id: page.id, format: :js }
+        expect(response).to redirect_to admin_pages_path
+        expect(flash[:warning]).to \
+          eq("Nodes are still attached to this page. Please remove them first.")
+      end
+    end
+
+    context "without nodes" do
+      it "removes the page" do
+        delete :destroy, params: { id: page.id, format: :js }
+        expect(response).to redirect_to admin_pages_path
+        expect(flash[:notice]).to eq("Page successfully removed.")
+      end
+    end
+  end
+
   describe "#publish" do
     let(:page) { create(:alchemy_page) }
 

--- a/spec/controllers/alchemy/admin/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/pages_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Alchemy::Admin::PagesController do
 
       it "returns with error message" do
         delete :destroy, params: { id: page.id, format: :js }
-        expect(response).to redirect_to admin_pages_path
+        expect(response).to redirect_to admin_page_path(page.id)
         expect(flash[:warning]).to \
           eq("Nodes are still attached to this page. Please remove them first.")
       end
@@ -63,8 +63,8 @@ RSpec.describe Alchemy::Admin::PagesController do
     context "without nodes" do
       it "removes the page" do
         delete :destroy, params: { id: page.id, format: :js }
-        expect(response).to redirect_to admin_pages_path
-        expect(flash[:notice]).to eq("Page successfully removed.")
+        expect(response).to redirect_to admin_page_path(page.id)
+        expect(flash[:notice]).to eq("A Page 61 deleted")
       end
     end
   end

--- a/spec/dummy/db/migrate/20220514072456_restrict_on_delete_page_id_foreign_key_from_alchemy_nodes.rb
+++ b/spec/dummy/db/migrate/20220514072456_restrict_on_delete_page_id_foreign_key_from_alchemy_nodes.rb
@@ -1,4 +1,4 @@
-class RestrictOnDeletePageIdForeignKeyFromAlchemyNodes < ActiveRecord::Migration[6.1]
+class RestrictOnDeletePageIdForeignKeyFromAlchemyNodes < ActiveRecord::Migration[6.0]
   def up
     remove_foreign_key :alchemy_nodes, :alchemy_pages
     add_foreign_key :alchemy_nodes, :alchemy_pages, column: :page_id, on_delete: :restrict

--- a/spec/dummy/db/migrate/20220514072456_restrict_on_delete_page_id_foreign_key_from_alchemy_nodes.rb
+++ b/spec/dummy/db/migrate/20220514072456_restrict_on_delete_page_id_foreign_key_from_alchemy_nodes.rb
@@ -1,0 +1,11 @@
+class RestrictOnDeletePageIdForeignKeyFromAlchemyNodes < ActiveRecord::Migration[6.1]
+  def up
+    remove_foreign_key :alchemy_nodes, :alchemy_pages
+    add_foreign_key :alchemy_nodes, :alchemy_pages, column: :page_id, on_delete: :restrict
+  end
+
+  def down
+    remove_foreign_key :alchemy_nodes, :alchemy_pages
+    add_foreign_key :alchemy_nodes, :alchemy_pages, column: :page_id, on_delete: :cascade
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2021_11_05_175532) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_14_072456) do
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string "name"
     t.string "file_name"
@@ -402,7 +402,7 @@ ActiveRecord::Schema[7.0].define(version: 2021_11_05_175532) do
   add_foreign_key "alchemy_essence_pages", "alchemy_pages", column: "page_id"
   add_foreign_key "alchemy_ingredients", "alchemy_elements", column: "element_id", on_delete: :cascade
   add_foreign_key "alchemy_nodes", "alchemy_languages", column: "language_id"
-  add_foreign_key "alchemy_nodes", "alchemy_pages", column: "page_id", on_delete: :cascade
+  add_foreign_key "alchemy_nodes", "alchemy_pages", column: "page_id", on_delete: :restrict
   add_foreign_key "alchemy_page_versions", "alchemy_pages", column: "page_id", on_delete: :cascade
   add_foreign_key "alchemy_pages", "alchemy_languages", column: "language_id"
   add_foreign_key "alchemy_picture_thumbs", "alchemy_pictures", column: "picture_id"


### PR DESCRIPTION
## What is this pull request for?

It changes the behavior on delete of the node table's page_id foreign key from cascade to restrict.
When the user wants to delete a page, if it still linked to any node, we show a warning and abort the deletion.

Closes #2301

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
