### PR TITLE
Add multi language image descriptions

### DIFF
--- a/app/assets/javascripts/alchemy/alchemy.image_overlay.coffee
+++ b/app/assets/javascripts/alchemy/alchemy.image_overlay.coffee
@@ -17,7 +17,8 @@ class window.Alchemy.ImageOverlay extends Alchemy.Dialog
     @$previous = $('.previous-picture')
     @$next = $('.next-picture')
     @$document.keydown (e) =>
-      return true if e.target.nodeName == 'INPUT'
+      if e.target.nodeName == 'INPUT' || e.target.nodeName == 'TEXTAREA'
+        return true
       switch e.which
         when 37
           @previous()

--- a/app/assets/stylesheets/alchemy/forms.scss
+++ b/app/assets/stylesheets/alchemy/forms.scss
@@ -19,6 +19,12 @@ form {
     @include form-label;
   }
 
+  .inline-label {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-1);
+  }
+
   .input {
     padding: $default-padding 0;
     @include clearfix;

--- a/app/controllers/alchemy/admin/ingredients_controller.rb
+++ b/app/controllers/alchemy/admin/ingredients_controller.rb
@@ -10,6 +10,8 @@ module Alchemy
       helper "Alchemy::Admin::Ingredients"
 
       def edit
+        @language = Alchemy::Language.find_by(id: params[:language_id]) ||
+          Alchemy::Current.language
       end
 
       def update

--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -114,6 +114,7 @@ module Alchemy
         end
         @preview_url = @preview_urls.first.last
         @layoutpage = @page.layoutpage?
+        Alchemy::Current.language = @page.language
       end
 
       # Set page configuration like page names, meta tags and states.

--- a/app/controllers/alchemy/admin/picture_descriptions_controller.rb
+++ b/app/controllers/alchemy/admin/picture_descriptions_controller.rb
@@ -1,0 +1,15 @@
+module Alchemy
+  module Admin
+    class PictureDescriptionsController < Alchemy::Admin::ResourcesController
+      def edit
+        @picture_description = @picture.descriptions.find_or_initialize_by(language_id: params[:language_id])
+      end
+
+      private
+
+      def load_resource
+        @picture = Alchemy::Picture.find(params[:picture_id])
+      end
+    end
+  end
+end

--- a/app/controllers/alchemy/admin/pictures_controller.rb
+++ b/app/controllers/alchemy/admin/pictures_controller.rb
@@ -5,6 +5,7 @@ module Alchemy
     class PicturesController < Alchemy::Admin::ResourcesController
       include UploaderResponses
       include ArchiveOverlay
+      include CurrentLanguage
 
       helper "alchemy/admin/tags"
 
@@ -33,6 +34,9 @@ module Alchemy
         @previous = filtered_pictures.where("name < ?", @picture.name).last
         @next = filtered_pictures.where("name > ?", @picture.name).first
         @assignments = @picture.picture_ingredients.joins(element: :page)
+        @picture_description = @picture.descriptions.find_or_initialize_by(
+          language_id: Alchemy::Current.language.id
+        )
 
         render action: "show"
       end
@@ -193,7 +197,20 @@ module Alchemy
       end
 
       def picture_params
-        params.require(:picture).permit(:image_file, :upload_hash, :name, :description, :tag_list)
+        params.require(:picture).permit(
+          :image_file,
+          :upload_hash,
+          :name,
+          {
+            descriptions_attributes: [
+              :id,
+              :text,
+              :language_id,
+              :picture_id
+            ]
+          },
+          :tag_list
+        )
       end
 
       def picture_url_params

--- a/app/models/alchemy/ingredients/picture.rb
+++ b/app/models/alchemy/ingredients/picture.rb
@@ -38,8 +38,10 @@ module Alchemy
         upsample
       ]
 
-      def alt_text
-        alt_tag.presence || picture&.description || picture&.name&.humanize
+      def alt_text(language: Alchemy::Current.language)
+        alt_tag.presence ||
+          picture&.description_for(language) ||
+          picture&.name&.humanize
       end
 
       # The first 30 characters of the pictures name

