### PR TITLE
Use ISO Date format in flatpickr

### DIFF
--- a/package/src/datepicker.js
+++ b/package/src/datepicker.js
@@ -24,6 +24,7 @@ export default function Datepicker(scope = document) {
         altInput: true,
         altFormat: Alchemy.t(`formats.${type}`),
         altInputClass: "flatpickr-input",
+        dateFormat: "Z",
         enableTime: /time/.test(type),
         noCalendar: type === "time",
         time_24hr: Alchemy.t("formats.time_24hr"),


### PR DESCRIPTION
## What is this pull request for?

Currently the date/time being displayed in flatpickr is (correctly) set to the user's current timezone (as detailed in
https://github.com/flatpickr/flatpickr/issues/1532)

Where this breaks is when it's sent back to the server to update the page. Flatpickr sends back the date in it's default format, which does not include any timezone information. Rails then takes that timestamp and assumes it's in UTC when saving it to the database.

Which means a user in UTC+10 can save a page to go public at 1PM local time, and after saving, it will actually be set to 11PM local time (== 1PM UTC)

By forcing the underlying string value in the form to adopt the ISO standard, Rails can parse both the time AND timezone from the incoming data, and ensure the timestamp is saved to the correct UTC time in the database, fixing the bug

Closes #2461

### Screenshots

In both cases, opening up a page properties modal, marking it to go public at 1PM local time (UTC+10)

![Screenshot 2023-04-21 at 12 09 03 pm](https://user-images.githubusercontent.com/221845/233528054-427cf3e7-cd4b-43b3-9bfd-5c8f48c8d9ca.png)

The expected result of this would be the timestamp persisted as `public_on = 3AM UTC time` in the database. Without the patch, this gets incorrectly persisted as `public_on = 1PM UTC time`.

Screenshots below show chrome dev tools XHR payload, the server side logs for the incoming PATCH request, and the server side logs for the underlying ActiveRecord DB update, to showcase the differences in the data flow

### Before the patch:

![Screenshot 2023-04-21 at 12 50 43 pm](https://user-images.githubusercontent.com/221845/233529642-aeee7b81-937a-40b7-bc03-3c68f7b7eb54.png)

![Screenshot 2023-04-21 at 12 51 10 pm](https://user-images.githubusercontent.com/221845/233529652-914e2a5f-168b-46be-a96b-d626de393870.png)

![Screenshot 2023-04-21 at 12 52 08 pm](https://user-images.githubusercontent.com/221845/233529667-85a31c86-9be4-4787-bf3d-4897f6e1ab30.png)

### After the patch:

![Screenshot 2023-04-21 at 12 10 05 pm](https://user-images.githubusercontent.com/221845/233528063-ecfc43e2-5eb3-443c-b692-a3e8d72e92a6.png)

![Screenshot 2023-04-21 at 12 14 34 pm](https://user-images.githubusercontent.com/221845/233528097-64970ffa-3005-4d59-9d8b-547e5a5e1685.png)

![Screenshot 2023-04-21 at 12 16 37 pm](https://user-images.githubusercontent.com/221845/233528128-c0fb0738-7462-4b0e-84ef-5e4eecbb503b.png)

## Checklist
- [X] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [X] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
