### PR TITLE
Picture Ingredient: Fix NaN error with free height

### DIFF
--- a/app/models/concerns/alchemy/picture_thumbnails.rb
+++ b/app/models/concerns/alchemy/picture_thumbnails.rb
@@ -115,6 +115,8 @@ module Alchemy
       return nil unless settings[:crop] && settings[:size]
 
       mask = inferred_dimensions_from_string(settings[:size])
+      return if mask.nil?
+
       zoom = thumbnail_zoom_factor(mask)
       return nil if zoom.zero?
 
@@ -149,6 +151,8 @@ module Alchemy
 
       width, height = dimensions_from_string(string)
       ratio = image_file_width.to_f / image_file_height.to_i
+
+      return if ratio.nan?
 
       if width.zero? && ratio.is_a?(Float)
         width = height * ratio

--- a/lib/alchemy/test_support/having_picture_thumbnails_examples.rb
+++ b/lib/alchemy/test_support/having_picture_thumbnails_examples.rb
@@ -385,6 +385,26 @@ RSpec.shared_examples_for "having picture thumbnails" do
           size: "160x120"
         )
       end
+
+      context "with settings indicating free height" do
+        let(:settings) do
+          {
+            crop: true,
+            size: "800x"
+          }
+        end
+
+        it "returns default thumbnail options" do
+          is_expected.to eq(
+            crop: true,
+            crop_from: nil,
+            crop_size: nil,
+            flatten: true,
+            format: "jpg",
+            size: "160x120"
+          )
+        end
+      end
     end
   end
 


### PR DESCRIPTION


## What is this pull request for?

When indicating that a picture can be cropped, but needs to have a certain height or width but leaves the other dimension free, current Alchemy throws a `NaN` error because of float division by Zero.

This commit handles this case by returning nil if the calculated mask is Not a Number.

### Notable changes (remove if none)

None.

### Screenshots

Before: 
![grafik](https://github.com/AlchemyCMS/alchemy_cms/assets/703401/447a0ef5-9a55-4006-8e27-a500533e52c3)

After:
![grafik](https://github.com/AlchemyCMS/alchemy_cms/assets/703401/ce57bdf0-a2fd-4fe3-a194-eed09b452b35)


## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
