### PR TITLE
Respect available locales set in application

### DIFF
--- a/lib/alchemy/i18n.rb
+++ b/lib/alchemy/i18n.rb
@@ -54,10 +54,12 @@ module Alchemy
       end
 
       def available_locales
-        @@available_locales ||= nil
-        @@available_locales || translation_files.collect { |f|
-          f.match(LOCALE_FILE_PATTERN)[1].to_sym
-        }.uniq.sort
+        Rails.application.config.i18n.available_locales || begin
+          @@available_locales ||= nil
+          @@available_locales || translation_files.collect { |f|
+            f.match(LOCALE_FILE_PATTERN)[1].to_sym
+          }.uniq.sort
+        end
       end
 
       def available_locales=(locales)

--- a/spec/libraries/i18n_spec.rb
+++ b/spec/libraries/i18n_spec.rb
@@ -16,6 +16,13 @@ module Alchemy
       it { is_expected.to be_a Array }
       it { is_expected.to include(:en) }
 
+      context "when locales are already set in application available_locales" do
+        it "returns them" do
+          expect(Rails.application.config.i18n).to receive(:available_locales) { [:de, :it] }
+          is_expected.to match_array([:de, :it])
+        end
+      end
+
       context "when locales are already set in @@available_locales" do
         before { I18n.class_variable_set(:@@available_locales, [:kl, :jp]) }
         it { is_expected.to match_array([:kl, :jp]) }


### PR DESCRIPTION
## What is this pull request for?

If the application has set

    Rails.application.config.i18n.available_locales

we use them for `Alchemy::I81n.available_locales` and only scan the locale files if not.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
