### PR TITLE
Clear unnecessary legacy URLs

### DIFF
--- a/app/models/alchemy/page/page_naming.rb
+++ b/app/models/alchemy/page/page_naming.rb
@@ -25,6 +25,8 @@ module Alchemy
         after_update :update_descendants_urlnames,
           if: :saved_change_to_urlname?
 
+        before_save :destroy_obsolete_legacy_urls, if: :renamed?
+
         after_move :update_urlname!
       end
 
@@ -53,6 +55,11 @@ module Alchemy
       def update_descendants_urlnames
         reload
         descendants.each(&:update_urlname!)
+      end
+
+      def destroy_obsolete_legacy_urls
+        obsolete_legacy_urls = legacy_urls.select { |legacy_url| legacy_url.urlname == urlname }
+        legacy_urls.destroy(obsolete_legacy_urls)
       end
 
       # Sets the urlname to a url friendly slug.

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1689,6 +1689,18 @@ module Alchemy
           expect(page.legacy_urls.pluck(:urlname)).to include("parentparent/parent/page")
         end
       end
+
+      context "if new urlname exists as a legacy url" do
+        it "will delete obsolete legacy_urls" do
+          expect(page.urlname).to eq("parentparent/parent/page")
+          page.update!(urlname: "other-name")
+          expect(page.legacy_urls.pluck(:urlname)).to include("parentparent/parent/page")
+          page.update!(urlname: "page")
+          expect(page.legacy_urls.pluck(:urlname)).to include("parentparent/parent/other-name")
+          expect(page.urlname).to eq("parentparent/parent/page")
+          expect(page.legacy_urls.pluck(:urlname)).not_to include("parentparent/parent/page")
+        end
+      end
     end
 
     describe "#update_node!" do


### PR DESCRIPTION

## What is this pull request for?

When renaming a page back to a URL it used to have, we get a legacy URL that is the same as the current URL of the page, which can lead to infinite redirects. This deletes any legacy URLs that are the same as the current URL name in a callback.


## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
