### PR TITLE
Fix datepicker in resource forms

### DIFF
--- a/lib/alchemy/forms/builder.rb
+++ b/lib/alchemy/forms/builder.rb
@@ -40,7 +40,7 @@ module Alchemy
         }.merge(options[:input_html] || {})
 
         date_field = input attribute_name, as: :string, input_html: input_options
-        template.content_tag("alchemy-datepicker", date_field, type: type)
+        template.content_tag("alchemy-datepicker", date_field, "input-type" => type)
       end
 
       # Renders a simple_form input that displays a richtext editor

--- a/lib/alchemy/resources_helper.rb
+++ b/lib/alchemy/resources_helper.rb
@@ -107,12 +107,7 @@ module Alchemy
       when "boolean"
         options
       when "date", "time", "datetime"
-        options.merge(
-          as: "string",
-          input_html: {
-            data: {datepicker_type: input_type}
-          }
-        )
+        options.merge(as: input_type)
       when "text"
         options.merge(as: "text", input_html: {rows: 4})
       else

--- a/spec/features/admin/resources_integration_spec.rb
+++ b/spec/features/admin/resources_integration_spec.rb
@@ -176,12 +176,12 @@ RSpec.describe "Resources", type: :system do
     it "renders an input field according to the attribute's type" do
       visit "/admin/events/new"
       expect(page).to have_selector('input#event_name[type="text"]')
-      expect(page).to have_selector('input#event_starts_at[data-datepicker-type="datetime"]')
-      expect(page).to have_selector('input#event_ends_at[data-datepicker-type="datetime"]')
+      expect(page).to have_selector('alchemy-datepicker[input-type="datetime"] input#event_starts_at')
+      expect(page).to have_selector('alchemy-datepicker[input-type="datetime"] input#event_ends_at')
       expect(page).to have_selector("textarea#event_description")
       expect(page).to have_selector('input#event_published[type="checkbox"]')
-      expect(page).to have_selector('input#event_lunch_starts_at[data-datepicker-type="time"]')
-      expect(page).to have_selector('input#event_lunch_ends_at[data-datepicker-type="time"]')
+      expect(page).to have_selector('alchemy-datepicker[input-type="time"] input#event_lunch_starts_at')
+      expect(page).to have_selector('alchemy-datepicker[input-type="time"] input#event_lunch_ends_at')
     end
 
     it "should have a select box for associated models" do
@@ -202,7 +202,7 @@ RSpec.describe "Resources", type: :system do
     describe "date fields" do
       it "have date picker" do
         visit "/admin/bookings/new"
-        expect(page).to have_selector('input#booking_from[data-datepicker-type="date"]')
+        expect(page).to have_selector('alchemy-datepicker[input-type="date"] input#booking_from')
       end
     end
   end

--- a/spec/libraries/forms/builder_spec.rb
+++ b/spec/libraries/forms/builder_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Alchemy::Forms::Builder, type: :controller do
 
   shared_examples_for "datepicker expect" do
     it "has the alchemy-datepicker" do
-      expect(template).to receive(:content_tag).with("alchemy-datepicker", "<alchemy-datepicker>", {type: type})
+      expect(template).to receive(:content_tag).with("alchemy-datepicker", "<alchemy-datepicker>", {"input-type" => type})
       subject
     end
 

--- a/spec/libraries/resources_helper_spec.rb
+++ b/spec/libraries/resources_helper_spec.rb
@@ -284,10 +284,7 @@ describe Alchemy::ResourcesHelper do
         is_expected.to match(
           hash_including(
             hint: nil,
-            as: "string",
-            input_html: {
-              data: {datepicker_type: "date"}
-            }
+            as: "date"
           )
         )
       end
@@ -304,10 +301,7 @@ describe Alchemy::ResourcesHelper do
         is_expected.to match(
           hash_including(
             hint: nil,
-            as: "string",
-            input_html: {
-              data: {datepicker_type: "datetime"}
-            }
+            as: "datetime"
           )
         )
       end
@@ -324,10 +318,7 @@ describe Alchemy::ResourcesHelper do
         is_expected.to match(
           hash_including(
             hint: nil,
-            as: "string",
-            input_html: {
-              data: {datepicker_type: "time"}
-            }
+            as: "time"
           )
         )
       end


### PR DESCRIPTION
## What is this pull request for?

The attribute that the `<alchemy-datepicker>` custom element needs to init the appropriate Datepickr type is called `input-type` and not a `data-` attribute anymore.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
