### PR TITLE
Fix disconnecting Tinymce intersection observer

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.initializer.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.initializer.js.coffee
@@ -52,5 +52,6 @@ $(document).on 'turbo:load', ->
 
 $(document).on 'turbo:before-fetch-request', ->
   # Ensure that all tinymce editors get removed before parsing a new page
+  Alchemy.Tinymce.removeIntersectionObserver()
   Alchemy.Tinymce.removeFrom $('.has_tinymce')
   return

--- a/app/javascript/alchemy_admin/tinymce.js
+++ b/app/javascript/alchemy_admin/tinymce.js
@@ -41,10 +41,6 @@ function initEditors(ids) {
 // initialize IntersectionObserver
 // the observer will initialize Tinymce if the textarea becomes visible
 function initializeIntersectionObserver() {
-  if (tinymceIntersectionObserver !== null) {
-    tinymceIntersectionObserver.disconnect()
-  }
-
   const observerCallback = (entries, observer) => {
     entries.forEach((entry) => {
       if (entry.intersectionRatio > 0) {
@@ -108,6 +104,12 @@ function removeEditor(editorId) {
   }
 }
 
+function removeIntersectionObserver() {
+  if (tinymceIntersectionObserver !== null) {
+    tinymceIntersectionObserver.disconnect()
+  }
+}
+
 export default {
   // Initializes all TinyMCE editors with given ids
   //
@@ -134,6 +136,8 @@ export default {
       removeEditor(element.id)
     })
   },
+
+  removeIntersectionObserver,
 
   // set tinymce configuration for a given selector key
   setCustomConfig(key, configuration) {


### PR DESCRIPTION
## What is this pull request for?

Before we were removing the intersection observer even if we are still on the same page.

Now removing it were we need to, in the Turbo page change event.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
