### PR TITLE
Fix installer: Add seeds file if not exists

### DIFF
--- a/lib/alchemy/install/tasks.rb
+++ b/lib/alchemy/install/tasks.rb
@@ -31,7 +31,13 @@ module Alchemy
         end
 
         def inject_seeder
-          append_file "./db/seeds.rb", "Alchemy::Seeder.seed!\n"
+          seed_file = Rails.root.join("db", "seeds.rb")
+          args = [seed_file, "Alchemy::Seeder.seed!\n"]
+          if File.exist?(seed_file)
+            append_file(*args)
+          else
+            add_file(*args)
+          end
         end
       end
     end


### PR DESCRIPTION
## What is this pull request for?

When we set up dummy apps for extensions it might
be the case that the db/seeds.rb file does not exists.

Let's create it in that case, so the installer does not fail.
