### PR TITLE
Disable Turbo on the leave overlay

### DIFF
--- a/app/views/alchemy/admin/leave.html.erb
+++ b/app/views/alchemy/admin/leave.html.erb
@@ -1,11 +1,13 @@
 <%= render_message do %>
   <%= Alchemy.t("You are about to leave Alchemy") %>
 <% end %>
-<p class="buttons">
-  <label><%= Alchemy.t("Do you want to") %></label>
-  <%= link_to Alchemy.t('stay logged in'), alchemy.root_path, class: 'button secondary' %>
-</p>
-<%= form_tag Alchemy.logout_path, method: Alchemy.logout_method, class: 'buttons' do %>
-  <label><%= Alchemy.t('or to completely') %></label>
-  <%= button_tag Alchemy.t(:logout), autofocus: true %>
-<% end %>
+<div data-turbo="false">
+  <p class="buttons">
+    <label><%= Alchemy.t("Do you want to") %></label>
+    <%= link_to Alchemy.t('stay logged in'), alchemy.root_path, class: 'button secondary' %>
+  </p>
+  <%= form_tag Alchemy.logout_path, method: Alchemy.logout_method, class: 'buttons' do %>
+    <label><%= Alchemy.t('or to completely') %></label>
+    <%= button_tag Alchemy.t(:logout), autofocus: true %>
+  <% end %>
+</div>


### PR DESCRIPTION
## What is this pull request for?

If someone leaves the alchemy admin
either via logout or visiting the frontend,
we must not use Turbo in order the reload
the assets.
