### PR TITLE
Nullify Ingredients::Page on Page destroy

### DIFF
--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -121,6 +121,8 @@ module Alchemy
     has_one :draft_version, -> { drafts }, class_name: "Alchemy::PageVersion"
     has_one :public_version, -> { published }, class_name: "Alchemy::PageVersion", autosave: -> { persisted? }
 
+    has_many :page_ingredients, class_name: "Alchemy::Ingredients::Page", foreign_key: :related_object_id, dependent: :nullify
+
     before_validation :set_language,
       if: -> { language.nil? }
 

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -224,6 +224,14 @@ module Alchemy
         it "destroys elements along with itself" do
           expect { page.destroy! }.to change(Alchemy::Element, :count).from(3).to(0)
         end
+
+        context "with a page ingredient pointing to the page" do
+          let!(:ingredient) { create(:alchemy_ingredient_page, page: page) }
+
+          it "nullifies the foreign key on the ingredient" do
+            expect { page.destroy! }.to change { ingredient.reload.related_object_id }.from(page.id).to(nil)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
When we delete a page, page ingredients that point to that page should be nullified.

