### PR TITLE
Fix tags view for missing taggables

### DIFF
--- a/app/assets/stylesheets/alchemy/labels.scss
+++ b/app/assets/stylesheets/alchemy/labels.scss
@@ -1,6 +1,3 @@
 .label {
-  @include label-base(
-    $margin: $default-margin/2 0,
-    $padding: $default-padding 2*$default-padding $default-padding
-  );
+  @include label-base($margin: 0, $padding: 0 2 * $default-padding);
 }

--- a/app/views/alchemy/admin/tags/_tag.html.erb
+++ b/app/views/alchemy/admin/tags/_tag.html.erb
@@ -2,7 +2,7 @@
   <td class="icon"><%= render_icon(:tag, size: "xl") %></td>
   <td class="name"><%= tag.name %></td>
   <td>
-    <%= tag.taggings.collect(&:taggable).collect { |t| t.class.model_name.human }.uniq.join(', ') %>
+    <%= tag.taggings.collect(&:taggable).compact.map { |t| t.class.model_name.human }.uniq.join(', ') %>
   </td>
   <td class="count"><%= tag.taggings.count %></td>
   <td class="tools">

--- a/app/views/alchemy/admin/tags/_tag.html.erb
+++ b/app/views/alchemy/admin/tags/_tag.html.erb
@@ -2,7 +2,11 @@
   <td class="icon"><%= render_icon(:tag, size: "xl") %></td>
   <td class="name"><%= tag.name %></td>
   <td>
-    <%= tag.taggings.collect(&:taggable).compact.map { |t| t.class.model_name.human }.uniq.join(', ') %>
+    <% tag.taggings.collect(&:taggable).compact.uniq.each do |taggable| %>
+      <span class="label">
+        <%= taggable.class.model_name.human %>
+      </span>
+    <% end %>
   </td>
   <td class="count"><%= tag.taggings.count %></td>
   <td class="tools">

--- a/spec/controllers/alchemy/admin/tags_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/tags_controller_spec.rb
@@ -10,9 +10,25 @@ module Alchemy
       before { authorize_user(:as_admin) }
 
       describe "#index" do
+        render_views
+
+        let!(:picture) { create(:alchemy_picture, tag_list: "Foo,Bar") }
+
         it "renders index template" do
           get :index
           expect(response).to be_successful
+        end
+
+        context "with taggable missing" do
+          before do
+            picture.thumbs.destroy_all
+            picture.delete
+          end
+
+          it "does not raise error" do
+            get :index
+            expect(response).to be_successful
+          end
         end
       end
 


### PR DESCRIPTION
## What is this pull request for?

When the taggable has been deleted it is nil in this collection and `model_name` is not available on `NilClass`.

Also gives the taggables a nice look

### Screenshots

![Screen Shot 2024-02-21 at 16 38 15](https://github.com/AlchemyCMS/alchemy_cms/assets/42868/f0e625b0-6cd3-4738-8c0e-0e33f40e3b8d)


## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
