### PR TITLE
Remove order in before_action callback

### DIFF
--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -7,11 +7,11 @@ module Alchemy
 
       helper "alchemy/pages"
 
-      before_action :load_resource, except: [:index, :flush, :new, :order, :create, :copy_language_tree, :link]
+      before_action :load_resource, except: [:index, :flush, :new, :create, :copy_language_tree, :link]
 
       authorize_resource class: Alchemy::Page, except: [:index, :tree]
 
-      before_action only: [:index, :tree, :flush, :new, :order, :create, :copy_language_tree] do
+      before_action only: [:index, :tree, :flush, :new, :create, :copy_language_tree] do
         authorize! :index, :alchemy_admin_pages
       end
 
@@ -21,7 +21,7 @@ module Alchemy
         except: [:show]
 
       before_action :set_root_page,
-        only: [:index, :show, :order]
+        only: [:index, :show]
 
       before_action :set_preview_mode, only: [:show]
 


### PR DESCRIPTION
## What is this pull request for?
The order method was remove a few days ago. In the latest version of Rails (v7.1) this leads to a warning if this option is enabled during development.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
