### PR TITLE
[6.1] Revert "Preload related objects in Alchemy::PagesController"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :development, :test do
   # in our case the culprit is `handlebars-assets`. The changes between 2.7.0 and 2.8.0 are
   # minimal, but breaking.
   gem "execjs", "= 2.8.1"
+  gem "selenium-webdriver", "< 4.9.1" # until https://github.com/teamcapybara/capybara/pull/2665 got merged
 
   if ENV["GITHUB_ACTIONS"]
     # Necessary because GH Actions gem cache does not have this "Bundled with Ruby" gem installed

--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -104,14 +104,7 @@ module Alchemy
     # If no index page and no admin users are present we show the "Welcome to Alchemy" page.
     #
     def load_index_page
-      @page ||= begin
-        Alchemy::Page.
-          contentpages.
-          language_roots.
-          where(language: Language.current).
-          includes(page_includes).
-          first
-      end
+      @page ||= Language.current_root_page
       render template: "alchemy/welcome", layout: false if signup_required?
     end
 
@@ -127,13 +120,10 @@ module Alchemy
     def load_page
       page_not_found! unless Language.current
 
-      @page ||= begin
-        Alchemy::Page.
-          contentpages.
-          where(language: Language.current).
-          includes(page_includes).
-          find_by(urlname: params[:urlname])
-      end
+      @page ||= Language.current.pages.contentpages.find_by(
+        urlname: params[:urlname],
+        language_code: params[:locale] || Language.current.code,
+      )
     end
 
     def enforce_locale
@@ -243,10 +233,6 @@ module Alchemy
 
     def page_not_found!
       not_found_error!("Alchemy::Page not found \"#{request.fullpath}\"")
-    end
-
-    def page_includes
-      Alchemy::EagerLoading.page_includes(version: :public_version)
     end
   end
 end


### PR DESCRIPTION
Same as #2472 but for 6.1-stable