### PR TITLE
Fix ActionNotFound in PictureController

### DIFF
--- a/app/controllers/alchemy/admin/pictures_controller.rb
+++ b/app/controllers/alchemy/admin/pictures_controller.rb
@@ -9,7 +9,7 @@ module Alchemy
       helper "alchemy/admin/tags"
 
       before_action :load_resource,
-        only: [:show, :edit, :update, :url, :destroy, :info]
+        only: [:show, :edit, :update, :url, :destroy]
 
       before_action :set_size, only: [:index, :show, :edit_multiple]
 


### PR DESCRIPTION


## What is this pull request for?

The default setting of Rails 7.1 will raise an exception if a callback action was not found. The info - method is not available in picture controller and will lead to an exception if the option is turned on in Rails 7.1.

### Screenshots

![CleanShot 2024-02-03 at 15 16 55@2x](https://github.com/AlchemyCMS/alchemy_cms/assets/68833/a9f6db45-d0a5-4e7f-a1a4-718894e42cdb)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
