### PR TITLE
A Proposal: A resource table component

### DIFF
--- a/app/components/alchemy/admin/resource/table.rb
+++ b/app/components/alchemy/admin/resource/table.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+module Alchemy
+  module Admin
+    module Resource
+      class Table < ViewComponent::Base
+        include BaseHelper
+        delegate :can?, :sort_link, :render_attribute, to: :helpers
+
+        attr_reader :actions, :columns, :collection, :ransack_query, :resource_url, :nothing_found_label
+
+        erb_template <<~ERB
+          <% if collection.any? %>
+            <table class="list">
+              <thead>
+                <tr>
+                  <% columns.each do |column| %>
+                    <th class="<%= column.name %>">
+                        <% if column.sortable %>
+                          <%= sort_link [resource_url, ransack_query],
+                              column.name,
+                              column.label,
+                              default_order: column.type.to_s =~ /date|time/ ? 'desc' : 'asc' %>
+                        <% else %>
+                          <%= column.label %>
+                        <% end %>
+                    </th>
+                  <% end %>
+                  <% if actions.present? %>
+                    <th class="tools"></th>
+                  <% end %>
+                </tr>
+              </thead>
+              <tbody>
+                <% collection.each do |row| %>
+                  <tr class="<%= cycle('even', 'odd') %>">
+                    <% columns.each do |column| %>
+                      <td class="<%= column.type %> <%= column.name %>">
+                        <%= view_context.capture(row, &column.block) %>
+                      </td>
+                    <% end %>
+                    <% if actions.present? %>
+                      <td class="tools">
+                        <% actions.each do |action| %>
+                          <% if action.name.nil? || can?(action.name, row) %>
+                            <% if action.tooltip.present? %>
+                              <sl-tooltip content="<%= action.tooltip %>">
+                                <%= view_context.capture(row, &action.block) %>
+                              </sl-tooltip>
+                            <% else %>
+                              <%= view_context.capture(row, &action.block) %>
+                            <% end %>
+                          <% end %>
+                        <% end %>
+                      </td>
+                    <% end %>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          <% else %>
+            <div class="info">
+              <%= render_icon('info') %>
+              <%= nothing_found_label %>
+            </div>
+          <% end %>
+        ERB
+
+        def initialize(collection, ransack_query: nil, nothing_found_label: Alchemy.t("Nothing found"), resource_url: :resource_url_proxy)
+          @collection = collection
+          @ransack_query = ransack_query
+          @nothing_found_label = nothing_found_label
+          @resource_url = resource_url
+          @columns = []
+          @actions = []
+        end
+
+        def column(name, label: nil, sortable: false, type: :string, &block)
+          @columns << Column.new(name, label: label, sortable: sortable, type: type, &block)
+        end
+
+        def icon_column(icon = nil)
+          @columns << Column.new(:icon, label: "") do |row|
+            render_icon(icon || yield(row), size: "xl")
+          end
+        end
+
+        def action(name = nil, tooltip: nil, &block)
+          @actions << Action.new(name, tooltip: tooltip, &block)
+        end
+
+        private
+
+        ##
+        # the before_render - method is necessary to force ViewComponent to evaluate the add_column - calls
+        def before_render
+          content
+        end
+
+        class Column
+          attr_reader :block, :label, :name, :sortable, :type
+
+          def initialize(name, sortable: false, label: nil, type: :string, &block)
+            @name = name
+            @label = label || name
+            @sortable = sortable
+            @block = block || lambda { |item| transform item[name] }
+            @type = type
+          end
+
+          private
+
+          def transform(value)
+            case value
+            when DateTime, ActiveSupport::TimeWithZone
+              ::I18n.l(value, format: :"alchemy.default")
+            when Time
+              ::I18n.l(value, format: :"alchemy.time")
+            else
+              value
+            end
+          end
+        end
+
+        class Action
+          attr_reader :name, :tooltip, :block
+
+          def initialize(name = nil, tooltip: nil, &block)
+            @name = name
+            @tooltip = tooltip
+            @block = block
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/components/alchemy/admin/resource/table_spec.rb
+++ b/spec/components/alchemy/admin/resource/table_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::Admin::Resource::Table, type: :component do
+  let(:collection) { [] }
+  before do
+    render
+  end
+
+  subject(:render) do
+    render_inline(described_class.new(collection))
+  end
+
+  context "with data" do
+    let(:collection) {
+      [
+        {name: "Foo", description: "Awesome description"},
+        {name: "Bar", description: "Another description"}
+      ]
+    }
+
+    it "doesn't renders an info message" do
+      expect(page).to_not have_content("Nothing found")
+    end
+
+    context "columns without block" do
+      subject(:render) do
+        render_inline(described_class.new(collection)) do |table|
+          table.column(:name)
+          table.column(:description)
+        end
+      end
+
+      it "renders a table header" do
+        expect(page).to have_selector("table th", text: "name")
+        expect(page).to have_selector("table th", text: "description")
+      end
+
+      it "renders a table cell" do
+        expect(page).to have_selector("table td.name", text: "Foo")
+        expect(page).to have_selector("table td.description", text: "Awesome description")
+      end
+    end
+
+    context "columns with custom label" do
+      subject(:render) do
+        render_inline(described_class.new(collection)) do |component|
+          component.column(:name, label: "Awesome Name")
+        end
+      end
+
+      it "renders a table header with custom label" do
+        expect(page).to have_selector("table th", text: "Awesome Name")
+      end
+    end
+
+    context "columns with a custom block" do
+      subject(:render) do
+        render_inline(described_class.new(collection)) do |table|
+          table.column(:description) { |item| item[:description].truncate(10) }
+        end
+      end
+
+      it "renders a table cell with a custom block" do
+        expect(page).to have_selector("table td", text: "Awesome...")
+      end
+    end
+
+    context "icon column with variable" do
+      subject(:render) do
+        render_inline(described_class.new(collection)) do |table|
+          table.icon_column(:home)
+        end
+      end
+
+      it "renders a table cell with a home icon" do
+        expect(page).to have_selector("table td alchemy-icon[name='home']")
+      end
+    end
+
+    context "icon column with custom block" do
+      subject(:render) do
+        render_inline(described_class.new(collection)) do |table|
+          table.icon_column { |row| (row[:name] == "Foo") ? :save : :home }
+        end
+      end
+
+      it "renders a table cell with a home icon another one with a save icon" do
+        expect(page).to have_selector("table td alchemy-icon[name='save']")
+        expect(page).to have_selector("table td alchemy-icon[name='home']")
+      end
+    end
+
+    context "actions" do
+      let(:name) { nil }
+      let(:tooltip) { nil }
+
+      subject(:render) do
+        render_inline(described_class.new(collection)) do |table|
+          table.action(name, tooltip: tooltip) { |row| "Foo" }
+        end
+      end
+
+      context "action without any config" do
+        it "renders an action entry" do
+          expect(page).to have_selector("table td.tools", text: "Foo")
+        end
+
+        it "does not render a tooltip without tooltip config" do
+          expect(page).to_not have_selector("table td.tools sl-tooltip")
+        end
+      end
+
+      context "with tooltip" do
+        let(:tooltip) { "Bar" }
+
+        it "does render a tooltip without tooltip config" do
+          expect(page).to have_selector("table td.tools sl-tooltip[content='Bar']")
+        end
+      end
+
+      context "with permission" do
+        let(:name) { :unknown_permission }
+
+        it "does not renders an action entry" do
+          expect(page).to_not have_selector("table td.tools", text: "Foo")
+        end
+      end
+    end
+  end
+
+  context "without any data" do
+    it "renders an info message" do
+      expect(page).to have_content("Nothing found")
+    end
+
+    context "with another nothing found - label" do
+      subject(:render) do
+        render_inline(described_class.new(collection, nothing_found_label: "No user found"))
+      end
+
+      it "renders an info message" do
+        expect(page).to have_content("No user found")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

Add an experimental resource table component. The idea is to make it easier to create resource tables without duplicating the table structure and be in sync between the index view and the row partial. 

### Screenshots

An example:
![CleanShot 2024-03-09 at 16 00 32@2x](https://github.com/AlchemyCMS/alchemy_cms/assets/68833/b48d7d19-7cc9-4169-845f-bdb8b6234fa0)


## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
