### PR TITLE
Revert "Set admin picture thumbnail quality to 90"

### DIFF
--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -22,8 +22,6 @@
 
 module Alchemy
   class Picture < BaseRecord
-    THUMBNAIL_QUALITY = 90
-
     THUMBNAIL_SIZES = {
       small: "80x60",
       medium: "160x120",
@@ -197,16 +195,14 @@ module Alchemy
     # Returns an url for the thumbnail representation of the picture
     #
     # @param [String] size - The size of the thumbnail
-    # @param [Integer] quality - The quality of the thumbnail
     #
     # @return [String]
-    def thumbnail_url(size: "160x120", quality: THUMBNAIL_QUALITY)
+    def thumbnail_url(size: "160x120")
       return if image_file.nil?
 
       url(
         flatten: true,
         format: image_file_format || "jpg",
-        quality: quality,
         size: size
       )
     end

--- a/app/models/concerns/alchemy/picture_thumbnails.rb
+++ b/app/models/concerns/alchemy/picture_thumbnails.rb
@@ -84,8 +84,7 @@ module Alchemy
         crop_from: crop && crop_from.presence || default_crop_from&.join("x"),
         crop_size: crop && crop_size.presence || default_crop_size&.join("x"),
         flatten: true,
-        format: picture&.image_file_format || "jpg",
-        quality: Alchemy::Picture::THUMBNAIL_QUALITY
+        format: picture&.image_file_format || "jpg"
       }
     end
 

--- a/lib/alchemy/test_support/having_picture_thumbnails_examples.rb
+++ b/lib/alchemy/test_support/having_picture_thumbnails_examples.rb
@@ -382,7 +382,6 @@ RSpec.shared_examples_for "having picture thumbnails" do
           crop_size: nil,
           flatten: true,
           format: "jpg",
-          quality: Alchemy::Picture::THUMBNAIL_QUALITY,
           size: "160x120"
         )
       end
@@ -402,7 +401,6 @@ RSpec.shared_examples_for "having picture thumbnails" do
             crop_size: nil,
             flatten: true,
             format: "jpg",
-            quality: Alchemy::Picture::THUMBNAIL_QUALITY,
             size: "160x120"
           )
         end

--- a/spec/models/alchemy/picture_spec.rb
+++ b/spec/models/alchemy/picture_spec.rb
@@ -335,7 +335,6 @@ module Alchemy
           expect(picture).to receive(:url).with(
             flatten: true,
             format: "png",
-            quality: Alchemy::Picture::THUMBNAIL_QUALITY,
             size: "160x120"
           )
           thumbnail_url
@@ -348,22 +347,7 @@ module Alchemy
             expect(picture).to receive(:url).with(
               flatten: true,
               format: "png",
-              quality: Alchemy::Picture::THUMBNAIL_QUALITY,
               size: "800x600"
-            )
-            thumbnail_url
-          end
-        end
-
-        context "with quality given" do
-          subject(:thumbnail_url) { picture.thumbnail_url(quality: 50) }
-
-          it "returns the url to the thumbnail" do
-            expect(picture).to receive(:url).with(
-              flatten: true,
-              format: "png",
-              quality: 50,
-              size: "160x120"
             )
             thumbnail_url
           end


### PR DESCRIPTION
## What is this pull request for?

We do not want that all thumbnails in the admin needs to be re-generated in the 7.1 release.
We already reverted webp images, this also reverts the quality change to 90.

This reverts commit bf6263a79dd6121c77ed096754167b63e4477802.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
