### PR TITLE
Remove defer from admin JS includes

### DIFF
--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -37,9 +37,9 @@
     <%= render 'alchemy/admin/partials/routes' %>
     <%= javascript_include_tag('alchemy/admin/all', 'data-turbolinks-track' => true) %>
     <% if respond_to?(:javascript_pack_tag) %>
-      <%= javascript_pack_tag('alchemy/admin', 'data-turbolinks-track' => true, defer: true) %>
+      <%= javascript_pack_tag('alchemy/admin', 'data-turbolinks-track' => true) %>
     <% else %>
-      <%= javascript_include_tag('alchemy_admin', 'data-turbolinks-track' => true, defer: true) %>
+      <%= javascript_include_tag('alchemy_admin', 'data-turbolinks-track' => true) %>
     <% end %>
     <%= yield :javascript_includes %>
   </head>


### PR DESCRIPTION
The admin JS is a first party JS and cannot be deferred.
