### PR TITLE
Create new pages as first child of parent page

### DIFF
--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -84,8 +84,10 @@ module Alchemy
       end
 
       def create
-        @page = paste_from_clipboard || Page.new(page_params)
+        parent_page = Alchemy::Page.find(page_params[:parent_id])
+        @page = paste_from_clipboard || parent_page.children.new(page_params)
         if @page.save
+          @page.move_to_child_with_index(parent_page, 0)
           flash[:notice] = Alchemy.t("Page created", name: @page.name)
           do_redirect_to(redirect_path_after_create_page)
         else

--- a/spec/requests/alchemy/admin/pages_controller_spec.rb
+++ b/spec/requests/alchemy/admin/pages_controller_spec.rb
@@ -414,6 +414,16 @@ module Alchemy
             expect(subject).to redirect_to(edit_admin_page_path(Alchemy::Page.last))
           end
 
+          context "if parent already has child pages" do
+            let!(:existing_child) { create(:alchemy_page, parent: parent) }
+
+            it "saves the new page as the first child" do
+              subject
+              expect(response).to be_redirect
+              expect(parent.children.map(&:id)).to match([instance_of(Integer), existing_child.id])
+            end
+          end
+
           context "if new page can not be saved" do
             let(:page_params) do
               {


### PR DESCRIPTION
When creating a new page, the user will click on the `+` button next to
a parent page. Consider the following situation: The parent page already
has a lot of child pages. When the user returns to the page tree, they
will not find their newly created page unless they scroll alll the way
to the bottom...

What this does is it moves the page up to near where the user has their
attention.


## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
