### PR TITLE
Add support for legacy icon styles

### DIFF
--- a/app/helpers/alchemy/base_helper.rb
+++ b/app/helpers/alchemy/base_helper.rb
@@ -28,7 +28,7 @@ module Alchemy
     # @return [String]
     def render_icon(icon_name, options = {})
       options = {style: "line", fixed_width: true}.merge(options)
-      style = options[:style] && "-#{options[:style]}"
+      style = options[:style] && "-#{ri_style(options[:style])}"
       classes = [
         "icon",
         "ri-#{ri_icon(icon_name)}#{style}",
@@ -132,6 +132,21 @@ module Alchemy
         "settings-3"
       else
         icon_name
+      end
+    end
+
+    # Returns the Remix icon style for given style
+    #
+    # @param style [String] The style name
+    # @return [String] The RemixIcon style
+    def ri_style(style)
+      case style.to_s
+      when "solid", "fill"
+        "fill"
+      when "line", "regular"
+        "line"
+      else
+        style
       end
     end
   end

--- a/spec/helpers/alchemy/base_helper_spec.rb
+++ b/spec/helpers/alchemy/base_helper_spec.rb
@@ -9,7 +9,7 @@ module Alchemy
 
       let(:options) { {} }
 
-      it "renders a solid remix icon with fixed width and line style" do
+      it "renders a remix icon with fixed width and line style" do
         is_expected.to have_css "i.icon.ri-information-line.ri-fw"
       end
 
@@ -18,6 +18,30 @@ module Alchemy
 
         it "renders a filled remix icon" do
           is_expected.to have_css 'i[class*="-fill"]'
+        end
+      end
+
+      context "with style set to solid" do
+        let(:options) { {style: "solid"} }
+
+        it "renders a filled remix icon" do
+          is_expected.to have_css 'i[class*="-fill"]'
+        end
+      end
+
+      context "with style set to regular" do
+        let(:options) { {style: "regular"} }
+
+        it "renders a line remix icon" do
+          is_expected.to have_css 'i[class*="-line"]'
+        end
+      end
+
+      context "with style set to m" do
+        let(:options) { {style: "m"} }
+
+        it "renders a line remix icon" do
+          is_expected.to have_css 'i[class*="-m"]'
         end
       end
 


### PR DESCRIPTION
## What is this pull request for?

If a module or extension uses old fontawesome icon styles it now returns the correct style class for remixicons.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
