### PR TITLE
Increase minimum Rails version to v7.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,6 @@ jobs:
       fail-fast: false
       matrix:
         rails:
-          - "6.1"
           - "7.0"
         ruby:
           - "3.0"

--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
     activesupport
     railties
   ].each do |rails_gem|
-    gem.add_runtime_dependency rails_gem, [">= 6.1", "< 7.1"]
+    gem.add_runtime_dependency rails_gem, [">= 7.0", "< 7.1"]
   end
 
   gem.add_runtime_dependency "active_model_serializers", ["~> 0.10.0"]

--- a/app/models/alchemy/picture/url.rb
+++ b/app/models/alchemy/picture/url.rb
@@ -35,7 +35,7 @@ module Alchemy
           thumb.uid
         else
           uid = PictureThumb::Uid.call(signature, variant)
-          ActiveRecord::Base.connected_to(role: ActiveRecord::Base.writing_role) do
+          ActiveRecord::Base.connected_to(role: ActiveRecord.writing_role) do
             PictureThumb::Create.call(variant, signature, uid)
           end
           uid

--- a/spec/models/alchemy/picture/url_spec.rb
+++ b/spec/models/alchemy/picture/url_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Alchemy::Picture::Url do
     end
 
     it "connects to writing database" do
-      writing_role = ActiveRecord::Base.writing_role
+      writing_role = ActiveRecord.writing_role
       expect(ActiveRecord::Base).to receive(:connected_to).with(role: writing_role)
       subject
     end


### PR DESCRIPTION
## What is this pull request for?

Remove Rails v6.1 compatibility to ease up the development and prepare the switch to Rails 7.1 in the long run. 

Older Pull Request: https://github.com/AlchemyCMS/alchemy_cms/pull/2437

### Notable changes

This Pull Request will allow only Rails 7.0 as dependency.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
