### PR TITLE
Fix order of elements after Page copy

### DIFF
--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -37,11 +37,20 @@ module Alchemy
         #
         def copy_elements(source, target)
           repository = source.draft_version.element_repository
+          elements = repository.not_nested
+          page_version = target.draft_version
+          duplicate_elements(elements.unfixed, repository, page_version) +
+            duplicate_elements(elements.fixed, repository, page_version)
+        end
+
+        private
+
+        def duplicate_elements(elements, repository, page_version)
           transaction do
             Element.acts_as_list_no_update do
-              repository.not_nested.each.with_index(1) do |element, position|
+              elements.each.with_index(1) do |element, position|
                 Alchemy::DuplicateElement.new(element, repository: repository).call(
-                  page_version_id: target.draft_version.id,
+                  page_version_id: page_version.id,
                   position: position
                 )
               end

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -392,6 +392,29 @@ module Alchemy
       end
     end
 
+    describe ".copy_elements" do
+      let(:page) { create(:alchemy_page) }
+      let(:page_2) { create(:alchemy_page) }
+      let!(:element_1) { create(:alchemy_element, page_version: page.draft_version) }
+      let!(:element_2) { create(:alchemy_element, page_version: page.draft_version) }
+      let!(:element_3) { create(:alchemy_element, page_version: page.draft_version) }
+      let!(:fixed_element_1) { create(:alchemy_element, :fixed, page_version: page.draft_version) }
+      let!(:fixed_element_2) { create(:alchemy_element, :fixed, page_version: page.draft_version) }
+
+      subject(:copy_elements) { Page.copy_elements(page, page_2) }
+
+      it "should keep original order of fixed and non-fixed elements" do
+        elements = copy_elements
+        expect(elements.map(&:position)).to match([
+          element_1.position,
+          element_2.position,
+          element_3.position,
+          fixed_element_1.position,
+          fixed_element_2.position
+        ])
+      end
+    end
+
     describe ".create" do
       context "before/after filter" do
         it "should automatically set the title from its name" do


### PR DESCRIPTION
## What is this pull request for?

A page with fixed and non-fixed elements need to copy each element group individually in order to maintain the list position, because the `acts_as_list` scope is

    [:page_version_id, :fixed, :parent_element_id]

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
