### PR TITLE
Fix taggable uniqueness in tags admin table

### DIFF
--- a/app/views/alchemy/admin/tags/_tag.html.erb
+++ b/app/views/alchemy/admin/tags/_tag.html.erb
@@ -2,7 +2,7 @@
   <td class="icon"><%= render_icon(:tag, size: "xl") %></td>
   <td class="name"><%= tag.name %></td>
   <td>
-    <% tag.taggings.collect(&:taggable).compact.uniq.each do |taggable| %>
+    <% tag.taggings.collect(&:taggable).compact.uniq(&:class).each do |taggable| %>
       <span class="label">
         <%= taggable.class.model_name.human %>
       </span>

--- a/spec/features/admin/tags_integration_spec.rb
+++ b/spec/features/admin/tags_integration_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Tags", type: :system do
+  let!(:picture) { create(:alchemy_picture, tag_list: "Foo") }
+  let!(:picture2) { create(:alchemy_picture, tag_list: "Foo") }
+  let!(:a_page) { create(:alchemy_page, tag_list: "Bar") }
+
+  before { authorize_user(:as_admin) }
+
+  describe "index view" do
+    it "should list taggable class names" do
+      visit "/admin/tags"
+      expect(page).to have_selector(".label", text: "Picture", count: 1)
+      expect(page).to have_selector(".label", text: "Page", count: 1)
+    end
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

In #2735 we introduced a bug that lead to duplicated taggable class labels.

We need to check the class for uniqueness check.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
