### PR TITLE
CI: Use latest version of GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           MARIADB_ROOT_PASSWORD: password
         options: --health-cmd="mariadb-admin ping" --health-interval=10s --health-timeout=5s --health-retries=5
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -62,7 +62,7 @@ jobs:
           bundler-cache: true
       - name: Restore apt cache
         id: apt-cache
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v3
         with:
           path: /home/runner/apt/cache
           key: ${{ runner.os }}-apt-${{ matrix.database }}
@@ -84,7 +84,7 @@ jobs:
           sudo chown -R runner /home/runner/apt/cache
       - name: Restore node modules cache
         id: yarn-cache
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v3
         with:
           path: spec/dummy/node_modules
           key: ${{ runner.os }}-yarn-dummy-${{ hashFiles('./package.json') }}
@@ -109,9 +109,9 @@ jobs:
     env:
       NODE_ENV: test
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
       - name: Restore node modules cache
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v3
         with:
           path: node_modules
           key: ${{ runner.os }}-yarn-${{ hashFiles('./package.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           bundle exec rake alchemy:spec:prepare
       - name: Run tests & publish code coverage
-        uses: paambaati/codeclimate-action@v2.7.5
+        uses: paambaati/codeclimate-action@v3.2.0
         env:
           CC_TEST_REPORTER_ID: bca4349e32f97919210ac8a450b04904b90683fcdd57d65a22c0f5065482bc22
         with:


### PR DESCRIPTION
Removes a warning of Node 12 support