### PR TITLE
Show page status inline

### DIFF
--- a/app/assets/stylesheets/alchemy/buttons.scss
+++ b/app/assets/stylesheets/alchemy/buttons.scss
@@ -100,6 +100,11 @@ input.button {
   &:focus:not(.disabled):not([disabled]) {
     @include default-focus-style;
   }
+
+  .spinner {
+    position: static;
+    transform: none;
+  }
 }
 
 button.icon_button {

--- a/app/assets/stylesheets/alchemy/sitemap.scss
+++ b/app/assets/stylesheets/alchemy/sitemap.scss
@@ -1,5 +1,6 @@
 $sitemap-url-large-width: 250px;
 $sitemap-url-xlarge-width: 350px;
+$sitemap-url-header-offset: 110px;
 
 #sort_panel {
   background: $light-gray;
@@ -177,12 +178,20 @@ $sitemap-url-xlarge-width: 350px;
   background-color: $sitemap-page-background-color;
   border-left: 1px solid $light-gray;
   float: right;
+  display: none;
+  justify-content: end;
+  width: 170px;
   height: $sitemap-line-height;
   line-height: $sitemap-line-height;
-  padding: 0 $default-padding;
 
   .page_status {
+    margin: 0 $default-margin;
     padding: 0 $default-padding;
+    white-space: nowrap;
+  }
+
+  @media screen and (min-width: $medium-screen-break-point) {
+    display: flex;
   }
 }
 
