### PR TITLE
Fix overlay picture grid

### DIFF
--- a/app/assets/stylesheets/alchemy/archive.scss
+++ b/app/assets/stylesheets/alchemy/archive.scss
@@ -125,6 +125,7 @@
 
   display: grid;
   gap: 2 * $default-margin;
+  grid-auto-rows: min-content;
   grid-template-columns: repeat(
     auto-fill,
     minmax(var(--picture-thumbnail-width), auto)


### PR DESCRIPTION
## What is this pull request for?

The grid had a very big gap between the rows, if the amount of pictures was too low. It uses now the minimal height for each row.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
