### PR TITLE
Fix ingredient boolean preview text

### DIFF
--- a/app/models/alchemy/ingredients/boolean.rb
+++ b/app/models/alchemy/ingredients/boolean.rb
@@ -14,7 +14,9 @@ module Alchemy
       # Used by the Element#preview_text method.
       #
       def preview_text(_max_length = nil)
-        Alchemy.t(value, scope: "ingredient_values.boolean")
+        return if value.nil?
+
+        Alchemy.t(value.to_s, scope: "ingredient_values.boolean")
       end
     end
   end


### PR DESCRIPTION
## What is this pull request for?

If the translation is missing I18n returns a boolean instead
of a string. Cast to string unless the value is nil.

Closes #2329

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
