### PR TITLE
Fix Ingredient Boolean View

### DIFF
--- a/app/components/alchemy/ingredients/boolean_view.rb
+++ b/app/components/alchemy/ingredients/boolean_view.rb
@@ -2,7 +2,7 @@ module Alchemy
   module Ingredients
     class BooleanView < BaseView
       def call
-        Alchemy.t(value, scope: "ingredient_values.boolean").html_safe
+        Alchemy.t(value.to_s, scope: "ingredient_values.boolean").html_safe
       end
 
       def render?


### PR DESCRIPTION
In case of a missing translation `html_safe` would raise an error on the returned value (a `Boolean`). 
So converting it into `String` is best option here.
