### PR TITLE
Remove old alchemy_admin files from sprockets builds

### DIFF
--- a/lib/alchemy/upgrader/seven_point_zero.rb
+++ b/lib/alchemy/upgrader/seven_point_zero.rb
@@ -9,6 +9,7 @@ module Alchemy
 
     class << self
       def remove_admin_entrypoint
+        FileUtils.rm_rf "app/assets/builds/alchemy_admin.*"
         FileUtils.rm_rf "app/javascript/packs/alchemy/admin.js"
         FileUtils.rm_rf "app/javascript/packs/alchemy_admin.js"
         FileUtils.rm_rf "app/javascript/packs/alchemy"


### PR DESCRIPTION
## What is this pull request for?

Fixes the upgrader.

We do not need this file anymore now that we use importmaps. Keeping the file will cause admin screens to error.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
