### PR TITLE
Improve Richtext editor view

### DIFF
--- a/app/models/alchemy/ingredients/richtext.rb
+++ b/app/models/alchemy/ingredients/richtext.rb
@@ -28,10 +28,6 @@ module Alchemy
         stripped_body.to_s[0..max_length - 1]
       end
 
-      def element_id
-        "tinymce_#{id}"
-      end
-
       def has_tinymce?
         true
       end

--- a/app/views/alchemy/ingredients/_richtext_editor.html.erb
+++ b/app/views/alchemy/ingredients/_richtext_editor.html.erb
@@ -1,17 +1,18 @@
 <%= content_tag :div,
   class: richtext_editor.css_classes,
   data: richtext_editor.data_attributes do %>
+  <%- richtext_dom_id = "tinymce_#{richtext_editor.id}" %>
   <%= element_form.fields_for(:ingredients, richtext_editor.ingredient) do |f| %>
-    <%= ingredient_label(richtext_editor) %>
+    <%= ingredient_label(richtext_editor, :value, for: richtext_dom_id) %>
     <div class="tinymce_container">
       <%= f.text_area :value,
         class: "has_tinymce",
-        id: richtext_editor.element_id %>
+        id: richtext_dom_id %>
     </div>
   <% end %>
   <% if richtext_editor.has_custom_tinymce_config? %>
     <script type="text/javascript" charset="utf-8">
-      Alchemy.Tinymce.setCustomConfig("<%= richtext_editor.element_id %>", {
+      Alchemy.Tinymce.setCustomConfig("<%= richtext_dom_id %>", {
         <% richtext_editor.custom_tinymce_config.each do |k, v| %>
         <%= k %>: <%== v.to_json %>,
         <% end %>

--- a/spec/models/alchemy/ingredients/richtext_spec.rb
+++ b/spec/models/alchemy/ingredients/richtext_spec.rb
@@ -33,12 +33,6 @@ RSpec.describe Alchemy::Ingredients::Richtext do
     expect(richtext_ingredient.sanitized_body).to eq("<h1>Hello!</h1><p class=\"green\">Welcome to Peters Petshop.</p>")
   end
 
-  describe "#element_id" do
-    subject { richtext_ingredient.element_id }
-
-    it { is_expected.to eq("tinymce_#{richtext_ingredient.id}") }
-  end
-
   describe "#has_custom_tinymce_config?" do
     subject { richtext_ingredient.has_custom_tinymce_config? }
 


### PR DESCRIPTION
## What is this pull request for?

Remove the element_id method from Richtext - ingredient and added the id directly to the input, label, and tinymce configuration.

Closes #2525 

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
