### PR TITLE
Revert "Preload related objects in Alchemy::PagesController"

### DIFF
--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -104,13 +104,7 @@ module Alchemy
     # If no index page and no admin users are present we show the "Welcome to Alchemy" page.
     #
     def load_index_page
-      @page ||= Alchemy::Page
-        .contentpages
-        .language_roots
-        .where(language: Language.current)
-        .includes(page_includes)
-        .first
-
+      @page ||= Language.current_root_page
       render template: "alchemy/welcome", layout: false if signup_required?
     end
 
@@ -126,11 +120,10 @@ module Alchemy
     def load_page
       page_not_found! unless Language.current
 
-      @page ||= Alchemy::Page
-        .contentpages
-        .where(language: Language.current)
-        .includes(page_includes)
-        .find_by(urlname: params[:urlname])
+      @page ||= Language.current.pages.contentpages.find_by(
+        urlname: params[:urlname],
+        language_code: params[:locale] || Language.current.code,
+      )
     end
 
     def enforce_locale
@@ -234,10 +227,6 @@ module Alchemy
 
     def page_not_found!
       not_found_error!("Alchemy::Page not found \"#{request.fullpath}\"")
-    end
-
-    def page_includes
-      Alchemy::EagerLoading.page_includes(version: :public_version)
     end
   end
 end

--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -122,7 +122,7 @@ module Alchemy
 
       @page ||= Language.current.pages.contentpages.find_by(
         urlname: params[:urlname],
-        language_code: params[:locale] || Language.current.code,
+        language_code: params[:locale] || Language.current.code
       )
     end
 


### PR DESCRIPTION
## What is this pull request for?

Pages make use of fragment caching and we cannot know which element is cached.

Therefore we cannot know what to eager load.

Refs #2468

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
