### PR TITLE
Set admin picture thumbnail quality to 90

### DIFF
--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -22,6 +22,8 @@
 
 module Alchemy
   class Picture < BaseRecord
+    THUMBNAIL_QUALITY = 90
+
     THUMBNAIL_SIZES = {
       small: "80x60",
       medium: "160x120",
@@ -195,14 +197,16 @@ module Alchemy
     # Returns an url for the thumbnail representation of the picture
     #
     # @param [String] size - The size of the thumbnail
+    # @param [Integer] quality - The quality of the thumbnail
     #
     # @return [String]
-    def thumbnail_url(size: "160x120")
+    def thumbnail_url(size: "160x120", quality: THUMBNAIL_QUALITY)
       return if image_file.nil?
 
       url(
         flatten: true,
         format: "webp",
+        quality: quality,
         size: size
       )
     end

--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -192,6 +192,21 @@ module Alchemy
       nil
     end
 
+    # Returns an url for the thumbnail representation of the picture
+    #
+    # @param [String] size - The size of the thumbnail
+    #
+    # @return [String]
+    def thumbnail_url(size: "160x120")
+      return if image_file.nil?
+
+      url(
+        flatten: true,
+        format: "webp",
+        size: size
+      )
+    end
+
     # Updates name and tag_list attributes.
     #
     # Used by +Admin::PicturesController#update_multiple+

--- a/app/models/concerns/alchemy/picture_thumbnails.rb
+++ b/app/models/concerns/alchemy/picture_thumbnails.rb
@@ -84,7 +84,8 @@ module Alchemy
         crop_from: crop && crop_from.presence || default_crop_from&.join("x"),
         crop_size: crop && crop_size.presence || default_crop_size&.join("x"),
         flatten: true,
-        format: "webp"
+        format: "webp",
+        quality: Alchemy::Picture::THUMBNAIL_QUALITY
       }
     end
 

--- a/app/views/alchemy/admin/crop.html.erb
+++ b/app/views/alchemy/admin/crop.html.erb
@@ -8,7 +8,7 @@
     <%= simple_format Alchemy.t(:explain_cropping) %>
   <% end %>
   <div class="thumbnail_background">
-    <%= image_tag @picture.url(size: '800x600', flatten: true, format: "webp"), id: 'imageToCrop' %>
+    <%= image_tag @picture.thumbnail_url(size: '800x600'), id: 'imageToCrop' %>
   </div>
   <form>
     <%= button_tag Alchemy.t(:apply), type: 'submit' %>

--- a/app/views/alchemy/admin/pictures/_picture.html.erb
+++ b/app/views/alchemy/admin/pictures/_picture.html.erb
@@ -20,7 +20,7 @@
     </sl-tooltip>
   </span>
   <% end %>
-  <% picture_url = picture.url(size: preview_size(@size), flatten: true, format: "webp") %>
+  <% picture_url = picture.thumbnail_url(size: preview_size(@size)) %>
   <% image = image_tag(picture_url || "alchemy/missing-image.svg", alt: picture.name) %>
   <% if can?(:edit, picture) && picture_url %>
     <%= link_to(

--- a/app/views/alchemy/admin/pictures/_picture_to_assign.html.erb
+++ b/app/views/alchemy/admin/pictures/_picture_to_assign.html.erb
@@ -2,7 +2,7 @@
   <sl-tooltip content="<%= Alchemy.t(:assign_image) %>">
     <%= link_to(
       image_tag(
-        picture_to_assign.url(size: preview_size(size), flatten: true, format: "webp") || "alchemy/missing-image.svg",
+        picture_to_assign.thumbnail_url(size: preview_size(size)) || "alchemy/missing-image.svg",
         alt: picture_to_assign.name
       ),
       alchemy.assign_admin_picture_path(

--- a/lib/alchemy/test_support/having_picture_thumbnails_examples.rb
+++ b/lib/alchemy/test_support/having_picture_thumbnails_examples.rb
@@ -382,6 +382,7 @@ RSpec.shared_examples_for "having picture thumbnails" do
           crop_size: nil,
           flatten: true,
           format: "webp",
+          quality: Alchemy::Picture::THUMBNAIL_QUALITY,
           size: "160x120"
         )
       end
@@ -401,6 +402,7 @@ RSpec.shared_examples_for "having picture thumbnails" do
             crop_size: nil,
             flatten: true,
             format: "webp",
+            quality: Alchemy::Picture::THUMBNAIL_QUALITY,
             size: "160x120"
           )
         end

--- a/spec/models/alchemy/picture_spec.rb
+++ b/spec/models/alchemy/picture_spec.rb
@@ -310,6 +310,51 @@ module Alchemy
       end
     end
 
+    describe "#thumbnail_url" do
+      subject(:thumbnail_url) { picture.thumbnail_url }
+
+      let(:picture) do
+        build(:alchemy_picture, image_file: image)
+      end
+
+      context "with no image file present" do
+        let(:image) { nil }
+
+        it { is_expected.to be_nil }
+      end
+
+      context "with image file present" do
+        let(:image) do
+          fixture_file_upload(
+            File.expand_path("../../fixtures/500x500.png", __dir__),
+            "image/png"
+          )
+        end
+
+        it "returns the url to the thumbnail" do
+          expect(picture).to receive(:url).with(
+            flatten: true,
+            format: "webp",
+            size: "160x120"
+          )
+          thumbnail_url
+        end
+
+        context "with size given" do
+          subject(:thumbnail_url) { picture.thumbnail_url(size: "800x600") }
+
+          it "returns the url to the thumbnail" do
+            expect(picture).to receive(:url).with(
+              flatten: true,
+              format: "webp",
+              size: "800x600"
+            )
+            thumbnail_url
+          end
+        end
+      end
+    end
+
     describe "#urlname" do
       subject { picture.urlname }
 

--- a/spec/models/alchemy/picture_spec.rb
+++ b/spec/models/alchemy/picture_spec.rb
@@ -335,6 +335,7 @@ module Alchemy
           expect(picture).to receive(:url).with(
             flatten: true,
             format: "webp",
+            quality: Alchemy::Picture::THUMBNAIL_QUALITY,
             size: "160x120"
           )
           thumbnail_url
@@ -347,7 +348,22 @@ module Alchemy
             expect(picture).to receive(:url).with(
               flatten: true,
               format: "webp",
+              quality: Alchemy::Picture::THUMBNAIL_QUALITY,
               size: "800x600"
+            )
+            thumbnail_url
+          end
+        end
+
+        context "with quality given" do
+          subject(:thumbnail_url) { picture.thumbnail_url(quality: 50) }
+
+          it "returns the url to the thumbnail" do
+            expect(picture).to receive(:url).with(
+              flatten: true,
+              format: "webp",
+              quality: 50,
+              size: "160x120"
             )
             thumbnail_url
           end


### PR DESCRIPTION
## What is this pull request for?

Make the picture thumbnail quality independent from the
frontend `output_image_quality` config.

Using 90 as value for quality should be a good compromise
between file size and image quality.

The same image with quality of 100 is three times the size of an image with quality of 90 while having nearly the same image
quality for a small thumbnail. An large thumbnail (as used in the
image cropper) is ten times the size in 100% quality!

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
