### PR TITLE
UI fixes for picture css class display

### DIFF
--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -641,15 +641,13 @@ alchemy-publish-element-button {
   .picture_ingredient_css_class {
     position: absolute;
     z-index: 1;
-    bottom: 24px;
-    width: 99px;
-    background-color: white;
+    bottom: 34px;
     background-color: rgba(255, 254, 255, 0.7);
     padding: 4px 8px;
     font-size: $small-font-size;
-    text-align: right;
-    height: 12px;
     overflow: hidden;
+    max-width: 100%;
+    text-overflow: ellipsis;
   }
 }
 


### PR DESCRIPTION
## What is this pull request for?

The `css_class` is shown as overlay on the picture ingredient editor. Since the toolbar has raised the height we need to adopt the position

![Alchemy CMS - Index 2024-04-18 09-02-00](https://github.com/AlchemyCMS/alchemy_cms/assets/42868/7926b50e-6dad-4fa1-abef-83b46883a33f)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
