### PR TITLE
Re-add Webpacker support.

### DIFF
--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -36,7 +36,11 @@
     </script>
     <%= render 'alchemy/admin/partials/routes' %>
     <%= javascript_include_tag('alchemy/admin/all', 'data-turbolinks-track' => true) %>
-    <%= javascript_include_tag('alchemy_admin', 'data-turbolinks-track' => true, defer: true) %>
+    <% if respond_to?(:javascript_pack_tag) %>
+      <%= javascript_pack_tag('alchemy/admin', 'data-turbolinks-track' => true, defer: true) %>
+    <% else %>
+      <%= javascript_include_tag('alchemy_admin', 'data-turbolinks-track' => true, defer: true) %>
+    <% end %>
     <%= yield :javascript_includes %>
   </head>
   <%= content_tag :body, id: 'alchemy', class: alchemy_body_class do %>


### PR DESCRIPTION
## What is this pull request for?

If you still have a webpacker based application and are not using jsbundling-rails or sourcemaps yet, we need to use the `javascript_pack_tag helper` instead of `javascript_link_tag`, or sprockets will complain about a missing asset.
