### PR TITLE
[7.0] Fix humanization for add nested element button

### DIFF
--- a/app/controllers/alchemy/admin/resources_controller.rb
+++ b/app/controllers/alchemy/admin/resources_controller.rb
@@ -34,16 +34,16 @@ module Alchemy
         respond_to do |format|
           format.html do
             items = items.page(params[:page] || 1).per(items_per_page)
-            instance_variable_set("@#{resource_handler.resources_name}", items)
+            instance_variable_set(:"@#{resource_handler.resources_name}", items)
           end
           format.csv do
-            instance_variable_set("@#{resource_handler.resources_name}", items)
+            instance_variable_set(:"@#{resource_handler.resources_name}", items)
           end
         end
       end
 
       def new
-        instance_variable_set("@#{resource_handler.resource_name}", resource_handler.model.new)
+        instance_variable_set(:"@#{resource_handler.resource_name}", resource_handler.model.new)
       end
 
       def show
@@ -54,7 +54,7 @@ module Alchemy
       end
 
       def create
-        instance_variable_set("@#{resource_handler.resource_name}", resource_handler.model.new(resource_params))
+        instance_variable_set(:"@#{resource_handler.resource_name}", resource_handler.model.new(resource_params))
         resource_instance_variable.save
         render_errors_or_redirect(
           resource_instance_variable,
@@ -169,7 +169,7 @@ module Alchemy
       end
 
       def load_resource
-        instance_variable_set("@#{resource_handler.resource_name}", resource_handler.model.find(params[:id]))
+        instance_variable_set(:"@#{resource_handler.resource_name}", resource_handler.model.find(params[:id]))
       end
 
       def authorize_resource

--- a/app/models/alchemy/element/element_ingredients.rb
+++ b/app/models/alchemy/element/element_ingredients.rb
@@ -158,8 +158,8 @@ module Alchemy
               "#{name}.#{role}.#{error}",
               scope: "ingredient_validations",
               default: [
-                "fields.#{role}.#{error}".to_sym,
-                "errors.#{error}".to_sym
+                :"fields.#{role}.#{error}",
+                :"errors.#{error}"
               ],
               field: Alchemy::Ingredient.translated_label_for(role, name)
             )

--- a/app/models/alchemy/ingredient.rb
+++ b/app/models/alchemy/ingredient.rb
@@ -45,14 +45,14 @@ module Alchemy
       # @param [String] The class name of the related object
       def related_object_alias(name, class_name:)
         alias_method name, :related_object
-        alias_method "#{name}=", :related_object=
+        alias_method :"#{name}=", :related_object=
 
         # Somehow Rails STI does not allow us to use `alias_method` for the related_object_id
-        define_method "#{name}_id" do
+        define_method :"#{name}_id" do
           related_object_id
         end
 
-        define_method "#{name}_id=" do |id|
+        define_method :"#{name}_id=" do |id|
           self.related_object_id = id
           self.related_object_type = class_name
         end

--- a/app/models/alchemy/ingredient_validator.rb
+++ b/app/models/alchemy/ingredient_validator.rb
@@ -51,10 +51,10 @@ module Alchemy
       validations.each do |validation|
         if validation.respond_to?(:keys)
           validation.map do |key, value|
-            send("validate_#{key}", value)
+            send(:"validate_#{key}", value)
           end
         else
-          send("validate_#{validation}")
+          send(:"validate_#{validation}")
         end
       end
     end

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -581,7 +581,7 @@ module Alchemy
 
     def set_fixed_attributes
       fixed_attributes.all.each do |attribute, value|
-        send("#{attribute}=", value)
+        send(:"#{attribute}=", value)
       end
     end
 

--- a/app/models/concerns/alchemy/picture_thumbnails.rb
+++ b/app/models/concerns/alchemy/picture_thumbnails.rb
@@ -168,7 +168,7 @@ module Alchemy
     def fix_crop_values
       %i[crop_from crop_size].each do |crop_value|
         if public_send(crop_value).is_a?(String)
-          public_send("#{crop_value}=", normalize_crop_value(crop_value))
+          public_send(:"#{crop_value}=", normalize_crop_value(crop_value))
         end
       end
     end

--- a/app/views/alchemy/admin/elements/_add_nested_element_form.html.erb
+++ b/app/views/alchemy/admin/elements/_add_nested_element_form.html.erb
@@ -1,7 +1,7 @@
 <%= content_tag :div, class: 'add-nested-element', data: { element_id: element.id } do %>
   <% if element.expanded? || element.fixed? %>
-    <% if element.nestable_elements.length == 1 && 
-      (nestable_element = element.nestable_elements.first) && 
+    <% if element.nestable_elements.length == 1 &&
+      (nestable_element = element.nestable_elements.first) &&
       Alchemy::Element.all_from_clipboard_for_parent_element(get_clipboard("elements"), element).none?
     %>
       <%= form_for [:admin, Alchemy::Element.new(name: nestable_element)],
