### PR TITLE
Allow editors to switch language

### DIFF
--- a/lib/alchemy/permissions.rb
+++ b/lib/alchemy/permissions.rb
@@ -160,6 +160,7 @@ module Alchemy
         can :manage, Alchemy::Attachment
         can :manage, Alchemy::Tag
         can :index, Alchemy::Language
+        can :switch, Alchemy::Language
       end
     end
 

--- a/spec/libraries/permissions_spec.rb
+++ b/spec/libraries/permissions_spec.rb
@@ -16,6 +16,7 @@ describe Alchemy::Permissions do
   let(:restricted_page) { build(:alchemy_page, :public, restricted: true) }
   let(:published_element) { mock_model(Alchemy::Element, restricted?: false, public?: true) }
   let(:restricted_element) { mock_model(Alchemy::Element, restricted?: true, public?: true) }
+  let(:language) { build(:alchemy_language) }
 
   context "A guest user" do
     let(:user) { nil }
@@ -144,6 +145,7 @@ describe Alchemy::Permissions do
       is_expected.to be_able_to(:flush, Alchemy::Page)
       is_expected.to be_able_to(:order, Alchemy::Page)
       is_expected.to be_able_to(:switch_language, Alchemy::Page)
+      is_expected.to be_able_to(:switch, Alchemy::Language)
     end
 
     context "if page language is public" do


### PR DESCRIPTION
## What is this pull request for?

I have a multi-language site with an editor user, and they're not able to switch to another language without this patch.

Not sure whether switching languages should at all be protected by CanCanCan; maybe it's a good idea to just skip the authorize_resource before action on the Alchemy::Admin::LanguagesController#switch instead.

I'm also not sure about all the other roles. Should they be able to switch language?

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [ ] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