--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -55,6 +55,9 @@ module Alchemy
     has_many :elements, through: :picture_ingredients
     has_many :pages, through: :elements
     has_many :thumbs, class_name: "Alchemy::PictureThumb", dependent: :destroy
+    has_many :descriptions, class_name: "Alchemy::PictureDescription", dependent: :destroy
+
+    accepts_nested_attributes_for :descriptions, allow_destroy: true, reject_if: ->(attr) { attr[:text].blank? }
 
     # Raise error, if picture is in use (aka. assigned to an Picture ingredient)
     #
@@ -229,6 +232,11 @@ module Alchemy
         size: image_file_size,
         error: errors[:image_file].join
       }
+    end
+
+    # Returns the picture description for a given language.
+    def description_for(language)
+      descriptions.find_by(language: language)&.text
     end
 
     # Returns an uri escaped name.

--- a/app/models/alchemy/picture_description.rb
+++ b/app/models/alchemy/picture_description.rb
@@ -1,0 +1,8 @@
+module Alchemy
+  class PictureDescription < ActiveRecord::Base
+    belongs_to :picture, class_name: "Alchemy::Picture"
+    belongs_to :language, class_name: "Alchemy::Language"
+
+    validates_uniqueness_of :picture_id, scope: :language_id
+  end
+end

--- a/app/views/alchemy/admin/ingredients/_picture_fields.html.erb
+++ b/app/views/alchemy/admin/ingredients/_picture_fields.html.erb
@@ -1,6 +1,6 @@
 <%= f.input :caption, as: ingredient.settings[:caption_as_textarea] ? 'text' : 'string' %>
 <%= f.input :title %>
