### PR TITLE
[6.1] Fix thumbnail writing for multi-concurrent and multi-db setups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
           sudo apt update -qq
           sudo apt install -qq --fix-missing libmysqlclient-dev -o dir::cache::archives="/home/runner/apt/cache"
           sudo chown -R runner /home/runner/apt/cache
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: Restore node modules cache
         id: yarn-cache
         uses: actions/cache@v2.1.3

--- a/app/models/alchemy/picture/url.rb
+++ b/app/models/alchemy/picture/url.rb
@@ -35,7 +35,9 @@ module Alchemy
           thumb.uid
         else
           uid = PictureThumb::Uid.call(signature, variant)
-          PictureThumb.generator_class.call(variant, signature, uid)
+          ActiveRecord::Base.connected_to(role: ActiveRecord::Base.writing_role) do
+            PictureThumb.generator_class.call(variant, signature, uid)
+          end
           uid
         end
       end

--- a/app/models/alchemy/picture_thumb/create.rb
+++ b/app/models/alchemy/picture_thumb/create.rb
@@ -19,11 +19,10 @@ module Alchemy
 
           # create the thumb before storing
           # to prevent db race conditions
-          thumb = Alchemy::PictureThumb.create!(
-            picture: variant.picture,
-            signature: signature,
-            uid: uid,
-          )
+          @thumb = Alchemy::PictureThumb.create_or_find_by!(signature: signature) do |thumb|
+            thumb.picture = variant.picture
+            thumb.uid = uid
+          end
           begin
             # process the image
             image = variant.image
@@ -32,7 +31,7 @@ module Alchemy
           rescue RuntimeError => e
             ErrorTracking.notification_handler.call(e)
             # destroy the thumb if processing or storing fails
-            thumb&.destroy
+            @thumb&.destroy
           end
         end
 

--- a/spec/models/alchemy/picture/url_spec.rb
+++ b/spec/models/alchemy/picture/url_spec.rb
@@ -34,5 +34,11 @@ RSpec.describe Alchemy::Picture::Url do
     it "returns the url to the thumbnail" do
       is_expected.to match(/\/pictures\/\d+\/.+\/image\.png/)
     end
+
+    it "connects to writing database" do
+      writing_role = ActiveRecord::Base.writing_role
+      expect(ActiveRecord::Base).to receive(:connected_to).with(role: writing_role)
+      subject
+    end
   end
 end

--- a/spec/models/alchemy/picture_thumb/create_spec.rb
+++ b/spec/models/alchemy/picture_thumb/create_spec.rb
@@ -15,6 +15,20 @@ RSpec.describe Alchemy::PictureThumb::Create do
     expect { create }.to change { variant.picture.thumbs.reload.length }.by(1)
   end
 
+  context "with a thumb already existing" do
+    let!(:thumb) do
+      Alchemy::PictureThumb.create!(
+        picture: picture,
+        signature: "1234",
+        uid: "/pictures/#{picture.id}/1234/image.png",
+      )
+    end
+
+    it "does not create a new thumb" do
+      expect { create }.to_not change { picture.thumbs.reload.length }
+    end
+  end
+
   context "with an invalid picture" do
     let(:picture) { FactoryBot.build(:alchemy_picture) }
 


### PR DESCRIPTION
The same as #2433 but for 6.1-stable branch