### PR TITLE
Implement custom scrubber for Alchemy::Ingredients::Richtext

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.link_dialog.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.link_dialog.js.coffee
@@ -129,10 +129,11 @@ class window.Alchemy.LinkDialog extends Alchemy.Dialog
 
   # Sets the link either in TinyMCE or on an Ingredient.
   setLink: (url, title, target) ->
+    trimmedUrl = url.trim()
     if @link_object.editor
-      @setTinyMCELink(url, title, target)
+      @setTinyMCELink(trimmedUrl, title, target)
     else
-      @link_object.setLink(url, title, target, @link_type)
+      @link_object.setLink(trimmedUrl, title, target, @link_type)
     return
 
   # Sets a link in TinyMCE editor.

--- a/app/models/alchemy/ingredients/richtext.rb
+++ b/app/models/alchemy/ingredients/richtext.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "alchemy/scrubbers/safe_list"
 module Alchemy
   module Ingredients
     # A blob of richtext
@@ -39,14 +40,12 @@ module Alchemy
       private
 
       def strip_content
-        self.stripped_body = Rails::Html::FullSanitizer.new.sanitize(value)
+        self.stripped_body = Rails::HTML5::FullSanitizer.new.sanitize(value)
       end
 
       def sanitize_content
-        self.sanitized_body = Rails::Html::SafeListSanitizer.new.sanitize(
-          value,
-          sanitizer_settings
-        )
+        scrubber = Alchemy::Scrubbers::SafeList.new(sanitizer_settings)
+        self.sanitized_body = Loofah.html5_fragment(value).scrub!(scrubber).to_html
       end
 
       def sanitizer_settings

--- a/lib/alchemy/scrubbers/safe_list.rb
+++ b/lib/alchemy/scrubbers/safe_list.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Alchemy
+  module Scrubbers
+    class SafeList < Loofah::Scrubber
+      attr_reader :safe_tags, :safe_attributes
+
+      def initialize(config)
+        @direction = :top_down
+        @safe_tags = config[:safe_tags] || Rails::HTML::SafeListSanitizer::DEFAULT_ALLOWED_TAGS
+        @safe_attributes = config[:safe_attributes] || Rails::HTML::SafeListSanitizer::DEFAULT_ALLOWED_ATTRIBUTES
+      end
+
+      def scrub(node)
+        return CONTINUE if sanitize(node) == CONTINUE
+
+        node.remove
+        STOP
+      end
+
+      private
+
+      def sanitize(node)
+        case node.type
+        when Nokogiri::XML::Node::ELEMENT_NODE
+          if allowed_element?(node.name)
+            scrub_attributes(node)
+            return Loofah::Scrubber::CONTINUE
+          end
+        when Nokogiri::XML::Node::TEXT_NODE
+          return Loofah::Scrubber::CONTINUE
+        end
+        Loofah::Scrubber::STOP
+      end
+
+      def allowed_element?(node_name)
+        node_name.in?(safe_tags)
+      end
+
+      def scrub_attributes(node)
+        node.attribute_nodes.each do |attr_node|
+          if safe_attributes.include?(attr_node.name)
+            next
+          else
+            attr_node.remove
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/alchemy/scrubbers/safe_list.rb
+++ b/lib/alchemy/scrubbers/safe_list.rb
@@ -13,7 +13,9 @@ module Alchemy
 
       def scrub(node)
         return CONTINUE if sanitize(node) == CONTINUE
-
+        if Loofah::HTML5::Scrub.allowed_element?(node.name)
+          node.before(node.children)
+        end
         node.remove
         STOP
       end

--- a/spec/libraries/alchemy/scrubbers/safe_list_spec.rb
+++ b/spec/libraries/alchemy/scrubbers/safe_list_spec.rb
@@ -12,31 +12,58 @@ RSpec.describe Alchemy::Scrubbers::SafeList do
     context "with a tag that is not allowed" do
       let(:html) { "<script> console.log('oops') </script>" }
 
-      it { is_expected.to eq("") }
+      it "removes the tag" do
+        is_expected.to eq("")
+      end
+    end
+
+    context "with an iframe" do
+      let(:html) { "<iframe> myframe </iframe>" }
+
+      it "removes the tag" do
+        is_expected.to eq("")
+      end
     end
 
     context "with an allowed tag" do
       let(:html) { "<p>Some text</p>" }
 
-      it { is_expected.to eq(html) }
+      it "does not remove the tag" do
+        is_expected.to eq(html)
+      end
     end
 
     context "with an allowed attribute" do
       let(:html) { "<p class=\"pretty\">Some text</p>" }
 
-      it { is_expected.to eq(html) }
+      it "does not remove the attribute" do
+        is_expected.to eq(html)
+      end
     end
 
     context "with a disallowed attribute" do
       let(:html) { "<p style='color: red;'>Some text</p>" }
 
