### PR TITLE
Add ability to restrict users to specific languages

### DIFF
--- a/app/controllers/concerns/alchemy/admin/current_language.rb
+++ b/app/controllers/concerns/alchemy/admin/current_language.rb
@@ -6,10 +6,28 @@ module Alchemy
       extend ActiveSupport::Concern
 
       included do
+        prepend_before_action :redirect_to_accessible_site_language, only: :index
         before_action :load_current_language
       end
 
       private
+
+      def current_alchemy_user_with_languages
+        UserWithLanguages.new(current_alchemy_user)
+      end
+
+      # If the current alchemy user has not been given access to the current site/language, change them to ones the user has access to.
+      def redirect_to_accessible_site_language
+        if Alchemy::Language.current
+          if current_alchemy_user_with_languages.accessible_sites.exclude? Alchemy::Site.current
+            set_alchemy_language current_alchemy_user_with_languages.accessible_languages.first
+            @current_alchemy_site = Language.current.site
+            set_current_alchemy_site
+          elsif current_alchemy_user_with_languages.accessible_languages.exclude? Alchemy::Language.current
+            set_alchemy_language current_alchemy_user_with_languages.accessible_languages.on_current_site.first
+          end
+        end
+      end
 
       def load_current_language
         @current_language = Alchemy::Language.current

--- a/app/decorators/alchemy/user_with_languages.rb
+++ b/app/decorators/alchemy/user_with_languages.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Alchemy
+  class UserWithLanguages < SimpleDelegator
+    alias_method :user, :__getobj__
+
+    def language_restriction_implemented?
+      user.respond_to? :languages
+    end
+
+    def accessible_languages
+      language_restriction_implemented? ? super : Alchemy::Language.all
+    end
+
+    def accessible_language_ids
+      accessible_languages.pluck(:id)
+    end
+
+    def languages_restricted?
+      !language_restriction_implemented? ||
+        accessible_languages != Alchemy::Language.all
+    end
+
+    def accessible_site_ids
+      accessible_languages.map(&:site_id).uniq
+    end
+
+    def accessible_sites
+      Alchemy::Site.where(id: accessible_site_ids).order(:id)
+    end
+
+    def can_access_language?(language)
+      accessible_languages.where(id: language.id).any?
+    end
+  end
+end

--- a/app/helpers/alchemy/admin/base_helper.rb
+++ b/app/helpers/alchemy/admin/base_helper.rb
@@ -70,9 +70,7 @@ module Alchemy
 
       # Used for site selector in Alchemy cockpit.
       def sites_for_select
-        Alchemy::Site.all.map do |site|
-          [site.name, site.id]
-        end
+        UserWithLanguages.new(current_alchemy_user).accessible_sites.pluck(:name, :id)
       end
 
       # Returns a javascript driven live filter for lists.

--- a/app/models/alchemy/language.rb
+++ b/app/models/alchemy/language.rb
@@ -27,6 +27,7 @@ module Alchemy
     belongs_to :site
     has_many :pages, inverse_of: :language
     has_many :nodes, inverse_of: :language
+    has_and_belongs_to_many :users, class_name: Alchemy.user_class_name, join_table: :alchemy_users_languages
 
     before_validation :set_locale, if: -> { locale.blank? }
 

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -471,15 +471,19 @@ module Alchemy
       fixed_attributes.fixed?(name)
     end
 
-    # Checks the current page's list of editors, if defined.
+    # Checks the current page's list of editors, if defined, and the user's accessible languages, if they are restricted
     #
-    # This allows us to pass in a user and see if any of their roles are enable
-    # them to make edits
+    # This allows us to pass in a user and see if any of their roles/languages enable them to make edits
     #
     def editable_by?(user)
-      return true unless has_limited_editors?
+      user = UserWithLanguages.new(user)
 
