### PR TITLE
[6.1] Allow to create element with warning in definition

### DIFF
--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -46,6 +46,7 @@ module Alchemy
       "compact",
       "message",
       "deprecated",
+      "warning",
     ].freeze
 
     # All Elements that share the same page version and parent element and are fixed or not are considered a list.

--- a/spec/dummy/config/alchemy/elements.yml
+++ b/spec/dummy/config/alchemy/elements.yml
@@ -299,3 +299,6 @@
     - name: key_words
       type: EssenceText
       group: details
+
+- name: element_with_warning
+  warning: "Do not use this element!"

--- a/spec/models/alchemy/element_spec.rb
+++ b/spec/models/alchemy/element_spec.rb
@@ -149,6 +149,16 @@ module Alchemy
           end
         end
       end
+
+      context "with warning in definition" do
+        let(:element) do
+          Alchemy::Element.new(name: "element_with_warning")
+        end
+
+        it "creates element" do
+          expect { element.save }.to_not raise_error
+        end
+      end
     end
 
     describe ".dom_id_class" do


### PR DESCRIPTION
Same as #2507 but for `6.1-stable`