### PR TITLE
Reload page sitemap on move errors

### DIFF
--- a/app/assets/stylesheets/alchemy/frame.scss
+++ b/app/assets/stylesheets/alchemy/frame.scss
@@ -1,12 +1,21 @@
 alchemy-overlay {
-  display: none;
+  visibility: hidden;
   position: fixed;
   left: 0;
   top: 0;
   width: 100%;
   height: 100%;
   z-index: 400000;
-  background-color: rgba(229, 229, 229, 0.4);
+  background-color: transparent;
+  transition: all $transition-duration $transition-easing;
+  transition-delay: 0;
+
+  &.visible {
+    visibility: visible;
+    transition-delay: 300ms;
+    transition-property: background-color;
+    background-color: rgba(229, 229, 229, 0.2);
+  }
 }
 
 div#overlay_text_box {

--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -51,7 +51,7 @@ module Alchemy
       authorize! :update, @page
       target_parent_page = Page.find(params[:target_parent_id])
       @page.move_to_child_with_index(target_parent_page, params[:new_position])
-      render json: @page, serializer: PageSerializer
+      render json: @page, serializer: PageNodeSerializer
     end
 
     private

--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -49,9 +49,13 @@ module Alchemy
     def move
       @page = Page.find(params[:id])
       authorize! :update, @page
-      target_parent_page = Page.find(params[:target_parent_id])
-      @page.move_to_child_with_index(target_parent_page, params[:new_position])
-      render json: @page, serializer: PageNodeSerializer
+      begin
+        target_parent_page = Page.find(params[:target_parent_id])
+        @page.move_to_child_with_index(target_parent_page, params[:new_position])
+        render json: @page, serializer: PageNodeSerializer
+      rescue => err
+        render json: {message: err.message}, status: 422
+      end
     end
 
     private