-      (editor_roles & user.alchemy_roles).any?
+      if has_limited_editors? || user.languages_restricted?
+        (!has_limited_editors? || (editor_roles & user.alchemy_roles).any?) &&
+          user.accessible_languages.include?(language)
+      else
+        true
+      end
     end
 
     # Returns the value of +public_on+ attribute from public version

--- a/app/models/alchemy/page/page_natures.rb
+++ b/app/models/alchemy/page/page_natures.rb
@@ -42,9 +42,7 @@ module Alchemy
       end
 
       def editor_roles
-        return unless has_limited_editors?
-
-        definition["editable_by"]
+        has_limited_editors? ? definition["editable_by"] : []
       end
 
       # True if page locked_at timestamp and locked_by id are set

--- a/app/views/alchemy/admin/partials/_language_tree_select.html.erb
+++ b/app/views/alchemy/admin/partials/_language_tree_select.html.erb
@@ -1,5 +1,5 @@
-<% languages = Alchemy::Language.on_current_site %>
-<% if can?(:switch_language, Alchemy::Page) && languages.many? %>
+<% languages = Alchemy::Language.accessible_by(Alchemy::Permissions.new(current_alchemy_user), :switch_language).on_current_site %>
+<% if can?(:switch_language, Alchemy::Page) && Alchemy::Language.current.site.languages.many? %>
 <div class="button_with_label">
   <%= form_tag switch_admin_languages_path, method: 'get' do %>
     <%= select_tag(

--- a/app/views/alchemy/admin/pictures/_infos.html.erb
+++ b/app/views/alchemy/admin/pictures/_infos.html.erb
@@ -27,12 +27,12 @@
             <li>
               <h3>
                 <%= render_icon 'file-alt' %>
-                <p><%= link_to page.name, edit_admin_page_path(page) %></p>
+                <p><%= link_to_if can?(:edit, page), page.name, edit_admin_page_path(page) %></p>
               </h3>
               <ul class="list">
                 <% picture_ingredients.group_by(&:element).each do |element, picture_ingredients| %>
                   <li class="<%= cycle('even', 'odd') %>">
-                    <% page_link = link_to element.display_name_with_preview_text,
+                    <% page_link = link_to_if can?(:edit, page), element.display_name_with_preview_text,
                                    edit_admin_page_path(page, anchor: "element_#{element.id}") %>
                     <% ingredients = picture_ingredients.map { |p| Alchemy::IngredientEditor.new(p).translated_role }.to_sentence %>
                     <% if element.public? %>

--- a/db/migrate/20230407153522_create_alchemy_users_languages.rb
+++ b/db/migrate/20230407153522_create_alchemy_users_languages.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateAlchemyUsersLanguages < ActiveRecord::Migration[6.1]
+  def change
+    create_table :alchemy_users_languages do |t|
+      t.bigint :user_id, null: false
+      t.bigint :language_id, full: false
+
+      t.index :user_id
+      t.index :language_id
+    end
+  end
+end

--- a/spec/dummy/app/models/dummy_user.rb
+++ b/spec/dummy/app/models/dummy_user.rb
@@ -2,6 +2,8 @@
 
 class DummyUser < ActiveRecord::Base
   has_many :folded_pages, class_name: "Alchemy::FoldedPage"
+  has_and_belongs_to_many :languages, class_name: "Alchemy::Language", foreign_key: :user_id, join_table: :alchemy_users_languages
+
   attr_writer :alchemy_roles, :name
 
   def self.logged_in
@@ -22,5 +24,13 @@ class DummyUser < ActiveRecord::Base
 
   def human_roles_string
     alchemy_roles.map(&:humanize)
+  end
+
+  # Languages this user is allowed to access
+  #
+  # An empty collection means allow all languages
+  #
+  def accessible_languages
+    languages.any? ? languages : Alchemy::Language.all
   end
 end

--- a/spec/dummy/db/migrate/20230419135736_create_alchemy_users_languages.alchemy.rb
+++ b/spec/dummy/db/migrate/20230419135736_create_alchemy_users_languages.alchemy.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This migration comes from alchemy (originally 20230407153522)
+class CreateAlchemyUsersLanguages < ActiveRecord::Migration[6.1]
+  def change
+    create_table :alchemy_users_languages do |t|
+      t.bigint :user_id, null: false
+      t.bigint :language_id, full: false
+
+      t.index :user_id
+      t.index :language_id
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -134,12 +134,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_13_104432) do
     t.index ["updater_id"], name: "index_alchemy_nodes_on_updater_id"
   end
 
