### PR TITLE
Pin selenium-webdriver to 4.9.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :development, :test do
   gem "execjs", "= 2.8.1"
   gem "jsbundling-rails", "~> 1.1"
   gem "standard", "~> 1.25", require: false
+  gem "selenium-webdriver", "< 4.9.1" # until https://github.com/teamcapybara/capybara/pull/2665 got merged
 
   if ENV["GITHUB_ACTIONS"]
     # Necessary because GH Actions gem cache does not have this "Bundled with Ruby" gem installed


### PR DESCRIPTION
Until https://github.com/teamcapybara/capybara/pull/2667 got released
