### PR TITLE
Restrict turbo-rails version

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "sassc-rails", ["~> 2.1"]
   gem.add_runtime_dependency "simple_form", [">= 4.0", "< 6"]
   gem.add_runtime_dependency "sprockets", [">= 3.0", "< 5"]
-  gem.add_runtime_dependency "turbo-rails", [">= 1.4"]
+  gem.add_runtime_dependency "turbo-rails", [">= 1.4", "< 2"]
   gem.add_runtime_dependency "view_component", ["~> 3.0"]
 
   gem.add_development_dependency "capybara", ["~> 3.0"]


### PR DESCRIPTION
## What is this pull request for?

Restrict turbo-rails version to below 2 to prevent compatibility issue with the new version. These issues will be addressed in one of the future versions.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
