### PR TITLE
Do not remove background from non transparent images

### DIFF
--- a/app/models/alchemy/picture_variant.rb
+++ b/app/models/alchemy/picture_variant.rb
@@ -14,6 +14,7 @@ module Alchemy
     include Alchemy::Picture::Transformations
 
     ANIMATED_IMAGE_FORMATS = %w[gif webp]
+    TRANSPARENT_IMAGE_FORMATS = %w[gif webp png]
 
     attr_reader :picture, :render_format
 
@@ -100,7 +101,9 @@ module Alchemy
       end
 
       if options[:flatten]
-        encoding_options << "-background transparent" if render_format == "png"
+        if render_format.in?(TRANSPARENT_IMAGE_FORMATS) && picture.image_file_format.in?(TRANSPARENT_IMAGE_FORMATS)
+          encoding_options << "-background transparent"
+        end
         encoding_options << "-flatten"
       end
 

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -118,7 +118,9 @@ en:
             gif: GIF Image
             jpeg: JPG Image
             png: PNG Image
+            svg: SVG Image
             tiff: TIFF Image
+            webp: WebP Image
         misc:
           name: Miscellaneous
           values:

--- a/spec/models/alchemy/picture_variant_spec.rb
+++ b/spec/models/alchemy/picture_variant_spec.rb
@@ -181,6 +181,37 @@ RSpec.describe Alchemy::PictureVariant do
         expect(step.arguments).to eq(["png", "-background transparent -flatten"])
       end
 
+      context "converted to non transparent format" do
+        let(:options) do
+          {format: "jpg"}
+        end
+
+        it "does not add transparent background." do
+          step = subject.steps[0]
+          expect(step.name).to eq(:encode)
+          expect(step.arguments).to eq(["jpg", "-quality 85 -flatten"])
+        end
+      end
+
+      context "converted from non transparent format" do
+        let(:options) do
+          {format: "png", flatten: true}
+        end
+
+        let(:image_file) do
+          fixture_file_upload(
+            File.expand_path("../../fixtures/image4.jpg", __dir__),
+            "image/jpeg"
+          )
+        end
+
+        it "does not add transparent background." do
+          step = subject.steps[0]
+          expect(step.name).to eq(:encode)
+          expect(step.arguments).to eq(["png", "-flatten"])
+        end
+      end
+
       context "converted to webp" do
         let(:options) do
           {format: "webp"}


### PR DESCRIPTION
## What is this pull request for?

We only need to remove the background while flatting an
image if the original and the target image are transparent.

Also adds two missing image format translations for webp and svg

## Checklist

- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
