### PR TITLE
Add tags to Alchemy::EagerLoading

### DIFF
--- a/app/models/alchemy/eager_loading.rb
+++ b/app/models/alchemy/eager_loading.rb
@@ -25,6 +25,7 @@ module Alchemy
               elements: [
                 :page,
                 :touchable_pages,
+                :tags,
                 {
                   ingredients: :related_object,
                   contents: :essence,

--- a/spec/models/alchemy/eager_loading_spec.rb
+++ b/spec/models/alchemy/eager_loading_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Alchemy::EagerLoading do
               elements: [
                 :page,
                 :touchable_pages,
+                :tags,
                 {
                   ingredients: :related_object,
                   contents: :essence,
@@ -39,6 +40,7 @@ RSpec.describe Alchemy::EagerLoading do
               elements: [
                 :page,
                 :touchable_pages,
+                :tags,
                 {
                   ingredients: :related_object,
                   contents: :essence,


### PR DESCRIPTION
Elements can be taggable just like pages, and it's probably that those
tags can be rendered out in the frontend. Let's also preload them.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