@@ -10,11 +10,11 @@
         <%= f.hidden_field :page_version_id, value: element.page_version_id %>
         <%= f.hidden_field :parent_element_id, value: element.id %>
         <button class="button add-nestable-element-button" data-alchemy-button>
-          <%= Alchemy.t(:add_nested_element, name: Alchemy.t(nestable_element, scope: 'element_names')) %>
+          <%= Alchemy.t(:add_nested_element, name: Alchemy.t(nestable_element.to_sym, scope: 'element_names')) %>
         </button>
       <% end %>
     <% else %>
-      <%= link_to_dialog (nestable_element ? Alchemy.t(:add_nested_element, name: Alchemy.t(nestable_element, scope: 'element_names')) : Alchemy.t("New Element")),
+      <%= link_to_dialog (nestable_element ? Alchemy.t(:add_nested_element, name: Alchemy.t(nestable_element.to_sym, scope: 'element_names')) : Alchemy.t("New Element")),
         alchemy.new_admin_element_path(
           parent_element_id: element.id,
           page_version_id: element.page_version_id

--- a/lib/alchemy/resource.rb
+++ b/lib/alchemy/resource.rb
@@ -108,7 +108,7 @@ module Alchemy
     def initialize(controller_path, module_definition = nil, custom_model = nil)
       @controller_path = controller_path
       @module_definition = module_definition
-      @model = (custom_model || guess_model_from_controller_path)
+      @model = custom_model || guess_model_from_controller_path
       if model.respond_to?(:alchemy_resource_relations)
         if !model.respond_to?(:reflect_on_all_associations)
           raise MissingActiveRecordAssociation
@@ -320,7 +320,7 @@ module Alchemy
       model.alchemy_resource_relations.each do |name, options|
         relation_name = name.to_s.gsub(/_id$/, "") # ensure that we don't have an id
         association = association_from_relation_name(relation_name)
-        foreign_key = association.options[:foreign_key] || "#{association.name}_id".to_sym
+        foreign_key = association.options[:foreign_key] || :"#{association.name}_id"
         collection = options[:collection] || resource_relation_class(association).all
         resource_relations[foreign_key] = options.merge(
           model_association: association,

--- a/lib/alchemy/resources_helper.rb
+++ b/lib/alchemy/resources_helper.rb
@@ -14,11 +14,11 @@ module Alchemy
     end
 
     def resource_instance_variable
-      instance_variable_get("@#{resource_handler.resource_name}")
+      instance_variable_get(:"@#{resource_handler.resource_name}")
     end
 
     def resources_instance_variable
-      instance_variable_get("@#{resource_handler.resources_name}")
+      instance_variable_get(:"@#{resource_handler.resources_name}")
     end
 
     def resource_url_proxy
@@ -46,7 +46,7 @@ module Alchemy
     end
 
     def edit_resource_path(resource = nil, options = {})
-      path_segments = (resource_scope + [resource] || resource_handler.resource_array)
+      path_segments = resource_scope + [resource] || resource_handler.resource_array
       edit_polymorphic_path path_segments, options
     end
 

--- a/spec/features/admin/edit_elements_feature_spec.rb
+++ b/spec/features/admin/edit_elements_feature_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "The edit elements feature", type: :system do
       scenario "the add button opens add element form with the clipboard tab" do
         visit alchemy.admin_elements_path(page_version_id: element.page_version_id)
         button = page.find(".add-nestable-element-button")
-        expect(button).to have_content "Add slide"
+        expect(button).to have_content "Add Slide"
         button.click
         expect(page).to have_select("Element")
         expect(page).to have_link("Paste from clipboard")
@@ -76,7 +76,7 @@ RSpec.describe "The edit elements feature", type: :system do
       scenario "the add element button immediately creates the nested element." do
         visit alchemy.admin_elements_path(page_version_id: element.page_version_id)
         button = page.find("button.add-nestable-element-button")
-        expect(button).to have_content "Add slide"
+        expect(button).to have_content "Add Slide"
         button.click
         expect(page).to have_selector(".element-editor[data-element-name='slide']")
       end

--- a/spec/features/admin/node_select_feature_spec.rb
+++ b/spec/features/admin/node_select_feature_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe "Node select", type: :system, js: true do
 
   %w[english klingon].each do |language|
     context language do
-      let(:element) { send "#{language}_element" }
-      let(:node) { send "#{language}_node" }
+      let(:element) { send :"#{language}_element" }
+      let(:node) { send :"#{language}_node" }
 
       it "restricts to the site/language of the page the element is on" do
         visit alchemy.admin_elements_path(page_version_id: element.page_version_id)


### PR DESCRIPTION
Backports #2654 to 7.0-stable

Converting `nestable_element` to a symbol allows us to humanize the nestable element name.

(cherry picked from commit 1281ae795899cafe39de9db6823b1da3c23aaa65)
