### PR TITLE
[7.0] Bugfix: Initialize PagePublicationFields on Pages Table

### DIFF
--- a/app/views/alchemy/admin/pages/_table.html.erb
+++ b/app/views/alchemy/admin/pages/_table.html.erb
@@ -25,3 +25,9 @@
     <%= render partial: "table_row", collection: @pages, as: "page" %>
   </tbody>
 </table>
+
+<script type="text/javascript">
+  $(function() {
+    Alchemy.PagePublicationFields();
+  });
+</script>


### PR DESCRIPTION
Same as #2528 but for 7.0-stable