-<%= f.input :alt_tag, as: :text, placeholder: ingredient.alt_text %>
+<%= f.input :alt_tag, as: :text, placeholder: ingredient.alt_text(language: @language) %>
 <%- if ingredient.settings[:sizes].present? && ingredient.settings[:srcset].blank? -%>
   <%= f.input :render_size,
     collection: [

--- a/app/views/alchemy/admin/picture_descriptions/_form.html.erb
+++ b/app/views/alchemy/admin/picture_descriptions/_form.html.erb
@@ -1,0 +1,11 @@
+<% field_name_prefix = "picture[descriptions_attributes][#{picture_description_counter}]" %>
+
+<% if picture_description.persisted? %>
+  <%= hidden_field field_name_prefix, :id, value: picture_description.id %>
+<% else %>
+  <%= hidden_field field_name_prefix, :language_id, value: picture_description.language_id %>
+  <%= hidden_field field_name_prefix, :picture_id, value: picture_description.picture_id %>
+<% end %>
+
+<%= label field_name_prefix, :text, Alchemy::PictureDescription.human_attribute_name(:text), class: "control-label" %>
+<%= text_area field_name_prefix, :text, value: picture_description.text, rows: 3 %>

--- a/app/views/alchemy/admin/picture_descriptions/edit.html.erb
+++ b/app/views/alchemy/admin/picture_descriptions/edit.html.erb
@@ -1,0 +1,6 @@
+<turbo-frame id="picture_descriptions">
+  <%= render "form", {
+    picture_description: @picture_description,
+    picture_description_counter: @picture.descriptions.index(@picture_description)
+  } %>
+</turbo-frame>

--- a/app/views/alchemy/admin/pictures/_picture_description_field.html.erb
+++ b/app/views/alchemy/admin/pictures/_picture_description_field.html.erb
@@ -1,1 +1,29 @@
-<%= f.input :description %>
+<div class="input">
+  <% if Alchemy::Language.many? %>
+    <label class="inline-label" style="float: right">
+      <%= Alchemy::Language.model_name.human %>
+      <%= select_tag :language_id, options_from_collection_for_select(
+          Alchemy::Language.published, :id, ->(l) { l.code.upcase },
+          selected: @picture_description.language_id,
+        ), data: {
+          url: alchemy.edit_admin_picture_description_url(id: "__ID__", picture_id: @picture)
+        } %>
+    </label>
+  <% end %>
+
+  <turbo-frame id="picture_descriptions">
+    <%= render "alchemy/admin/picture_descriptions/form",
+      picture_description_counter: @picture.descriptions.index(@picture_description),
+      picture_description: @picture_description %>
+  </turbo-frame>
+</div>
+
+<script type="module">
+  const select = document.querySelector("#language_id")
+
+  select.addEventListener("change", () => {
+    const url = new URL(select.dataset.url)
+    url.searchParams.set("language_id", select.value)
+    Turbo.visit(url, { frame: "picture_descriptions" })
+  })
+</script>

--- a/app/views/alchemy/ingredients/shared/_picture_tools.html.erb
+++ b/app/views/alchemy/ingredients/shared/_picture_tools.html.erb
@@ -41,7 +41,7 @@
 
 <%= content_tag "sl-tooltip", content: Alchemy.t(:edit_image_properties), placement: "top-end" do %>
   <%= link_to_dialog render_icon(:edit),
-    alchemy.edit_admin_ingredient_path(id: picture_editor.id),
+    alchemy.edit_admin_ingredient_path(id: picture_editor.id, language_id: @page.language_id),
     {
       title: Alchemy.t(:edit_image_properties),
       size: "380x255"

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -812,6 +812,9 @@ en:
       alchemy/picture:
         one: Picture
         other: Pictures
+      alchemy/picture_description:
+        one: Picture Description
+        other: Picture Descriptions
       alchemy/user:
         one: User
         other: User
@@ -902,6 +905,8 @@ en:
         image_file_size: "Filesize"
         name: "Name"
         tag_list: Tags
+      alchemy/picture_description:
+        text: "Description"
       alchemy/site:
         name: "Name"
         host: "Primary Host"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,8 @@ Alchemy::Engine.routes.draw do
       end
     end
 
+    resources :picture_descriptions, only: [:index, :edit]
+
     resources :attachments, except: [:new] do
       member do
         get :download

--- a/db/migrate/20240208101342_add_description_to_picture.rb
+++ b/db/migrate/20240208101342_add_description_to_picture.rb
@@ -1,5 +1,0 @@
-class AddDescriptionToPicture < ActiveRecord::Migration[7.0]
-  def change
-    add_column :alchemy_pictures, :description, :text
-  end
-end

--- a/db/migrate/20240314105244_create_alchemy_picture_descriptions.rb
+++ b/db/migrate/20240314105244_create_alchemy_picture_descriptions.rb
@@ -1,0 +1,11 @@
+class CreateAlchemyPictureDescriptions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :alchemy_picture_descriptions do |t|
+      t.belongs_to :picture, null: false, foreign_key: {to_table: :alchemy_pictures}
+      t.belongs_to :language, null: false, foreign_key: {to_table: :alchemy_languages}
+      t.text :text
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/alchemy/permissions.rb
+++ b/lib/alchemy/permissions.rb
@@ -157,6 +157,7 @@ module Alchemy
         end
 
         can :manage, Alchemy::Picture
+        can :manage, Alchemy::PictureDescription
         can :manage, Alchemy::Attachment
         can :manage, Alchemy::Tag
         can :index, Alchemy::Language

--- a/spec/controllers/alchemy/admin/pictures_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/pictures_controller_spec.rb
@@ -26,6 +26,8 @@ module Alchemy
       authorize_user(:as_admin)
     end
 
+    let!(:language) { create(:alchemy_language) }
+
     describe "#index" do
       context "with search params" do
         let!(:picture_1) { create(:alchemy_picture, name: "cute kitten") }
@@ -250,12 +252,23 @@ module Alchemy
         let(:picture) { create(:alchemy_picture) }
 
         subject do
-          put :update, params: {id: 1, picture: {name: "", description: "foo bar"}}, xhr: true
+          put :update, params: {
+            id: 1,
+            picture: {
+              name: "",
+              descriptions_attributes: {
+                0 => {
+                  text: "foo bar",
+                  language_id: language.id
+                }
+              }
+            }
+          }, xhr: true
         end
 
         it "sets the description" do
           subject
-          expect(picture.description).to eq("foo bar")
+          expect(picture.description_for(language)).to eq("foo bar")
         end
       end
     end

--- a/spec/dummy/config/locales/alchemy.de.yml
+++ b/spec/dummy/config/locales/alchemy.de.yml
@@ -22,3 +22,8 @@ de:
       richtext: Dieser Inhaltstyp stellt formatierbaren Text dar
       select: Dieser Inhaltstyp stellt Werte dar aus denen der Redakteur wählen kann
       text: Dieser Inhaltstyp stellt eine einfache Zeile Text dar
+
+  activerecord:
+    attributes:
+      alchemy/picture_description:
+        text: "Bildbeschreibung"

--- a/spec/dummy/db/migrate/20240208101342_add_description_to_picture.rb
+++ b/spec/dummy/db/migrate/20240208101342_add_description_to_picture.rb
@@ -1,5 +1,0 @@
-class AddDescriptionToPicture < ActiveRecord::Migration[7.0]
-  def change
-    add_column :alchemy_pictures, :description, :text
-  end
-end

--- a/spec/dummy/db/migrate/20240411155901_create_alchemy_picture_descriptions.alchemy.rb
+++ b/spec/dummy/db/migrate/20240411155901_create_alchemy_picture_descriptions.alchemy.rb
@@ -1,0 +1,12 @@
+# This migration comes from alchemy (originally 20240314105244)
+class CreateAlchemyPictureDescriptions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :alchemy_picture_descriptions do |t|
+      t.belongs_to :picture, null: false, foreign_key: {to_table: :alchemy_pictures}
+      t.belongs_to :language, null: false, foreign_key: {to_table: :alchemy_languages}
+      t.text :text
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_08_101342) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_11_155901) do
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string "name"
     t.string "file_name"
