### PR TITLE
Copying pages: Only add "(Copy)" if necessary

### DIFF
--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -295,7 +295,15 @@ module Alchemy
         differences.stringify_keys!
         attributes = source.attributes.merge(differences)
         attributes.merge!(DEFAULT_ATTRIBUTES_FOR_COPY)
-        attributes["name"] = new_name_for_copy(differences["name"], source.name)
+        attributes["name"] = begin
+          desired_name = differences["name"].presence || source.name
+          new_parent_id = differences["parent"]&.id || differences["parent_id"]
+          if new_parent_id && !Alchemy::Page.where(parent_id: new_parent_id, name: desired_name).exists?
+            desired_name
+          else
+            new_name_for_copy(differences["name"], source.name)
+          end
+        end
         attributes.except(*SKIPPED_ATTRIBUTES_ON_COPY)
       end
 

--- a/app/services/alchemy/copy_page.rb
+++ b/app/services/alchemy/copy_page.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module Alchemy
+  # Creates a copy of given source page.
+  #
+  # Also copies all elements included in source page.
+  #
+  # === Note:
+  #
+  # It prevents the element auto generator from running.
+  class CopyPage
+    DEFAULT_ATTRIBUTES_FOR_COPY = {
+      autogenerate_elements: false,
+      public_on: nil,
+      public_until: nil,
+      locked_at: nil,
+      locked_by: nil
+    }
+
+    SKIPPED_ATTRIBUTES_ON_COPY = %w[
+      id
+      updated_at
+      created_at
+      creator_id
+      updater_id
+      lft
+      rgt
+      depth
+      urlname
+      cached_tag_list
+    ]
+
+    attr_reader :page
+
+    # @param page [Alchemy::Page]
+    #   The source page the copy is taken from
+    def initialize(page:)
+      @page = page
+    end
+
+    # @param changed_attributes [Hash]
+    #   A optional hash with attributes that take precedence over the source attributes
+    #
+    # @return [Alchemy::Page]
+    #
+    def call(changed_attributes:)
+      Alchemy::Page.transaction do
+        new_page = Alchemy::Page.new(attributes_from_source_for_copy(changed_attributes))
+        new_page.tag_list = page.tag_list
+        if new_page.save!
+          Alchemy::Page.copy_elements(page, new_page)
+        end
+        new_page
+      end
+    end
+
+    private
+
+    # Aggregates the attributes from given source for copy of page.
+    #
+    # @param [Alchemy::Page]
+    #   The source page
+    # @param [Hash]
+    #   A optional hash with attributes that take precedence over the source attributes
+    #
+    def attributes_from_source_for_copy(differences = {})
+      source_attributes = page.attributes.stringify_keys
+      differences.stringify_keys!
+      desired_attributes = source_attributes
+        .merge(DEFAULT_ATTRIBUTES_FOR_COPY)
+        .merge(differences)
+      desired_attributes["name"] = best_name_for_copy(source_attributes, desired_attributes)
+      desired_attributes.except(*SKIPPED_ATTRIBUTES_ON_COPY)
+    end
+
+    # Returns a new name for copy of page.
+    #
+    # If the differences hash includes a new name this is taken.
+    # Otherwise +source.name+
+    #
+    # @param [Hash]
+    #   The differences hash that contains a new name
+    # @param [Hash]
+    #   The name of the source
+    #
+    def best_name_for_copy(source_attributes, desired_attributes)
+      desired_name = desired_attributes["name"].presence || source_attributes["name"]
+
+      new_parent_id = desired_attributes["parent"]&.id || desired_attributes["parent_id"]
+
+      if Alchemy::Page.where(parent_id: new_parent_id, name: desired_name).exists?
+        "#{desired_name} (#{Alchemy.t("Copy")})"
+      else
+        desired_name
+      end
+    end
+  end
+end

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -479,6 +479,18 @@ module Alchemy
           }.to_not change(Alchemy::Page, :count)
         end
       end
+
+      context "copying a different parent" do
+        let(:different_page) { create(:alchemy_page) }
+        let(:page) { create(:alchemy_page, parent: different_page) }
+        let(:destination) { create(:alchemy_page) }
+
+        subject { Page.copy(page, parent_id: destination.id) }
+
+        it "should not add (copy) to name" do
+          expect(subject.name).to eq(page.name)
+        end
+      end
     end
 
     describe ".create" do

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1206,19 +1206,6 @@ module Alchemy
       end
     end
 
