### PR TITLE
Page sort mode

### DIFF
--- a/app/assets/stylesheets/alchemy/frame.scss
+++ b/app/assets/stylesheets/alchemy/frame.scss
@@ -86,10 +86,13 @@ div#overlay_text_box {
   padding-left: $collapsed-main-menu-width + 8px;
   z-index: 0;
   width: 100%;
-  height: 100%;
 
   @media screen and (min-width: $large-screen-break-point) {
     padding-left: $main-menu-width + 8px;
+  }
+
+  .sortable & {
+    background-color: var(--color-yellow_light);
   }
 }
 

--- a/app/assets/stylesheets/alchemy/frame.scss
+++ b/app/assets/stylesheets/alchemy/frame.scss
@@ -1,12 +1,21 @@
 alchemy-overlay {
-  display: none;
+  visibility: hidden;
   position: fixed;
   left: 0;
   top: 0;
   width: 100%;
   height: 100%;
   z-index: 400000;
-  background-color: rgba(229, 229, 229, 0.4);
+  background-color: transparent;
+  transition: all $transition-duration $transition-easing;
+  transition-delay: 0;
+
+  &.visible {
+    visibility: visible;
+    transition-delay: 300ms;
+    transition-property: background-color;
+    background-color: rgba(229, 229, 229, 0.2);
+  }
 }
 
 div#overlay_text_box {

--- a/app/assets/stylesheets/alchemy/sitemap.scss
+++ b/app/assets/stylesheets/alchemy/sitemap.scss
@@ -51,6 +51,10 @@
       margin-left: initial;
     }
   }
+
+  .sortable & {
+    display: none;
+  }
 }
 
 #sitemap-wrapper {
@@ -91,6 +95,12 @@
       padding-left: $sitemap-line-height;
       padding-right: 0;
     }
+  }
+}
+
+.sitemap-item {
+  .children.droppable {
+    background-color: var(--color-yellow_light);
   }
 }
 
