### PR TITLE
Clear definitions cache after file change

### DIFF
--- a/lib/alchemy/element_definition.rb
+++ b/lib/alchemy/element_definition.rb
@@ -42,6 +42,16 @@ module Alchemy
         all.detect { |a| a["name"] == name }
       end
 
+      def reset!
+        @definitions = nil
+      end
+
+      # The absolute +elements.yml+ file path
+      # @return [Pathname]
+      def definitions_file_path
+        Rails.root.join("config", "alchemy", "elements.yml")
+      end
+
       private
 
       # Reads the element definitions from +config/alchemy/elements.yml+.
@@ -57,12 +67,6 @@ module Alchemy
           raise LoadError,
             "Could not find elements.yml file! Please run `rails generate alchemy:install`"
         end
-      end
-
-      # Returns the elements.yml file path
-      #
-      def definitions_file_path
-        Rails.root.join "config/alchemy/elements.yml"
       end
     end
   end

--- a/lib/alchemy/engine.rb
+++ b/lib/alchemy/engine.rb
@@ -35,6 +35,23 @@ module Alchemy
       end
     end
 
+    initializer "alchemy.watch_definition_changes" do |app|
+      elements_reloader = app.config.file_watcher.new([ElementDefinition.definitions_file_path]) do
+        Rails.logger.info "[#{engine_name}] Reloading Element Definitions."
+        ElementDefinition.reset!
+      end
+      page_layouts_reloader = app.config.file_watcher.new([PageLayout.layouts_file_path]) do
+        Rails.logger.info "[#{engine_name}] Reloading Page Layouts."
+        PageLayout.reset!
+      end
+      [elements_reloader, page_layouts_reloader].each do |reloader|
+        app.reloaders << reloader
+        app.reloader.to_run do
+          reloader.execute_if_updated
+        end
+      end
+    end
+
     # Gutentag downcases all tags before save
     # and Gutentag validations are not case sensitive.
     # But we support having tags with uppercase characters.

--- a/lib/alchemy/page_layout.rb
+++ b/lib/alchemy/page_layout.rb
@@ -41,6 +41,16 @@ module Alchemy
         all.detect { |a| a["name"].casecmp(name).zero? }
       end
 
+      def reset!
+        @definitions = nil
+      end
+
+      # The absolute +page_layouts.yml+ file path
+      # @return [Pathname]
+      def layouts_file_path
+        Rails.root.join("config", "alchemy", "page_layouts.yml")
+      end
+
       private
 
       # Reads the layout definitions from +config/alchemy/page_layouts.yml+.
@@ -57,12 +67,6 @@ module Alchemy
         else
           raise LoadError, "Could not find page_layouts.yml file! Please run `rails generate alchemy:install`"
         end
-      end
-
-      # Returns the page_layouts.yml file path
-      #
-      def layouts_file_path
-        Rails.root.join "config/alchemy/page_layouts.yml"
       end
     end
   end

--- a/spec/libraries/element_definition_spec.rb
+++ b/spec/libraries/element_definition_spec.rb
@@ -35,5 +35,13 @@ module Alchemy
         expect(ElementDefinition.get("default")).to eq({"name" => "default"})
       end
     end
+
+    describe ".reset!" do
+      it "sets @definitions to nil" do
+        ElementDefinition.all
+        ElementDefinition.reset!
+        expect(ElementDefinition.instance_variable_get(:@definitions)).to be_nil
+      end
+    end
   end
 end

--- a/spec/libraries/page_layout_spec.rb
+++ b/spec/libraries/page_layout_spec.rb
@@ -67,5 +67,13 @@ module Alchemy
         expect(PageLayout.get("default")).to eq({"name" => "default"})
       end
     end
+
+    describe ".reset!" do
+      it "sets @definitions to nil" do
+        PageLayout.all
+        PageLayout.reset!
+        expect(PageLayout.instance_variable_get(:@definitions)).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
## What is this pull request for?

When the `elements.yml` or `page_layouts.yml` files change the memoiziation gets resetted, so that the next app reload includes the latest changes to these files.

This removes the need to restart the Rails server after one changed an element definition or page layout.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