@@ -136,7 +136,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_08_101342) do
 
   create_table "alchemy_page_mutexes", force: :cascade do |t|
     t.integer "page_id", null: false
-    t.datetime "created_at"
+    t.datetime "created_at", precision: nil
     t.index ["page_id"], name: "index_alchemy_page_mutexes_on_page_id", unique: true
   end
 
@@ -186,6 +186,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_08_101342) do
     t.index ["urlname"], name: "index_pages_on_urlname"
   end
 
+  create_table "alchemy_picture_descriptions", force: :cascade do |t|
+    t.integer "picture_id", null: false
+    t.integer "language_id", null: false
+    t.text "text"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["language_id"], name: "index_alchemy_picture_descriptions_on_language_id"
+    t.index ["picture_id"], name: "index_alchemy_picture_descriptions_on_picture_id"
+  end
+
   create_table "alchemy_picture_thumbs", force: :cascade do |t|
     t.integer "picture_id", null: false
     t.string "signature", null: false
@@ -207,7 +217,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_08_101342) do
     t.string "image_file_uid"
     t.integer "image_file_size"
     t.string "image_file_format"
-    t.text "description"
     t.index ["creator_id"], name: "index_alchemy_pictures_on_creator_id"
     t.index ["image_file_name"], name: "index_alchemy_pictures_on_image_file_name"
     t.index ["name"], name: "index_alchemy_pictures_on_name"
@@ -293,5 +302,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_08_101342) do
   add_foreign_key "alchemy_page_mutexes", "alchemy_pages", column: "page_id"
   add_foreign_key "alchemy_page_versions", "alchemy_pages", column: "page_id", on_delete: :cascade
   add_foreign_key "alchemy_pages", "alchemy_languages", column: "language_id"
+  add_foreign_key "alchemy_picture_descriptions", "alchemy_languages", column: "language_id"
+  add_foreign_key "alchemy_picture_descriptions", "alchemy_pictures", column: "picture_id"
   add_foreign_key "alchemy_picture_thumbs", "alchemy_pictures", column: "picture_id"
 end

