### PR TITLE
Add possibility to show an outline in preview if no tag is present

### DIFF
--- a/app/helpers/alchemy/elements_block_helper.rb
+++ b/app/helpers/alchemy/elements_block_helper.rb
@@ -113,7 +113,13 @@ module Alchemy
       end
 
       # wrap output in a useful DOM element
-      if (tag = options.delete(:tag))
+      tag = options.delete(:tag)
+
+      # add custom element with no representation if the user is in the preview mode to allow
+      # an interaction with the element
+      tag = "alchemy-preview" if tag.blank? && is_element_in_preview_mode?(element)
+
+      if tag.present?
         # add preview attributes
         options.merge!(element_preview_code_attributes(element))
 

--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -171,9 +171,14 @@ module Alchemy
       tag_builder.tag_options(element_preview_code_attributes(element))
     end
 
+    # is element in preview mode and connected with current page
+    def is_element_in_preview_mode?(element)
+      element.present? && @preview_mode && element.page == @page
+    end
+
     # Returns a hash containing the HTML tag attributes required for preview mode.
     def element_preview_code_attributes(element)
-      return {} unless element.present? && @preview_mode && element.page == @page
+      return {} unless is_element_in_preview_mode?(element)
 
       {"data-alchemy-element" => element.id}
     end

--- a/app/views/alchemy/_preview_mode_code.html.erb
+++ b/app/views/alchemy/_preview_mode_code.html.erb
@@ -1,4 +1,9 @@
 <% if @preview_mode %>
+  <style>
+    alchemy-preview {
+      display: flow;
+    }
+  </style>
   <script type="text/javascript">
     Alchemy = { locale: "<%= session[:alchemy_locale] %>" };
   </script>

--- a/spec/helpers/alchemy/elements_block_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_block_helper_spec.rb
@@ -56,6 +56,11 @@ module Alchemy
 
         subject { helper.element_view_for(element) }
         it { is_expected.to have_css "#{expected_wrapper_tag}[data-alchemy-element='#{element.id}']" }
+
+        context "without tag" do
+          subject { helper.element_view_for(element, tag: false) }
+          it { is_expected.to have_css "alchemy-preview[data-alchemy-element='#{element.id}']" }
+        end
       end
     end
 

--- a/spec/helpers/alchemy/elements_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_helper_spec.rb
@@ -202,6 +202,20 @@ module Alchemy
       end
     end
 
+    describe "#is_element_in_preview_mode?" do
+      subject { helper.is_element_in_preview_mode?(element) }
+
+      context "in preview_mode" do
+        before { assign(:preview_mode, true) }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context "not in preview_mode" do
+        it { is_expected.to be_falsy }
+      end
+    end
+
     describe "#element_preview_code" do
       subject { helper.element_preview_code(element) }
 


### PR DESCRIPTION
## What is this pull request for?
Extend the element_view_for - method to show an outline to element, that has a disabled tag - option. It adds an unregistered custom component tag (which will have no visual representation except one display property), to make the element clickable and highlightable.

### Screenshots

![CleanShot 2024-02-25 at 15 25 30@2x](https://github.com/AlchemyCMS/alchemy_cms/assets/68833/4cf298ac-889b-4c4c-9d5b-51407d27f58f)
![CleanShot 2024-02-25 at 15 24 54@2x](https://github.com/AlchemyCMS/alchemy_cms/assets/68833/a5ce91be-36db-4c0f-bb42-f72131dcfee4)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