-    def copy_children_to(new_parent)
-      children.each do |child|
-        next if child == new_parent
-
-        new_child = Page.copy(child, {
-          language_id: new_parent.language_id,
-          language_code: new_parent.language_code
-        })
-        new_child.move_to_child_of(new_parent)
-        child.copy_children_to(new_child) unless child.children.blank?
-      end
-    end
-
     describe "#definition" do
       context "if the page layout could not be found in the definition file" do
         let(:page) { build_stubbed(:alchemy_page, page_layout: "notexisting") }

--- a/spec/services/alchemy/copy_page_spec.rb
+++ b/spec/services/alchemy/copy_page_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::CopyPage do
+  let(:page) { create(:alchemy_page) }
+  let(:changed_attributes) { {} }
+
+  subject(:copy_page) { described_class.new(page: page).call(changed_attributes: changed_attributes) }
+
+  it "the copy should have added (copy) to name" do
+    expect(subject.name).to eq("#{page.name} (Copy)")
+  end
+
+  it "the copy should have one draft version" do
+    expect(subject.versions.length).to eq(1)
+    expect(subject.draft_version).to be
+  end
+
+  context "a public page" do
+    let(:page) { create(:alchemy_page, :public, name: "Source", public_until: Time.current) }
+
+    it "the copy should not be public" do
+      expect(subject.public_on).to be(nil)
+      expect(subject.public_until).to be(nil)
+    end
+  end
+
+  context "a locked page" do
+    let(:page) do
+      create(:alchemy_page, :public, :locked, name: "Source")
+    end
+
+    it "the copy should not be locked" do
+      expect(subject.locked?).to be(false)
+      expect(subject.locked_by).to be(nil)
+    end
+  end
+
+  context "page with tags" do
+    before do
+      page.tag_list = "red, yellow"
+      page.save!
+    end
+
+    it "the copy should have source tag_list" do
+      expect(subject.tag_list).not_to be_empty
+      expect(subject.tag_list).to match_array(page.tag_list)
+    end
+  end
+
+  context "page with elements" do
+    before { create(:alchemy_element, page: page, page_version: page.draft_version) }
+
+    it "the copy should have source elements on its draft version" do
+      expect(subject.draft_version.elements).not_to be_empty
+      expect(subject.draft_version.elements.count).to eq(page.draft_version.elements.count)
+    end
+  end
+
+  context "page with fixed elements" do
+    before { create(:alchemy_element, :fixed, page: page, page_version: page.draft_version) }
+
+    it "the copy should have source fixed elements on its draft version" do
+      expect(subject.draft_version.elements.fixed).not_to be_empty
+      expect(subject.draft_version.elements.fixed.count).to eq(page.draft_version.elements.fixed.count)
+    end
+  end
+
+  context "page with autogenerate elements" do
+    before do
+      page = create(:alchemy_page)
+      allow(page).to receive(:definition).and_return({
+        "name" => "standard",
+        "elements" => ["headline"],
+        "autogenerate" => ["headline"]
+      })
+    end
+
+    it "the copy should not autogenerate elements" do
+      expect(subject.draft_version.elements).to be_empty
+    end
+  end
+
+  context "with different page name given" do
+    let(:changed_attributes) { {name: "Different name"} }
+
+    it "should take this name" do
+      expect(subject.name).to eq("Different name")
+    end
+  end
+
+  context "with exceptions during copy" do
+    before do
+      expect(Alchemy::Page).to receive(:copy_elements) { raise "boom" }
+    end
+
+    it "rolls back all changes" do
+      page
+      expect {
+        expect { Alchemy::Page.copy(page, {name: "Different name"}) }.to raise_error("boom")
+      }.to_not change(Alchemy::Page, :count)
+    end
+  end
+
+  context "copying a different parent" do
+    let(:original_parent) { create(:alchemy_page) }
+    let(:page) { create(:alchemy_page, parent: original_parent) }
+    let(:destination) { create(:alchemy_page) }
+    let(:changed_attributes) { {parent_id: destination.id} }
+
+    it "should not add (copy) to name" do
+      expect(subject.name).to eq(page.name)
+    end
+  end
+end


### PR DESCRIPTION


## What is this pull request for?

This should help with copying and pasting page trees. If one copies to a different parent page from the source page, then we don't need to add the "(Copy)" string to the new page. This is especially useful for copying larger structures between language trees.


### Notable changes (remove if none)

Much less ` (Copy)`.


## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
