### PR TITLE
Fix non_stupid_digest_assets

### DIFF
--- a/lib/non_stupid_digest_assets.rb
+++ b/lib/non_stupid_digest_assets.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "sprockets/manifest"
+require "active_support/core_ext/module/attribute_accessors"
 
 module NonStupidDigestAssets
   mattr_accessor :whitelist
@@ -18,7 +19,7 @@ module NonStupidDigestAssets
     def whitelisted_assets(assets)
       assets.select do |logical_path, _digest_path|
         whitelist.any? do |item|
-          item == logical_path
+          item =~ logical_path
         end
       end
     end

--- a/spec/libraries/non_stupid_digest_assets_spec.rb
+++ b/spec/libraries/non_stupid_digest_assets_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "non_stupid_digest_assets"
+
+RSpec.describe NonStupidDigestAssets do
+  describe ".assets" do
+    context "when the whitelist is empty" do
+      it "returns the assets" do
+        NonStupidDigestAssets.whitelist = []
+        assets = { "foo.js" => "foo-123.js" }
+        expect(NonStupidDigestAssets.assets(assets)).to eq(assets)
+      end
+    end
+
+    context "when the whitelist is not empty" do
+      it "returns the assets that match the whitelist" do
+        NonStupidDigestAssets.whitelist = [/foo/]
+        assets = { "foo.js" => "foo-123.js", "bar.js" => "bar-123.js" }
+        expect(NonStupidDigestAssets.assets(assets)).to eq("foo.js" => "foo-123.js")
+      end
+    end
+  end
+end


### PR DESCRIPTION
We imported the file from a wrong version. We need the version that allows a RegExp whitelist.
