### PR TITLE
Add task to eagerly generate ingredients pictures thumbnails

### DIFF
--- a/lib/tasks/alchemy/thumbnails.rake
+++ b/lib/tasks/alchemy/thumbnails.rake
@@ -36,12 +36,18 @@ namespace :alchemy do
       puts "Done!"
     end
 
-    desc "Generates thumbnails for Alchemy Picture Ingredients."
+    desc "Generates thumbnails for Alchemy Picture Ingredients (set ELEMENTS=element1,element2 to only generate thumbnails for a subset of elements)."
     task ingredient_picture_thumbnails: :environment do
       ingredient_pictures = Alchemy::Ingredients::Picture.
         joins(:element).
         preload({ related_object: :thumbs }).
         merge(Alchemy::Element.available)
+
+      if ENV["ELEMENTS"].present?
+        ingredient_pictures = ingredient_pictures.merge(
+          Alchemy::Element.named(ENV["ELEMENTS"].split(","))
+        )
+      end
 
       puts "Regenerate #{ingredient_pictures.count} ingredient picture thumbnails."
       puts "Please wait..."

--- a/lib/tasks/alchemy/thumbnails.rake
+++ b/lib/tasks/alchemy/thumbnails.rake
@@ -35,5 +35,23 @@ namespace :alchemy do
 
       puts "Done!"
     end
+
+    desc "Generates thumbnails for Alchemy Picture Ingredients."
+    task ingredient_picture_thumbnails: :environment do
+      ingredient_pictures = Alchemy::Ingredients::Picture.
+        joins(:element).
+        preload({ related_object: :thumbs }).
+        merge(Alchemy::Element.available)
+
+      puts "Regenerate #{ingredient_pictures.count} ingredient picture thumbnails."
+      puts "Please wait..."
+
+      ingredient_pictures.find_each do |ingredient_picture|
+        puts ingredient_picture.picture_url
+        puts ingredient_picture.thumbnail_url
+      end
+
+      puts "Done!"
+    end
   end
 end


### PR DESCRIPTION
## What is this pull request for?

This allows to eagerly generate picture thumbnails for all picture ingredients.

In order to only eagerly generate only a subset of ingredients you can pass `ELEMENTS=element_name1,element_name2`
to the `alchemy:generate:ingredient_picture_thumbnails` rake task.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
