### PR TITLE
add playsinline attribute to ingredient and essence

### DIFF
--- a/app/controllers/alchemy/admin/essence_videos_controller.rb
+++ b/app/controllers/alchemy/admin/essence_videos_controller.rb
@@ -24,6 +24,7 @@ module Alchemy
           :controls,
           :loop,
           :muted,
+          :playsinline,
           :preload,
           :attachment_id
         )

--- a/app/models/alchemy/ingredients/video.rb
+++ b/app/models/alchemy/ingredients/video.rb
@@ -12,6 +12,7 @@ module Alchemy
         :height,
         :loop,
         :muted,
+        :playsinline,
         :preload,
         :width
 

--- a/app/views/alchemy/admin/essence_videos/edit.html.erb
+++ b/app/views/alchemy/admin/essence_videos/edit.html.erb
@@ -5,6 +5,7 @@
   <%= f.input :controls %>
   <%= f.input :loop %>
   <%= f.input :muted %>
+  <%= f.input :playsinline %>
   <%= f.input :preload, collection: %w(auto none metadata),
     include_blank: false, input_html: {class: 'alchemy_selectbox'} %>
   <%= f.submit Alchemy.t(:save) %>

--- a/app/views/alchemy/admin/ingredients/_video_fields.html.erb
+++ b/app/views/alchemy/admin/ingredients/_video_fields.html.erb
@@ -4,5 +4,6 @@
 <%= f.input :controls, as: :boolean %>
 <%= f.input :loop, as: :boolean %>
 <%= f.input :muted, as: :boolean %>
+<%= f.input :playsinline, as: :boolean %>
 <%= f.input :preload, collection: %w(auto none metadata),
   include_blank: false, input_html: {class: 'alchemy_selectbox'} %>

--- a/app/views/alchemy/essences/_essence_video_view.html.erb
+++ b/app/views/alchemy/essences/_essence_video_view.html.erb
@@ -5,6 +5,7 @@
     autoplay: content.essence.autoplay,
     loop: content.essence.loop,
     muted: content.essence.muted,
+    playsinline: content.essence.playsinline,
     preload: content.essence.preload.presence,
     width: content.essence.width.presence,
     height: content.essence.height.presence do %>

--- a/app/views/alchemy/ingredients/_video_view.html.erb
+++ b/app/views/alchemy/ingredients/_video_view.html.erb
@@ -4,6 +4,7 @@
     autoplay: video_view.autoplay,
     loop: video_view.loop,
     muted: video_view.muted,
+    playsinline: video_view.playsinline,
     preload: video_view.preload.presence,
     width: video_view.width.presence,
     height: video_view.height.presence do %>

--- a/db/migrate/20220622130905_add_playsinline_to_alchemy_essence_videos.rb
+++ b/db/migrate/20220622130905_add_playsinline_to_alchemy_essence_videos.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddPlaysinlineToAlchemyEssenceVideos < ActiveRecord::Migration[6.0]
+  def change
+    return if column_exists?(:alchemy_essence_videos, :playsinline)
+
+    add_column :alchemy_essence_videos, :playsinline, :boolean, default: false, null: false
+  end
+end

--- a/spec/models/alchemy/ingredients/video_spec.rb
+++ b/spec/models/alchemy/ingredients/video_spec.rb
@@ -53,6 +53,12 @@ RSpec.describe Alchemy::Ingredients::Video do
     it { is_expected.to eq(true) }
   end
 
+  describe "#playsinline" do
+    subject { video_ingredient.playsinline }
+    before { video_ingredient.playsinline = true }
+    it { is_expected.to eq(true) }
+  end
+
   describe "#preload" do
     subject { video_ingredient.preload }
     before { video_ingredient.preload = "auto" }

--- a/spec/views/alchemy/ingredients/video_view_spec.rb
+++ b/spec/views/alchemy/ingredients/video_view_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe "alchemy/ingredients/_video_view" do
       height: 720,
       loop: true,
       muted: true,
+      playsinline: true,
       preload: "auto",
       width: 1280,
     )
@@ -39,7 +40,7 @@ RSpec.describe "alchemy/ingredients/_video_view" do
     it "renders a video tag with source" do
       render ingredient
       expect(rendered).to have_selector(
-        "video[controls][muted][loop][autoplay][preload='auto'][width='1280'][height='720'] source[src]"
+        "video[controls][muted][playsinline][loop][autoplay][preload='auto'][width='1280'][height='720'] source[src]"
       )
     end
   end


### PR DESCRIPTION
## What is this pull request for?

It adds the `playsinline` attribute for videos.

Attribute is added to `Alchemy::Ingredients::Video` as well as `Alchemy::Essence::Video`.
See https://css-tricks.com/what-does-playsinline-mean-in-web-video/ for details on the attribute.


Closes #2350 

### Notable changes

No breaking changes since the column added to _alchemy_essence_videos_ defaults to `false`

### Screenshots

Remove if no visual changes have been made.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
