### PR TITLE
Fix language and site creation

### DIFF
--- a/app/controllers/alchemy/admin/languages_controller.rb
+++ b/app/controllers/alchemy/admin/languages_controller.rb
@@ -22,7 +22,7 @@ module Alchemy
         @language = Alchemy::Language.new(resource_params)
         if @language.save
           flash[:notice] = Alchemy.t("Language successfully created")
-          redirect_to alchemy.admin_pages_path(language_id: @language)
+          do_redirect_to alchemy.admin_pages_path(language_id: @language)
         else
           render :new
         end
@@ -48,7 +48,7 @@ module Alchemy
         @current_site = Alchemy::Site.current
         if @current_site.nil?
           flash[:warning] = Alchemy.t("Please create a site first.")
-          redirect_to admin_sites_path
+          do_redirect_to admin_sites_path
         end
       end
     end

--- a/app/controllers/alchemy/admin/sites_controller.rb
+++ b/app/controllers/alchemy/admin/sites_controller.rb
@@ -7,7 +7,7 @@ module Alchemy
         @site = Alchemy::Site.new(resource_params)
         if @site.save
           flash[:notice] = Alchemy.t("Please create a default language for this site.")
-          redirect_to alchemy.admin_languages_path(site_id: @site)
+          do_redirect_to alchemy.admin_languages_path(site_id: @site)
         else
           render :new
         end


### PR DESCRIPTION
## What is this pull request for?

With the switch from Turbolinks to Turbo the redirect after submitting the remote form inside the dialog stopped working. The resulting page was rendered inside the dialog instead.

Using our own `do_redirect_to` method that gracefully handles JS remote forms we can fix this.
