### PR TITLE
Allow redirecting to other host in site redirect

### DIFF
--- a/app/controllers/concerns/alchemy/site_redirects.rb
+++ b/app/controllers/concerns/alchemy/site_redirects.rb
@@ -12,7 +12,7 @@ module Alchemy
     private
 
     def enforce_primary_host_for_site
-      redirect_to url_for(host: current_alchemy_site.host), status: :moved_permanently
+      redirect_to url_for(host: current_alchemy_site.host), status: :moved_permanently, allow_other_host: true
     end
 
     def needs_redirect_to_primary_host?

--- a/spec/requests/alchemy/site_requests_spec.rb
+++ b/spec/requests/alchemy/site_requests_spec.rb
@@ -3,19 +3,39 @@
 require "rails_helper"
 
 RSpec.describe "Site requests" do
+  let(:language) { create(:alchemy_language, site: site) }
+
+  let(:page) do
+    Alchemy::Site.current = site
+    root = create(:alchemy_page, :language_root, language: language)
+    create(:alchemy_page, :public, parent: root)
+  end
+
   context "a site with host" do
     let!(:site) { create(:alchemy_site, :public, host: "alchemy-cms.com") }
-    let(:language) { create(:alchemy_language, site: site) }
-
-    let(:page) do
-      Alchemy::Site.current = site
-      root = create(:alchemy_page, :language_root, language: language)
-      create(:alchemy_page, :public, parent: root)
-    end
 
     it "loads this site by host" do
       get "http://#{site.host}/#{page.urlname}"
       expect(assigns(:current_alchemy_site).host).to eq(site.host)
+    end
+  end
+
+  context "a site with alias and redirecting to primary host" do
+    let!(:site) do
+      create(
+        :alchemy_site,
+        :public,
+        host: "real.example.com",
+        aliases: "something.alchemy-cms.com",
+        redirect_to_primary_host: true
+      )
+    end
+
+    context "requested by alias host" do
+      it "redirects to primary host" do
+        get "http://something.alchemy-cms.com/#{page.urlname}"
+        expect(response).to redirect_to("http://real.example.com/#{page.urlname}")
+      end
     end
   end
 end


### PR DESCRIPTION
## What is this pull request for?

If we have a site that has a domain alias and that is configured to redirect to primary host, we need to allow that other host in Rails 7.0. It raises an exception otherwise.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
