### PR TITLE
Add indexes to pictures table

### DIFF
--- a/db/migrate/20230505132743_add_indexes_to_alchemy_pictures.rb
+++ b/db/migrate/20230505132743_add_indexes_to_alchemy_pictures.rb
@@ -1,0 +1,6 @@
+class AddIndexesToAlchemyPictures < ActiveRecord::Migration[6.1]
+  def change
+    add_index :alchemy_pictures, :name, if_not_exists: true
+    add_index :alchemy_pictures, :image_file_name, if_not_exists: true
+  end
+end

--- a/spec/dummy/db/migrate/20230505132743_add_indexes_to_alchemy_pictures.rb
+++ b/spec/dummy/db/migrate/20230505132743_add_indexes_to_alchemy_pictures.rb
@@ -1,0 +1,6 @@
+class AddIndexesToAlchemyPictures < ActiveRecord::Migration[6.1]
+  def change
+    add_index :alchemy_pictures, :name, if_not_exists: true
+    add_index :alchemy_pictures, :image_file_name, if_not_exists: true
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_23_105660) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_05_132743) do
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string "name"
     t.string "file_name"
@@ -202,6 +202,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_23_105660) do
     t.integer "image_file_size"
     t.string "image_file_format"
     t.index ["creator_id"], name: "index_alchemy_pictures_on_creator_id"
+    t.index ["image_file_name"], name: "index_alchemy_pictures_on_image_file_name"
+    t.index ["name"], name: "index_alchemy_pictures_on_name"
     t.index ["updater_id"], name: "index_alchemy_pictures_on_updater_id"
   end
 


### PR DESCRIPTION
## What is this pull request for?

Added two indexes to `alchemy_pictures` to prevent temp tables if the user is searching for named pictures. This is only necessary if the size of the table increases.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