@@ -210,21 +219,27 @@ $sitemap-url-xlarge-width: 350px;
   .page_urlname {
     display: none;
     margin-left: auto;
+    padding-left: $default-padding;
 
     @media screen and (min-width: $large-screen-break-point) {
       display: block;
-      width: $sitemap-url-large-width;
+      width: $sitemap-url-large-width + $sitemap-url-header-offset;
     }
 
     @media screen and (min-width: 1440px) {
-      width: $sitemap-url-xlarge-width;
+      width: $sitemap-url-xlarge-width + $sitemap-url-header-offset;
     }
   }
 
   .page_status {
+    display: none;
     padding-left: 2 * $default-padding;
     margin-right: 190px;
     margin-left: auto;
+
+    @media screen and (min-width: $medium-screen-break-point) {
+      display: block;
+    }
 
     @media screen and (min-width: $large-screen-break-point) {
       margin-left: initial;

--- a/app/javascript/alchemy_admin/components/char_counter.js
+++ b/app/javascript/alchemy_admin/components/char_counter.js
@@ -1,7 +1,7 @@
 /**
  * Show the character counter below input fields and textareas
  */
-import { AlchemyHTMLElement } from "./alchemy_html_element"
+import { AlchemyHTMLElement } from "alchemy_admin/components/alchemy_html_element"
 import { translate } from "alchemy_admin/i18n"
 
 class CharCounter extends AlchemyHTMLElement {

--- a/app/javascript/alchemy_admin/components/datepicker.js
+++ b/app/javascript/alchemy_admin/components/datepicker.js
@@ -1,4 +1,4 @@
-import { AlchemyHTMLElement } from "./alchemy_html_element"
+import { AlchemyHTMLElement } from "alchemy_admin/components/alchemy_html_element"
 import { translate, currentLocale } from "alchemy_admin/i18n"
 import flatpickr from "flatpickr"
 

--- a/app/javascript/alchemy_admin/components/node_select.js
+++ b/app/javascript/alchemy_admin/components/node_select.js
@@ -1,4 +1,4 @@
-import { RemoteSelect } from "./remote_select"
+import { RemoteSelect } from "alchemy_admin/components/remote_select"
 
 class NodeSelect extends RemoteSelect {
   _searchQuery(term, page) {

--- a/app/javascript/alchemy_admin/components/overlay.js
+++ b/app/javascript/alchemy_admin/components/overlay.js
@@ -1,4 +1,4 @@
-import { AlchemyHTMLElement } from "./alchemy_html_element"
+import { AlchemyHTMLElement } from "alchemy_admin/components/alchemy_html_element"
 
 class Overlay extends AlchemyHTMLElement {
   static properties = {

--- a/app/javascript/alchemy_admin/components/page_select.js
+++ b/app/javascript/alchemy_admin/components/page_select.js
@@ -1,4 +1,4 @@
-import { RemoteSelect } from "./remote_select"
+import { RemoteSelect } from "alchemy_admin/components/remote_select"
 
 class PageSelect extends RemoteSelect {
   onChange(event) {

--- a/app/javascript/alchemy_admin/components/remote_select.js
+++ b/app/javascript/alchemy_admin/components/remote_select.js
@@ -1,4 +1,4 @@
-import { AlchemyHTMLElement } from "./alchemy_html_element"
+import { AlchemyHTMLElement } from "alchemy_admin/components/alchemy_html_element"
 
 export class RemoteSelect extends AlchemyHTMLElement {
   static properties = {

--- a/app/javascript/alchemy_admin/components/spinner.js
+++ b/app/javascript/alchemy_admin/components/spinner.js
@@ -1,4 +1,4 @@
-import { AlchemyHTMLElement } from "./alchemy_html_element"
+import { AlchemyHTMLElement } from "alchemy_admin/components/alchemy_html_element"
 
 class Spinner extends AlchemyHTMLElement {
   static properties = {

--- a/app/javascript/alchemy_admin/components/tinymce.js
+++ b/app/javascript/alchemy_admin/components/tinymce.js
@@ -1,4 +1,4 @@
-import { AlchemyHTMLElement } from "./alchemy_html_element"
+import { AlchemyHTMLElement } from "alchemy_admin/components/alchemy_html_element"
 import { currentLocale } from "alchemy_admin/i18n"
 
 const TOOLBAR_ROW_HEIGHT = 30

--- a/app/models/alchemy/page/page_natures.rb
+++ b/app/models/alchemy/page/page_natures.rb
@@ -62,12 +62,20 @@ module Alchemy
         }
       end
 
-      # Returns the translated status for given status type.
+      # Returns the long translated status message for given status type.
+      #
+      # @param [Symbol] status_type
+      #
+      def status_message(status_type)
+        Alchemy.t(status[status_type].to_s, scope: "page_states.#{status_type}")
+      end
+
+      # Returns the sort translated status title for given status type.
       #
       # @param [Symbol] status_type
       #
       def status_title(status_type)
-        Alchemy.t(status[status_type].to_s, scope: "page_states.#{status_type}")
+        Alchemy.t(status[status_type].to_s, scope: "page_status_titles.#{status_type}")
       end
 
       # Returns the self#page_layout definition from config/alchemy/page_layouts.yml file.

--- a/app/views/alchemy/admin/pages/_page.html.erb
+++ b/app/views/alchemy/admin/pages/_page.html.erb
@@ -123,16 +123,18 @@
       {{/if}}
     </div>
     <div class="page_infos">
+      {{#if restricted}}
       <span class="page_status">
-        <sl-tooltip content="{{status_titles.public}}" class="like-hint-tooltip" placement="bottom-start">
-          <i class="icon ri-fw ri-1x ri-cloud{{#unless public}}-off{{/unless}}-line {{#if public}}disabled{{/if}}"></i>
-        </sl-tooltip>
+        <i class="icon ri-fw ri-1x ri-lock-line"></i>
+        {{status_titles.restricted}}
       </span>
+      {{/if}}
+      {{#unless public}}
       <span class="page_status">
-        <sl-tooltip content="{{status_titles.restricted}}" class="like-hint-tooltip" placement="bottom-start">
-          <i class="icon ri-fw ri-1x ri-lock{{#unless restricted}}-unlock{{/unless}}-line {{#unless restricted}}disabled{{/unless}}"></i>
-        </sl-tooltip>
+        <i class="icon ri-fw ri-1x ri-cloud-off-line"></i>
+        {{status_titles.public}}
       </span>
+      {{/unless}}
     </div>
     <div class="sitemap_url" title="{{url_path}}">
       {{ url_path }}

--- a/app/views/alchemy/admin/pages/_page_status.html.erb
+++ b/app/views/alchemy/admin/pages/_page_status.html.erb
@@ -1,18 +1,14 @@
 <span class="page_status">
-  <sl-tooltip content="<%= page.status_title(:public) %>" placement="bottom" class="like-hint-tooltip">
-    <% if page.public? %>
-      <%= render_icon(:cloud, size: "1x", class: "disabled") %>
-    <% else %>
-      <%= render_icon("cloud-off", size: "1x") %>
-    <% end %>
-  </sl-tooltip>
+  <% if page.public? %>
+    <%= render_icon(:cloud, size: "1x", class: "disabled") %>
+  <% else %>
+    <%= render_icon("cloud-off", size: "1x") %>
+  <% end %>
 </span>
 <span class="page_status">
-  <sl-tooltip content="<%= page.status_title(:restricted) %>" placement="bottom" class="like-hint-tooltip">
-    <% if page.restricted? %>
-      <%= render_icon(:lock, size: "1x") %>
-    <% else %>
-      <%= render_icon("lock-unlock", size: "1x", class: "disabled") %>
-    <% end %>
-  </sl-tooltip>
+  <% if page.restricted? %>
+    <%= render_icon(:lock, size: "1x") %>
+  <% else %>
+    <%= render_icon("lock-unlock", size: "1x", class: "disabled") %>
+  <% end %>
 </span>

--- a/app/views/alchemy/admin/pages/_table.html.erb
+++ b/app/views/alchemy/admin/pages/_table.html.erb
@@ -17,7 +17,7 @@
           Alchemy::Page.human_attribute_name(:updated_at),
           default_order: "desc" %>
       </th>
-      <th class="status center"><%= Alchemy::Page.human_attribute_name(:status) %></th>
+      <th class="status right"><%= Alchemy::Page.human_attribute_name(:status) %></th>
       <th class="tools"></th>
     </tr>
   </thead>

--- a/app/views/alchemy/admin/pages/_table_row.html.erb
+++ b/app/views/alchemy/admin/pages/_table_row.html.erb
@@ -36,8 +36,19 @@
   <td class="date">
     <%= l(page.updated_at, format: :"alchemy.default") %>
   </td>
-  <td class="status center">
-    <%= render "alchemy/admin/pages/page_status", page: page %>
+  <td class="status right">
+    <% if page.restricted? %>
+      <span class="page_status">
+        <%= render_icon(:lock, size: "1x") %>
+        <%= page.status_title(:restricted) %>
+      </span>
+    <% end %>
+    <% unless page.public? %>
+      <span class="page_status">
+        <%= render_icon("cloud-off", size: "1x") %>
+        <%= page.status_title(:public) %>
+      </span>
+    <% end %>
   </td>
   <td class="tools">
     <% if can?(:info, page) %>

--- a/app/views/alchemy/admin/pages/_toolbar.html.erb
+++ b/app/views/alchemy/admin/pages/_toolbar.html.erb
@@ -5,12 +5,12 @@
     icon: "file-add",
     url: alchemy.new_admin_page_path(language: @current_language),
     hotkey: 'alt+n',
+    tooltip_placement: "top-start",
     dialog_options: {
       title: Alchemy.t('Add a page'),
       size: '340x215',
       overflow: true
     },
-    title: Alchemy.t('Add a page'),
     label: Alchemy.t('Add a page'),
     if_permitted_to: [:create, Alchemy::Page]
   ) %>

--- a/app/views/alchemy/admin/pages/info.html.erb
+++ b/app/views/alchemy/admin/pages/info.html.erb
@@ -22,19 +22,19 @@
     <p>
       <span class="page_status">
         <% if @page.public? %>
-          <%= render_icon(:cloud, size: "1x", class: "disabled") %>
+          <%= render_icon(:cloud, size: "1x") %>
         <% else %>
           <%= render_icon("cloud-off", size: "1x") %>
         <% end %>
-        <%= @page.status_title(:public) %>
+        <%= @page.status_message(:public) %>
       </span>
       <span class="page_status">
         <% if @page.restricted? %>
           <%= render_icon(:lock, size: "1x") %>
         <% else %>
-          <%= render_icon("lock-unlock", size: "1x", class: "disabled") %>
+          <%= render_icon("lock-unlock", size: "1x") %>
         <% end %>
-        <%= @page.status_title(:restricted) %>
+        <%= @page.status_message(:restricted) %>
       </span>
     </p>
   </div>

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -527,19 +527,27 @@ en:
     "Page created": "Page: '%{name}' created."
     page_infos: "Page info"
     page_properties: "Page properties"
-    page_public: "published"
     page_published: "Published page"
-    page_restricted: "restricted"
     page_states:
       public:
-        "true": "Page is published."
-        "false": "Page is unpublished."
+        "true": "Page is available online."
+        "false": "Page is unavailable for website visitors."
       locked:
         "true": "Page is being edited at the moment."
         "false": ""
       restricted:
-        "true": "Page is restricted."
-        "false": "Page is not restricted."
+        "true": "Page is only accessible by members."
+        "false": "Page is accessible by all visitors."
+    page_status_titles:
+      public:
+        "true": "online"
+        "false": "offline"
+      locked:
+        "true": "locked"
+        "false": ""
+      restricted:
+        "true": "restricted"
+        "false": "accessible"
     page_status: "Status"
     page_title: "Title"
     page_type: "Type"

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1683,7 +1683,7 @@ module Alchemy
 
       describe "#status_title" do
         it "returns a translated status string for public status" do
-          expect(page.status_title(:public)).to eq("Page is published.")
+          expect(page.status_title(:public)).to eq("online")
         end
 
         it "returns a translated status string for locked status" do
@@ -1691,7 +1691,21 @@ module Alchemy
         end
 
         it "returns a translated status string for restricted status" do
-          expect(page.status_title(:restricted)).to eq("Page is not restricted.")
+          expect(page.status_title(:restricted)).to eq("accessible")
+        end
+      end
+
+      describe "#status_message" do
+        it "returns a translated status string for public status" do
+          expect(page.status_message(:public)).to eq("Page is available online.")
+        end
+
+        it "returns a translated status string for locked status" do
+          expect(page.status_message(:locked)).to eq("")
+        end
+
+        it "returns a translated status string for restricted status" do
+          expect(page.status_message(:restricted)).to eq("Page is accessible by all visitors.")
         end
       end
     end


### PR DESCRIPTION
## What is this pull request for?

This makes it more clear that these icons are status icons and not buttons. Also we only show them if a page has not the default state (online and not restricted) in order to unclutter the screen from obvious information.

### Screenshots

<img width="" alt="page info inline" src="https://github.com/AlchemyCMS/alchemy_cms/assets/42868/829a60f2-580f-4e07-a8e4-c695dc1c7f4a">

![Screen Shot 2023-12-12 at 15 53 08](https://github.com/AlchemyCMS/alchemy_cms/assets/42868/2d9438b3-86e2-4c96-9f6a-d4d515f752d6)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
