### PR TITLE
Revert "Optimize events on handler"

### DIFF
--- a/app/javascript/alchemy_admin/utils/events.js
+++ b/app/javascript/alchemy_admin/utils/events.js
@@ -1,8 +1,7 @@
 export function on(eventName, baseSelector, targetSelector, callback) {
   document.querySelectorAll(baseSelector).forEach((baseNode) => {
-    const targets = Array.from(baseNode.querySelectorAll(targetSelector))
-
     baseNode.addEventListener(eventName, (evt) => {
+      const targets = Array.from(baseNode.querySelectorAll(targetSelector))
       let currentNode = evt.target
 
       while (currentNode !== baseNode) {


### PR DESCRIPTION
The targets might not yet be present in the DOM
during initialization. Delegating to the time of
the event fixes issues with the node tree.

This reverts commit 006454a18b4776f1cd3da8c3a4e5a90e59bfc799.
