### PR TITLE
Use rails-ujs instead of jquery_ujs

### DIFF
--- a/app/assets/javascripts/alchemy/admin.js
+++ b/app/assets/javascripts/alchemy/admin.js
@@ -1,7 +1,6 @@
 // Alchemy CMS Sprockets Manifest
 // ------------------------------
 //= require jquery2
-//= require jquery_ujs
 //= require jquery-ui/widgets/draggable
 //= require jquery-ui/widgets/sortable
 //= require tinymce/tinymce.min

--- a/app/assets/javascripts/alchemy/alchemy.dialog.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.dialog.js.coffee
@@ -109,17 +109,23 @@ class window.Alchemy.Dialog
   # Watches ajax requests inside of dialog body and replaces the content accordingly
   watch_remote_forms: ->
     form = $('[data-remote="true"]', @dialog_body)
-    form.bind "ajax:complete", (e, xhr, status) =>
-      content_type = xhr.getResponseHeader('Content-Type')
+    form.bind "ajax:complete", () =>
       Alchemy.Buttons.enable(@dialog_body)
-      if status == 'success'
-        if content_type.match(/javascript/)
-          return
-        else
-          @dialog_body.html(xhr.responseText)
-          @init()
+      return
+    form.bind "ajax:success", (event) =>
+      xhr = event.detail[2]
+      content_type = xhr.getResponseHeader('Content-Type')
+      if content_type.match(/javascript/)
+        return
       else
-        @show_error(xhr, status)
+        @dialog_body.html(xhr.responseText)
+        @init()
+      return
+    form.bind "ajax:error", (event, b, c) =>
+      statusText = event.detail[1]
+      xhr = event.detail[2]
+      @show_error(xhr, statusText)
+      return
 
   # Displays an error message
   show_error: (xhr, status_message, $container = @dialog_body) ->

--- a/app/javascript/alchemy_admin.js
+++ b/app/javascript/alchemy_admin.js
@@ -1,4 +1,5 @@
 import "@hotwired/turbo-rails"
+import Rails from "@rails/ujs"
 
 import Buttons from "alchemy_admin/buttons"
 import GUI from "alchemy_admin/gui"
@@ -56,5 +57,7 @@ Object.assign(Alchemy, {
   Spinner,
   PagePublicationFields
 })
+
+Rails.start()
 
 $(document).on("turbo:load", Initializer)

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,6 +6,7 @@ pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "@shoelace/tab", to: "https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.9.0/cdn/components/tab/tab.js", preload: true
 pin "@shoelace/tab-group", to: "https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.9.0/cdn/components/tab-group/tab-group.js", preload: true
 pin "@shoelace/tab-panel", to: "https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.9.0/cdn/components/tab-panel/tab-panel.js", preload: true
+pin "@rails/ujs", to: "https://ga.jspm.io/npm:@rails/ujs@7.1.2/app/assets/javascripts/rails-ujs.esm.js"
 
 pin "alchemy_admin", to: "alchemy_admin.js", preload: true
 pin_all_from File.expand_path("../app/javascript/alchemy_admin", __dir__), under: "alchemy_admin"


### PR DESCRIPTION
## What is this pull request for?

Use Rails' unobstrusive scripting adapater without jQuery.

The event response of the custom "ajax:" events have changed, so we have to adopt. Otherwise it is a drop in replacement.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
