### PR TITLE
Use fewer select2

### DIFF
--- a/app/javascript/alchemy_admin/components/select.js
+++ b/app/javascript/alchemy_admin/components/select.js
@@ -3,7 +3,7 @@ class Select extends HTMLSelectElement {
     this.classList.add("alchemy_selectbox")
 
     $(this).select2({
-      minimumResultsForSearch: 7,
+      minimumResultsForSearch: 5,
       dropdownAutoWidth: true
     })
   }

--- a/app/views/alchemy/admin/ingredients/_file_fields.html.erb
+++ b/app/views/alchemy/admin/ingredients/_file_fields.html.erb
@@ -14,5 +14,5 @@
       [Alchemy.t(:above), "no_float"],
       [Alchemy.t(:left), "left"],
       [Alchemy.t(:right), "right"]
-    ], include_blank: Alchemy.t('Layout default'), input_html: {is: 'alchemy-select'} %>
+    ], include_blank: Alchemy.t('Layout default') %>
 <%- end -%>

--- a/app/views/alchemy/admin/ingredients/_picture_fields.html.erb
+++ b/app/views/alchemy/admin/ingredients/_picture_fields.html.erb
@@ -21,5 +21,5 @@
       [Alchemy.t(:above), "no_float"],
       [Alchemy.t(:left), "left"],
       [Alchemy.t(:right), "right"]
-    ], include_blank: Alchemy.t("Layout default"), input_html: {is: 'alchemy-select'} %>
+    ], include_blank: Alchemy.t("Layout default") %>
 <%- end -%>

--- a/app/views/alchemy/admin/ingredients/_video_fields.html.erb
+++ b/app/views/alchemy/admin/ingredients/_video_fields.html.erb
@@ -5,5 +5,4 @@
 <%= f.input :loop, as: :boolean %>
 <%= f.input :muted, as: :boolean %>
 <%= f.input :playsinline, as: :boolean %>
-<%= f.input :preload, collection: %w(auto none metadata),
-  include_blank: false, input_html: {is: 'alchemy-select'} %>
+<%= f.input :preload, collection: %w(auto none metadata), include_blank: false %>

--- a/app/views/alchemy/admin/languages/_form.html.erb
+++ b/app/views/alchemy/admin/languages/_form.html.erb
@@ -8,8 +8,7 @@
   <% if language.errors[:locale].present? || language.locale.present? %>
     <%= f.input :locale,
       collection: language.matching_locales.presence || ::I18n.available_locales,
-      selected: language.locale || language.language_code || ::I18n.default_locale.to_s,
-      input_html: {is: 'alchemy-select'} %>
+      selected: language.locale || language.language_code || ::I18n.default_locale.to_s %>
   <% end %>
   <%= f.input :frontpage_name %>
   <%= f.input :page_layout,

--- a/app/views/alchemy/admin/pages/_external_link.html.erb
+++ b/app/views/alchemy/admin/pages/_external_link.html.erb
@@ -23,7 +23,7 @@
     </label>
     <%= select_tag 'external_link_target',
       options_for_select(Alchemy::Page.link_target_options),
-      {class: 'link_target', is: 'alchemy-select'} %>
+      class: 'link_target' %>
   </div>
   <div class="submit">
     <%= button_tag Alchemy.t(:apply), class: 'create-link button', data: { link_type: 'external' } %>

--- a/app/views/alchemy/admin/pages/_file_link.html.erb
+++ b/app/views/alchemy/admin/pages/_file_link.html.erb
@@ -23,7 +23,7 @@
     </label>
     <%= select_tag 'file_link_target',
       options_for_select(Alchemy::Page.link_target_options),
-      class: 'link_target', is: 'alchemy-select' %>
+      class: 'link_target' %>
   </div>
   <div class="submit">
     <%= button_tag Alchemy.t(:apply), class: 'create-link button', data: { link_type: 'file' } %>

--- a/app/views/alchemy/admin/pages/_internal_link.html.erb
+++ b/app/views/alchemy/admin/pages/_internal_link.html.erb
@@ -27,7 +27,7 @@
     </label>
     <%= select_tag 'internal_link_target',
       options_for_select(Alchemy::Page.link_target_options),
-      class: 'link_target', is: 'alchemy-select' %>
+      class: 'link_target' %>
   </div>
   <div class="submit">
     <%= button_tag Alchemy.t(:apply), class: 'create-link button', data: { link_type: 'internal' } %>

--- a/app/views/alchemy/admin/partials/_language_tree_select.html.erb
+++ b/app/views/alchemy/admin/partials/_language_tree_select.html.erb
@@ -13,7 +13,9 @@
       data: {'auto-submit' => true}
     ) %>
   <% end %>
-  <label><%= Alchemy.t("Language tree") %></label>
+  <label for="language_id">
+    <%= Alchemy.t("Language tree") %>
+  </label>
 </div>
 <div class="toolbar_spacer"></div>
 <% end %>


### PR DESCRIPTION
## What is this pull request for?

On the long run we want to get rid of the select2 dependency.

For now we just remove the number of select2 instance, because most selects do not need the select2 features, because the list of options is small.
