### PR TITLE
Fix SVG Preview size

### DIFF
--- a/app/assets/stylesheets/alchemy/archive.scss
+++ b/app/assets/stylesheets/alchemy/archive.scss
@@ -74,7 +74,7 @@
       background: $thumbnail-background;
     }
 
-    &[src*=".svg"]:not([src*="alchemy/missing-image"]) {
+    &[src*="svg"]:not([src*="alchemy/missing-image"]) {
       width: var(--picture-width);
       max-height: var(--picture-height);
     }


### PR DESCRIPTION
## What is this pull request for?

The URL of the SVG preview normally don't have an SVG extension, but it contains svg in the given asset URL. There is a (rare) possibility, that the asset hash of a non-SVG image will also contain that three characters, but it does not seem like a big deal, because it would only increase the height of outer container.

### Screenshots

![Aufnahme 2024-03-12 at 08 33 18@2x](https://github.com/AlchemyCMS/alchemy_cms/assets/122262394/0d13f37a-3e3d-41a2-b79a-abf4145be94d)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