--- a/spec/features/admin/ingredient_pictures_feature_spec.rb
+++ b/spec/features/admin/ingredient_pictures_feature_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.feature "Ingredient Pictures admin feature", type: :system do
+  before do
+    authorize_user(:as_editor)
+  end
+
+  let(:language) { create(:alchemy_language) }
+  let(:picture) { create(:alchemy_picture) }
+  let(:ingredient_picture) { create(:alchemy_ingredient_picture, picture: picture) }
+
+  let!(:picture_description) do
+    Alchemy::PictureDescription.create!(picture: picture, language: language, text: "A nice picture")
+  end
+
+  scenario "Picture description is used as default for ingredient picture alt text" do
+    visit alchemy.edit_admin_ingredient_path(ingredient_picture)
+    expect(page).to have_field("Alternative text", placeholder: "A nice picture")
+  end
+end

--- a/spec/features/admin/picture_library_integration_spec.rb
+++ b/spec/features/admin/picture_library_integration_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe "Picture Library", type: :system do
     authorize_user(:as_admin)
   end
 
+  let!(:language) { create(:alchemy_language) }
+
   describe "Tagging" do
     let!(:picture_1) { create(:alchemy_picture, tag_list: "tag1", name: "TaggedWith1") }
     let!(:picture_2) { create(:alchemy_picture, tag_list: "tag2", name: "TaggedWith2") }
@@ -59,6 +61,36 @@ RSpec.describe "Picture Library", type: :system do
       click_on "bla (1)"
 
       expect(page).to have_content("bla")
+    end
+  end
+
+  describe "Picture descriptions" do
+    let!(:picture) { create(:alchemy_picture) }
+
+    scenario "allows to add a picture description", :js do
+      visit alchemy.admin_pictures_path
+      page.find("a.thumbnail_background").click
+      expect(page).to have_field("Description")
+      fill_in "Description", with: "This is an amazing image."
+      click_button "Save"
+      within "#flash_notices" do
+        expect(page).to have_content("Picture updated successfully")
+      end
+      expect(picture.description_for(language)).to eq("This is an amazing image.")
+    end
+
+    scenario "allows to add multi language picture descriptions", :js do
+      german = create(:alchemy_language, :german)
+      visit alchemy.admin_pictures_path
+      page.find("a.thumbnail_background").click
+      expect(page).to have_field("Description")
+      select(german.language_code.upcase, from: "Language")
+      fill_in "Description", with: "Tolles Bild."
+      click_button "Save"
+      within "#flash_notices" do
+        expect(page).to have_content("Picture updated successfully")
+      end
+      expect(picture.description_for(german)).to eq("Tolles Bild.")
     end
   end
 end

--- a/spec/models/alchemy/ingredients/picture_spec.rb
+++ b/spec/models/alchemy/ingredients/picture_spec.rb
@@ -34,14 +34,32 @@ RSpec.describe Alchemy::Ingredients::Picture do
     end
 
     context "with a picture description" do
-      before { picture.description = "Another cute kitten" }
+      it "returns picture description" do
+        expect(picture).to receive(:description_for) {
+          "Another cute kitten"
+        }
+        is_expected.to eq("Another cute kitten")
+      end
 
-      it { is_expected.to eq("Another cute kitten") }
+      context "with language given" do
+        let(:language) { create(:alchemy_language, :german) }
+
+        subject { picture_ingredient.alt_text(language: language) }
+
+        it "returns picture description for given language" do
+          expect(picture).to receive(:description_for).with(language) {
+            "Eine süße Katze"
+          }
+          is_expected.to eq("Eine süße Katze")
+        end
+      end
 
       context "with a alt_tag" do
         before { picture_ingredient.alt_tag = "A cute kitten" }
 
-        it { is_expected.to eq("A cute kitten") }
+        it "returns alt text" do
+          is_expected.to eq("A cute kitten")
+        end
       end
     end
 
@@ -50,10 +68,16 @@ RSpec.describe Alchemy::Ingredients::Picture do
 
       it { is_expected.to eq("Cute kitten") }
 
-      context "with a picture description" do
-        before { picture.description = "Another cute kitten" }
+      context "with a picture description for current language" do
+        before do
+          expect(picture).to receive(:description_for) {
+            "Another cute kitten"
+          }
+        end
 
-        it { is_expected.to eq("Another cute kitten") }
+        it "returns the picture description" do
+          is_expected.to eq("Another cute kitten")
+        end
       end
     end
   end

