### PR TITLE
Define #preload_relations on Ingredients

### DIFF
--- a/app/models/alchemy/ingredient.rb
+++ b/app/models/alchemy/ingredient.rb
@@ -90,6 +90,12 @@ module Alchemy
       end
     end
 
+    # This method can be overwritten in individual ingredients to fetch objects that belong to the related object in some form.
+    # This takes an Array of things that can be passed to the Rails preloader.
+    def preload_relations
+      []
+    end
+
     # The value or the related object if present
     def value
       related_object || self[:value]

--- a/app/models/alchemy/ingredients/picture.rb
+++ b/app/models/alchemy/ingredients/picture.rb
@@ -38,6 +38,10 @@ module Alchemy
         upsample
       ]
 
+      def preload_relations
+        [:thumbs]
+      end
+
       # The first 30 characters of the pictures name
       #
       # Used by the Element#preview_text method.

--- a/spec/models/alchemy/ingredient_spec.rb
+++ b/spec/models/alchemy/ingredient_spec.rb
@@ -213,4 +213,12 @@ RSpec.describe Alchemy::Ingredient do
       )
     end
   end
+
+  describe "#preload_relations" do
+    let(:ingredient) { Alchemy::Ingredients::Text.new(role: "intro", element: element) }
+
+    subject { ingredient.preload_relations }
+
+    it { is_expected.to eq([]) }
+  end
 end

--- a/spec/models/alchemy/ingredients/picture_spec.rb
+++ b/spec/models/alchemy/ingredients/picture_spec.rb
@@ -125,4 +125,12 @@ RSpec.describe Alchemy::Ingredients::Picture do
       )
     end
   end
+
+  describe "#preload_relations" do
+    let(:ingredient) { described_class.new }
+
+    subject { ingredient.preload_relations }
+
+    it { is_expected.to eq([:thumbs]) }
+  end
 end


### PR DESCRIPTION
## What is this pull request for?

This allows code that renders pages or elements with ingredients to preload the object graphs below ingredient's related objects. 

### Notable changes (remove if none)

In order to be able to preload ingredients' related object graphs, we need to be able to tell the rails preloader how those graphs look.

This adds a method that can be used on for example an element like this:

```
def preload_ingredient_relations(element)
  element.ingredients.group_by(&:preload_relations).each do |preload_relations, ingredients|
    preload(records: ingredients.map(&:related_object).compact, associations: preload_relations)
  end
  element
end

def preload(records:, associations:)
  if Rails::VERSION::MAJOR >= 7
    ActiveRecord::Associations::Preloader.new(records: records, associations: associations).call
  else
    ActiveRecord::Associations::Preloader.new.preload(records, associations)
  end
end
```

Most notorious for n+1 problems is the picture ingredient that tends to have a lot of thumbs that we actually need.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
