### PR TITLE
Set Tinymce editor form min-height

### DIFF
--- a/app/javascript/alchemy_admin/components/tinymce.js
+++ b/app/javascript/alchemy_admin/components/tinymce.js
@@ -100,12 +100,19 @@ class Tinymce extends AlchemyHTMLElement {
       }
     })
 
-    return {
+    const config = {
       ...Alchemy.TinymceDefaults,
       ...customConfig,
       language: currentLocale(),
       selector: `#${this.editorId}`
     }
+
+    // Tinymce has a height of 400px by default
+    // if the element has a min_height set, we use this value for the height as well
+    // so we do not need to set both values in the element configuration
+    config.height = config.min_height
+
+    return config
   }
 
   get editorId() {

--- a/lib/alchemy/tinymce.rb
+++ b/lib/alchemy/tinymce.rb
@@ -22,7 +22,6 @@ module Alchemy
       width: "auto",
       resize: true,
       min_height: 250,
-      height: 250,
       menubar: false,
       statusbar: true,
       toolbar: [

--- a/spec/javascript/alchemy_admin/components/tinymce.spec.js
+++ b/spec/javascript/alchemy_admin/components/tinymce.spec.js
@@ -52,6 +52,29 @@ describe("alchemy-tinymce", () => {
         <textarea id="${textareaId}"></textarea>
       </alchemy-tinymce>
     `
+      // The tinymce configuration is set in the global Alchemy object
+      // because we translate the configuration from the Rails backend
+      // into the JS world.
+      Alchemy.TinymceDefaults = {
+        skin: "alchemy",
+        content_css: "/assets/tinymce/skins/content/alchemy/content.min.css",
+        icons: "remixicons",
+        width: "auto",
+        resize: true,
+        min_height: 250,
+        menubar: false,
+        statusbar: true,
+        toolbar: [
+          "bold italic underline | strikethrough subscript superscript | numlist bullist indent outdent | removeformat | fullscreen",
+          "pastetext charmap hr | undo redo | alchemy_link unlink anchor | code"
+        ],
+        fix_list_elements: true,
+        convert_urls: false,
+        entity_encoding: "raw",
+        paste_as_text: true,
+        element_format: "html",
+        branding: false
+      }
       component = renderComponent("alchemy-tinymce", html)
     })
 
@@ -70,6 +93,22 @@ describe("alchemy-tinymce", () => {
 
     it("should set the selector to textarea id", () => {
       expect(component.configuration.selector).toEqual("#tinymce-textarea")
+    })
+
+    it("sets height to min_height from defaults", () => {
+      expect(component.configuration.height).toEqual(250)
+    })
+
+    describe("if min-height is set on component", () => {
+      it("uses that value for height", () => {
+        const html = `
+          <alchemy-tinymce toolbar="bold italic" foo-bar="bar | foo" min-height="400">
+            <textarea id="${textareaId}"></textarea>
+          </alchemy-tinymce>
+        `
+        component = renderComponent("alchemy-tinymce", html)
+        expect(component.configuration.height).toEqual(400)
+      })
     })
   })
 


### PR DESCRIPTION
## What is this pull request for?

Sites have set `min_height` on their custom tinymce config or on element definitions. Since Tinymce v6 now has a default height of 400 and a min-height of 100, but treats it as min-height (because of the resizable feature) we simply set the height to min-height for ease of upgrade.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
