### PR TITLE
Fix PictureTransformations#inferred_sizes_from_string

### DIFF
--- a/app/models/alchemy/picture/transformations.rb
+++ b/app/models/alchemy/picture/transformations.rb
@@ -98,10 +98,10 @@ module Alchemy
       ratio = image_file_width.to_f / image_file_height
 
       if sizes[:width].zero?
-        sizes[:width] = image_file_width * ratio
+        sizes[:width] = (sizes[:height] * ratio).round.to_i
       end
       if sizes[:height].zero?
-        sizes[:height] = image_file_width / ratio
+        sizes[:height] = (sizes[:width] / ratio).round.to_i
       end
 
       sizes

--- a/spec/models/alchemy/picture_variant_spec.rb
+++ b/spec/models/alchemy/picture_variant_spec.rb
@@ -111,6 +111,19 @@ RSpec.describe Alchemy::PictureVariant do
       it "resizes the image inferring the height" do
         expect(subject.steps[0].arguments).to eq(["40>"])
       end
+
+      context "and crop set to true" do
+        let(:image_file) do
+          File.new(File.expand_path("../../fixtures/80x60.png", __dir__))
+        end
+        let(:options) do
+          { size: "17x", crop: true }
+        end
+
+        it "resizes the image inferring the height" do
+          expect(subject.steps[0].arguments).to eq(["17x13#"])
+        end
+      end
     end
 
     context "with no width given" do


### PR DESCRIPTION
## What is this pull request for?

We want to infer the correct height or width of an image given that either height or
width are not given. In this case we (correctly) calculate the original
aspect ratio of the image, and then infer the width or height
respectively from the given width/height and the ration.

The previous implementation could have been more simple:

```
if sizes[:height].zero?
  sizes[:width] = image_file_width
else
  sizes[:height] = image_file_height
end
```

But that implementation does not make that much sense.

Additionally I'm rounding things here, because DragonFly does not like
decimal points in their transformation strings.

Remove if no visual changes have been made.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
