### PR TITLE
Decide locale prefix with page language in show_alchemy_page_url helper

### DIFF
--- a/app/helpers/alchemy/url_helper.rb
+++ b/app/helpers/alchemy/url_helper.rb
@@ -20,8 +20,8 @@ module Alchemy
     def show_page_path_params(page, optional_params = {})
       raise ArgumentError, "Page is nil" if page.nil?
 
-      url_params = {urlname: page.urlname}.update(optional_params)
-      prefix_locale? ? url_params.update(locale: page.language_code) : url_params
+      url_params = { urlname: page.urlname }.update(optional_params)
+      prefix_locale?(page.language_code) ? url_params.update(locale: page.language_code) : url_params
     end
 
     # Returns the path for downloading an alchemy attachment

--- a/spec/helpers/alchemy/url_helper_spec.rb
+++ b/spec/helpers/alchemy/url_helper_spec.rb
@@ -14,7 +14,7 @@ module Alchemy
 
         context "if prefix_locale? is false" do
           before do
-            expect(helper).to receive(:prefix_locale?) { false }
+            expect(helper).to receive(:prefix_locale?).with(page.language_code) { false }
           end
 
           it "returns a Hash with urlname and no locale parameter" do
@@ -22,7 +22,7 @@ module Alchemy
             expect(show_page_path_params).to_not include(locale: "en")
           end
 
-          context "with addiitonal parameters" do
+          context "with additional parameters" do
             subject(:show_page_path_params) do
               helper.show_page_path_params(page, { query: "test" })
             end
@@ -38,7 +38,7 @@ module Alchemy
 
         context "if prefix_locale? is false" do
           before do
-            expect(helper).to receive(:prefix_locale?) { true }
+            expect(helper).to receive(:prefix_locale?).with(page.language_code) { true }
           end
 
           it "returns a Hash with urlname and locale parameter" do
@@ -62,7 +62,7 @@ module Alchemy
       describe "#show_alchemy_page_path" do
         context "when prefix_locale? set to true" do
           before do
-            expect(helper).to receive(:prefix_locale?) { true }
+            expect(helper).to receive(:prefix_locale?).with(page.language_code) { true }
           end
 
           it "should return the correct relative path string" do
@@ -77,7 +77,7 @@ module Alchemy
 
         context "when prefix_locale? set to false" do
           before do
-            expect(helper).to receive(:prefix_locale?) { false }
+            expect(helper).to receive(:prefix_locale?).with(page.language_code) { false }
           end
 
           it "should return the correct relative path string" do
@@ -94,7 +94,7 @@ module Alchemy
       describe "#show_alchemy_page_url" do
         context "when prefix_locale? set to true" do
           before do
-            expect(helper).to receive(:prefix_locale?) { true }
+            expect(helper).to receive(:prefix_locale?).with(page.language_code) { true }
           end
 
           it "should return the correct url string" do
@@ -110,7 +110,7 @@ module Alchemy
 
         context "when prefix_locale? set to false" do
           before do
-            expect(helper).to receive(:prefix_locale?) { false }
+            expect(helper).to receive(:prefix_locale?).with(page.language_code) { false }
           end
 
           it "should return the correct url string" do


### PR DESCRIPTION
## What is this pull request for?

Instead of using the current languages locale, we use the locale
of the page in question. That way we can use it in places were
the current language is not the pages language (ie. sitemaps)

Closes #2349

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
