### PR TITLE
Bugfix: Init PagePublicationFields on Pages Table

### DIFF
--- a/app/views/alchemy/admin/pages/_table.html.erb
+++ b/app/views/alchemy/admin/pages/_table.html.erb
@@ -25,3 +25,9 @@
     <%= render partial: "table_row", collection: @pages, as: "page" %>
   </tbody>
 </table>
+
+<script type="text/javascript">
+  $(function() {
+    Alchemy.PagePublicationFields();
+  });
+</script>


### PR DESCRIPTION

## What is this pull request for?

On the sitemap and on the Edit page, `Alchemy::PagePublicationFields` is run. On the table, it isn't, leading to behavior where an admin cannot un-publish or publish a page from the pages table.

### Notable changes (remove if none)

Fixes a little Bug

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
