### PR TITLE
Use cache_key_with_version in page_etag

### DIFF
--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -218,12 +218,12 @@ module Alchemy
     #
     # IMPORTANT:
     #
-    # If your user does not have a +cache_key+ method (i.e. it's not an ActiveRecord model),
+    # If your user does not have a +cache_key_with_version+ method (i.e. it's not an ActiveRecord model),
     # you have to ensure to implement it and return a unique identifier for that particular user.
     # Otherwise all users will see the same cached page, regardless of user's state.
     #
     def page_etag
-      @page.cache_key + current_alchemy_user.try(:cache_key).to_s
+      [@page, current_alchemy_user]
     end
 
     # We only render the page if either the cache is disabled for this page

--- a/spec/controllers/alchemy/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/pages_controller_spec.rb
@@ -273,21 +273,20 @@ module Alchemy
         subject { controller.send(:page_etag) }
 
         before do
-          expect(page).to receive(:cache_key).and_return("aaa")
           controller.instance_variable_set("@page", page)
         end
 
         it "returns the etag for response headers" do
-          expect(subject).to eq("aaa")
+          expect(subject).to include(page)
         end
 
         context "with user logged in" do
           before do
-            authorize_user(mock_model(Alchemy.user_class, cache_key: "bbb"))
+            authorize_user(mock_model(Alchemy.user_class, cache_key_with_version: "bbb"))
           end
 
           it "returns another etag for response headers" do
-            expect(subject).to eq("aaabbb")
+            expect(subject).to include(an_instance_of(Alchemy.user_class))
           end
         end
       end


### PR DESCRIPTION
## What is this pull request for?

Fixes the `page_etag` so that it includes the `published_at` date form the page instead of just the `page#id`.

Closes #2363

### Notable changes (remove if none)

The pages `cache_key` was including the `published_at` date before we
changed it to just the `cache_version` (used by Rails to form the `cache_key`)

### Screenshots

Remove if no visual changes have been made.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
