### PR TITLE
Fix picture show overlay if picture in use

### DIFF
--- a/app/views/alchemy/admin/pictures/_infos.html.erb
+++ b/app/views/alchemy/admin/pictures/_infos.html.erb
@@ -34,7 +34,7 @@
                   <li class="<%= cycle('even', 'odd') %>">
                     <% page_link = link_to element.display_name_with_preview_text,
                                    edit_admin_page_path(page, anchor: "element_#{element.id}") %>
-                    <% ingredients = picture_ingredients.collect(&:translated_role).to_sentence %>
+                    <% ingredients = picture_ingredients.map { |p| Alchemy::IngredientEditor.new(p).translated_role }.to_sentence %>
                     <% if element.public? %>
                       <%= render_icon('window-maximize', style: 'regular') %>
                     <% else %>

--- a/spec/views/admin/pictures/show_spec.rb
+++ b/spec/views/admin/pictures/show_spec.rb
@@ -20,13 +20,15 @@ describe "alchemy/admin/pictures/show.html.erb" do
 
   before do
     allow(view).to receive(:admin_picture_path).and_return("/path")
+    allow(view).to receive(:edit_admin_page_path).and_return("/path")
     allow(view).to receive(:render_message)
     allow(view).to receive(:search_filter_params) { {} }
     view.extend Alchemy::Admin::FormHelper
+    view.extend Alchemy::BaseHelper
+    assign(:picture, picture)
   end
 
   it "displays picture in original format" do
-    assign(:picture, picture)
     assign(:assignments, [])
 
     render
@@ -36,11 +38,23 @@ describe "alchemy/admin/pictures/show.html.erb" do
 
   it "separates the tags with a comma" do
     allow(picture).to receive(:tag_list).and_return(["one", "two", "three"])
-    assign(:picture, picture)
     assign(:assignments, [])
 
     render
 
     expect(rendered).to have_selector('input[value*="one,two,three"]')
+  end
+
+  context "if picture is used" do
+    let!(:picture_ingredient) { create(:alchemy_ingredient_picture, picture: picture) }
+
+    it "displays a list of ingredients using the picture" do
+      assign(:assignments, picture.picture_ingredients.joins(element: :page))
+
+      render
+
+      expect(rendered).to have_css("#pictures_page_list .list")
+      expect(rendered).to have_content Alchemy::IngredientEditor.new(picture_ingredient).translated_role
+    end
   end
 end


### PR DESCRIPTION
The `translated_role` is only available in the `IngredientEditor` presenter.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
