### PR TITLE
[7.0] Fix DOM ids and labels of ingredient editors

### DIFF
--- a/app/helpers/alchemy/admin/ingredients_helper.rb
+++ b/app/helpers/alchemy/admin/ingredients_helper.rb
@@ -32,8 +32,8 @@ module Alchemy
       end
 
       # Renders the label and hint for a ingredient.
-      def ingredient_label(ingredient, column = :value)
-        label_tag ingredient.form_field_id(column) do
+      def ingredient_label(ingredient, column = :value, html_options = {})
+        label_tag ingredient.form_field_id(column), html_options do
           [render_ingredient_role(ingredient), render_hint_for(ingredient)].compact.join("&nbsp;").html_safe
         end
       end

--- a/app/views/alchemy/ingredients/_boolean_editor.html.erb
+++ b/app/views/alchemy/ingredients/_boolean_editor.html.erb
@@ -2,8 +2,8 @@
   class: boolean_editor.css_classes,
   data: boolean_editor.data_attributes do %>
   <%= element_form.fields_for(:ingredients, boolean_editor.ingredient) do |f| %>
-    <%= f.label :value, style: "display: inline-block" do %>
-      <%= f.check_box :value, id: boolean_editor.form_field_id %>
+    <%= f.label :value, style: "display: inline-block", for: nil do %>
+      <%= f.check_box :value, id: nil %>
       <%= render_ingredient_role(boolean_editor) %>
     <% end %>
     <%= render_hint_for(boolean_editor) %>

--- a/app/views/alchemy/ingredients/_picture_editor.html.erb
+++ b/app/views/alchemy/ingredients/_picture_editor.html.erb
@@ -4,7 +4,7 @@
   class: picture_editor.css_classes,
   data: picture_editor.data_attributes do %>
   <%= element_form.fields_for(:ingredients, picture_editor.ingredient) do |f| %>
-    <%= ingredient_label(picture_editor, :picture_id) %>
+    <%= ingredient_label(picture_editor, :picture_id, for: nil) %>
     <%= content_tag :div,
       data: {
         target_size: picture_editor.settings[:size] || [

--- a/spec/helpers/alchemy/admin/ingredients_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/ingredients_helper_spec.rb
@@ -33,6 +33,12 @@ describe Alchemy::Admin::IngredientsHelper do
         is_expected.to have_selector("label > .hint-with-icon", text: "This is a hint")
       end
     end
+
+    context "with html_options given" do
+      it "adds them to the label tag" do
+        expect(helper.ingredient_label(ingredient_editor, :value, for: "foo")).to have_selector('label[for="foo"]')
+      end
+    end
   end
 
   describe "#render_ingredient_role" do

--- a/spec/views/alchemy/ingredients/boolean_editor_spec.rb
+++ b/spec/views/alchemy/ingredients/boolean_editor_spec.rb
@@ -38,4 +38,9 @@ RSpec.describe "alchemy/ingredients/_boolean_editor" do
       end
     end
   end
+
+  it "does not add a for attribute to the label tag" do
+    is_expected.to have_selector("label", text: "Boolean")
+    is_expected.to_not have_selector("label[for]", text: "Boolean")
+  end
 end

--- a/spec/views/alchemy/ingredients/picture_editor_spec.rb
+++ b/spec/views/alchemy/ingredients/picture_editor_spec.rb
@@ -86,4 +86,9 @@ RSpec.describe "alchemy/ingredients/_picture_editor" do
       is_expected.to have_selector("a.disabled .icon.fa-crop")
     end
   end
+
+  it "does not add a for attribute to the label tag" do
+    is_expected.to have_selector("label", text: "Image")
+    is_expected.to_not have_selector("label[for]", text: "Image")
+  end
 end


### PR DESCRIPTION
Same as #2526 but for 7.0-stable