### PR TITLE
Allow to import additional admin JS modules

### DIFF
--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -35,6 +35,13 @@
     <%= render 'alchemy/admin/partials/routes' %>
     <%= javascript_include_tag('alchemy/admin/all', 'data-turbo-track' => true) %>
     <%= javascript_importmap_tags("alchemy_admin", importmap: Alchemy.importmap) %>
+    <% if Alchemy.admin_js_imports.any? %>
+      <script type="module">
+        <% Alchemy.admin_js_imports.each do |path| %>
+          import "<%= path %>"
+        <% end %>
+      </script>
+    <% end %>
     <%= yield :javascript_includes %>
   </head>
   <%= content_tag :body, id: 'alchemy', class: alchemy_body_class do %>

--- a/lib/alchemy.rb
+++ b/lib/alchemy.rb
@@ -43,6 +43,25 @@ module Alchemy
     @_preview_sources = Array(sources)
   end
 
+  # Additional JS modules to be imported in the Alchemy admin UI
+  #
+  # Be sure to also pin the modules with +Alchemy.importmap+.
+  #
+  # == Example
+  #
+  #    Alchemy.importmap.pin "flatpickr/de",
+  #      to: "https://ga.jspm.io/npm:flatpickr@4.6.13/dist/l10n/de.js"
+  #
+  #    Alchemy.admin_js_imports << "flatpickr/de"
+  #
+  def self.admin_js_imports
+    @_admin_js_imports ||= Set.new
+  end
+
+  def self.admin_js_imports=(sources)
+    @_admin_js_imports = Set[sources]
+  end
+
   # Define page publish targets
   #
   # A publish target is a ActiveJob that gets performed

--- a/spec/views/layouts/alchemy/admin.html.erb.spec
+++ b/spec/views/layouts/alchemy/admin.html.erb.spec
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "layouts/alchemy/admin.html.erb" do
+  before do
+    view.extend Alchemy::Admin::BaseHelper
+    allow(view).to receive(:alchemy_modules).and_return([])
+    allow(view).to receive(:current_alchemy_user).and_return(DummyUser.new)
+    allow(view).to receive(:configuration).and_return({})
+  end
+
+  subject do
+    render template: "layouts/alchemy/admin"
+    rendered
+  end
+
+  context "with Alchemy.admin_js_imports" do
+    around do |example|
+      current = Alchemy.admin_js_imports
+      Alchemy.admin_js_imports << "foo"
+      example.run
+      Alchemy.admin_js_imports = current
+    end
+
+    it "renders the given javascripts module imports" do
+      expect(subject).to have_selector("script[type=\"module\"]:last-of-type", text: /import "foo"/)
+    end
+  end
+
+  context "without Alchemy.admin_js_imports" do
+    it "does not render the given javascripts module imports" do
+      expect(subject).to_not have_selector("script[type=\"module\"]:last-of-type", text: /import "foo"/)
+    end
+  end
+end


### PR DESCRIPTION
In order to be able to import additional JS modules into the Alchemy admin UI you can use this.

Be sure to also pin the modules with `Alchemy.importmap`.

## Example

    Alchemy.importmap.pin "flatpickr/de",
      to: "https://ga.jspm.io/npm:flatpickr@4.6.13/dist/l10n/de.js"

    Alchemy.admin_js_imports << "flatpickr/de"