@@ -207,6 +217,13 @@
 
   @media screen and (min-width: $small-screen-break-point) {
     display: flex;
+  }
+
+  .icon_button,
+  .sitemap_tool {
+    .sortable & {
+      display: none !important;
+    }
   }
 
   .sitemap_tool {

--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -54,6 +54,8 @@ module Alchemy
 
           items = items.page(params[:page] || 1).per(items_per_page)
           @pages = items
+        elsif params[:sortable] == "true"
+          @sortable = true
         end
       end
 

--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -51,7 +51,7 @@ module Alchemy
       authorize! :update, @page
       target_parent_page = Page.find(params[:target_parent_id])
       @page.move_to_child_with_index(target_parent_page, params[:new_position])
-      render json: @page, serializer: PageSerializer
+      render json: @page, serializer: PageNodeSerializer
     end
 
     private

--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -52,6 +52,8 @@ module Alchemy
       target_parent_page = Page.find(params[:target_parent_id])
       @page.move_to_child_with_index(target_parent_page, params[:new_position])
       render json: @page, serializer: PageNodeSerializer
+    rescue => err
+      render json: {message: err.message}, status: 422
     end
 
     private

--- a/app/javascript/alchemy_admin/components/overlay.js
+++ b/app/javascript/alchemy_admin/components/overlay.js
@@ -3,15 +3,15 @@ import { AlchemyHTMLElement } from "alchemy_admin/components/alchemy_html_elemen
 class Overlay extends AlchemyHTMLElement {
   render() {
     return `
-        <alchemy-spinner></alchemy-spinner>
-        <div id="overlay_text_box">
-            <span id="overlay_text">${this.getAttribute("text")}</span>
-        </div>
-        `
+      <alchemy-spinner></alchemy-spinner>
+      <div id="overlay_text_box">
+        <span id="overlay_text">${this.getAttribute("text")}</span>
+      </div>
+      `
   }
 
   set show(value) {
-    this.style.setProperty("display", value ? "block" : "none")
+    this.classList.toggle("visible", value)
   }
 }
 

--- a/app/javascript/alchemy_admin/page_sorter.js
+++ b/app/javascript/alchemy_admin/page_sorter.js
@@ -23,6 +23,7 @@ function onFinishDragging(evt) {
     })
     .catch((error) => {
       Alchemy.growl(error.message || error, "error")
+      Alchemy.currentSitemap.reload()
     })
     .finally(() => {
       pleaseWaitOverlay(false)

--- a/app/javascript/alchemy_admin/page_sorter.js
+++ b/app/javascript/alchemy_admin/page_sorter.js
@@ -1,5 +1,6 @@
 import Sortable from "sortablejs"
 import { patch } from "alchemy_admin/utils/ajax"
+import pleaseWaitOverlay from "alchemy_admin/please_wait_overlay"
 
 function onFinishDragging(evt) {
   const pageId = evt.item.dataset.pageId
@@ -9,6 +10,7 @@ function onFinishDragging(evt) {
     new_position: evt.newIndex
   }
 
+  pleaseWaitOverlay(true)
   patch(url, data)
     .then(async (response) => {
       const pageData = await response.data
@@ -21,6 +23,9 @@ function onFinishDragging(evt) {
     })
     .catch((error) => {
       Alchemy.growl(error.message || error, "error")
+    })
+    .finally(() => {
+      pleaseWaitOverlay(false)
     })
 }
 

--- a/app/javascript/alchemy_admin/page_sorter.js
+++ b/app/javascript/alchemy_admin/page_sorter.js
@@ -2,7 +2,7 @@ import Sortable from "sortablejs"
 import { patch } from "alchemy_admin/utils/ajax"
 import pleaseWaitOverlay from "alchemy_admin/please_wait_overlay"
 
-function onFinishDragging(evt) {
+function onSort(evt) {
   const pageId = evt.item.dataset.pageId
   const url = Alchemy.routes.move_admin_page_path(pageId)
   const data = {
@@ -10,24 +10,26 @@ function onFinishDragging(evt) {
     new_position: evt.newIndex
   }
 
-  pleaseWaitOverlay(true)
-  patch(url, data)
-    .then(async (response) => {
-      const pageData = await response.data
-      const pageEl = document.getElementById(`page_${pageId}`)
-      const urlPathEl = pageEl.querySelector(".sitemap_url")
+  if (evt.target === evt.to) {
+    pleaseWaitOverlay(true)
+    patch(url, data)
+      .then(async (response) => {
+        const pageData = await response.data
+        const pageEl = document.getElementById(`page_${pageId}`)
+        const urlPathEl = pageEl.querySelector(".sitemap_url")
 
-      Alchemy.growl(Alchemy.t("Successfully moved page"))
-      urlPathEl.textContent = pageData.url_path
-      displayPageFolders()
-    })
-    .catch((error) => {
-      Alchemy.growl(error.message || error, "error")
-      Alchemy.currentSitemap.reload()
-    })
-    .finally(() => {
-      pleaseWaitOverlay(false)
-    })
+        Alchemy.growl(Alchemy.t("Successfully moved page"))
+        urlPathEl.textContent = pageData.url_path
+        displayPageFolders()
+      })
+      .catch((error) => {
+        Alchemy.growl(error.message || error, "error")
+        Alchemy.currentSitemap.reload()
+      })
+      .finally(() => {
+        pleaseWaitOverlay(false)
+      })
+  }
 }
 
 export function displayPageFolders() {
@@ -56,7 +58,7 @@ export function createSortables(sortables) {
       fallbackOnBody: true,
       swapThreshold: 0.65,
       handle: ".handle",
-      onEnd: onFinishDragging
+      onSort,
     })
   })
 }

--- a/app/javascript/alchemy_admin/page_sorter.js
+++ b/app/javascript/alchemy_admin/page_sorter.js
@@ -57,8 +57,7 @@ export function createSortables(sortables) {
       animation: 150,
       fallbackOnBody: true,
       swapThreshold: 0.65,
-      handle: ".handle",
-      onSort,
+      onSort
     })
   })
 }

--- a/app/javascript/alchemy_admin/sitemap.js
+++ b/app/javascript/alchemy_admin/sitemap.js
@@ -79,7 +79,10 @@ export default class Sitemap {
       .querySelectorAll(".sitemap_page")
     this.sitemap_wrapper = document.getElementById("sitemap-wrapper")
     this._observe()
-    PageSorter()
+    displayPageFolders()
+    if (this.options.sortable) {
+      PageSorter()
+    }
   }
 
   reRender(pageId, data) {
@@ -87,8 +90,10 @@ export default class Sitemap {
     pageEl.outerHTML = this.list_template({ children: data.pages })
     pageEl = document.getElementById(`page_${pageId}`)
     const sortables = pageEl.querySelectorAll("ul.children")
-    createSortables(sortables)
     displayPageFolders()
+    if (this.options.sortable) {
+      createSortables(sortables)
+    }
   }
 
   // Filters the sitemap

--- a/app/javascript/alchemy_admin/sitemap.js
+++ b/app/javascript/alchemy_admin/sitemap.js
@@ -40,6 +40,11 @@ export default class Sitemap {
       .catch(this.errorHandler)
   }
 
+  // Reloads the sitemap
+  reload() {
+    this.load(this.options.page_root_id)
+  }
+
   // Watch page folder clicks and re-render the page branch
   handlePageFolders() {
     on(

--- a/app/serializers/alchemy/page_node_serializer.rb
+++ b/app/serializers/alchemy/page_node_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Alchemy
+  class PageNodeSerializer < ActiveModel::Serializer
+    attributes :id,
+      :url_path,
+      :parent_id
+  end
+end

--- a/app/views/alchemy/admin/pages/_page.html.erb
+++ b/app/views/alchemy/admin/pages/_page.html.erb
@@ -6,13 +6,21 @@
         <%= page_layout_missing_warning %>
       {{else}}
         {{#if permissions.edit_content}}
-          <span class="{{#unless root}}handle{{/unless}}">
+          <span class="<%= sortable && '{{#unless root}}handle{{/unless}}' %>">
             {{#if locked}}
-              <sl-tooltip content="{{locked_notice}}" class="like-hint-tooltip" placement="bottom-start">
-                <i class="icon ri-file-edit-line ri-fw ri-xl"></i>
-              </sl-tooltip>
+              <% if sortable %>
+                <i class="icon ri-{{#if root}}file-line{{else}}draggable{{/if}} ri-fw ri-xl"></i>
+              <% else %>
+                <sl-tooltip content="{{locked_notice}}" class="like-hint-tooltip" placement="bottom-start">
+                  <i class="icon ri-file-edit-line ri-fw ri-xl"></i>
+                </sl-tooltip>
+              <% end %>
             {{else}}
-              <i class="icon ri-file-line ri-fw ri-xl"></i>
+              <% if sortable %>
+                <i class="icon ri-{{#if root}}file-line{{else}}draggable{{/if}} ri-fw ri-xl"></i>
+              <% else %>
+                <i class="icon ri-file-line ri-fw ri-xl"></i>
+              <% end %>
             {{/if}}
           </span>
         {{else}}
@@ -23,16 +31,20 @@
       {{/if}}
     </div>
     <div class="sitemap_sitename">
-      {{#if permissions.edit_content}}
-        <%= link_to(
-          "{{name}}",
-          alchemy.edit_admin_page_path(id: "__ID__"),
-          title: Alchemy.t(:edit_page),
-          class: "sitemap_pagename_link"
-        ) -%>
-      {{else}}
+      <% if sortable %>
         <%= content_tag("span", "{{name}}", class: "sitemap_pagename_link") %>
-      {{/if}}
+      <% else %>
+        {{#if permissions.edit_content}}
+          <%= link_to(
+            "{{name}}",
+            alchemy.edit_admin_page_path(id: "__ID__"),
+            title: Alchemy.t(:edit_page),
+            class: "sitemap_pagename_link"
+          ) -%>
+        {{else}}
+          <%= content_tag("span", "{{name}}", class: "sitemap_pagename_link") %>
+        {{/if}}
+      <% end %>
     </div>
     <div class="sitemap_url" title="{{url_path}}">
       {{ url_path }}

--- a/app/views/alchemy/admin/pages/_sitemap.html.erb
+++ b/app/views/alchemy/admin/pages/_sitemap.html.erb
@@ -1,3 +1,9 @@
+<% if @sortable %>
+  <%= render_message do %>
+    <%= t(".sortable_info") %>
+  <% end %>
+<% end %>
+
 <h4 id="sitemap_heading">
   <span class="page_name"><%= Alchemy::Page.human_attribute_name(:name) %></span>
   <span class="page_urlname"><%= Alchemy::Page.human_attribute_name(:urlname) %></span>
@@ -15,7 +21,7 @@
 
 <script id="sitemap-list" type="text/x-handlebars-template">
   {{#each children}}
-  <%= render partial: page_partial, object: @page_root %>
+  <%= render partial: page_partial, object: @page_root, locals: {sortable: @sortable} %>
   {{/each}}
 </script>
 
@@ -23,7 +29,8 @@
  $(function() {
    Alchemy.currentSitemap = new Alchemy.Sitemap({
      url: '<%= alchemy.tree_admin_pages_path %>',
-     page_root_id: <%= @page_root.id %>
+     page_root_id: <%= @page_root.id %>,
+     sortable: <%= !!@sortable %>
    });
    Alchemy.PagePublicationFields();
  });

--- a/app/views/alchemy/admin/pages/_toolbar.html.erb
+++ b/app/views/alchemy/admin/pages/_toolbar.html.erb
@@ -46,6 +46,26 @@
   </div>
   <div class="toolbar_spacer"></div>
   <div class="toolbar_button">
+    <% if @sortable %>
+      <sl-tooltip content="<%= Alchemy.t("Disable sorting") %>">
+        <%= link_to(
+          render_icon(:"drag-drop"),
+          alchemy.admin_pages_path(view: "tree"),
+          class: ["icon_button", "active"].compact
+        ) %>
+      </sl-tooltip>
+    <% else %>
+      <sl-tooltip content="<%= Alchemy.t("Enable sorting") %>">
+        <%= link_to(
+          render_icon(:"drag-drop"),
+          alchemy.admin_pages_path(view: "tree", sortable: true),
+          class: ["icon_button"].compact
+        ) %>
+      </sl-tooltip>
+    <% end %>
+  </div>
+  <div class="toolbar_spacer"></div>
+  <div class="toolbar_button">
     <sl-tooltip content="<%= Alchemy.t("Hierarchical") %>">
       <%= link_to(
         render_icon(:"menu-2"),

--- a/app/views/alchemy/admin/pages/index.html.erb
+++ b/app/views/alchemy/admin/pages/index.html.erb
@@ -6,6 +6,10 @@
   <%= render "alchemy/admin/pages/toolbar" %>
 <% end %>
 
+<% if @sortable %>
+  <% content_for(:alchemy_body_class) { "sortable" } %>
+<% end %>
+
 <%= content_tag :div,
   id: "archive_all",
   class: [@view == "list" && "resources-table-wrapper with_tag_filter"] do %>

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -229,6 +229,9 @@ en:
       elements:
         toolbar:
           hide: Hide
+      pages:
+        sitemap:
+          sortable_info: "Use Drag'n'Drop to sort pages"
     add_nested_element: "Add %{name}"
     anchor: "Anchor"
     anchor_link_headline: You can link to an anchor from the current page.

--- a/spec/controllers/alchemy/api/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/api/pages_controller_spec.rb
@@ -362,6 +362,7 @@ module Alchemy
           expect(response.status).to eq(200)
           response_json = JSON.parse(response.body)
           expect(response_json["parent_id"]).to eq(page.id)
+          expect(response_json["url_path"]).to eq(page_3.reload.url_path)
           expect(page.children).to include(page_3)
         end
       end

--- a/spec/controllers/alchemy/api/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/api/pages_controller_spec.rb
@@ -365,6 +365,16 @@ module Alchemy
           expect(response_json["url_path"]).to eq(page_3.reload.url_path)
           expect(page.children).to include(page_3)
         end
+
+        context "when moving causes error" do
+          it "returns JSON with error message" do
+            allow_any_instance_of(Alchemy::Page).to receive(:move_to_child_with_index).and_raise(CollectiveIdea::Acts::NestedSet::Move::ImpossibleMove.new("Impossible move"))
+            patch :move, params: {id: page_3, target_parent_id: page.id, new_position: 0, format: :json}
+            expect(response.status).to eq(422)
+            response_json = JSON.parse(response.body)
+            expect(response_json["message"]).to eq("Impossible move")
+          end
+        end
       end
 
       context "with unauthorized access" do


### PR DESCRIPTION
## What is this pull request for?

In order to prevent accidental moves (that would alter the page url) users now need to enable sortable mode.

We hide the tooltip on the page icon (which is the draggable handle) in order to make it easier to see that move cursor for
locked pages. Also hiding page actions.

Coloring the background light yellow indicates that we now are in a special mode.

### Screenshots

![Bildschirmfoto am 2024-03-07 um 12 06 06](https://github.com/AlchemyCMS/alchemy_cms/assets/42868/c43ded2d-714b-42a9-b1c9-70e7f8ccda1c)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message

