### PR TITLE
Show page locked status in page status

### DIFF
--- a/app/assets/javascripts/alchemy/templates/page_folder.hbs
+++ b/app/assets/javascripts/alchemy/templates/page_folder.hbs
@@ -1,3 +1,3 @@
-<a class="page_folder" data-page-id="{{ page.id }}">
-  <i class="ri-arrow-{{#if page.folded }}right{{else}}down{{/if}}-s-line ri-fw"></i>
+<a class="page_folder icon_button" data-page-id="{{ page.id }}">
+  <i class="icon ri-arrow-{{#if page.folded }}right{{else}}down{{/if}}-s-line ri-fw"></i>
 </a>

--- a/app/serializers/alchemy/page_tree_serializer.rb
+++ b/app/serializers/alchemy/page_tree_serializer.rb
@@ -105,7 +105,8 @@ module Alchemy
     def page_status_titles(page)
       {
         public: page.status_title(:public),
-        restricted: page.status_title(:restricted)
+        restricted: page.status_title(:restricted),
+        locked: page.status_title(:locked)
       }
     end
   end

--- a/app/views/alchemy/admin/pages/_page.html.erb
+++ b/app/views/alchemy/admin/pages/_page.html.erb
@@ -123,6 +123,12 @@
       {{/if}}
     </div>
     <div class="page_infos">
+      {{#if locked}}
+      <span class="page_status">
+        <i class="icon ri-fw ri-1x ri-edit-line"></i>
+        {{status_titles.locked}}
+      </span>
+      {{/if}}
       {{#if restricted}}
       <span class="page_status">
         <i class="icon ri-fw ri-1x ri-lock-line"></i>

--- a/app/views/alchemy/admin/pages/_page.html.erb
+++ b/app/views/alchemy/admin/pages/_page.html.erb
@@ -6,15 +6,15 @@
         <%= page_layout_missing_warning %>
       {{else}}
         {{#if permissions.edit_content}}
-          {{#if locked}}
-            <sl-tooltip content="{{locked_notice}}" class="like-hint-tooltip" placement="bottom-start">
-              <i class="icon ri-file-edit-fill ri-fw ri-xl"></i>
-            </sl-tooltip>
-          {{else}}
           <span class="{{#unless root}}handle{{/unless}}">
-            <i class="icon ri-file-line ri-fw ri-xl"></i>
+            {{#if locked}}
+              <sl-tooltip content="{{locked_notice}}" class="like-hint-tooltip" placement="bottom-start">
+                <i class="icon ri-file-edit-line ri-fw ri-xl"></i>
+              </sl-tooltip>
+            {{else}}
+              <i class="icon ri-file-line ri-fw ri-xl"></i>
+            {{/if}}
           </span>
-          {{/if}}
         {{else}}
           <sl-tooltip content="<%= Alchemy.t("Your user role does not allow you to edit this page") %>" class="like-hint-tooltip" placement="bottom-start">
             <i class="icon ri-file-forbid-line ri-fw ri-xl"></i>

--- a/app/views/alchemy/admin/pages/_table_row.html.erb
+++ b/app/views/alchemy/admin/pages/_table_row.html.erb
@@ -3,7 +3,7 @@
     <% if can?(:edit_content, page) %>
       <% if page.locked? %>
         <sl-tooltip class="like-hint-tooltip" content="<%= Alchemy.t("This page is locked", name: page.locker_name) %>" placement="bottom-start">
-          <i class="icon ri-file-edit-fill ri-fw ri-xl"></i>
+          <i class="icon ri-file-edit-line ri-fw ri-xl"></i>
         </sl-tooltip>
       <% else %>
         <i class="icon ri-file-line ri-fw ri-xl"></i>
@@ -37,6 +37,12 @@
     <%= l(page.updated_at, format: :"alchemy.default") %>
   </td>
   <td class="status right">
+    <% if page.locked? %>
+      <span class="page_status">
+        <%= render_icon(:edit, size: "1x") %>
+        <%= page.status_title(:locked) %>
+      </span>
+    <% end %>
     <% if page.restricted? %>
       <span class="page_status">
         <%= render_icon(:lock, size: "1x") %>

--- a/app/views/alchemy/admin/pages/info.html.erb
+++ b/app/views/alchemy/admin/pages/info.html.erb
@@ -20,6 +20,13 @@
   <div class="value">
     <label><%= Alchemy.t(:page_status) %></label>
     <p>
+      <% if @page.locked? %>
+        <span class="page_status">
+          <%= render_icon(:edit, size: "1x") %>
+          <%= Alchemy.t(:currently_edited_by) %>
+          <%= @page.locker_name %>
+        </span>
+      <% end %>
       <span class="page_status">
         <% if @page.public? %>
           <%= render_icon(:cloud, size: "1x") %>
@@ -46,10 +53,4 @@
     <label><%= Alchemy.t(:page_was_updated) %></label>
     <p><%= Alchemy.t(:from_at) % {by: @page.updater_name, at: l(@page.updated_at, format: :'alchemy.page_status')} %></p>
   </div>
-  <% if @page.locked? %>
-  <div class="value">
-    <label><%= Alchemy.t(:currently_edited_by) %></label>
-    <p><%= @page.locker_name %></p>
-  </div>
-  <% end %>
 </div>


### PR DESCRIPTION
## What is this pull request for?

To make this more accessible and obvious in what state a locked
page is, we show this state as well.

Also we allow to drag locked pages, because this does not effect page content.

### Screenshots

![Screen Shot 2023-12-14 at 09 58 57](https://github.com/AlchemyCMS/alchemy_cms/assets/42868/e2fd9d57-8152-4b3b-aaf3-68ad0f0d5f04)
![Screen Shot 2023-12-14 at 09 58 51](https://github.com/AlchemyCMS/alchemy_cms/assets/42868/5412a323-343b-49d8-b6bd-c5250831a2f8)


## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
