### PR TITLE
Un-deprecate rendering ingredient view partials

### DIFF
--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -210,20 +210,5 @@ module Alchemy
 
       {"data-element-tags" => options[:formatter].call(element.tag_list)}
     end
-
-    def ingredient_view_deprecation_notice(ingredient, file)
-      Alchemy::Deprecation.warn(<<~WARN)
-        rendering `alchemy/ingredients/#{file.split("/").last.sub(/^_/, "")}` partial is deprecated.
-
-        Please render the view component directly instead:
-
-          <%= render ingredient.as_view_component %>
-
-        or use the `el.render` helper inside a `element_view_for` helper:
-
-          <%= el.render(:#{ingredient.role}) %>
-
-      WARN
-    end
   end
 end

--- a/app/views/alchemy/ingredients/_audio_view.html.erb
+++ b/app/views/alchemy/ingredients/_audio_view.html.erb
@@ -1,2 +1,1 @@
-<%- ingredient_view_deprecation_notice(audio_view, __FILE__) -%>
 <%= render audio_view.as_view_component -%>

--- a/app/views/alchemy/ingredients/_boolean_view.html.erb
+++ b/app/views/alchemy/ingredients/_boolean_view.html.erb
@@ -1,2 +1,1 @@
-<%- ingredient_view_deprecation_notice(boolean_view, __FILE__) -%>
 <%= render boolean_view.as_view_component -%>

--- a/app/views/alchemy/ingredients/_datetime_view.html.erb
+++ b/app/views/alchemy/ingredients/_datetime_view.html.erb
@@ -1,4 +1,3 @@
-<%- ingredient_view_deprecation_notice(datetime_view, __FILE__) -%>
 <%= render datetime_view.as_view_component(
   **local_assigns.slice(:options)
 ) -%>

--- a/app/views/alchemy/ingredients/_file_view.html.erb
+++ b/app/views/alchemy/ingredients/_file_view.html.erb
@@ -1,4 +1,3 @@
-<%- ingredient_view_deprecation_notice(file_view, __FILE__) -%>
 <%= render file_view.as_view_component(
   **local_assigns.slice(:options),
   **local_assigns.slice(:html_options)

--- a/app/views/alchemy/ingredients/_headline_view.html.erb
+++ b/app/views/alchemy/ingredients/_headline_view.html.erb
@@ -1,4 +1,3 @@
-<%- ingredient_view_deprecation_notice(headline_view, __FILE__) -%>
 <%= render headline_view.as_view_component(
   **local_assigns.slice(:options),
   **local_assigns.slice(:html_options)

--- a/app/views/alchemy/ingredients/_html_view.html.erb
+++ b/app/views/alchemy/ingredients/_html_view.html.erb
@@ -1,2 +1,1 @@
-<%- ingredient_view_deprecation_notice(html_view, __FILE__) -%>
 <%= render html_view.as_view_component -%>

--- a/app/views/alchemy/ingredients/_link_view.html.erb
+++ b/app/views/alchemy/ingredients/_link_view.html.erb
@@ -1,4 +1,3 @@
-<%- ingredient_view_deprecation_notice(link_view, __FILE__) -%>
 <%= render link_view.as_view_component(
   **local_assigns.slice(:options),
   **local_assigns.slice(:html_options)

--- a/app/views/alchemy/ingredients/_node_view.html.erb
+++ b/app/views/alchemy/ingredients/_node_view.html.erb
@@ -1,2 +1,1 @@
-<%- ingredient_view_deprecation_notice(node_view, __FILE__) -%>
 <%= render node_view.as_view_component -%>

--- a/app/views/alchemy/ingredients/_page_view.html.erb
+++ b/app/views/alchemy/ingredients/_page_view.html.erb
@@ -1,2 +1,1 @@
-<%- ingredient_view_deprecation_notice(page_view, __FILE__) -%>
 <%= render page_view.as_view_component -%>

--- a/app/views/alchemy/ingredients/_picture_view.html.erb
+++ b/app/views/alchemy/ingredients/_picture_view.html.erb
@@ -1,4 +1,3 @@
-<%- ingredient_view_deprecation_notice(picture_view, __FILE__) -%>
 <%= render picture_view.as_view_component(
   **local_assigns.slice(:options),
   **local_assigns.slice(:html_options)

--- a/app/views/alchemy/ingredients/_richtext_view.html.erb
+++ b/app/views/alchemy/ingredients/_richtext_view.html.erb
@@ -1,4 +1,3 @@
-<%- ingredient_view_deprecation_notice(richtext_view, __FILE__) -%>
 <%= render richtext_view.as_view_component(
   **local_assigns.slice(:options)
 ) -%>

--- a/app/views/alchemy/ingredients/_select_view.html.erb
+++ b/app/views/alchemy/ingredients/_select_view.html.erb
@@ -1,2 +1,1 @@
-<%- ingredient_view_deprecation_notice(select_view, __FILE__) -%>
 <%= render select_view.as_view_component -%>

--- a/app/views/alchemy/ingredients/_text_view.html.erb
+++ b/app/views/alchemy/ingredients/_text_view.html.erb
@@ -1,4 +1,3 @@
-<%- ingredient_view_deprecation_notice(text_view, __FILE__) -%>
 <%= render text_view.as_view_component(
   **local_assigns.slice(:options),
   **local_assigns.slice(:html_options)

--- a/app/views/alchemy/ingredients/_video_view.html.erb
+++ b/app/views/alchemy/ingredients/_video_view.html.erb
@@ -1,2 +1,1 @@
-<%- ingredient_view_deprecation_notice(video_view, __FILE__) -%>
 <%= render video_view.as_view_component -%>


### PR DESCRIPTION
Rendering an model instance in Rails is common.
Let's keep the ingredient view partials as proxy
to render the ingredient view component.
