### PR TITLE
Do not touch pages when toggling element

### DIFF
--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -90,14 +90,12 @@ module Alchemy
         end
       end
 
-      # Toggle fodls the element and persists the state in the db
+      # Toggle folds the element and persists the state in the db
       #
-      # Ingredient validations might make the element invalid.
-      # In this case we are just toggling a UI state and do not care about the validations.
       def fold
         @page = @element.page
-        @element.folded = !@element.folded
-        @element.save(validate: false)
+        # We do not want to trigger the touch callback or any validations
+        @element.update_columns(folded: !@element.folded)
       end
 
       private

--- a/spec/controllers/alchemy/admin/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/elements_controller_spec.rb
@@ -282,28 +282,28 @@ module Alchemy
     describe "#fold" do
       subject { post :fold, params: { id: element.id }, xhr: true }
 
-      let(:element) { build_stubbed(:alchemy_element) }
+      let(:page) { create(:alchemy_page) }
 
       before do
-        expect(element).to receive(:save).and_return true
-        expect(Element).to receive(:find).and_return element
+        expect(Element).to receive(:find).and_return(element)
+        element.touchable_pages << page
       end
 
       context "if element is folded" do
-        before { expect(element).to receive(:folded).and_return true }
+        let(:element) { create(:alchemy_element, folded: true) }
 
         it "sets folded to false." do
-          expect(element).to receive(:folded=).with(false).and_return(false)
-          subject
+          expect(page).not_to receive(:touch)
+          expect { subject }.to change { element.folded }.to(false)
         end
       end
 
       context "if element is not folded" do
-        before { expect(element).to receive(:folded).and_return false }
+        let(:element) { create(:alchemy_element, folded: false) }
 
         it "sets folded to true." do
-          expect(element).to receive(:folded=).with(true).and_return(true)
-          subject
+          expect(page).not_to receive(:touch)
+          expect { subject }.to change { element.folded }.to(true)
         end
       end
     end

--- a/spec/controllers/alchemy/admin/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/pages_controller_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Alchemy::Admin::PagesController do
       it "removes the page" do
         delete :destroy, params: { id: page.id, format: :js }
         expect(response).to redirect_to admin_page_path(page.id)
-        expect(flash[:notice]).to eq("A Page 61 deleted")
+        expect(flash[:notice]).to eq Alchemy.t("Page deleted", name: page.name)
       end
     end
   end


### PR DESCRIPTION
## What is this pull request for?

Touching the page after toggle folding an element does not makes sense and can lead to database locks.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
