### PR TITLE
Use HashWithIndifferentAccess for Page definition.  Key hint translation by page_layout

### DIFF
--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -565,6 +565,12 @@ module Alchemy
       locker.try(:name) || Alchemy.t("unknown")
     end
 
+    # Key hint translations by page layout, rather than the default name.
+    #
+    def hint_translation_attribute
+      page_layout
+    end
+
     # Menus (aka. root nodes) this page is attached to
     #
     def menus

--- a/lib/alchemy/page_layout.rb
+++ b/lib/alchemy/page_layout.rb
@@ -8,7 +8,7 @@ module Alchemy
       # They are defined in +config/alchemy/page_layout.yml+ file.
       #
       def all
-        @definitions ||= read_definitions_file
+        @definitions ||= read_definitions_file.map(&:with_indifferent_access)
       end
 
       # Add additional page definitions to collection.
@@ -151,11 +151,13 @@ module Alchemy
       #
       def read_definitions_file
         if File.exist?(layouts_file_path)
-          YAML.safe_load(
-            ERB.new(File.read(layouts_file_path)).result,
-            permitted_classes: YAML_PERMITTED_CLASSES,
-            aliases: true,
-          ) || []
+          Array.wrap(
+            YAML.safe_load(
+              ERB.new(File.read(layouts_file_path)).result,
+              permitted_classes: YAML_PERMITTED_CLASSES,
+              aliases: true,
+            ) || []
+          )
         else
           raise LoadError, "Could not find page_layouts.yml file! Please run `rails generate alchemy:install`"
         end

--- a/spec/dummy/config/alchemy/page_layouts.yml
+++ b/spec/dummy/config/alchemy/page_layouts.yml
@@ -23,6 +23,7 @@
   autogenerate: [header, article, download]
 
 - name: everything
+  hint: true
   elements:
     [
       text,

--- a/spec/dummy/config/locales/alchemy.en.yml
+++ b/spec/dummy/config/locales/alchemy.en.yml
@@ -56,6 +56,9 @@ en:
       all_you_can_eat_ingredients:
         headline:
           blank: Please enter a headline for all you can eat
+    page_hints:
+      everything: This page is for everything.
+
 
   activemodel:
     models:

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1957,6 +1957,12 @@ module Alchemy
       let(:subject) { Page.new }
     end
 
+    it "keys hint translation by page_layout" do
+      page = Page.new(page_layout: :everything)
+      expect(page).to have_hint
+      expect(page.hint).to eq Alchemy.t("page_hints.everything")
+    end
+
     describe "#layout_partial_name" do
       let(:page) { Page.new(page_layout: "Standard Page") }
 

--- a/spec/models/alchemy/site_spec.rb
+++ b/spec/models/alchemy/site_spec.rb
@@ -312,6 +312,7 @@ module Alchemy
                   "element_with_ingredient_groups",
                   "element_with_content_groups",
                 ],
+                "hint" => true,
               },
               {
                 "name" => "news",


### PR DESCRIPTION
## What is this pull request for?
Page hints don't currently display anywhere because `Alchemy::Hints` is expecting definition to be keyed by symbols, but it is keyed by strings in the case of `Page`.  Additionally the I18n key should be by `Page#page_layout` rather than `#name`

Closes #2335

### Notable changes

Make `Page` definition a `HashWithIndifferentAccess`.
Key `Page` hints by `page_layout`

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
