### PR TITLE
Fix module error

### DIFF
--- a/lib/alchemy/modules.rb
+++ b/lib/alchemy/modules.rb
@@ -35,7 +35,7 @@ module Alchemy
             defined_controllers.concat(definition_hash["navigation"]["sub_navigation"].map { |x| x["controller"] })
           end
 
-          validate_controllers_existence(defined_controllers)
+          validate_controllers_existence(defined_controllers, definition_hash)
         end
 
         @@alchemy_modules |= [definition_hash]
@@ -43,7 +43,7 @@ module Alchemy
 
       private
 
-      def validate_controllers_existence(controllers)
+      def validate_controllers_existence(controllers, definition_hash)
         controllers.each do |controller_val|
           next if controller_val.blank?
 

--- a/spec/libraries/modules_spec.rb
+++ b/spec/libraries/modules_spec.rb
@@ -162,11 +162,15 @@ module Alchemy
       end
 
       it "fails to register a module when a matching navigation controller cannot be found" do
-        expect { Modules.register_module(bad_alchemy_module_a) }.to raise_error(NameError)
+        expect { Modules.register_module(bad_alchemy_module_a) }.to raise_error(
+          "Error in AlchemyCMS module definition: 'bad_module_a'. Could not find the matching controller class BadModuleController for the specified controller: 'bad_module'"
+        )
       end
 
       it "fails to register a module when a matching sub_navigation controller cannot be found" do
-        expect { Modules.register_module(bad_alchemy_module_b) }.to raise_error(NameError)
+        expect { Modules.register_module(bad_alchemy_module_b) }.to raise_error(
+          "Error in AlchemyCMS module definition: 'bad_module_b'. Could not find the matching controller class BadModuleController for the specified controller: 'bad_module'"
+        )
       end
 
       it "registers a module definition only once" do


### PR DESCRIPTION

## What is this pull request for?

The error message in Alchemy::Modules.validate_controllers_existence relies on the definition_hash variable to be present. Because it isn't, we get a NameError rather than the expected RuntimeError.
