### PR TITLE
[v6.1]  Use selenium-webdriver instead of webdrivers gem 

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -62,7 +62,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec-activemodel-mocks", ["~> 1.0"]
   gem.add_development_dependency "rspec-rails", [">= 4.0.0.beta2"]
   gem.add_development_dependency "simplecov", ["~> 0.20"]
-  gem.add_development_dependency "webdrivers", ["~> 5.0"]
+  gem.add_development_dependency "selenium-webdriver", ["~> 4.10"]
   gem.add_development_dependency "webmock", ["~> 3.3"]
   gem.add_development_dependency "shoulda-matchers", ["~> 5.0"]
   gem.add_development_dependency "timecop", ["~> 0.9"]

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,7 +12,6 @@ require "capybara-screenshot/rspec"
 require "rails-controller-testing"
 require "rspec-activemodel-mocks"
 require "rspec/rails"
-require "webdrivers/chromedriver"
 require "shoulda-matchers"
 require "factory_bot"
 


### PR DESCRIPTION

## What is this pull request for?

Selenium-Webdriver now has a feature that makes the webdrivers gem obsolete: https://github.com/titusfortner/webdrivers#update-future-of-this-project

Backport of #2529 



## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
