### PR TITLE
Add richtext input type for form builder

### DIFF
--- a/lib/alchemy/forms/builder.rb
+++ b/lib/alchemy/forms/builder.rb
@@ -43,6 +43,13 @@ module Alchemy
         template.content_tag("alchemy-datepicker", date_field, type: type)
       end
 
+      # Renders a simple_form input that displays a richtext editor
+      #
+      def richtext(attribute_name, options = {})
+        text_area = input(attribute_name, options.merge(as: :text))
+        template.content_tag("alchemy-tinymce", text_area)
+      end
+
       # Renders a button tag wrapped in a div with 'submit' class.
       #
       def submit(label, options = {})

--- a/spec/libraries/forms/builder_spec.rb
+++ b/spec/libraries/forms/builder_spec.rb
@@ -26,20 +26,20 @@ RSpec.describe Alchemy::Forms::Builder, type: :controller do
     end
   end
 
-  let(:template) do
-    double(
-      "Template",
-      controller: controller,
-      label: "<label>",
-      text_field: "<input>",
-      content_tag: "<alchemy-datepicker>"
-    )
-  end
-
   let(:builder) { described_class.new(object_name, form_object, template, {}) }
 
   describe "#datepicker" do
     let(:attribute) { :foo }
+
+    let(:template) do
+      double(
+        "Template",
+        controller: controller,
+        label: "<label>",
+        text_field: "<input>",
+        content_tag: "<alchemy-datepicker>"
+      )
+    end
 
     subject { builder.datepicker(attribute, options) }
 
@@ -89,6 +89,34 @@ RSpec.describe Alchemy::Forms::Builder, type: :controller do
         let(:type) { :datetime }
         let(:value) { nil }
       end
+    end
+  end
+
+  describe "#richtext" do
+    let(:attribute) { :foo }
+
+    let(:template) do
+      double(
+        "Template",
+        controller: controller,
+        label: "<label>",
+        text_area: "<textarea>",
+        content_tag: "<alchemy-tinymce>"
+      )
+    end
+
+    subject { builder.richtext(attribute) }
+
+    it "uses a alchemy-tinymce" do
+      expect(template).to receive(:text_area).with(
+        "Ding",
+        :foo,
+        hash_including(
+          class: [:text, :required]
+        )
+      )
+      expect(template).to receive(:content_tag).with("alchemy-tinymce", "<alchemy-tinymce>")
+      subject
     end
   end
 end


### PR DESCRIPTION
## What is this pull request for?

This makes it easier to add a tinymce editor to a
form field. Nice for migrating a resource form from using the `"tinymce"` class.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
