### PR TITLE
Add task(s) to visualize element and page usage

### DIFF
--- a/lib/alchemy/tasks/usage.rb
+++ b/lib/alchemy/tasks/usage.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Alchemy
+  module Tasks
+    module Usage
+      extend self
+
+      def elements_count_by_name
+        res = Alchemy::Element.all
+          .select("name, COUNT(*) AS count")
+          .group(:name)
+          .order("count DESC, name ASC")
+          .map { |e| {"name" => e.name, "count" => e.count} }
+        Alchemy::Element.definitions.reject { |definition| res.map { |e| e["name"] }.include? definition["name"] }.each do |definition|
+          res << {"name" => definition["name"], "count" => 0}
+        end
+        res
+      end
+
+      def pages_count_by_type
+        res = Alchemy::Page.all
+          .select("page_layout, COUNT(*) AS count")
+          .group(:page_layout)
+          .order("count DESC, page_layout ASC")
+          .map { |p| {"page_layout" => p.page_layout, "count" => p.count} }
+        Alchemy::PageLayout.all.reject { |page_layout| res.map { |p| p["page_layout"] }.include? page_layout["name"] }.each do |page_layout|
+          res << {"page_layout" => page_layout["name"], "count" => 0}
+        end
+        res
+      end
+    end
+  end
+end

--- a/lib/tasks/alchemy/usage.rake
+++ b/lib/tasks/alchemy/usage.rake
@@ -1,0 +1,40 @@
+require "alchemy/tasks/usage"
+
+namespace :alchemy do
+  desc "List Alchemy elements and pages usage"
+  task usage: [:page_usage, :element_usage]
+
+  desc "List Alchemy elements usage"
+  task page_usage: :environment do
+    include ActionView::Helpers::NumberHelper
+    puts "\n  Alchemy pages usage"
+    results = Alchemy::Tasks::Usage.pages_count_by_type
+    if results.any?
+      puts "  ----------------------"
+      puts "\n"
+      results.each do |row|
+        puts "  #{number_with_delimiter(row["count"])} 𝗑 #{row["page_layout"]}"
+      end
+      puts "\n  = #{number_with_delimiter(Alchemy::Page.count)} pages in total."
+    else
+      puts "  > No pages found!"
+    end
+  end
+
+  desc "List Alchemy elements usage"
+  task element_usage: :environment do
+    include ActionView::Helpers::NumberHelper
+    puts "\n  Alchemy elements usage"
+    results = Alchemy::Tasks::Usage.elements_count_by_name
+    if results.any?
+      puts "  ----------------------"
+      puts "\n"
+      results.each do |row|
+        puts "  #{number_with_delimiter(row["count"])} 𝗑 #{row["name"]}"
+      end
+      puts "\n  = #{number_with_delimiter(Alchemy::Element.count)} elements in total."
+    else
+      puts "  > No elements found!"
+    end
+  end
+end

--- a/spec/libraries/alchemy/tasks/usage_spec.rb
+++ b/spec/libraries/alchemy/tasks/usage_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+require "alchemy/tasks/usage"
+
+RSpec.describe Alchemy::Tasks::Usage do
+  describe ".elements_count_by_name" do
+    subject { described_class.elements_count_by_name }
+
+    before do
+      create_list(:alchemy_element, 3, name: "headline")
+      create_list(:alchemy_element, 2, name: "image")
+      create(:alchemy_element, name: "text")
+    end
+
+    it "returns the elements count by name" do
+      expect(subject).to eq [
+        {"name" => "headline", "count" => 3},
+        {"name" => "image", "count" => 2},
+        {"name" => "text", "count" => 1},
+        {"name" => "header", "count" => 0},
+        {"name" => "article", "count" => 0},
+        {"name" => "search", "count" => 0},
+        {"name" => "news", "count" => 0},
+        {"name" => "download", "count" => 0},
+        {"name" => "bild", "count" => 0},
+        {"name" => "contactform", "count" => 0},
+        {"name" => "all_you_can_eat", "count" => 0},
+        {"name" => "erb_element", "count" => 0},
+        {"name" => "slide", "count" => 0},
+        {"name" => "slider", "count" => 0},
+        {"name" => "gallery", "count" => 0},
+        {"name" => "gallery_picture", "count" => 0},
+        {"name" => "right_column", "count" => 0},
+        {"name" => "left_column", "count" => 0},
+        {"name" => "erb_cell", "count" => 0},
+        {"name" => "menu", "count" => 0},
+        {"name" => "old", "count" => 0},
+        {"name" => "element_with_ingredient_groups", "count" => 0},
+        {"name" => "element_with_warning", "count" => 0}
+      ]
+    end
+  end
+
+  describe ".pages_count_by_type" do
+    subject { described_class.pages_count_by_type }
+
+    before do
+      create_list(:alchemy_page, 2, page_layout: "standard")
+      create(:alchemy_page, page_layout: "home")
+    end
+
+    it "returns the pages count by type" do
+      expect(subject).to eq [
+        {"page_layout" => "standard", "count" => 2},
+        {"page_layout" => "home", "count" => 1},
+        {"page_layout" => "index", "count" => 1},
+        {"page_layout" => "readonly", "count" => 0},
+        {"page_layout" => "everything", "count" => 0},
+        {"page_layout" => "news", "count" => 0},
+        {"page_layout" => "contact", "count" => 0},
+        {"page_layout" => "footer", "count" => 0},
+        {"page_layout" => "erb_layout", "count" => 0}
+      ]
+    end
+  end
+end


