### PR TITLE
Fix hidden element visibility

### DIFF
--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -81,7 +81,7 @@ alchemy-tinymce {
   line-height: 1;
   max-width: 85%;
 
-  .hidden & {
+  .element-hidden & {
     max-width: 65%;
   }
 
@@ -117,7 +117,7 @@ alchemy-tinymce {
   padding: 0;
   margin: 0 0 0 auto;
 
-  .hidden & {
+  .element-hidden & {
     margin-left: unset;
   }
 
@@ -131,10 +131,6 @@ alchemy-tinymce {
 
   .icon {
     pointer-events: none;
-
-    &.hidden {
-      display: none;
-    }
   }
 }
 
@@ -151,7 +147,7 @@ alchemy-tinymce {
     margin-top: 0;
   }
 
-  &.hidden {
+  &.element-hidden {
     display: block;
     border-style: dashed;
     opacity: 0.7;
@@ -220,12 +216,12 @@ alchemy-tinymce {
 
   &.selected:not(.is-fixed),
   &:hover:not(.is-fixed) {
-    &:not(.hidden) {
+    &:not(.element-hidden) {
       box-shadow: 0 2px 8px rgba(#9b9b9b, 0.75);
     }
   }
 
-  &.selected:not(.is-fixed):not(.folded):not(.dirty):not(.hidden):not(
+  &.selected:not(.is-fixed):not(.folded):not(.dirty):not(.element-hidden):not(
       .deprecated
     ) {
     > .element-header {
@@ -918,10 +914,6 @@ textarea.has_tinymce {
   border-radius: $default-border-radius;
   color: $error_text_color;
   border: 1px solid $error_border_color;
-
-  &.hidden {
-    display: none;
-  }
 
   p {
     margin: 0;

--- a/app/decorators/alchemy/element_editor.rb
+++ b/app/decorators/alchemy/element_editor.rb
@@ -59,8 +59,8 @@ module Alchemy
         compact? ? "compact" : nil,
         deprecated? ? "deprecated" : nil,
         fixed? ? "is-fixed" : "not-fixed",
-        public? ? "visible" : "hidden"
-      ].join(" ")
+        public? ? nil : "element-hidden"
+      ]
     end
 
     # Tells us, if we should show the element footer and form inputs.

--- a/app/javascript/alchemy_admin/components/element_editor.js
+++ b/app/javascript/alchemy_admin/components/element_editor.js
@@ -351,9 +351,9 @@ export class ElementEditor extends HTMLElement {
    */
   set published(isPublished) {
     if (isPublished) {
-      this.classList.remove("hidden")
+      this.classList.remove("element-hidden")
     } else {
-      this.classList.add("hidden")
+      this.classList.add("element-hidden")
     }
   }
 

--- a/app/views/alchemy/admin/elements/_element.html.erb
+++ b/app/views/alchemy/admin/elements/_element.html.erb
@@ -2,7 +2,7 @@
   id="element_<%= element.id %>"
   data-element-id="<%= element.id %>"
   data-element-name="<%= element.name %>"
-  class="<%= element.css_classes %>"
+  class="<%= element.css_classes.join(" ") %>"
   <%= element.compact? ? "compact" : nil %>
   <%= element.fixed? ? "fixed" : nil %>
 >

--- a/spec/decorators/alchemy/element_editor_spec.rb
+++ b/spec/decorators/alchemy/element_editor_spec.rb
@@ -66,13 +66,13 @@ RSpec.describe Alchemy::ElementEditor do
     context "with element is public" do
       let(:element) { build_stubbed(:alchemy_element, public: true) }
 
-      it { is_expected.to include("visible") }
+      it { is_expected.to_not include("element-hidden") }
     end
 
     context "with element is not public" do
       let(:element) { build_stubbed(:alchemy_element, public: false) }
 
-      it { is_expected.to include("hidden") }
+      it { is_expected.to include("element-hidden") }
     end
 
     context "with element is folded" do


### PR DESCRIPTION
## What is this pull request for?

We recently made sure that all HTML elements with
the `hidden` class do not display at all. But we want to show elements that are hidden, but dim them. Using a dedicated `element-hidden` class instead.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
