### PR TITLE
Allow Site managers to remove page locks

### DIFF
--- a/app/views/alchemy/admin/dashboard/_locked_pages.html.erb
+++ b/app/views/alchemy/admin/dashboard/_locked_pages.html.erb
@@ -36,7 +36,7 @@
         <% end %>
       </td>
       <td>
-        <% if current_alchemy_user.id == page.locked_by %>
+        <% if (current_alchemy_user.id == page.locked_by) || can?(:manage, Alchemy::Site.current) %>
         <%= form_tag(alchemy.unlock_admin_page_path(page, :redirect_to => alchemy.admin_dashboard_url)) do %>
           <button class="icon_button small" title="<%= Alchemy.t(:explain_unlocking) %>">
             <%= render_icon(:times, size: 'xs') %>

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Dashboard feature", type: :system do
-  let(:user) { create(:alchemy_dummy_user, :as_admin, name: "Joe User") }
+  let(:user) { create(:alchemy_dummy_user, :as_editor, name: "Joe Editor") }
 
   before do
     authorize_user(user)
@@ -27,6 +27,7 @@ RSpec.describe "Dashboard feature", type: :system do
         expect(locked_pages_widget).to have_content "Currently locked pages"
         expect(locked_pages_widget).to have_content a_page.name
         expect(locked_pages_widget).to have_content "Me"
+        expect(locked_pages_widget).to have_css "button[title=\"#{Alchemy.t(:explain_unlocking)}\"]"
       end
     end
 
@@ -40,6 +41,22 @@ RSpec.describe "Dashboard feature", type: :system do
         expect(locked_pages_widget).to have_content "Currently locked pages"
         expect(locked_pages_widget).to have_content a_page.name
         expect(locked_pages_widget).to have_content other_user.name
+        expect(locked_pages_widget).not_to have_css "button[title=\"#{Alchemy.t(:explain_unlocking)}\"]"
+      end
+    end
+
+    context "when logged in as admin" do
+      let(:user) { create(:alchemy_dummy_user, :as_admin, name: "Joe Editor") }
+      let(:other_user) { create(:alchemy_dummy_user, :as_admin) }
+
+      it "shows the name of the user who locked the page" do
+        a_page.lock_to!(other_user)
+        visit admin_dashboard_path
+        locked_pages_widget = all('div[@class="widget"]').first
+        expect(locked_pages_widget).to have_content "Currently locked pages"
+        expect(locked_pages_widget).to have_content a_page.name
+        expect(locked_pages_widget).to have_content other_user.name
+        expect(locked_pages_widget).to have_css "button[title=\"#{Alchemy.t(:explain_unlocking)}\"]"
       end
     end
   end


### PR DESCRIPTION
One of my client has page locks that are years old, due to users that
are not in the organization any longer and that never properly locked
out. This change allows admin users to remove stale page locks.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
