### PR TITLE
[7.1] Reload preview window (again) after element create

### DIFF
--- a/app/views/alchemy/admin/elements/create.js.erb
+++ b/app/views/alchemy/admin/elements/create.js.erb
@@ -28,6 +28,7 @@
 
   Alchemy.growl('<%= Alchemy.t(:successfully_added_element) %>');
   Alchemy.closeCurrentDialog();
+  Alchemy.reloadPreview();
 
   el = document.querySelector('#element_<%= @element.id %>');
   el.focusElement();


### PR DESCRIPTION
This has been removed during refactoring the element editor into a custom web-component in https://github.com/AlchemyCMS/alchemy_cms/pull/2614

This restores the behavior.
