### PR TITLE
Always provide format with attachment URLs

### DIFF
--- a/app/models/alchemy/attachment/url.rb
+++ b/app/models/alchemy/attachment/url.rb
@@ -23,6 +23,7 @@ module Alchemy
       # @return [String]
       #
       def call(options = {})
+        options[:format] ||= @attachment.suffix
         if options.delete(:download)
           routes.download_attachment_path(@attachment, options)
         else

--- a/spec/models/alchemy/attachment_spec.rb
+++ b/spec/models/alchemy/attachment_spec.rb
@@ -63,14 +63,14 @@ module Alchemy
         let(:attachment) { create(:alchemy_attachment) }
 
         it "returns local path" do
-          is_expected.to eq "/attachment/#{attachment.id}/show"
+          is_expected.to eq "/attachment/#{attachment.id}/show.png"
         end
 
         context "with download enabled" do
           subject { attachment.url(download: true) }
 
           it "returns local download path" do
-            is_expected.to eq "/attachment/#{attachment.id}/download"
+            is_expected.to eq "/attachment/#{attachment.id}/download.png"
           end
 
           context "with extra params given" do
@@ -88,7 +88,7 @@ module Alchemy
           subject { attachment.url(download: false) }
 
           it "returns local path" do
-            is_expected.to eq "/attachment/#{attachment.id}/show"
+            is_expected.to eq "/attachment/#{attachment.id}/show.png"
           end
 
           context "with extra params given" do


### PR DESCRIPTION
## What is this pull request for?

When linking to an attachment without the format, the browser does not necessarily know what to do with the file. Adding the suffix by default makes that better: Firefox won't, for example, try rendering a PDF file as HTML.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have ~added~ changed tests to cover this change
