### PR TITLE
Only initialize Alchemy Admin JS locally

### DIFF
--- a/app/javascript/alchemy_admin.js
+++ b/app/javascript/alchemy_admin.js
@@ -59,7 +59,6 @@ Object.assign(Alchemy, {
   growl,
   ImageLoader: ImageLoader.init,
   ImageCropper,
-  Initializer,
   IngredientAnchorLink,
   LinkDialog,
   pictureSelector,

--- a/app/javascript/alchemy_admin/initializer.js
+++ b/app/javascript/alchemy_admin/initializer.js
@@ -18,7 +18,7 @@ function selectHandler(selectId, parameterName, forcedReload = false) {
   })
 }
 
-function Initialize() {
+export default function Initializer() {
   // We obviously have javascript enabled.
   $("html").removeClass("no-js")
 
@@ -56,5 +56,3 @@ function Initialize() {
     )
   }
 }
-
-export default Initialize


### PR DESCRIPTION
## What is this pull request for?

Instead of exposing the Initializer into the global Alchemy object we can initialize it locally in the ES module.

Also remove an empty file that was left over from the coffeescript conversion

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
