### PR TITLE
Do not create thumbs for invalid pictures

### DIFF
--- a/app/models/alchemy/picture_thumb/create.rb
+++ b/app/models/alchemy/picture_thumb/create.rb
@@ -30,7 +30,7 @@ module Alchemy
             # store the processed image
             image.to_file(server_path(uid)).close
           rescue RuntimeError => e
-            Rails.logger.warn(e)
+            ErrorTracking.notification_handler.call(e)
             # destroy the thumb if processing or storing fails
             thumb&.destroy
           end

--- a/spec/models/alchemy/picture_thumb/create_spec.rb
+++ b/spec/models/alchemy/picture_thumb/create_spec.rb
@@ -7,9 +7,54 @@ RSpec.describe Alchemy::PictureThumb::Create do
   let(:picture) { FactoryBot.create(:alchemy_picture, image_file: image) }
   let(:variant) { Alchemy::PictureVariant.new(picture, { size: "1x1" }) }
 
+  subject(:create) do
+    Alchemy::PictureThumb::Create.call(variant, "1234", "/pictures/#{picture.id}/1234/image.png")
+  end
+
   it "creates thumb on picture thumbs collection" do
-    expect {
-      Alchemy::PictureThumb::Create.call(variant, "1234", "/pictures/#{picture.id}/1234/image.png")
-    }.to change { variant.picture.thumbs.length }.by(1)
+    expect { create }.to change { variant.picture.thumbs.reload.length }.by(1)
+  end
+
+  context "with an invalid picture" do
+    let(:picture) { FactoryBot.build(:alchemy_picture) }
+
+    before do
+      expect(picture).to receive(:valid?) { false }
+    end
+
+    it "does not create a thumb" do
+      expect { create }.not_to change { variant.picture.thumbs.reload.length }
+    end
+
+    it "does not process the image" do
+      expect(variant).to_not receive(:image)
+      create
+    end
+  end
+
+  context "on processing errors" do
+    before do
+      variant
+      expect(variant).to receive(:image) do
+        raise(Dragonfly::Job::Fetch::NotFound)
+      end
+    end
+
+    it "destroys thumbnail" do
+      expect { subject }.to_not change { variant.picture.thumbs.reload.length }
+    end
+  end
+
+  context "on file errors" do
+    before do
+      variant
+      expect_any_instance_of(Dragonfly::Content).to receive(:to_file) do
+        raise("Bam!")
+      end
+    end
+
+    it "destroys thumbnail" do
+      expect { subject }.to_not change { variant.picture.thumbs.reload.length }
+    end
   end
 end


### PR DESCRIPTION
## What is this pull request for?

If a picture has validation errors (ie. an invalid format) a cryptic exception is raised:

"You cannot call create unless the parent is saved"

Let's not try to create a thumb if the picture is invalid. Also make sure we do not keep an thumb if an exception is raised during processing of the image.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
