### PR TITLE
Fix picture file format filter

### DIFF
--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -138,14 +138,15 @@ module Alchemy
       end
 
       def alchemy_resource_filters
+        @_file_formats ||= distinct.pluck(:image_file_format).compact.presence || []
         [
           {
             name: :by_file_format,
-            values: distinct.pluck(:image_file_format),
+            values: @_file_formats,
           },
           {
             name: :misc,
-            values: %w(recent last_upload without_tag),
+            values: %w(recent last_upload without_tag deletable),
           },
         ]
       end

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -125,6 +125,7 @@ en:
             last_upload: Last upload only
             recent: Recently uploaded only
             without_tag: Without tag
+            deletable: Not linked by file content
       attachment:
         by_file_type:
           name: File Type
@@ -136,7 +137,6 @@ en:
             last_upload: Last upload only
             recent: Recently uploaded only
             without_tag: Without tag
-            deletable: Not linked by file content
 
     # === Translations for ingredient validations
     # Used when a user did not enter (correct) values to the ingredient field.

--- a/spec/models/alchemy/picture_spec.rb
+++ b/spec/models/alchemy/picture_spec.rb
@@ -143,6 +143,25 @@ module Alchemy
       end
     end
 
+    describe ".alchemy_resource_filters" do
+      context "with image file formats" do
+        let!(:picture) { create(:alchemy_picture, image_file_format: "png") }
+
+        it "returns a list of filters with image file formats" do
+          expect(Alchemy::Picture.alchemy_resource_filters).to eq([
+            {
+              name: :by_file_format,
+              values: ["png"],
+            },
+            {
+              name: :misc,
+              values: %w[recent last_upload without_tag deletable],
+            },
+          ])
+        end
+      end
+    end
+
     describe ".last_upload" do
       it "should return all pictures that have the same upload-hash as the most recent picture" do
         other_upload = Picture.create!(image_file: image_file, upload_hash: "456")


### PR DESCRIPTION
## What is this pull request for?

Databases may not have a value for `image_file_format`, returning `nil`, leading to cryptic errors. Make sure we only return values that are not `nil`.

Also move the `deletable` filter into the picture resource filters, as the attachment class does not have this scope.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
