### PR TITLE
Remove iOS switch for data pickers

### DIFF
--- a/app/javascript/alchemy_admin/datepicker.js
+++ b/app/javascript/alchemy_admin/datepicker.js
@@ -9,32 +9,25 @@ export default function Datepicker(scope = document) {
 
   const datepickerInputs = scope.querySelectorAll("input[data-datepicker-type]")
 
-  // Initializes the datepickers on the text inputs and sets the proper type
-  // to enable browsers default datepicker if the current OS is iOS.
-  if (Alchemy.isiOS) {
-    datepickerInputs.forEach((input) => {
-      input.attributes.type = input.dataset.datepickerType
-    })
-  } else {
-    datepickerInputs.forEach((input) => {
-      const type = input.dataset.datepickerType
-      const options = {
-        // alchemy_i18n supports `zh_CN` etc., but flatpickr only has two-letter codes (`zh`)
-        locale: Alchemy.locale.slice(0, 2),
-        altInput: true,
-        altFormat: Alchemy.t(`formats.${type}`),
-        altInputClass: "flatpickr-input",
-        dateFormat: "Z",
-        enableTime: /time/.test(type),
-        noCalendar: type === "time",
-        time_24hr: Alchemy.t("formats.time_24hr"),
-        onValueUpdate(_selectedDates, _dateStr, instance) {
-          return Alchemy.setElementDirty(
-            instance.element.closest(".element-editor")
-          )
-        }
+  // Initializes the datepickers
+  datepickerInputs.forEach((input) => {
+    const type = input.dataset.datepickerType
+    const options = {
+      // alchemy_i18n supports `zh_CN` etc., but flatpickr only has two-letter codes (`zh`)
+      locale: Alchemy.locale.slice(0, 2),
+      altInput: true,
+      altFormat: Alchemy.t(`formats.${type}`),
+      altInputClass: "flatpickr-input",
+      dateFormat: "Z",
+      enableTime: /time/.test(type),
+      noCalendar: type === "time",
+      time_24hr: Alchemy.t("formats.time_24hr"),
+      onValueUpdate(_selectedDates, _dateStr, instance) {
+        return Alchemy.setElementDirty(
+          instance.element.closest(".element-editor")
+        )
       }
-      flatpickr(input, options)
-    })
-  }
+    }
+    flatpickr(input, options)
+  })
 }


### PR DESCRIPTION
## What is this pull request for?

This is no necessary anymore, because flatpicker is doing that on its own. Also the Alchemy.isiOS - field was removed.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
