### PR TITLE
TinyMCE: Trim spaces from pasted links

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.link_dialog.js.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.link_dialog.js.coffee
@@ -129,10 +129,11 @@ class window.Alchemy.LinkDialog extends Alchemy.Dialog
 
   # Sets the link either in TinyMCE or on an Ingredient.
   setLink: (url, title, target) ->
+    trimmedUrl = url.trim()
     if @link_object.editor
-      @setTinyMCELink(url, title, target)
+      @setTinyMCELink(trimmedUrl, title, target)
     else
-      @link_object.setLink(url, title, target, @link_type)
+      @link_object.setLink(trimmedUrl, title, target, @link_type)
     return
 
   # Sets a link in TinyMCE editor.


### PR DESCRIPTION

## What is this pull request for?

It's a common occurrence for pasted content to contain a space at the end. For links, this can make the links invalid, as TinyMCE will URL-encode that space and make it meaningful - even though it is not.

This commit trims whitespace from URLs before setting them in TinyMCE.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