--- a/app/javascript/alchemy_admin/components/overlay.js
+++ b/app/javascript/alchemy_admin/components/overlay.js
@@ -3,15 +3,15 @@ import { AlchemyHTMLElement } from "alchemy_admin/components/alchemy_html_elemen
 class Overlay extends AlchemyHTMLElement {
   render() {
     return `
-        <alchemy-spinner></alchemy-spinner>
-        <div id="overlay_text_box">
-            <span id="overlay_text">${this.getAttribute("text")}</span>
-        </div>
-        `
+      <alchemy-spinner></alchemy-spinner>
+      <div id="overlay_text_box">
+        <span id="overlay_text">${this.getAttribute("text")}</span>
+      </div>
+      `
   }
 
   set show(value) {
-    this.style.setProperty("display", value ? "block" : "none")
+    this.classList.toggle("visible", value)
   }
 }
 

--- a/app/javascript/alchemy_admin/page_sorter.js
+++ b/app/javascript/alchemy_admin/page_sorter.js
@@ -23,6 +23,7 @@ function onFinishDragging(evt) {
     })
     .catch((error) => {
       Alchemy.growl(error.message || error, "error")
+      Alchemy.currentSitemap.reload()
     })
     .finally(() => {
       pleaseWaitOverlay(false)

--- a/app/javascript/alchemy_admin/page_sorter.js
+++ b/app/javascript/alchemy_admin/page_sorter.js
@@ -1,5 +1,6 @@
 import Sortable from "sortablejs"
 import { patch } from "alchemy_admin/utils/ajax"
+import pleaseWaitOverlay from "alchemy_admin/please_wait_overlay"
 
 function onFinishDragging(evt) {
   const pageId = evt.item.dataset.pageId
@@ -9,6 +10,7 @@ function onFinishDragging(evt) {
     new_position: evt.newIndex
   }
 
+  pleaseWaitOverlay(true)
   patch(url, data)
     .then(async (response) => {
       const pageData = await response.data
@@ -21,6 +23,9 @@ function onFinishDragging(evt) {
     })
     .catch((error) => {
       Alchemy.growl(error.message || error, "error")
+    })
+    .finally(() => {
+      pleaseWaitOverlay(false)
     })
 }
 

--- a/app/javascript/alchemy_admin/page_sorter.js
+++ b/app/javascript/alchemy_admin/page_sorter.js
@@ -2,7 +2,7 @@ import Sortable from "sortablejs"
 import { patch } from "alchemy_admin/utils/ajax"
 import pleaseWaitOverlay from "alchemy_admin/please_wait_overlay"
 
-function onFinishDragging(evt) {
+function onSort(evt) {
   const pageId = evt.item.dataset.pageId
   const url = Alchemy.routes.move_admin_page_path(pageId)
   const data = {
@@ -10,24 +10,26 @@ function onFinishDragging(evt) {
     new_position: evt.newIndex
   }
 
-  pleaseWaitOverlay(true)
-  patch(url, data)
-    .then(async (response) => {
-      const pageData = await response.data
-      const pageEl = document.getElementById(`page_${pageId}`)
-      const urlPathEl = pageEl.querySelector(".sitemap_url")
+  if (evt.target === evt.to) {
+    pleaseWaitOverlay(true)
+    patch(url, data)
+      .then(async (response) => {
+        const pageData = await response.data
+        const pageEl = document.getElementById(`page_${pageId}`)
+        const urlPathEl = pageEl.querySelector(".sitemap_url")
 
-      Alchemy.growl(Alchemy.t("Successfully moved page"))
-      urlPathEl.textContent = pageData.url_path
-      displayPageFolders()
-    })
-    .catch((error) => {
-      Alchemy.growl(error.message || error, "error")
-      Alchemy.currentSitemap.reload()
-    })
-    .finally(() => {
-      pleaseWaitOverlay(false)
-    })
+        Alchemy.growl(Alchemy.t("Successfully moved page"))
+        urlPathEl.textContent = pageData.url_path
+        displayPageFolders()
+      })
+      .catch((error) => {
+        Alchemy.growl(error.message || error, "error")
+        Alchemy.currentSitemap.reload()
+      })
+      .finally(() => {
+        pleaseWaitOverlay(false)
+      })
+  }
 }
 
 export function displayPageFolders() {
@@ -56,7 +58,7 @@ export function createSortables(sortables) {
       fallbackOnBody: true,
       swapThreshold: 0.65,
       handle: ".handle",
-      onEnd: onFinishDragging
+      onSort
     })
   })
 }

--- a/app/javascript/alchemy_admin/sitemap.js
+++ b/app/javascript/alchemy_admin/sitemap.js
@@ -40,6 +40,11 @@ export default class Sitemap {
       .catch(this.errorHandler)
   }
 
+  // Reloads the sitemap
+  reload() {
+    this.load(this.options.page_root_id)
+  }
+
   // Watch page folder clicks and re-render the page branch
   handlePageFolders() {
     on(

--- a/app/serializers/alchemy/page_node_serializer.rb
+++ b/app/serializers/alchemy/page_node_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Alchemy
+  class PageNodeSerializer < ActiveModel::Serializer
+    attributes :id,
+      :url_path,
+      :parent_id
+  end
+end

--- a/spec/controllers/alchemy/api/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/api/pages_controller_spec.rb
@@ -362,6 +362,7 @@ module Alchemy
           expect(response.status).to eq(200)
           response_json = JSON.parse(response.body)
           expect(response_json["parent_id"]).to eq(page.id)
+          expect(response_json["url_path"]).to eq(page_3.reload.url_path)
           expect(page.children).to include(page_3)
         end
       end

--- a/spec/controllers/alchemy/api/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/api/pages_controller_spec.rb
@@ -365,6 +365,16 @@ module Alchemy
           expect(response_json["url_path"]).to eq(page_3.reload.url_path)
           expect(page.children).to include(page_3)
         end
+
+        context "when moving causes error" do
+          it "returns JSON with error message" do
+            allow_any_instance_of(Alchemy::Page).to receive(:move_to_child_with_index).and_raise(CollectiveIdea::Acts::NestedSet::Move::ImpossibleMove.new("Impossible move"))
+            patch :move, params: {id: page_3, target_parent_id: page.id, new_position: 0, format: :json}
+            expect(response.status).to eq(422)
+            response_json = JSON.parse(response.body)
+            expect(response_json["message"]).to eq("Impossible move")
+          end
+        end
       end
 
       context "with unauthorized access" do

--- a/spec/features/admin/legacy_page_url_management_spec.rb
+++ b/spec/features/admin/legacy_page_url_management_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Legacy page url management", type: :system, js: true do
 
   def open_page_properties
     visit admin_pages_path
-    expect(page.find("alchemy-overlay").style("display")["display"]).to have_content("none")
+    expect(page.find("alchemy-overlay")).to_not have_css(".visible")
     page.find("a[href='#{configure_admin_page_path(a_page)}']", wait: 10).click
   end
 

--- a/spec/features/admin/nodes_management_spec.rb
+++ b/spec/features/admin/nodes_management_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Nodes management", type: :system, js: true do
 
   def open_page_properties
     visit admin_pages_path
-    expect(page.find("alchemy-overlay").style("display")["display"]).to have_content("none")
+    expect(page.find("alchemy-overlay")).to_not have_css(".visible")
     page.find("a[href='#{configure_admin_page_path(a_page)}']", wait: 10).click
     find("[panel='nodes']").click
   end

--- a/spec/javascript/alchemy_admin/components/overlay.spec.js
+++ b/spec/javascript/alchemy_admin/components/overlay.spec.js
@@ -21,7 +21,7 @@ describe("alchemy-overlay", () => {
   it("should be hidden", () => {
     renderComponent()
     overlay.show = false
-    expect(overlay.style.getPropertyValue("display")).toBe("none")
+    expect(overlay.classList).not.toContain("visible")
   })
 
   it("should have a given text", () => {
@@ -32,6 +32,6 @@ describe("alchemy-overlay", () => {
   it("should be visible", () => {
     renderComponent()
     overlay.show = true
-    expect(overlay.style.getPropertyValue("display")).toBe("block")
+    expect(overlay.classList).toContain("visible")
   })
 })


### PR DESCRIPTION
## What is this pull request for?

Locking the screen with "please wait overlay" after page has been moved in order to make sure that people do not
drag too many pages in a short time frame.

Also fixes a bug with error handling if the page cannot be moved. We now reload the page sitemap after an error
happened.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message

