### PR TITLE
Fix humanization for add nested element button

### DIFF
--- a/app/views/alchemy/admin/elements/_add_nested_element_form.html.erb
+++ b/app/views/alchemy/admin/elements/_add_nested_element_form.html.erb
@@ -9,11 +9,11 @@
       <%= f.hidden_field :page_version_id, value: element.page_version_id %>
       <%= f.hidden_field :parent_element_id, value: element.id %>
       <button class="add-nestable-element-button" is="alchemy-button">
-        <%= Alchemy.t(:add_nested_element, name: Alchemy.t(nestable_element, scope: 'element_names')) %>
+        <%= Alchemy.t(:add_nested_element, name: Alchemy.t(nestable_element.to_sym, scope: 'element_names')) %>
       </button>
     <% end %>
   <% else %>
-    <%= link_to_dialog (nestable_element ? Alchemy.t(:add_nested_element, name: Alchemy.t(nestable_element, scope: 'element_names')) : Alchemy.t("New Element")),
+    <%= link_to_dialog (nestable_element ? Alchemy.t(:add_nested_element, name: Alchemy.t(nestable_element.to_sym, scope: 'element_names')) : Alchemy.t("New Element")),
       alchemy.new_admin_element_path(
         parent_element_id: element.id,
         page_version_id: element.page_version_id


### PR DESCRIPTION
## What is this pull request for?
Add new element button is not translated properly for nested elements.

Converting `nestable_element` to a symbol allows us to humanize the nestable element name if a locale translation does not exist, given the i18n helper. See [humanize_default_string function](https://github.com/AlchemyCMS/alchemy_cms/blob/10fb0e4d986c465fbbe5319277666d3aecce9d1c/lib/alchemy/i18n.rb#L76C1-L80C10).


### Screenshots
Before:
![Screenshot from 2023-12-19 10-55-59](https://github.com/AlchemyCMS/alchemy_cms/assets/110138549/2b77ca72-c42e-473b-a51e-49a742bbb6d1)

After:
![Screenshot from 2023-12-20 15-41-00](https://github.com/AlchemyCMS/alchemy_cms/assets/110138549/eb15267d-2141-45db-99e1-eebe5f821df2)


## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change

