### PR TITLE
Increase minimum Rails version to v6.1

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
     activesupport
     railties
   ].each do |rails_gem|
-    gem.add_runtime_dependency rails_gem, [">= 6.0", "< 7.1"]
+    gem.add_runtime_dependency rails_gem, [">= 6.1", "< 7.1"]
   end
 
   gem.add_runtime_dependency "active_model_serializers", ["~> 0.10.0"]


### PR DESCRIPTION
## What is this pull request for?

All tests are running against Rails 6.1 and 7.0. One migration is using a active support key, which is only available in Rails 6.1 and later.

### Notable changes

Alchemy CMS is requiring at least Rails 6.1.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
