### PR TITLE
feat(alchemy-button): Re-enable on turbo:submit-end

### DIFF
--- a/app/javascript/alchemy_admin/components/button.js
+++ b/app/javascript/alchemy_admin/components/button.js
@@ -8,6 +8,8 @@ class Button extends HTMLButtonElement {
       if (this.form.dataset.remote == "true") {
         this.form.addEventListener("ajax:complete", this)
       }
+
+      this.form.addEventListener("turbo:submit-end", this)
     } else {
       console.warn("No form for button found!", this)
     }
@@ -26,6 +28,7 @@ class Button extends HTMLButtonElement {
         }
         break
       case "ajax:complete":
+      case "turbo:submit-end":
         this.enable()
         break
     }

--- a/spec/javascript/alchemy_admin/components/button.spec.js
+++ b/spec/javascript/alchemy_admin/components/button.spec.js
@@ -61,4 +61,30 @@ describe("alchemy-button", () => {
       expect(button.innerHTML).toEqual("Save")
     })
   })
+
+  describe("on turbo forms", () => {
+    it("re-enables button on turbo:submit-end", () => {
+      const html = `
+        <turbo-frame>
+          <form>
+            <button type="submit" is="alchemy-button">Save</button>
+          </form>
+        </turbo-frame>
+      `
+      const button = renderComponent("alchemy-button", html)
+
+      const submit = new Event("submit", { bubbles: true })
+      button.form.dispatchEvent(submit)
+
+      expect(button.getAttribute("disabled")).toEqual("disabled")
+
+      const submitEnd = new CustomEvent("turbo:submit-end", { bubbles: true })
+      button.form.dispatchEvent(submitEnd)
+
+      expect(button.getAttribute("disabled")).toBeNull()
+      expect(button.getAttribute("tabindex")).toBeNull()
+      expect(button.classList.contains("disabled")).toBeFalsy()
+      expect(button.innerHTML).toEqual("Save")
+    })
+  })
 })


### PR DESCRIPTION
## What is this pull request for?

When nested in a turbo frame the form fires a
`turbo:submit-end` event. In this case we want
the button to be enabled again.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
