### PR TITLE
Web Component Safari fixes

### DIFF
--- a/app/helpers/alchemy/admin/base_helper.rb
+++ b/app/helpers/alchemy/admin/base_helper.rb
@@ -322,8 +322,10 @@ module Alchemy
         date = Time.zone.parse(date) if date.is_a?(String)
         value = date&.iso8601
 
-        text_field object.class.name.demodulize.underscore.to_sym,
-          method.to_sym, {:type => "text", :class => type, :is => "alchemy-datepicker", "data-datepicker-type" => type, :value => value}.merge(html_options)
+        input_field = text_field object.class.name.demodulize.underscore.to_sym,
+          method.to_sym, {type: "text", class: type, value: value}.merge(html_options)
+
+        content_tag("alchemy-datepicker", input_field, type: type)
       end
 
       # Render a hint icon with tooltip for given object.

--- a/app/javascript/alchemy_admin/components/alchemy_html_element.js
+++ b/app/javascript/alchemy_admin/components/alchemy_html_element.js
@@ -63,6 +63,12 @@ export class AlchemyHTMLElement extends HTMLElement {
   }
 
   /**
+   * after render callback
+   * the function will be triggered after the DOM was updated
+   */
+  afterRender() {}
+
+  /**
    * (re)render the component content inside the component container
    * @private
    */
@@ -70,6 +76,7 @@ export class AlchemyHTMLElement extends HTMLElement {
     if (this.changeComponent) {
       this.innerHTML = this.render()
       this.changeComponent = false
+      this.afterRender()
     }
   }
 

