### PR TITLE
Add spec for ingredients migrator; fix preloading in Rails 6.1+

### DIFF
--- a/lib/alchemy/upgrader/tasks/ingredients_migrator.rb
+++ b/lib/alchemy/upgrader/tasks/ingredients_migrator.rb
@@ -16,7 +16,7 @@ module Alchemy::Upgrader::Tasks
           # eager load all elements that have ingredients defined but no ingredient records yet.
           all_elements = Alchemy::Element
             .named(elements_with_ingredients.map { |d| d[:name] })
-            .includes(contents: :essence)
+            .preload(contents: :essence)
             .left_outer_joins(:ingredients).where(alchemy_ingredients: { id: nil })
             .to_a
           elements_with_ingredients.map do |element_definition|

--- a/spec/libraries/alchemy/upgrader/tasks/ingredients_migrator_spec.rb
+++ b/spec/libraries/alchemy/upgrader/tasks/ingredients_migrator_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "alchemy/upgrader/tasks/ingredients_migrator"
+
+RSpec.describe Alchemy::Upgrader::Tasks::IngredientsMigrator do
+  let!(:element) do
+    FactoryBot.create(
+      :alchemy_element,
+      name: "element_with_ingredients",
+      autogenerate_ingredients: false,
+      contents: [content1, content2]
+    )
+  end
+
+  let(:content1) { Alchemy::Content.new(name: "headline", essence: headline) }
+  let(:headline) { FactoryBot.create(:alchemy_essence_text) }
+  let(:content2) { Alchemy::Content.new(name: "text", essence: text) }
+  let(:text) { Alchemy::EssenceRichtext.new(body: "Hello World") }
+
+  subject { described_class.new.create_ingredients }
+
+  it "changes existing elements with contents and essences to ingredients" do
+    expect(Alchemy::Content.count).to eq(2)
+    expect(Alchemy::Ingredient.count).to eq(0)
+
+    subject
+
+    expect(Alchemy::Content.count).to eq(0)
+    expect(Alchemy::Ingredient.count).to eq(2)
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

This adds a spec for the ingredients migrator that tests its
functionality. It also serves to reproduce an error under Rails 6.1+,
where the ingredients migrator would fail at preloading essences with
the following error:

ActiveRecord::EagerLoadPolymorphicError: Cannot eagerly load the
polymorphic association.

### Notable changes (remove if none)

Allows people with Rails greater than 6.1 to migrate their elements to ingredients.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
