### PR TITLE
Remove return statement in datepicker

### DIFF
--- a/app/javascript/alchemy_admin/datepicker.js
+++ b/app/javascript/alchemy_admin/datepicker.js
@@ -23,9 +23,7 @@ export default function Datepicker(scope = document) {
       noCalendar: type === "time",
       time_24hr: Alchemy.t("formats.time_24hr"),
       onValueUpdate(_selectedDates, _dateStr, instance) {
-        return Alchemy.setElementDirty(
-          instance.element.closest(".element-editor")
-        )
+        Alchemy.setElementDirty(instance.element.closest(".element-editor"))
       }
     }
     flatpickr(input, options)


### PR DESCRIPTION


## What is this pull request for?
Remove an unnecessary return statement in the onValueUpdate flatepickr - hock in the datepicker. The hook does not use any return values from the given function.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
