### PR TITLE
Collapse all nested elements on fold

### DIFF
--- a/app/views/alchemy/admin/elements/_element.html.erb
+++ b/app/views/alchemy/admin/elements/_element.html.erb
@@ -54,20 +54,23 @@
 
       <%= render 'alchemy/admin/elements/footer', element: element %>
     <% end %>
+  <% end %>
 
-    <% if element.nestable_elements.any? %>
-      <div class="nestable-elements">
-        <%= content_tag :div,
-          class: "nested-elements", data: {
-            'droppable-elements' => element.nestable_elements.join(' ')
-          } do %>
-          <%= render element.all_nested_elements.map { |element|
-            Alchemy::ElementEditor.new(element)
-          } %>
-        <% end %>
+  <%# We need to render nested elements even if the element is folded,
+      because we need the element present in the DOM for the feature
+      "click element in the preview => load and expand element editor". %>
+  <% if element.nestable_elements.any? %>
+    <div class="nestable-elements">
+      <%= content_tag :div,
+        class: "nested-elements", data: {
+          'droppable-elements' => element.nestable_elements.join(' ')
+        } do %>
+        <%= render element.all_nested_elements.map { |element|
+          Alchemy::ElementEditor.new(element)
+        } %>
+      <% end %>
 
-        <%= render "alchemy/admin/elements/add_nested_element_form", element: element %>
-      </div>
-    <% end %>
+      <%= render "alchemy/admin/elements/add_nested_element_form", element: element %>
+    </div>
   <% end %>
 <% end %>

--- a/lib/alchemy/test_support/factories/element_factory.rb
+++ b/lib/alchemy/test_support/factories/element_factory.rb
@@ -25,6 +25,10 @@ FactoryBot.define do
       name { "slide" }
     end
 
+    trait :compact do
+      name { "slide" }
+    end
+
     trait :with_ingredients do
       autogenerate_ingredients { true }
     end


### PR DESCRIPTION
## What is this pull request for?

On a page with lots of nested elements multiple levels deep
the performance regresses very much especially with lots of
TinyMCE instances. Also UX is getting messy very soon.

In order to make the page faster and clean up the interface,
we now collapse all nested elements and their nested elements
if an element gets folded by the user. Next time the element
expands it will present all nested elements collapsed to the
user making a) the UX much faster and more cleaned up.

This also reverts https://github.com/AlchemyCMS/alchemy_cms/pull/2470
because we need to render nested elements even if the element is folded,
because we need the element present in the DOM for the feature
"click element in the preview => load and expand element editor".

### Screenshots

Remove if no visual changes have been made.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
