### PR TITLE
Fix thumbnail writing for multi-concurrent and multi-db setups

### DIFF
--- a/app/models/alchemy/picture/url.rb
+++ b/app/models/alchemy/picture/url.rb
@@ -35,7 +35,9 @@ module Alchemy
           thumb.uid
         else
           uid = PictureThumb::Uid.call(signature, variant)
-          PictureThumb.generator_class.call(variant, signature, uid)
+          ActiveRecord::Base.connected_to(role: ActiveRecord::Base.writing_role) do
+            PictureThumb.generator_class.call(variant, signature, uid)
+          end
           uid
         end
       end

--- a/app/models/alchemy/picture_thumb/create.rb
+++ b/app/models/alchemy/picture_thumb/create.rb
@@ -19,11 +19,10 @@ module Alchemy
 
           # create the thumb before storing
           # to prevent db race conditions
-          thumb = Alchemy::PictureThumb.create!(
-            picture: variant.picture,
-            signature: signature,
-            uid: uid,
-          )
+          @thumb = Alchemy::PictureThumb.create_or_find_by!(signature: signature) do |thumb|
+            thumb.picture = variant.picture
+            thumb.uid = uid
+          end
           begin
             # process the image
             image = variant.image
@@ -32,7 +31,7 @@ module Alchemy
           rescue RuntimeError => e
             ErrorTracking.notification_handler.call(e)
             # destroy the thumb if processing or storing fails
-            thumb&.destroy
+            @thumb&.destroy
           end
         end
 

--- a/spec/models/alchemy/picture/url_spec.rb
+++ b/spec/models/alchemy/picture/url_spec.rb
@@ -34,5 +34,11 @@ RSpec.describe Alchemy::Picture::Url do
     it "returns the url to the thumbnail" do
       is_expected.to match(/\/pictures\/\d+\/.+\/image\.png/)
     end
+
+    it "connects to writing database" do
+      writing_role = ActiveRecord::Base.writing_role
+      expect(ActiveRecord::Base).to receive(:connected_to).with(role: writing_role)
+      subject
+    end
   end
 end

--- a/spec/models/alchemy/picture_thumb/create_spec.rb
+++ b/spec/models/alchemy/picture_thumb/create_spec.rb
@@ -15,6 +15,20 @@ RSpec.describe Alchemy::PictureThumb::Create do
     expect { create }.to change { variant.picture.thumbs.reload.length }.by(1)
   end
 
+  context "with a thumb already existing" do
+    let!(:thumb) do
+      Alchemy::PictureThumb.create!(
+        picture: picture,
+        signature: "1234",
+        uid: "/pictures/#{picture.id}/1234/image.png",
+      )
+    end
+
+    it "does not create a new thumb" do
+      expect { create }.to_not change { picture.thumbs.reload.length }
+    end
+  end
+
   context "with an invalid picture" do
     let(:picture) { FactoryBot.build(:alchemy_picture) }
 


### PR DESCRIPTION
## What is this pull request for?

### [Fix race condition in PictureThumb::Create](https://github.com/AlchemyCMS/alchemy_cms/commit/611397418d7b9f15b6ffdf74944ab2ed82b78887)

In a multi concurrent application server (like Puma) it happens that
a thumb might already exist for a given signature during the very
short timeframe of finding it vs creating it.

Using ARs [create_or_find_by!](https://github.com/rails/rails/blob/8015c2c2cf5c8718449677570f372ceb01318a32/activerecord/lib/active_record/relation.rb#L218) do avoid `ActiveRecord::RecordNotUnique` errors. ActiveStorage does the
exact same thing to avoid concurrency issues.

Closes #2429 

### [Connect to writing database during thumbnail generation](https://github.com/AlchemyCMS/alchemy_cms/commit/b9d6cc49ee0599e9aa58c285d6ebbfdc173b2ade)

In a multi db setup where you have a reading and a writing database
we need to make sure that we are using the writing database.

This is necessary, because we are writing (caching) picture
thumbnails in a GET request. Usually Rails would handle this for us
on POST, PATCH/PUT and DELETE requests.

ActiveStorage does the same thing to support multi database
setups.

Closes #2428 

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
