### PR TITLE
[BACKPORT] check presence of page_public checkbox

### DIFF
--- a/package/src/page_publication_fields.js
+++ b/package/src/page_publication_fields.js
@@ -7,21 +7,22 @@ export default function () {
     const publication_date_fields = dialog.querySelector(
       ".page-publication-date-fields"
     )
+    const public_field = dialog.querySelector("#page_public")
 
-    dialog
-      .querySelector("#page_public")
-      .addEventListener("click", function (evt) {
-        const checkbox = evt.target
-        const now = new Date()
+    if(!public_field) return
 
-        if (checkbox.checked) {
-          publication_date_fields.classList.remove("hidden")
-          public_on_field._flatpickr.setDate(now)
-        } else {
-          publication_date_fields.classList.add("hidden")
-          public_on_field.value = ""
-        }
-        public_until_field.value = ""
-      })
+    public_field.addEventListener("click", function (evt) {
+      const checkbox = evt.target
+      const now = new Date()
+
+      if (checkbox.checked) {
+        publication_date_fields.classList.remove("hidden")
+        public_on_field._flatpickr.setDate(now)
+      } else {
+        publication_date_fields.classList.add("hidden")
+        public_on_field.value = ""
+      }
+      public_until_field.value = ""
+    })
   })
 }


### PR DESCRIPTION
## What is this pull request for?

Backport #2269 onto the 5.3 branch

### Notable changes 

Avoid error in the js console if the page_public field is not found in the current dialog.

## Checklist
- [X] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [X] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