### PR DESCRIPTION
Adds two rake tasks

```
bin/rake alchemy:element_usage
bin/rake alchemy:page_usage
```

or short

```
bin/rake alchemy:usage
```

for a combined list for counts per element and page type.

## Example from a real world site.

```
  Alchemy pages usage
  ----------------------

  11.749 𝗑 kiosk_article_page
  420 𝗑 landing_page
  354 𝗑 table_of_contents
  88 𝗑 product_landing_page
  54 𝗑 standard
  25 𝗑 years_issues
  11 𝗑 advertorial_article
  4 𝗑 main_navigation
  4 𝗑 advertorial
  3 𝗑 discount_quiz
  2 𝗑 footer
  2 𝗑 companies_page
  2 𝗑 top_bar
  2 𝗑 kiosk_standard
  2 𝗑 b1_footer
  2 𝗑 search
  2 𝗑 home
  1 𝗑 zukunftsabo
  1 𝗑 relaunch_home
  1 𝗑 safari_application
  1 𝗑 classified_page
  1 𝗑 global_navigation
  1 𝗑 contact_page
  1 𝗑 lottery_page
  1 𝗑 index
  1 𝗑 issue_archive_page

  = 12.735 pages in total.

  Alchemy elements usage
  ----------------------

  64.644 𝗑 textblock
  36.620 𝗑 paywall_product
  23.209 𝗑 opengraph_metatags
  22.849 𝗑 article_settings_elements
  22.839 𝗑 article_settings
  22.834 𝗑 article_intro
  21.389 𝗑 ihv_teaser
  19.105 𝗑 paywall
  17.542 𝗑 figure
  16.041 𝗑 pictures
  8.728 𝗑 info_box
  4.759 𝗑 picture
  4.624 𝗑 article_teaser
  4.128 𝗑 separator
  3.243 𝗑 multicolumn_wrapper
  3.114 𝗑 table
  2.911 𝗑 two_col_wrapper
  2.667 𝗑 world_in_figures
  2.512 𝗑 text
  1.606 𝗑 quote
  1.567 𝗑 container
  1.410 𝗑 twitter_card_metatags
  1.192 𝗑 page_intro_elements
  984 𝗑 image_gallery_picture
  927 𝗑 html_code
  707 𝗑 table_of_content_settings_elements
  705 𝗑 issue_teaser
  704 𝗑 table_of_content_settings
  680 𝗑 landingpage_intro
  474 𝗑 cta
  353 𝗑 video
  236 𝗑 image_gallery
  181 𝗑 page_intro
  143 𝗑 archive_teaser_item
  132 𝗑 page_title
  123 𝗑 big_picture
  89 𝗑 footer_menu_link
  88 𝗑 footer_navigation_link
  56 𝗑 flyout_teaser
  32 𝗑 main_nav_link
  32 𝗑 top_bar_meta_link
  31 𝗑 big_headline
  30 𝗑 top_bar_navigation_sub_link
  26 𝗑 archive_teaser_small
  22 𝗑 html
  22 𝗑 send_in_blue_newsletter
  21 𝗑 two_line_separator
  20 𝗑 top_bar_navigation_link
  20 𝗑 article_collection_item
  19 𝗑 send_in_blue_form
  18 𝗑 submenu
  18 𝗑 latest_taxon_products
  16 𝗑 footer_navigation
  15 𝗑 footer_menu
  14 𝗑 product_slide
  14 𝗑 separation_headline
  9 𝗑 image_text
  8 𝗑 lottery
  8 𝗑 link
  8 𝗑 headline
  8 𝗑 text_teaser
  7 𝗑 article_collection
  6 𝗑 magazin_teaser
  6 𝗑 product_teaser
  6 𝗑 safari_peergroup_date
  5 𝗑 banner
  4 𝗑 top_bar_meta
  4 𝗑 product_teasers
  4 𝗑 taxon_products
  4 𝗑 product_slider
  4 𝗑 top_bar_navigation
  3 𝗑 companies
  2 𝗑 safari_application_form
  2 𝗑 safari_peergroup
  2 𝗑 zukunftsabo
  2 𝗑 archive_teaser
  2 𝗑 slide
  2 𝗑 newsletter
  2 𝗑 ihv_audio_file
  2 𝗑 contact_form
  2 𝗑 classified_form
  1 𝗑 live_box
  1 𝗑 newsletter_subscription

  = 316.599 elements in total.
```