### PR TITLE
[7.0] Disable Turbolinks on menubar

### DIFF
--- a/app/views/alchemy/_menubar.html.erb
+++ b/app/views/alchemy/_menubar.html.erb
@@ -1,5 +1,5 @@
 <% if !@preview_mode && @page && can?(:edit_content, @page) %>
-  <div id="alchemy_menubar" style="display: none" data-turbo="false">
+  <div id="alchemy_menubar" style="display: none" data-turbo="false" data-turbolinks="false">
     <ul>
       <li><%= link_to Alchemy.t(:to_alchemy), alchemy.admin_dashboard_url %></li>
       <li><%= link_to Alchemy.t(:edit_page), alchemy.edit_admin_page_url(@page) %></li>


### PR DESCRIPTION
## What is this pull request for?

If a site still uses Turbolinks we need to disable it as well on the menubar. Otherwise the head part of the document will not get replaced and all the
JS and CSS from the site is still loaded in Alchemy admin.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message

