### PR TITLE
Fix error linking text in tinymce

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.link_dialog.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.link_dialog.js.coffee
@@ -154,7 +154,7 @@ class window.Alchemy.LinkDialog extends Alchemy.Dialog
       @$link = $(@link_object.node)
       @link_object.selection.moveToBookmark(@link_object.bookmark)
     # Creating an temporary anchor node if we are linking an Picture Ingredient.
-    else if @link_object.getAttribute("is") == "alchemy-link-button"
+    else if @link_object.getAttribute && @link_object.getAttribute("is") == "alchemy-link-button"
       @$link = $(@createTempLink())
     else
       return false


### PR DESCRIPTION
## What is this pull request for?

When the text does not have a link yet and also is a object from tinymce editor it does not have the getAttribute function. We can simply check for its existance.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