-  create_table "alchemy_page_mutexes", force: :cascade do |t|
-    t.integer "page_id", null: false
-    t.datetime "created_at"
-    t.index ["page_id"], name: "index_alchemy_page_mutexes_on_page_id", unique: true
-  end
-
   create_table "alchemy_page_versions", force: :cascade do |t|
     t.integer "page_id", null: false
     t.datetime "public_on", precision: nil
@@ -208,8 +202,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_13_104432) do
     t.integer "image_file_size"
     t.string "image_file_format"
     t.index ["creator_id"], name: "index_alchemy_pictures_on_creator_id"
-    t.index ["image_file_name"], name: "index_alchemy_pictures_on_image_file_name"
-    t.index ["name"], name: "index_alchemy_pictures_on_name"
     t.index ["updater_id"], name: "index_alchemy_pictures_on_updater_id"
   end
 
@@ -289,7 +281,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_13_104432) do
   add_foreign_key "alchemy_languages", "alchemy_sites", column: "site_id"
   add_foreign_key "alchemy_nodes", "alchemy_languages", column: "language_id"
   add_foreign_key "alchemy_nodes", "alchemy_pages", column: "page_id", on_delete: :restrict
-  add_foreign_key "alchemy_page_mutexes", "alchemy_pages", column: "page_id"
   add_foreign_key "alchemy_page_versions", "alchemy_pages", column: "page_id", on_delete: :cascade
   add_foreign_key "alchemy_pages", "alchemy_languages", column: "language_id"
   add_foreign_key "alchemy_picture_thumbs", "alchemy_pictures", column: "picture_id"

--- a/spec/features/admin/navigation_feature_spec.rb
+++ b/spec/features/admin/navigation_feature_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "Admin navigation feature", type: :system do
 
   context "editor users" do
     let!(:default_site) { create(:alchemy_site) }
+    let!(:default_language) { create(:alchemy_language) }
     before { authorize_user(:as_editor) }
 
     it "can access the languages page" do

--- a/spec/features/admin/site_select_feature_spec.rb
+++ b/spec/features/admin/site_select_feature_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe "Site select", type: :system do
 
   context "with multiple sites" do
     let!(:default_site) { create(:alchemy_site, :default) }
+    let!(:default_language) { create(:alchemy_language) }
     let!(:a_site) { create(:alchemy_site) }
+    let!(:a_language) { create(:alchemy_language, site: a_site) }
 
     context "not on pages or languages module" do
       it "does not display the site select" do

--- a/spec/views/admin/pictures/show_spec.rb
+++ b/spec/views/admin/pictures/show_spec.rb
@@ -19,6 +19,7 @@ describe "alchemy/admin/pictures/show.html.erb" do
   end
 
   before do
+    allow(view).to receive(:can?).and_return(true)
     allow(view).to receive(:admin_picture_path).and_return("/path")
     allow(view).to receive(:edit_admin_page_path).and_return("/path")
     allow(view).to receive(:render_message)


### PR DESCRIPTION
## What is this pull request for?

Add a feature to enable restricting CMS users to specific languages.  This applies to Site, Language, Page, and Node CMS functionality.  This integrates with user roles to provide additional restrictions when used.  Another PR to `alchemy-devise` will add additional functionality and UI specific to that Alchemy User implementation.

User of this feature is optional and does not break any existing functionality.

### Screenshots

See forthcoming `alchemy-devise` PR.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
