### PR TITLE
Re-introduce deleted methods

### DIFF
--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -166,6 +166,14 @@ module Alchemy
       render "alchemy/elements/view_not_found", name: element.name
     end
 
+    # Returns a string for the id attribute of a html element for the given element
+    # @deprecated
+    def element_dom_id(element)
+      element&.dom_id
+    end
+
+    deprecate element_dom_id: "element.dom_id", deprecator: Alchemy::Deprecation
+
     # Renders the HTML tag attributes required for preview mode.
     def element_preview_code(element)
       tag_builder.tag_options(element_preview_code_attributes(element))

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -105,6 +105,7 @@ module Alchemy
     scope :published, -> { where(public: true) }
     scope :hidden, -> { where(public: false) }
     scope :not_restricted, -> { joins(:page).merge(Page.not_restricted) }
+    scope :available, -> { published }
     scope :named, ->(names) { where(name: names) }
     scope :excluded, ->(names) { where.not(name: names) }
     scope :fixed, -> { where(fixed: true) }
@@ -191,6 +192,8 @@ module Alchemy
 
         all_from_clipboard(clipboard).where(name: parent_element.definition["nestable_elements"])
       end
+
+      deprecate available: :published, deprecator: Alchemy::Deprecation
     end
 
     # Returns next public element from same page.

--- a/lib/alchemy/upgrader/tasks/add_page_versions.rb
+++ b/lib/alchemy/upgrader/tasks/add_page_versions.rb
@@ -15,10 +15,10 @@ module Alchemy::Upgrader::Tasks
             Alchemy::Page.transaction do
               page.versions.create!(
                 public_on: page.legacy_public_on,
-                public_until: page.legacy_public_until,
+                public_until: page.legacy_public_until
               ).tap do |version|
                 # We must not use .find_each here to not mess up the order of elements
-                page.draft_version.elements.not_nested.published.each do |element|
+                page.draft_version.elements.not_nested.available.each do |element|
                   Alchemy::Element.copy(element, page_version_id: version.id)
                 end
               end

--- a/lib/generators/alchemy/elements/templates/view.html.erb
+++ b/lib/generators/alchemy/elements/templates/view.html.erb
@@ -19,7 +19,7 @@
     <%- end -%>
   <%- end -%>
   <%- if @element['nestable_elements'].present? -%>
-    <%%= render <%= @element_name %>.nested_elements.published %>
+    <%%= render <%= @element_name %>.nested_elements.available %>
   <%- end -%>
   <%%- end -%>
 <%%- end -%>

--- a/lib/generators/alchemy/elements/templates/view.html.haml
+++ b/lib/generators/alchemy/elements/templates/view.html.haml
@@ -18,5 +18,5 @@
     <%- end -%>
   <%- end -%>
   <%- if @element['nestable_elements'].present? -%>
-    = render <%= @element_name -%>.nested_elements.published
+    = render <%= @element_name -%>.nested_elements.available
   <%- end -%>

--- a/lib/generators/alchemy/elements/templates/view.html.slim
+++ b/lib/generators/alchemy/elements/templates/view.html.slim
@@ -18,5 +18,5 @@
     <%- end -%>
   <%- end -%>
   <%- if @element['nestable_elements'].present? -%>
-    = render <%= @element_name -%>.nested_elements.published
+    = render <%= @element_name -%>.nested_elements.available
   <%- end -%>

--- a/lib/tasks/alchemy/thumbnails.rake
+++ b/lib/tasks/alchemy/thumbnails.rake
@@ -46,7 +46,7 @@ namespace :alchemy do
       ingredient_pictures = Alchemy::Ingredients::Picture.
         joins(:element).
         preload({ related_object: :thumbs }).
-        merge(Alchemy::Element.published)
+        merge(Alchemy::Element.available)
 
       if ENV["ELEMENTS"].present?
         ingredient_pictures = ingredient_pictures.merge(

--- a/spec/helpers/alchemy/elements_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_helper_spec.rb
@@ -64,6 +64,20 @@ module Alchemy
       end
     end
 
+    describe "#element_dom_id" do
+      around do |example|
+        Alchemy::Deprecation.silence do
+          example.run
+        end
+      end
+
+      subject { helper.element_dom_id(element) }
+
+      it "should render a unique dom id for element" do
+        is_expected.to eq(element.dom_id)
+      end
+    end
+
     describe "#render_elements" do
       subject { helper.render_elements(options) }
 

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -1170,4 +1170,13 @@ module Alchemy
       element.reload.destroy!
     end
   end
+
+  describe ".available" do
+    subject { Alchemy::Element.available }
+
+    it "is deprecated" do
+      expect(Alchemy::Deprecation).to receive(:warn)
+      subject
+    end
+  end
 end


### PR DESCRIPTION
## What is this pull request for?

Re-introduces `Element.available` scope and the `element_dom_id` helper for v6.1

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
