### PR TITLE
Fix layoutpages configuration

### DIFF
--- a/app/views/alchemy/admin/pages/update.js.erb
+++ b/app/views/alchemy/admin/pages/update.js.erb
@@ -18,10 +18,16 @@
 <% else -%>
 
   if (page) {
-    var page_html = "<%= j render('page', page: @page) %>".replace(/__ID__/g, "<%= @page.id %>");;
-    var compiler = Handlebars.compile(page_html);
-    var tree = <%== @tree.to_json %>;
-    page.outerHTML = compiler(tree.pages[0]);
+
+    <% if @page.layoutpage %>
+       page.outerHTML = "<%= j render('alchemy/admin/layoutpages/layoutpage', layoutpage: @page) %>"
+    <% else %>
+       const page_html = "<%= j render('page', page: @page) %>".replace(/__ID__/g, "<%= @page.id %>");
+       const compiler = Handlebars.compile(page_html);
+       const tree = <%== @tree.to_json %>;
+       page.outerHTML = compiler(tree.pages[0]);
+    <% end %>
+
     Alchemy.growl("<%= j @notice %>");
     Alchemy.closeCurrentDialog();
   } else {


### PR DESCRIPTION
## What is this pull request for?
Problem: `alchemy/admin/pages/update.js.erb` - try render partial `_page.html.erb`, but `Alchemy.Sitemap` not inialized. Sitemap can't be inialized, because `Alchemy::Page` can't be `root_page` and `layoutpage` in same time

This small solution solve problem, when admin try to update any `Shared section` configuration and got error

### Screenshots

Error example:
<img width="373" alt="image" src="https://user-images.githubusercontent.com/40061096/232193847-8e98fd88-6492-4eaa-9ff7-f008a9a1cee0.png">


Remove if no visual changes have been made.