### PR TITLE
Fix sizing of tinymce textarea

### DIFF
--- a/app/assets/stylesheets/tinymce/skins/ui/alchemy/skin.min.scss
+++ b/app/assets/stylesheets/tinymce/skins/ui/alchemy/skin.min.scss
@@ -2229,6 +2229,11 @@ body.tox-dialog__disable-scroll {
   -ms-flex-preferred-size: auto;
 }
 
+.tox .tox-form__group--stretched .tox-textarea-wrap {
+  display: flex;
+  flex: 1;
+}
+
 .tox .tox-form__group--stretched .tox-textarea {
   flex: 1;
   -ms-flex-preferred-size: auto;


### PR DESCRIPTION
## What is this pull request for?

Used ie. in the sourcecode view.

### Screenshots

<img width="629" alt="Monosnap 2024-01-09 14-35-21" src="https://github.com/AlchemyCMS/alchemy_cms/assets/42868/3cece6c0-fe90-458b-8ad8-75bcd1fff389">
<img width="674" alt="Monosnap 2024-01-09 14-35-05" src="https://github.com/AlchemyCMS/alchemy_cms/assets/42868/1504f7f8-e19b-4c7d-a3aa-4b8746787622">


## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
