### PR TITLE
Fix page seeder

### DIFF
--- a/lib/alchemy/seeder.rb
+++ b/lib/alchemy/seeder.rb
@@ -83,7 +83,11 @@ module Alchemy
       end
 
       def page_yml
-        @_page_yml ||= YAML.load_file(page_seeds_file)
+        @_page_yml ||= YAML.safe_load(
+          page_seeds_file.read,
+          permitted_classes: [Date],
+          aliases: true
+        )
       end
 
       def contentpages

--- a/lib/alchemy/seeder.rb
+++ b/lib/alchemy/seeder.rb
@@ -104,7 +104,9 @@ module Alchemy
 
       def create_page(draft, attributes = {})
         children = draft.delete("children") || []
-        page = Alchemy::Page.create!(draft.merge(attributes))
+        page = Alchemy::Page.new(draft.merge(attributes))
+        page.versions.build
+        page.save!
         log "Created page: #{page.name}"
         children.each do |child|
           create_page(child, parent: page, language: page.language)

--- a/spec/features/page_seeder_spec.rb
+++ b/spec/features/page_seeder_spec.rb
@@ -33,6 +33,13 @@ RSpec.describe "Page seeding", type: :system do
         expect(Alchemy::Page.find_by(name: "Footer")).to be_present
       end
 
+      it "public pages have two page versions" do
+        seed
+        home_page = Alchemy::Page.find_by(name: "Home")
+        expect(home_page.public_version).to be_present
+        expect(home_page.draft_version).to be_present
+      end
+
       context "when more then one content root page is present" do
         let(:seeds_file) do
           "spec/fixtures/pages_with_two_roots.yml"

--- a/spec/fixtures/pages.yml
+++ b/spec/fixtures/pages.yml
@@ -1,9 +1,9 @@
 ---
-
 - name: Index
   page_layout: index
   children:
     - name: Home
+      public_on: 2015-01-01
       page_layout: standard
     - name: About
       page_layout: about


### PR DESCRIPTION
## What is this pull request for?

If you pass a public_on date to the page seeder,
Alchemy will create a public version (because of the
`public_on=` attribute writer). The before_create filter
kicks in too late, leading to public pages without a
draft version.

Tried to use different before filters in the page model,
but nothing worked. So I fixed the problem where it
happens in the page seeder.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