--- a/app/javascript/alchemy_admin/components/alchemy_html_element.js
+++ b/app/javascript/alchemy_admin/components/alchemy_html_element.js
@@ -1,26 +1,76 @@
 export class AlchemyHTMLElement extends HTMLElement {
   static properties = {}
 
+  /**
+   * create the list of observed attributes
+   * this function is a requirement for the `attributeChangedCallback` - method
+   * @returns {string[]}
+   * @link https://developer.mozilla.org/en-US/docs/Web/API/Web_Components#reference
+   */
   static get observedAttributes() {
     return Object.keys(this.properties)
   }
 
-  constructor() {
+  constructor(options = {}) {
     super()
+
+    this.options = options
+    this.changeComponent = true
+    this.initialContent = this.innerHTML // store the inner content of the component
   }
 
+  /**
+   * run when the component will be initialized by the Browser
+   * this is a default function
+   * @link https://developer.mozilla.org/en-US/docs/Web/API/Web_Components#reference
+   */
   connectedCallback() {
     // parse the properties object and register property variables
     Object.keys(this.constructor.properties).forEach((propertyName) => {
-      this.updateProperty(propertyName, this.getAttribute(propertyName))
+      // if the options was given via the constructor, they should be prefer (e.g. new <WebComponentName>({title: "Foo"}))
+      if (this.options[propertyName]) {
+        this[propertyName] = this.options[propertyName]
+      } else {
+        this._updateProperty(propertyName, this.getAttribute(propertyName))
+      }
     })
+
     // render the component
-    this.updateComponent()
+    this._updateComponent()
+    this.connected()
   }
 
+  /**
+   * triggered by the browser, if one of the observed attributes is changing
+   * @link https://developer.mozilla.org/en-US/docs/Web/API/Web_Components#reference
+   */
   attributeChangedCallback(name, oldValue, newValue) {
-    this.updateProperty(name, newValue)
-    this.updateComponent()
+    this._updateProperty(name, newValue)
+    this._updateComponent()
+  }
+
+  /**
+   * a connected method to make it easier to overwrite the connection callback
+   */
+  connected() {}
+
+  /**
+   * empty method container to allow the child component to put the rendered string into this method
+   * @returns {String}
+   */
+  render() {
+    return this.initialContent
+  }
+
+  /**
+   * (re)render the component content inside the component container
+   * @private
+   */
+  _updateComponent() {
+    if (this.changeComponent) {
+      this.innerHTML = this.render()
+      this.changeComponent = false
+    }
   }
 
   /**
@@ -29,27 +79,19 @@ export class AlchemyHTMLElement extends HTMLElement {
    *
    * @param {string} propertyName
    * @param {string} value
+   * @private
    */
-  updateProperty(propertyName, value) {
+  _updateProperty(propertyName, value) {
     const property = this.constructor.properties[propertyName]
-    this[propertyName] = value
-    if (property.default && this[propertyName] === null) {
-      this[propertyName] = property.default
+    if (this[propertyName] !== value) {
+      this[propertyName] = value
+      if (
+        typeof property.default !== "undefined" &&
+        this[propertyName] === null
+      ) {
+        this[propertyName] = property.default
+      }
+      this.changeComponent = true
     }
-  }
-
-  /**
-   * (re)render the component content inside the component container
-   */
-  updateComponent() {
-    this.innerHTML = this.render()
-  }
-
-  /**
-   * empty method container to allow the child component to put the rendered string into this method
-   * @returns {String}
-   */
-  render() {
-    return ""
   }
 }

--- a/app/javascript/alchemy_admin/components/alchemy_html_element.js
+++ b/app/javascript/alchemy_admin/components/alchemy_html_element.js
@@ -41,6 +41,16 @@ export class AlchemyHTMLElement extends HTMLElement {
   }
 
   /**
+   * disconnected callback if the component is removed from the DOM
+   * this is currently only a Proxy to the disconnected - callback to use the same callback structure
+   * as for the connected - callback
+   * @link https://developer.mozilla.org/en-US/docs/Web/API/Web_Components#reference
+   */
+  disconnectedCallback() {
+    this.disconnected()
+  }
+
+  /**
    * triggered by the browser, if one of the observed attributes is changing
    * @link https://developer.mozilla.org/en-US/docs/Web/API/Web_Components#reference
    */
@@ -53,6 +63,11 @@ export class AlchemyHTMLElement extends HTMLElement {
    * a connected method to make it easier to overwrite the connection callback
    */
   connected() {}
+
+  /**
+   * a disconnected method to make it easier to overwrite the disconnection callback
+   */
+  disconnected() {}
 
   /**
    * empty method container to allow the child component to put the rendered string into this method

--- a/app/javascript/alchemy_admin/components/datepicker.js
+++ b/app/javascript/alchemy_admin/components/datepicker.js
@@ -1,27 +1,29 @@
+import { AlchemyHTMLElement } from "./alchemy_html_element"
 import flatpickr from "flatpickr"
 
-class Datepicker extends HTMLInputElement {
-  constructor() {
-    super()
+class Datepicker extends AlchemyHTMLElement {
+  static properties = {
+    type: { default: "date" }
+  }
 
-    const type = this.dataset.datepickerType
+  afterRender() {
     const options = {
       // alchemy_i18n supports `zh_CN` etc., but flatpickr only has two-letter codes (`zh`)
       locale: Alchemy.locale.slice(0, 2),
       altInput: true,
-      altFormat: Alchemy.t(`formats.${type}`),
+      altFormat: Alchemy.t(`formats.${this.type}`),
       altInputClass: "flatpickr-input",
       dateFormat: "Z",
-      enableTime: /time/.test(type),
-      noCalendar: type === "time",
+      enableTime: /time/.test(this.type),
+      noCalendar: this.type === "time",
       time_24hr: Alchemy.t("formats.time_24hr"),
       onValueUpdate(_selectedDates, _dateStr, instance) {
         Alchemy.setElementDirty(instance.element.closest(".element-editor"))
       }
     }
 
-    flatpickr(this, options)
+    flatpickr(this.getElementsByTagName("input")[0], options)
   }
 }
 
-customElements.define("alchemy-datepicker", Datepicker, { extends: "input" })
+customElements.define("alchemy-datepicker", Datepicker)

--- a/app/javascript/alchemy_admin/components/tinymce.js
+++ b/app/javascript/alchemy_admin/components/tinymce.js
@@ -1,24 +1,16 @@
-import { createHtmlElement, wrap } from "alchemy_admin/utils/dom_helpers"
-import Spinner from "alchemy_admin/spinner"
+import { AlchemyHTMLElement } from "./alchemy_html_element"
 
-class Tinymce extends HTMLTextAreaElement {
-  constructor() {
-    super()
-
-    // create a wrapper around the the textarea and place everything inside that container
-    this.container = createHtmlElement('<div class="tinymce_container" />')
-    wrap(this, this.container)
-    this.className = "has_tinymce"
-  }
-
+class Tinymce extends AlchemyHTMLElement {
   /**
    * the observer will initialize Tinymce if the textarea becomes visible
    */
-  connectedCallback() {
+  connected() {
+    this.className = "tinymce_container"
+
     const observerCallback = (entries, observer) => {
       entries.forEach((entry) => {
         if (entry.intersectionRatio > 0) {
-          this.initTinymceEditor()
+          this._initTinymceEditor()
           // disable observer after the Tinymce was initialized
           observer.unobserve(entry.target)
         }
@@ -35,42 +27,53 @@ class Tinymce extends HTMLTextAreaElement {
       observerCallback,
       options
     )
-    this.tinymceIntersectionObserver.observe(this.container)
+    this.tinymceIntersectionObserver.observe(this)
   }
 
   /**
    * disconnect intersection observer and remove Tinymce editor if the web components get destroyed
    */
-  disconnectedCallback() {
+  disconnected() {
     if (this.tinymceIntersectionObserver !== null) {
       this.tinymceIntersectionObserver.disconnect()
     }
 
-    tinymce.get(this.id)?.remove(this.id)
+    tinymce.get(this.editorId)?.remove(this.editorId)
   }
 
-  initTinymceEditor() {
-    const spinner = new Spinner("small")
-    spinner.spin(this)
+  render() {
+    return `
+      ${this.initialContent}
+      <alchemy-spinner size="small"></alchemy-spinner>
+    `
+  }
 
-    // initialize TinyMCE
+  /**
+   * hide the textarea until TinyMCE is ready to show the editor
+   */
+  afterRender() {
+    this.editor.style.display = "none"
+  }
+
+  /**
+   * initialize Richtext area after the Intersection observer triggered
+   * @private
+   */
+  _initTinymceEditor() {
     tinymce.init(this.configuration).then((editors) => {
-      spinner.stop()
-
       editors.forEach((editor) => {
         // mark the editor container as visible
         // without these correction the editor remains hidden
         // after a drag and drop action
         editor.show()
 
-        const elementEditor = document
-          .getElementById(this.id)
-          .closest(".element-editor")
+        // remove the spinner after the Tinymce initialized
+        this.getElementsByTagName("alchemy-spinner")[0].remove()
 
         // event listener to mark the editor as dirty
-        editor.on("dirty", () => Alchemy.setElementDirty(elementEditor))
+        editor.on("dirty", () => Alchemy.setElementDirty(this.elementEditor))
         editor.on("click", (event) => {
-          event.target = elementEditor
+          event.target = this.elementEditor
           Alchemy.ElementEditors.onClickElement(event)
         })
       })
@@ -99,9 +102,21 @@ class Tinymce extends HTMLTextAreaElement {
       ...Alchemy.TinymceDefaults,
       ...customConfig,
       locale: Alchemy.locale,
-      selector: `#${this.id}`
+      selector: `#${this.editorId}`
     }
+  }
+
+  get editorId() {
+    return this.editor.id
+  }
+
+  get editor() {
+    return this.getElementsByTagName("textarea")[0]
+  }
+
+  get elementEditor() {
+    return document.getElementById(this.editorId).closest(".element-editor")
   }
 }
 
-customElements.define("alchemy-tinymce", Tinymce, { extends: "textarea" })
+customElements.define("alchemy-tinymce", Tinymce)

--- a/app/views/alchemy/ingredients/_richtext_editor.html.erb
+++ b/app/views/alchemy/ingredients/_richtext_editor.html.erb
@@ -5,6 +5,8 @@
     <%= ingredient_label(richtext_editor, :value) %>
 
     <%- custom_tinymce_config = richtext_editor.custom_tinymce_config.inject({}) { |obj, (k, v)| obj[k.to_s.dasherize] = v.to_json; obj} %>
-    <%= f.text_area :value, custom_tinymce_config.merge(is: "alchemy-tinymce", id: richtext_editor.form_field_id(:value)) %>
+    <%= content_tag("alchemy-tinymce", custom_tinymce_config) do %>
+      <%= f.text_area :value, id: richtext_editor.form_field_id(:value) %>
+    <% end %>
   <% end %>
 <% end %>

--- a/lib/alchemy/forms/builder.rb
+++ b/lib/alchemy/forms/builder.rb
@@ -22,8 +22,6 @@ module Alchemy
       # Renders a simple_form input that displays a datepicker
       #
       def datepicker(attribute_name, options = {})
-        options[:wrapper] = :alchemy
-
         type = options[:as] || :date
         value = options.fetch(:input_html, {}).delete(:value)
         date = value || object.send(attribute_name.to_sym).presence
@@ -32,11 +30,11 @@ module Alchemy
         input_options = {
           type: :text,
           class: type,
-          data: {datepicker_type: type},
           value: date&.iso8601
         }.merge(options[:input_html] || {})
 
-        input attribute_name, as: :string, input_html: input_options
+        date_field = input attribute_name, as: :string, input_html: input_options
+        template.content_tag("alchemy-datepicker", date_field, type: type)
       end
 
       # Renders a button tag wrapped in a div with 'submit' class.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "flatpickr": "^4.6.9",
     "jest": "^29.6.4",
     "jest-environment-jsdom": "^29.6.4",
+    "jsdom-testing-mocks": "^1.11.0",
     "lodash-es": "^4.17.21",
     "prettier": "^3.0.0",
     "sortablejs": "^1.10.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "globals": {
       "Alchemy": {}
     },
+    "moduleNameMapper": {
+      "alchemy_admin/(.*)": "<rootDir>/app/javascript/alchemy_admin/$1"
+    },
     "testEnvironment": "jsdom",
     "roots": [
       "spec/javascript/alchemy_admin"

--- a/spec/helpers/alchemy/admin/base_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/base_helper_spec.rb
@@ -126,14 +126,14 @@ module Alchemy
       let(:type) { nil }
 
       it "renders a text field with data attribute for 'date'" do
-        is_expected.to have_selector("input[type='text'][data-datepicker-type='date']")
+        is_expected.to have_selector("alchemy-datepicker[type='date'] input[type='text']")
       end
 
       context "when datetime given as type" do
         let(:type) { :datetime }
 
         it "renders a text field with data attribute for 'datetime'" do
-          is_expected.to have_selector("input[type='text'][data-datepicker-type='datetime']")
+          is_expected.to have_selector("alchemy-datepicker[type='datetime'] input[type='text']")
         end
       end
 
@@ -141,7 +141,7 @@ module Alchemy
         let(:type) { :time }
 
         it "renders a text field with data attribute for 'time'" do
-          is_expected.to have_selector("input[type='text'][data-datepicker-type='time']")
+          is_expected.to have_selector("alchemy-datepicker[type='time'] input[type='text']")
         end
       end
 

--- a/spec/javascript/alchemy_admin/components/alchemy_html_element.spec.js
+++ b/spec/javascript/alchemy_admin/components/alchemy_html_element.spec.js
@@ -1,0 +1,149 @@
+import { AlchemyHTMLElement } from "../../../../app/javascript/alchemy_admin/components/alchemy_html_element"
+import { renderComponent } from "./component.helper"
+
+describe("AlchemyHTMLElement", () => {
+  let component = undefined
+
+  const componentName = () =>
+    `test-element-${Math.ceil(Math.random() * 10000000000000)}`
+
+  describe("Render", () => {
+    /**
+     * create a new web component
+     * you can't recreate (or remove) a web component. So it has to be a new one with another name
+     * @param {string} content
+     * @param {string} initialContent
+     */
+    const createComponent = (content = "", initialContent = "") => {
+      const name = componentName()
+
+      customElements.define(
+        name,
+        class Test extends AlchemyHTMLElement {
+          render() {
+            return content
+          }
+        }
+      )
+      component = renderComponent(name, `<${name}>${initialContent}</${name}>`)
+    }
+
+    it("should render only the component", () => {
+      createComponent()
+      expect(component).toBeInstanceOf(HTMLElement)
+      expect(component.innerHTML).toEqual("")
+    })
+
+    it("should render the content of the given render function", () => {
+      createComponent("Foo")
+      expect(component.innerHTML).toEqual("Foo")
+    })
+
+    it("should store the initial content", () => {
+      createComponent("", "Bar")
+      expect(component.initialContent).toEqual("Bar")
+    })
+
+    it("should render the initial content if no render function is given", () => {
+      customElements.define(
+        "test-initial-content",
+        class Test extends AlchemyHTMLElement {}
+      )
+      component = renderComponent(
+        "test-initial-content",
+        `<test-initial-content>FooBar</test-initial-content>`
+      )
+      expect(component.innerHTML).toEqual("FooBar")
+    })
+  })
+
+  describe("Attributes", () => {
+    /**
+     * @param {string} name
+     */
+    const createComponent = (name = componentName()) => {
+      customElements.define(
+        name,
+        class Test extends AlchemyHTMLElement {
+          static properties = {
+            size: { default: "medium" },
+            color: { default: "currentColor" }
+          }
+        }
+      )
+      component = renderComponent(name, `<${name}></${name}>`)
+    }
+
+    it("should configure attributes and set default values", () => {
+      createComponent()
+      expect(component.size).toEqual("medium")
+      expect(component.color).toEqual("currentColor")
+    })
+
+    it("should be able to set attributes", () => {
+      createComponent("test-size")
+      component = renderComponent(
+        "test-size",
+        `<test-size size="large"></test-size>`
+      )
+      expect(component.size).toEqual("large")
+    })
+
+    it("should observe an attribute change", () => {
+      createComponent("test-color")
+      expect(component.color).toEqual("currentColor")
+      component.setAttribute("color", "pink")
+      expect(component.color).toEqual("pink")
+    })
+
+    it("should rerender after a attribute change", () => {
+      customElements.define(
+        "test-attribute-change",
+        class Test extends AlchemyHTMLElement {
+          static properties = {
+            foo: { default: "bar" }
+          }
+
+          render() {
+            return `Test: ${this.foo}`
+          }
+        }
+      )
+      component = renderComponent(
+        "test-attribute-change",
+        "<test-attribute-change foo='foo'></test-attribute-change>"
+      )
+      expect(component.innerHTML).toEqual("Test: foo")
+      component.setAttribute("foo", "fooBar")
+      expect(component.innerHTML).toEqual("Test: fooBar")
+    })
+  })
+
+  describe("Options", () => {
+    class Test extends AlchemyHTMLElement {
+      static properties = {
+        test: { default: "foo" }
+      }
+    }
+
+    beforeAll(() => {
+      customElements.define("test-options", Test)
+      component = renderComponent(
+        "test-options",
+        "<test-options></test-options>"
+      )
+    })
+
+    it("should have options", () => {
+      const newComponent = new Test({ test: "bar" })
+      expect(newComponent.options).toEqual({ test: "bar" })
+    })
+
+    it("should use the given option as default property", () => {
+      const newComponent = new Test({ test: "bar" })
+      document.body.append(newComponent) // the new component should be append to a DOM node to run as a Web Component
+      expect(component.test).toEqual("foo")
+      expect(newComponent.test).toEqual("bar")
+    })
+  })
+})

--- a/spec/javascript/alchemy_admin/components/alchemy_html_element.spec.js
+++ b/spec/javascript/alchemy_admin/components/alchemy_html_element.spec.js
@@ -1,4 +1,4 @@
-import { AlchemyHTMLElement } from "../../../../app/javascript/alchemy_admin/components/alchemy_html_element"
+import { AlchemyHTMLElement } from "alchemy_admin/components/alchemy_html_element"
 import { renderComponent } from "./component.helper"
 
 describe("AlchemyHTMLElement", () => {

--- a/spec/javascript/alchemy_admin/components/component.helper.js
+++ b/spec/javascript/alchemy_admin/components/component.helper.js
@@ -1,0 +1,10 @@
+/**
+ * render component helper
+ * @param {string} name
+ * @param {string} html
+ * @returns {HTMLElement}
+ */
+export const renderComponent = (name, html) => {
+  document.body.innerHTML = html
+  return document.querySelector(name)
+}

--- a/spec/javascript/alchemy_admin/components/datepicker.spec.js
+++ b/spec/javascript/alchemy_admin/components/datepicker.spec.js
@@ -1,4 +1,4 @@
-import "../../../../app/javascript/alchemy_admin/components/datepicker"
+import "alchemy_admin/components/datepicker"
 import { renderComponent } from "./component.helper"
 
 describe("alchemy-datepicker", () => {

--- a/spec/javascript/alchemy_admin/components/datepicker.spec.js
+++ b/spec/javascript/alchemy_admin/components/datepicker.spec.js
@@ -1,0 +1,42 @@
+import "../../../../app/javascript/alchemy_admin/components/datepicker"
+import { renderComponent } from "./component.helper"
+
+describe("alchemy-datepicker", () => {
+  /**
+   *
+   * @type {HTMLElement | undefined}
+   */
+  let component = undefined
+
+  beforeAll(() => {
+    window.Alchemy = {
+      locale: "en_US",
+      t: (key) => key
+    }
+  })
+
+  beforeEach(() => {
+    const html = `
+      <alchemy-datepicker>
+        <input type="text">
+      </alchemy-datepicker>
+    `
+    component = renderComponent("alchemy-datepicker", html)
+  })
+
+  it("should render the input field", () => {
+    expect(component.getElementsByTagName("input")[0]).toBeInstanceOf(
+      HTMLElement
+    )
+  })
+
+  it("should enhance the input field with a flat picker config", () => {
+    expect(component.getElementsByTagName("input")[0].className).toEqual(
+      "flatpickr-input"
+    )
+  })
+
+  it("should have a type attribute", () => {
+    expect(component.type).toEqual("date")
+  })
+})

--- a/spec/javascript/alchemy_admin/components/spinner.spec.js
+++ b/spec/javascript/alchemy_admin/components/spinner.spec.js
@@ -1,4 +1,4 @@
-import "../../../../app/javascript/alchemy_admin/components/spinner"
+import "alchemy_admin/components/spinner"
 
 describe("alchemy-spinner", () => {
   /**

--- a/spec/javascript/alchemy_admin/components/tinymce.spec.js
+++ b/spec/javascript/alchemy_admin/components/tinymce.spec.js
@@ -1,5 +1,5 @@
 import { renderComponent } from "./component.helper"
-import "../../../../app/javascript/alchemy_admin/components/tinymce"
+import "alchemy_admin/components/tinymce"
 import "../../../../vendor/assets/javascripts/tinymce/tinymce.min"
 import { mockIntersectionObserver } from "jsdom-testing-mocks"
 

--- a/spec/javascript/alchemy_admin/components/tinymce.spec.js
+++ b/spec/javascript/alchemy_admin/components/tinymce.spec.js
@@ -1,0 +1,81 @@
+import { renderComponent } from "./component.helper"
+import "../../../../app/javascript/alchemy_admin/components/tinymce"
+import "../../../../vendor/assets/javascripts/tinymce/tinymce.min"
+import { mockIntersectionObserver } from "jsdom-testing-mocks"
+
+describe("alchemy-tinymce", () => {
+  const intersectionObserver = mockIntersectionObserver()
+  /**
+   *
+   * @type {HTMLElement | undefined}
+   */
+  let component = undefined
+
+  const textareaId = "tinymce-textarea"
+
+  beforeAll(() => {
+    window.Alchemy = {
+      locale: "en_US"
+    }
+  })
+
+  describe("render", () => {
+    beforeEach(() => {
+      const html = `
+      <alchemy-tinymce>
+        <textarea id="${textareaId}"></textarea>
+      </alchemy-tinymce>
+    `
+      component = renderComponent("alchemy-tinymce", html)
+    })
+
+    it("should render the textarea field", () => {
+      expect(component.getElementsByTagName("textarea")[0]).toBeInstanceOf(
+        HTMLElement
+      )
+    })
+
+    it("should have an tinymce container after the intersection observer triggered", () => {
+      expect(component.getElementsByClassName("mce-tinymce").length).toEqual(0)
+      intersectionObserver.enterNode(component)
+      expect(component.getElementsByClassName("mce-tinymce").length).toEqual(1)
+    })
+
+    it("should show a spinner", async () => {
+      expect(component.getElementsByTagName("alchemy-spinner").length).toEqual(
+        1
+      )
+    })
+  })
+
+  describe("configuration", () => {
+    beforeEach(() => {
+      const html = `
+      <alchemy-tinymce toolbar="bold italic" foo-bar="bar | foo">
+        <textarea id="${textareaId}"></textarea>
+      </alchemy-tinymce>
+    `
+      component = renderComponent("alchemy-tinymce", html)
+    })
+
+    it("has a tinymce configuration", () => {
+      expect(component.configuration).toBeInstanceOf(Object)
+    })
+
+    it("should have the locale", () => {
+      expect(component.configuration.locale).toEqual("en_US")
+    })
+
+    it("should add the attributes to configuration and cast dashes with underscores", () => {
+      expect(component.configuration.toolbar).toEqual("bold italic")
+      expect(component.configuration.foo_bar).toEqual("bar | foo")
+    })
+
+    it("should use these configuration for the tinymce", () => {
+      intersectionObserver.enterNode(component)
+      const tinymceSettings = tinymce.get(textareaId).settings
+      expect(tinymceSettings.id).toEqual(textareaId)
+      expect(tinymceSettings.toolbar).toEqual("bold italic")
+    })
+  })
+})

--- a/spec/javascript/alchemy_admin/i18n.spec.js
+++ b/spec/javascript/alchemy_admin/i18n.spec.js
@@ -1,4 +1,4 @@
-import translate from "../../../app/javascript/alchemy_admin/i18n"
+import translate from "alchemy_admin/i18n"
 
 describe("translate", () => {
   describe("if Alchemy.locale is not set", () => {

--- a/spec/javascript/alchemy_admin/utils/ajax.spec.js
+++ b/spec/javascript/alchemy_admin/utils/ajax.spec.js
@@ -1,9 +1,5 @@
 import xhrMock from "xhr-mock"
-import {
-  get,
-  patch,
-  post
-} from "../../../../app/javascript/alchemy_admin/utils/ajax"
+import { get, patch, post } from "alchemy_admin/utils/ajax"
 
 const token = "s3cr3t"
 

--- a/spec/javascript/alchemy_admin/utils/events.spec.js
+++ b/spec/javascript/alchemy_admin/utils/events.spec.js
@@ -1,4 +1,4 @@
-import { on } from "../../../../app/javascript/alchemy_admin/utils/events"
+import { on } from "alchemy_admin/utils/events"
 
 describe("on", () => {
   const callback = jest.fn()

--- a/spec/libraries/forms/builder_spec.rb
+++ b/spec/libraries/forms/builder_spec.rb
@@ -6,13 +6,33 @@ RSpec.describe Alchemy::Forms::Builder, type: :controller do
   let(:object_name) { "Ding" }
   let(:form_object) { double("FormObject", foo: "Baz") }
 
+  shared_examples_for "datepicker expect" do
+    it "has the alchemy-datepicker" do
+      expect(template).to receive(:content_tag).with("alchemy-datepicker", "<alchemy-datepicker>", {type: type})
+      subject
+    end
+
+    it "returns input field" do
+      expect(template).to receive(:text_field).with(
+        "Ding",
+        :foo,
+        hash_including(
+          type: :text,
+          value: value,
+          class: [:string, :required, type]
+        )
+      )
+      subject
+    end
+  end
+
   let(:template) do
     double(
       "Template",
       controller: controller,
       label: "<label>",
       text_field: "<input>",
-      content_tag: "<div>"
+      content_tag: "<alchemy-datepicker>"
     )
   end
 
@@ -28,36 +48,18 @@ RSpec.describe Alchemy::Forms::Builder, type: :controller do
         let(:options) { {as: :date} }
         let(:form_object) { double("FormObject", foo: "2021-07-14") }
 
-        it "returns input field with date value set" do
-          expect(template).to receive(:text_field).with(
-            "Ding",
-            :foo,
-            hash_including(
-              type: :text,
-              data: {datepicker_type: :date},
-              value: "2021-07-14T00:00:00Z",
-              class: [:string, :required, :date]
-            )
-          )
-          subject
+        it_behaves_like "datepicker expect" do
+          let(:type) { :date }
+          let(:value) { "2021-07-14T00:00:00Z" }
         end
       end
 
       context "in the html options" do
         let(:options) { {as: :date, input_html: {value: "2021-08-01"}} }
 
-        it "returns input field with parsed date value set" do
-          expect(template).to receive(:text_field).with(
-            "Ding",
-            :foo,
-            hash_including(
-              type: :text,
-              data: {datepicker_type: :date},
-              value: "2021-08-01T00:00:00Z",
-              class: [:string, :required, :date]
-            )
-          )
-          subject
+        it_behaves_like "datepicker expect" do
+          let(:type) { :date }
+          let(:value) { "2021-08-01T00:00:00Z" }
         end
       end
     end
@@ -65,54 +67,27 @@ RSpec.describe Alchemy::Forms::Builder, type: :controller do
     context "as date" do
       let(:options) { {as: :date} }
 
-      it "returns input field with datepicker attributes" do
-        expect(template).to receive(:text_field).with(
-          "Ding",
-          :foo,
-          hash_including(
-            type: :text,
-            data: {datepicker_type: :date},
-            value: nil,
-            class: [:string, :required, :date]
-          )
-        )
-        subject
+      it_behaves_like "datepicker expect" do
+        let(:type) { :date }
+        let(:value) { nil }
       end
     end
 
     context "as time" do
       let(:options) { {as: :time} }
 
-      it "returns input field with datepicker attributes" do
-        expect(template).to receive(:text_field).with(
-          "Ding",
-          :foo,
-          hash_including(
-            type: :text,
-            data: {datepicker_type: :time},
-            value: nil,
-            class: [:string, :required, :time]
-          )
-        )
-        subject
+      it_behaves_like "datepicker expect" do
+        let(:type) { :time }
+        let(:value) { nil }
       end
     end
 
     context "as datetime" do
       let(:options) { {as: :datetime} }
 
-      it "returns input field with datepicker attributes" do
-        expect(template).to receive(:text_field).with(
-          "Ding",
-          :foo,
-          hash_including(
-            type: :text,
-            data: {datepicker_type: :datetime},
-            value: nil,
-            class: [:string, :required, :datetime]
-          )
-        )
-        subject
+      it_behaves_like "datepicker expect" do
+        let(:type) { :datetime }
+        let(:value) { nil }
       end
     end
   end

--- a/spec/views/alchemy/ingredients/datetime_editor_spec.rb
+++ b/spec/views/alchemy/ingredients/datetime_editor_spec.rb
@@ -17,6 +17,6 @@ RSpec.describe "alchemy/ingredients/_datetime_editor" do
 
   it "renders a datepicker" do
     render element_editor
-    expect(rendered).to have_css('input[type="text"][data-datepicker-type="date"].date')
+    expect(rendered).to have_css('alchemy-datepicker[type="date"] input[type="text"].date')
   end
 end

--- a/spec/views/alchemy/ingredients/richtext_editor_spec.rb
+++ b/spec/views/alchemy/ingredients/richtext_editor_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "alchemy/ingredients/_richtext_editor" do
   end
 
   it "renders a text area for tinymce" do
-    expect(rendered).to have_selector("textarea[is=alchemy-tinymce]")
+    expect(rendered).to have_selector("alchemy-tinymce textarea")
   end
 
   context "without custom configuration" do
@@ -32,11 +32,11 @@ RSpec.describe "alchemy/ingredients/_richtext_editor" do
     let(:settings) { {tinymce: {plugin: "link", foo_bar: "foo-bar"}} }
 
     it "renders a custom configuration" do
-      expect(rendered).to have_selector("textarea[is=alchemy-tinymce][plugin]")
+      expect(rendered).to have_selector("alchemy-tinymce[plugin] textarea")
     end
 
     it "dasherize the attribute keys" do
-      expect(rendered).to have_selector("textarea[is=alchemy-tinymce][foo-bar]")
+      expect(rendered).to have_selector("alchemy-tinymce[foo-bar] textarea")
     end
   end
 end


### PR DESCRIPTION
## What is this pull request for?

- extend the base web component class
- update the alchemy-datepicker component to be compatible with Safari
- update the alchemy-tinymce component to be compatible with Safari

### Notable changes

- Instead of `<input is="alchemy-datepicker" ...>` use `<alchemy-datepicker><input .../></alchemy-datepicker>`
- Instead of `<textarea is="alchemy-tinymce" ...></textarea>` use `<alchemy-tinymce><textarea id="..." ...></textarea></alchemy-tinymce>`

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
