### PR TITLE
Delete Gutentag Taggings in Alchemy::DeleteElements

### DIFF
--- a/app/services/alchemy/delete_elements.rb
+++ b/app/services/alchemy/delete_elements.rb
@@ -21,6 +21,7 @@ module Alchemy
           class_name.constantize.where(id: ids).delete_all
         end
       contents.delete_all
+      Gutentag::Tagging.where(taggable: elements).delete_all
       delete_elements
     end
 

--- a/spec/services/alchemy/delete_elements_spec.rb
+++ b/spec/services/alchemy/delete_elements_spec.rb
@@ -5,14 +5,17 @@ require "rails_helper"
 RSpec.describe Alchemy::DeleteElements do
   let!(:parent_element) { create(:alchemy_element, :with_nestable_elements, :with_contents) }
   let!(:nested_element) { parent_element.nested_elements.first }
-  let!(:normal_element) { create(:alchemy_element, :with_contents) }
+  let!(:normal_element) { create(:alchemy_element, :with_contents, tag_names: ["Zero"]) }
 
   before do
+    nested_element.tag_names = ["Cool"]
+    nested_element.save!
     expect(Alchemy::Element.count).not_to be_zero
     expect(Alchemy::Content.count).not_to be_zero
     expect(Alchemy::EssenceText.count).not_to be_zero
     expect(Alchemy::EssencePicture.count).not_to be_zero
     expect(Alchemy::EssenceRichtext.count).not_to be_zero
+    expect(Gutentag::Tagging.count).not_to be_zero
   end
 
   subject { Alchemy::DeleteElements.new(elements).call }
@@ -27,6 +30,7 @@ RSpec.describe Alchemy::DeleteElements do
       expect(Alchemy::EssenceText.count).to be_zero
       expect(Alchemy::EssencePicture.count).to be_zero
       expect(Alchemy::EssenceRichtext.count).to be_zero
+      expect(Gutentag::Tagging.count).to be_zero
     end
 
     context "when calling with an ActiveRecord::Relation" do
@@ -39,6 +43,7 @@ RSpec.describe Alchemy::DeleteElements do
         expect(Alchemy::EssenceText.count).to be_zero
         expect(Alchemy::EssencePicture.count).to be_zero
         expect(Alchemy::EssenceRichtext.count).to be_zero
+        expect(Gutentag::Tagging.count).to be_zero
       end
     end
 
@@ -56,6 +61,7 @@ RSpec.describe Alchemy::DeleteElements do
         expect(Alchemy::EssenceText.count).to be_zero
         expect(Alchemy::EssencePicture.count).to be_zero
         expect(Alchemy::EssenceRichtext.count).to be_zero
+        expect(Gutentag::Tagging.count).to be_zero
       end
     end
   end


### PR DESCRIPTION
Elements can have tags, and the `Gutentag::Tagging` join records must be
deleted along with the elements.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
