### PR TITLE
Fix NonStupidDigestAssets with String whitelist

### DIFF
--- a/lib/non_stupid_digest_assets.rb
+++ b/lib/non_stupid_digest_assets.rb
@@ -19,7 +19,7 @@ module NonStupidDigestAssets
     def whitelisted_assets(assets)
       assets.select do |logical_path, _digest_path|
         whitelist.any? do |item|
-          item =~ logical_path
+          /#{item}/ =~ logical_path
         end
       end
     end

--- a/spec/libraries/non_stupid_digest_assets_spec.rb
+++ b/spec/libraries/non_stupid_digest_assets_spec.rb
@@ -14,8 +14,14 @@ RSpec.describe NonStupidDigestAssets do
     end
 
     context "when the whitelist is not empty" do
-      it "returns the assets that match the whitelist" do
+      it "returns the assets that match the whitelist of regex" do
         NonStupidDigestAssets.whitelist = [/foo/]
+        assets = {"foo.js" => "foo-123.js", "bar.js" => "bar-123.js"}
+        expect(NonStupidDigestAssets.assets(assets)).to eq("foo.js" => "foo-123.js")
+      end
+
+      it "returns the assets that match the whitelist of strings" do
+        NonStupidDigestAssets.whitelist = ["foo.js"]
         assets = {"foo.js" => "foo-123.js", "bar.js" => "bar-123.js"}
         expect(NonStupidDigestAssets.assets(assets)).to eq("foo.js" => "foo-123.js")
       end


### PR DESCRIPTION
## What is this pull request for?

We need to support Strings as well as Regexp.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
