### PR TITLE
install generator: Add option to force patched babel config

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -48,7 +48,7 @@ namespace :alchemy do
           bin/rake db:create && \
           bin/rake db:environment:set && \
           bin/rake db:migrate:reset && \
-          bin/rails g alchemy:install --skip --skip-demo-files --auto-accept --skip-db-create && \
+          bin/rails g alchemy:install --skip --skip-demo-files --auto-accept --skip-db-create --force-babel-config && \
           yarn link @alchemy_cms/admin && \
           RAILS_ENV=test bin/webpack && \
           cd -

--- a/lib/generators/alchemy/install/files/babel.config.js
+++ b/lib/generators/alchemy/install/files/babel.config.js
@@ -1,0 +1,64 @@
+module.exports = function (api) {
+  var validEnv = ["development", "test", "production"]
+  var currentEnv = api.env()
+  var isDevelopmentEnv = api.env("development")
+  var isProductionEnv = api.env("production")
+  var isTestEnv = api.env("test")
+
+  if (!validEnv.includes(currentEnv)) {
+    throw new Error(
+      "Please specify a valid `NODE_ENV` or " +
+        '`BABEL_ENV` environment variables. Valid values are "development", ' +
+        '"test", and "production". Instead, received: ' +
+        JSON.stringify(currentEnv) +
+        "."
+    )
+  }
+
+  return {
+    presets: [
+      isTestEnv && [
+        "@babel/preset-env",
+        {
+          targets: {
+            node: "current"
+          }
+        }
+      ],
+      (isProductionEnv || isDevelopmentEnv) && [
+        "@babel/preset-env",
+        {
+          forceAllTransforms: true,
+          useBuiltIns: "entry",
+          corejs: 3,
+          modules: false,
+          exclude: ["transform-typeof-symbol"]
+        }
+      ]
+    ].filter(Boolean),
+    plugins: [
+      "babel-plugin-macros",
+      "@babel/plugin-syntax-dynamic-import",
+      isTestEnv && "babel-plugin-dynamic-import-node",
+      "@babel/plugin-transform-destructuring",
+      [
+        "@babel/plugin-proposal-object-rest-spread",
+        {
+          useBuiltIns: true
+        }
+      ],
+      [
+        "@babel/plugin-transform-runtime",
+        {
+          helpers: false
+        }
+      ],
+      [
+        "@babel/plugin-transform-regenerator",
+        {
+          async: false
+        }
+      ]
+    ].filter(Boolean)
+  }
+}

--- a/lib/generators/alchemy/install/install_generator.rb
+++ b/lib/generators/alchemy/install/install_generator.rb
@@ -23,6 +23,11 @@ module Alchemy
         default: false,
         desc: "Skip running the webpacker installer."
 
+      class_option :force_babel_config,
+        type: :boolean,
+        default: false,
+        desc: "Force installing a patched babel config."
+
       class_option :skip_db_create,
         type: :boolean,
         default: false,
@@ -110,6 +115,13 @@ module Alchemy
             in_root { run "echo '{}' > package.json" }
           end
           rake("webpacker:install", abort_on_failure: true)
+        end
+      end
+
+      # We need to force the babel.config.js file, because webpacker has an invalid one
+      def copy_babel_config
+        if options[:force_babel_config]
+          copy_file "babel.config.js", app_root.join("babel.config.js"), force: true
         end
       end
 


### PR DESCRIPTION
The latest babel version has these plugins:

- @babel/plugin-transform-class-properties
- @babel/plugin-proposal-private-methods
- @babel/plugin-proposal-private-property-in-object

already installed, but the webpacker installer still installs an old babel.config that includes these plugins.

Adding an option to the installer to force a patched babel config allows to run the installer on CI.
