### PR TITLE
Fix menubar styling

### DIFF
--- a/app/assets/stylesheets/alchemy/menubar.scss
+++ b/app/assets/stylesheets/alchemy/menubar.scss
@@ -69,6 +69,7 @@
           $margin: 0,
           $color: $white
         );
+        display: block;
         width: 100%;
         text-decoration: none !important;
 


### PR DESCRIPTION
## What is this pull request for?

The anchor in the menubar didn't had the correct styling anymore. The button-defaults - mixin didn't adjust the display - property anymore. Therefor the display - property must be again block in the menubar.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
