### PR TITLE
Fix sortable elements

### DIFF
--- a/app/javascript/alchemy_admin/sortable_elements.js
+++ b/app/javascript/alchemy_admin/sortable_elements.js
@@ -29,12 +29,17 @@ function onSort(event) {
     params.parent_element_id = parentElement.dataset.elementId
   }
 
-  post(Alchemy.routes.order_admin_elements_path, params).then((response) => {
-    const data = response.data
-    Alchemy.growl(data.message)
-    Alchemy.PreviewWindow.refresh()
-    item.updateTitle(data.preview_text)
-  })
+  // Only send the request if the item was moved to a different container
+  // or sorted in the same list. Not on the old list in order to avoid incrementing
+  // the position of the other elements.
+  if (event.target === event.to) {
+    post(Alchemy.routes.order_admin_elements_path, params).then((response) => {
+      const data = response.data
+      Alchemy.growl(data.message)
+      Alchemy.PreviewWindow.refresh()
+      item.updateTitle(data.preview_text)
+    })
+  }
 }
 
 function onEnd() {

--- a/app/views/alchemy/admin/elements/create.js.erb
+++ b/app/views/alchemy/admin/elements/create.js.erb
@@ -24,9 +24,7 @@
   $element_area.append(element_html);
 <%- end -%>
 
-<% if @element.fixed? %>
-  Alchemy.SortableElements('[name="fixed-element-<%= @element.id %>"] .nested-elements');
-<% end %>
+  Alchemy.SortableElements('[data-element-id="<%= @element.id %>"] .nested-elements');
 
   Alchemy.growl('<%= Alchemy.t(:successfully_added_element) %>');
   Alchemy.closeCurrentDialog();


### PR DESCRIPTION
## What is this pull request for?

**1. Fix sorting of nested elements of freshly created elements**
  Make sure that nested elements of all elements get initialized as sortable after being created, not just fixed.

**2. Avoid sending sort events twice**
  SortableJS sends two events if you drag an element from one nesteable elements container to another. Leading to incrementing the target lists positions to high.

Since `acts_as_list` maintains both lists correctly we can simply suppress the second event on the source list.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message