--- a/spec/models/alchemy/picture_description_spec.rb
+++ b/spec/models/alchemy/picture_description_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::PictureDescription do
+  it { should belong_to(:picture).class_name("Alchemy::Picture") }
+  it { should belong_to(:language).class_name("Alchemy::Language") }
+
+  describe "validations" do
+    let(:picture) { create(:alchemy_picture) }
+    let(:language) { create(:alchemy_language) }
+
+    let!(:description) do
+      described_class.create!(picture: picture, language: language, text: "Test description")
+    end
+
+    it { should validate_uniqueness_of(:picture_id).scoped_to(:language_id) }
+  end
+end

--- a/spec/models/alchemy/picture_spec.rb
+++ b/spec/models/alchemy/picture_spec.rb
@@ -373,6 +373,29 @@ module Alchemy
       end
     end
 
+    describe "#description_for" do
+      subject { picture.description_for(language) }
+
+      let(:picture) { create(:alchemy_picture) }
+      let(:language) { create(:alchemy_language) }
+
+      context "with a description for the given language" do
+        let!(:description) do
+          Alchemy::PictureDescription.create!(
+            picture: picture,
+            language: language,
+            text: "A nice picture"
+          )
+        end
+
+        it { is_expected.to eq(description.text) }
+      end
+
+      context "without a description for the given language" do
+        it { is_expected.to be_nil }
+      end
+    end
+
     describe "#to_jq_upload" do
       subject { picture.to_jq_upload }
 

--- a/spec/requests/alchemy/admin/pictures_controller_spec.rb
+++ b/spec/requests/alchemy/admin/pictures_controller_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "Alchemy::Admin::PicturesController" do
     context "as author" do
       before do
         authorize_user(:as_author)
+        create(:alchemy_language)
       end
 
       it "returns the url to picture" do

--- a/spec/views/admin/pictures/show_spec.rb
+++ b/spec/views/admin/pictures/show_spec.rb
@@ -18,6 +18,16 @@ describe "alchemy/admin/pictures/show.html.erb" do
     })
   end
 
+  let(:language) { create(:alchemy_language) }
+
+  let(:picture_description) do
+    Alchemy::PictureDescription.create!(
+      picture: picture,
+      language: language,
+      text: "This is an amazing image."
+    )
+  end
+
   before do
     allow(view).to receive(:admin_picture_path).and_return("/path")
     allow(view).to receive(:edit_admin_page_path).and_return("/path")
@@ -26,6 +36,7 @@ describe "alchemy/admin/pictures/show.html.erb" do
     view.extend Alchemy::Admin::FormHelper
     view.extend Alchemy::BaseHelper
     assign(:picture, picture)
+    assign(:picture_description, picture_description)
   end
 
   it "displays picture in original format" do

--- a/spec/views/alchemy/ingredients/picture_editor_spec.rb
+++ b/spec/views/alchemy/ingredients/picture_editor_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "alchemy/ingredients/_picture_editor" do
+  let(:page) { stub_model(Alchemy::Page) }
   let(:picture) { stub_model(Alchemy::Picture) }
   let(:element) { build_stubbed(:alchemy_element, name: "all_you_can_eat") }
   let(:element_editor) { Alchemy::ElementEditor.new(element) }
@@ -27,6 +28,7 @@ RSpec.describe "alchemy/ingredients/_picture_editor" do
     allow(ingredient).to receive(:settings) { settings }
     view.class.send :include, Alchemy::Admin::BaseHelper
     view.class.send :include, Alchemy::Admin::IngredientsHelper
+    assign(:page, page)
   end
 
   subject do


### PR DESCRIPTION
## What is this pull request for?

Create a language based picture description model and UI to choose the description by language

### Screenshots

![Alchemy CMS - Bilder 2024-04-11 20-19-20](https://github.com/AlchemyCMS/alchemy_cms/assets/42868/ba660f8a-f66d-4c41-bef9-3ea75a97f1a6)

![Alchemy CMS - Bilder 2024-04-11 20-19-30](https://github.com/AlchemyCMS/alchemy_cms/assets/42868/cbb0b7a7-537c-4ee2-8b19-c6255d48f315)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
