### PR TITLE
Update backport action to v9.3.1

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,7 +23,7 @@ jobs:
       )
     steps:
       - name: Backport pull request
-        uses: sqren/backport-github-action@v8.9.7
+        uses: sqren/backport-github-action@v9.3.1
         with:
           github_token: ${{ secrets.ALCHEMY_CI_BOT_ACCESS_TOKEN }}
           auto_backport_label_prefix: backport-to-


### PR DESCRIPTION
Removes a Node 20 warning

https://github.com/sorenlouv/backport-github-action/releases/tag/v9.3.1