### PR TITLE
Add dependent: :nullify to Page#nodes

### DIFF
--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -116,7 +116,7 @@ module Alchemy
     has_many :site_languages, through: :site, source: :languages
     has_many :folded_pages, dependent: :destroy
     has_many :legacy_urls, class_name: "Alchemy::LegacyPageUrl", dependent: :destroy
-    has_many :nodes, class_name: "Alchemy::Node", inverse_of: :page
+    has_many :nodes, class_name: "Alchemy::Node", inverse_of: :page, dependent: :nullify
     has_many :versions, class_name: "Alchemy::PageVersion", inverse_of: :page, dependent: :destroy
     has_one :draft_version, -> { drafts }, class_name: "Alchemy::PageVersion"
     has_one :public_version, -> { published }, class_name: "Alchemy::PageVersion", autosave: -> { persisted? }

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -224,6 +224,14 @@ module Alchemy
         it "destroys elements along with itself" do
           expect { page.destroy! }.to change(Alchemy::Element, :count).from(3).to(0)
         end
+
+        context "with a node attached to the page" do
+          let!(:node) { create(:alchemy_node, page: page) }
+
+          it "nullifies the node" do
+            expect { page.destroy! }.to change { node.reload.page_id }.from(page.id).to(nil)
+          end
+        end
       end
     end
 


### PR DESCRIPTION


## What is this pull request for?

If a page is used in a node, we need to nullify that page_id upon destruction. Otherwise we get foreign key constraint errors.

