### PR TITLE
Send language_id (of the currently editing page) parameter to Pages API requests for page select on link overlay

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.link_dialog.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.link_dialog.js.coffee
@@ -59,12 +59,17 @@ class window.Alchemy.LinkDialog extends Alchemy.Dialog
   initPageSelect: ->
     pageTemplate = HandlebarsTemplates.page
     element_anchor_placeholder = @$element_anchor.attr('placeholder')
+    if @link_object.dataset.languageId
+      api_url = "#{Alchemy.routes.api_pages_path}?language_id=#{@link_object.dataset.languageId}"
+    else
+      api_url = Alchemy.routes.api_pages_path
+
     @$internal_link.select2
       placeholder: Alchemy.t('Search page')
       allowClear: true
       minimumInputLength: 3
       ajax:
-        url: Alchemy.routes.api_pages_path
+        url: api_url
         datatype: 'json'
         quietMillis: 300
         data: (term, page) ->

--- a/app/views/alchemy/ingredients/shared/_link_tools.html.erb
+++ b/app/views/alchemy/ingredients/shared/_link_tools.html.erb
@@ -5,6 +5,7 @@
     onclick: 'new Alchemy.LinkDialog(this).open(); return false;',
     class: "icon_button#{ingredient_editor.linked? ? ' linked' : ''} link-ingredient",
     "data-parent-selector": "[data-ingredient-id='#{ingredient_editor.id}']",
+    "data-language-id": ingredient_editor.page&.language_id,
     title: Alchemy.t(:place_link),
     id: "edit_link_#{ingredient_editor.id}"
   ) %>

--- a/app/views/alchemy/ingredients/shared/_picture_tools.html.erb
+++ b/app/views/alchemy/ingredients/shared/_picture_tools.html.erb
@@ -34,6 +34,7 @@
   class: picture_editor.linked? ? "linked" : nil,
   title: Alchemy.t(:link_image),
   "data-parent-selector": "[data-ingredient-id='#{picture_editor.id}']",
+  "data-language-id": picture_editor.page&.language_id,
   id: "edit_link_#{picture_editor.id}"
 } do %>
   <span class="disabled" tabindex="-1"><%= render_icon(:link) %></span>

--- a/spec/features/admin/link_overlay_spec.rb
+++ b/spec/features/admin/link_overlay_spec.rb
@@ -53,6 +53,23 @@ RSpec.describe "Link overlay", type: :system do
       )
     end
 
+    it "should only return pages from the language of the page being edited" do
+      page_in_other_language = create :alchemy_page, :public, language: create(:alchemy_language, language_code: "es", public: true)
+
+      visit edit_admin_page_path(page1)
+
+      within "#element_#{article.id}" do
+        fill_in "Intro", with: "Link me"
+        click_link "Link text"
+      end
+
+      within "#overlay_tab_internal_link" do
+        expect(page).to have_selector("#s2id_internal_link")
+        expect { select2(page_in_other_language.name, from: "Page") }.to raise_error(Capybara::ElementNotFound)
+        expect(find("#internal_link").value).not_to eq page_in_other_language.urlname
+      end
+    end
+
     it "should be possible to link a page" do
       visit edit_admin_page_path(page1)
 


### PR DESCRIPTION
## What is this pull request for?

Describe you pull request here...
`API::PagesController#index` defaults to filtering to Pages from `Alchemy::Language.current` if `language_id` is not given.  The `language_id` of the page being edited should be given.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
