### PR TITLE
Do not include timezone in datepickers only displaying date

### DIFF
--- a/app/javascript/alchemy_admin/components/datepicker.js
+++ b/app/javascript/alchemy_admin/components/datepicker.js
@@ -13,14 +13,25 @@ class Datepicker extends AlchemyHTMLElement {
   }
 
   afterRender() {
+    this.flatpickr = flatpickr(
+      this.getElementsByTagName("input")[0],
+      this.flatpickrOptions
+    )
+  }
+
+  disconnected() {
+    this.flatpickr.destroy()
+  }
+
+  get flatpickrOptions() {
+    const enableTime = /time/.test(this.inputType)
     const options = {
       // alchemy_i18n supports `zh_CN` etc., but flatpickr only has two-letter codes (`zh`)
       locale: currentLocale().slice(0, 2),
       altInput: true,
       altFormat: translate(`formats.${this.inputType}`),
       altInputClass: "flatpickr-input",
-      dateFormat: "Z",
-      enableTime: /time/.test(this.inputType),
+      enableTime,
       noCalendar: this.inputType === "time",
       time_24hr: translate("formats.time_24hr"),
       onValueUpdate(_selectedDates, _dateStr, instance) {
@@ -28,11 +39,11 @@ class Datepicker extends AlchemyHTMLElement {
       }
     }
 
-    this.flatpickr = flatpickr(this.getElementsByTagName("input")[0], options)
-  }
+    if (enableTime) {
+      options.dateFormat = "Z"
+    }
 
-  disconnected() {
-    this.flatpickr.destroy()
+    return options
   }
 }
 

--- a/spec/javascript/alchemy_admin/components/datepicker.spec.js
+++ b/spec/javascript/alchemy_admin/components/datepicker.spec.js
@@ -58,4 +58,34 @@ describe("alchemy-datepicker", () => {
       expect(document.querySelector(".flatpickr-calendar")).toBeNull()
     })
   })
+
+  it("should include timezone for time inputs", () => {
+    const html = `
+      <alchemy-datepicker input-type="time">
+        <input type="text">
+      </alchemy-datepicker>
+    `
+    component = renderComponent("alchemy-datepicker", html)
+    expect(component.flatpickrOptions.dateFormat).toEqual("Z")
+  })
+
+  it("should include timezone for datetime inputs", () => {
+    const html = `
+      <alchemy-datepicker input-type="datetime">
+        <input type="text">
+      </alchemy-datepicker>
+    `
+    component = renderComponent("alchemy-datepicker", html)
+    expect(component.flatpickrOptions.dateFormat).toEqual("Z")
+  })
+
+  it("should not include timezone for date inputs", () => {
+    const html = `
+      <alchemy-datepicker input-type="date">
+        <input type="text">
+      </alchemy-datepicker>
+    `
+    component = renderComponent("alchemy-datepicker", html)
+    expect(component.flatpickrOptions.dateFormat).toBeUndefined()
+  })
 })


### PR DESCRIPTION
## What is this pull request for?

We must not include timezone information when storing date columns. It would lead to wrongly stored dates otherwise.

Follow up to https://github.com/AlchemyCMS/alchemy_cms/pull/2462

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
