### PR TITLE
Visually highlight droppable areas

### DIFF
--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -231,8 +231,9 @@ alchemy-tinymce {
   }
 
   &.dragged {
-    border: 1px dashed var(--color-blue_light);
-    background-color: var(--color-blue_very_light);
+    border: 1px solid var(--color-grey_dark);
+    background-color: var(--color-grey_medium);
+    opacity: 0.5;
     box-shadow: none !important;
 
     &:not(.compact) {
@@ -924,9 +925,18 @@ textarea.has_tinymce {
   display: flex;
   flex-wrap: wrap;
 
+  &.droppable-elements {
+    border-radius: var(--border-radius_medium);
+  }
+
   .element-editor {
     position: relative;
   }
+}
+
+.droppable-elements {
+  min-height: 36px;
+  background-color: var(--color-yellow_light);
 }
 
 .ingredient-date--label,

--- a/app/javascript/alchemy_admin/sortable_elements.js
+++ b/app/javascript/alchemy_admin/sortable_elements.js
@@ -44,7 +44,7 @@ function onEnd() {
   )
 }
 
-function createSortable(element) {
+function createSortable(element, options = {}) {
   const group = {
     name: element.dataset.elementName,
     put(to, _from, item) {
@@ -55,6 +55,7 @@ function createSortable(element) {
   }
   new Sortable(element, {
     ...SORTABLE_OPTIONS,
+    ...options,
     onStart,
     onSort,
     onEnd,
@@ -66,7 +67,9 @@ export default function SortableElements(selector) {
   if (selector == null) {
     selector = "#element_area .sortable-elements"
   }
-  const sortable_areas = document.querySelectorAll(selector)
+  const sortable_areas = document.querySelectorAll(selector, {
+    direction: "vertical"
+  })
 
   sortable_areas.forEach((element) => {
     createSortable(element)

--- a/app/javascript/alchemy_admin/sortable_elements.js
+++ b/app/javascript/alchemy_admin/sortable_elements.js
@@ -10,6 +10,13 @@ const SORTABLE_OPTIONS = {
   easing: "cubic-bezier(1, 0, 0, 1)"
 }
 
+function onStart(event) {
+  const name = event.item.dataset.elementName
+  document
+    .querySelectorAll(`[data-droppable-elements~="${name}"]`)
+    .forEach((dropzone) => dropzone.classList.add("droppable-elements"))
+}
+
 function onSort(event) {
   const item = event.item
   const parentElement = event.to.parentElement.closest(".element-editor")
@@ -30,6 +37,13 @@ function onSort(event) {
   })
 }
 
+function onEnd() {
+  const dropzones = document.querySelectorAll("[data-droppable-elements]")
+  dropzones.forEach((dropzone) =>
+    dropzone.classList.remove("droppable-elements")
+  )
+}
+
 function createSortable(element) {
   const group = {
     name: element.dataset.elementName,
@@ -41,7 +55,9 @@ function createSortable(element) {
   }
   new Sortable(element, {
     ...SORTABLE_OPTIONS,
+    onStart,
     onSort,
+    onEnd,
     group
   })
 }


### PR DESCRIPTION
## What is this pull request for?

To make it obvious where an element can be dropped to we highlight the areas.

### Screenshots

<img width="" alt="" src="https://github.com/AlchemyCMS/alchemy_cms/assets/42868/a3e5cf5a-0fe0-4771-a065-1d63986c9976">


## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