-      it { is_expected.to eq("<p>Some text</p>") }
+      it "removes the attribute" do
+        is_expected.to eq("<p>Some text</p>")
+      end
     end
 
     context "with a link with a space in the href" do
       let(:html) { "<a href=\"/hello/ \">Hello!</a>" }
 
-      it { is_expected.to eq(html) }
+      it "does not escape the trailing whitespace" do
+        is_expected.to eq(html)
+      end
+    end
+
+    context "with a node nested in a disallowed node" do
+      let(:config) { {safe_tags: ["a"]} }
+      let(:html) { "<h1><a href=\"/hello/ \">Hello!</a></h1>" }
+
+      it "keeps the nested node" do
+        is_expected.to eq("<a href=\"/hello/ \">Hello!</a>")
+      end
     end
   end
 end

--- a/spec/libraries/alchemy/scrubbers/safe_list_spec.rb
+++ b/spec/libraries/alchemy/scrubbers/safe_list_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "alchemy/scrubbers/safe_list"
+
+RSpec.describe Alchemy::Scrubbers::SafeList do
+  let(:config) { {} }
+  let(:scrubber) { described_class.new(config) }
+  subject { Loofah.html5_fragment(html).scrub!(scrubber).to_html }
+
+  describe "#scrub" do
+    context "with a tag that is not allowed" do
+      let(:html) { "<script> console.log('oops') </script>" }
+
+      it { is_expected.to eq("") }
+    end
+
+    context "with an allowed tag" do
+      let(:html) { "<p>Some text</p>" }
+
+      it { is_expected.to eq(html) }
+    end
+
+    context "with an allowed attribute" do
+      let(:html) { "<p class=\"pretty\">Some text</p>" }
+
+      it { is_expected.to eq(html) }
+    end
+
+    context "with a disallowed attribute" do
+      let(:html) { "<p style='color: red;'>Some text</p>" }
+
+      it { is_expected.to eq("<p>Some text</p>") }
+    end
+
+    context "with a link with a space in the href" do
+      let(:html) { "<a href=\"/hello/ \">Hello!</a>" }
+
+      it { is_expected.to eq(html) }
+    end
+  end
+end

--- a/spec/models/alchemy/ingredients/richtext_spec.rb
+++ b/spec/models/alchemy/ingredients/richtext_spec.rb
@@ -10,12 +10,14 @@ RSpec.describe Alchemy::Ingredients::Richtext do
   end
   let(:richtext_settings) { {} }
 
+  let(:value) { "<h1 style=\"color: red;\">Hello!</h1><p class=\"green\">Welcome to Peters Petshop.</p>" }
+
   let(:richtext_ingredient) do
     described_class.new(
       element: element,
       type: described_class.name,
       role: "text",
-      value: "<h1 style=\"color: red;\">Hello!</h1><p class=\"green\">Welcome to Peters Petshop.</p>"
+      value: value
     )
   end
 
@@ -31,6 +33,16 @@ RSpec.describe Alchemy::Ingredients::Richtext do
   it "has a sanitized version of body column" do
     richtext_ingredient.save
     expect(richtext_ingredient.sanitized_body).to eq("<h1>Hello!</h1><p class=\"green\">Welcome to Peters Petshop.</p>")
+  end
+
+  context "sanitizing with spaces in a link" do
+    let(:value) { "<a href=\"/hello/ \">Hello!</a><p class=\"green\">Welcome to Peters Petshop.</p>" }
+
+    it "won't HTML escape spaces in links" do
+      richtext_ingredient.save
+
+      expect(richtext_ingredient.sanitized_body).to eq("<a href=\"/hello/ \">Hello!</a><p class=\"green\">Welcome to Peters Petshop.</p>")
+    end
   end
 
   describe "#custom_tinymce_config" do


### PR DESCRIPTION


## What is this pull request for?

We found that using Rails' HTML sanitizer does more than we want the Richtext sanitization to do: It does not just remove nodes that are not in the safelist, it also escapes some markup (especially in links).

This introduces a custom Loofah "scrubber" that only cares about the element safelist.

The `sanitized_body` attribute is not for escaping at the view layer, where all these safety precautions are necessary, but just for making sure admin's don't use iframes when we don't want to.

See the following related issues and commits:
https://github.com/rails/rails-html-sanitizer/commit/f3ba1a839a35f2ba7f941c15e239a1cb379d56ae https://github.com/sparklemotion/nokogiri/issues/3104 https://github.com/sparklemotion/nokogiri/issues/969#issuecomment-973068692 https://github.com/flavorjones/loofah/issues/14#issuecomment-1006617141

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
