### PR TITLE
Deprecate `toolbar_button` helper

### DIFF
--- a/app/helpers/alchemy/admin/base_helper.rb
+++ b/app/helpers/alchemy/admin/base_helper.rb
@@ -2,12 +2,10 @@
 
 module Alchemy
   module Admin
-    # This module contains helper methods for rendering dialogs, toolbar buttons and confirmation windows.
+    # This module contains helper methods for rendering dialogs and confirmation windows.
     #
     # The most important helpers for module developers are:
     #
-    # * {#toolbar}
-    # * {#toolbar_button}
     # * {#link_to_dialog}
     # * {#link_to_confirm_dialog}
     #
@@ -258,10 +256,11 @@ module Alchemy
       #   Skip the permission check. NOT RECOMMENDED!
       # @option options [Boolean] :loading_indicator (true)
       #   Shows the please wait dialog while loading. Only for buttons not opening an dialog.
-      #
+      # @deprecated render Alchemy::Admin::ToolbarButton.new instead
       def toolbar_button(options = {})
         render Alchemy::Admin::ToolbarButton.new(**options)
       end
+      deprecate toolbar_button: "render Alchemy::Admin::ToolbarButton.new instead", deprecator: Alchemy::Deprecation
 
       # Renders a textfield ready to display a datepicker
       #

--- a/app/views/alchemy/admin/dashboard/index.html.erb
+++ b/app/views/alchemy/admin/dashboard/index.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :toolbar do %>
   <div class="toolbar_buttons">
-    <%= toolbar_button(
+    <%= render Alchemy::Admin::ToolbarButton.new(
       icon: 'information',
       label: Alchemy.t(:info),
       url: alchemy.dashboard_info_path,

--- a/app/views/alchemy/admin/elements/index.html.erb
+++ b/app/views/alchemy/admin/elements/index.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag "alchemy_elements_window" do %>
   <alchemy-elements-window>
     <div class="elements-window-toolbar">
-      <%= toolbar_button(
+      <%= render Alchemy::Admin::ToolbarButton.new(
         url: alchemy.new_admin_element_path(page_version_id: @page_version.id),
         icon: :add,
         hotkey: "alt+n",
@@ -12,7 +12,7 @@
         },
         if_permitted_to: [:create, Alchemy::Element]
       ) %>
-      <%= toolbar_button(
+      <%= render Alchemy::Admin::ToolbarButton.new(
         url: alchemy.admin_clipboard_path(remarkable_type: "elements"),
         label: Alchemy.t("Show clipboard"),
         icon: :clipboard,

--- a/app/views/alchemy/admin/languages/index.html.erb
+++ b/app/views/alchemy/admin/languages/index.html.erb
@@ -3,7 +3,7 @@
 <% content_for :toolbar do %>
   <div class="toolbar_buttons">
     <%= render 'alchemy/admin/partials/site_select' %>
-    <%= toolbar_button(
+    <%= render Alchemy::Admin::ToolbarButton.new(
       icon: :plus,
       label: label_title,
       url: new_resource_path,

--- a/app/views/alchemy/admin/layoutpages/index.html.erb
+++ b/app/views/alchemy/admin/layoutpages/index.html.erb
@@ -2,7 +2,7 @@
 <div class="toolbar_buttons">
   <%= render 'alchemy/admin/partials/site_select' %>
   <%= render 'alchemy/admin/partials/language_tree_select' %>
-  <%= toolbar_button(
+  <%= render Alchemy::Admin::ToolbarButton.new(
     icon: "file-add",
     url: alchemy.new_admin_page_path(language: @current_language, layoutpage: true),
     hotkey: 'alt+n',
@@ -15,7 +15,7 @@
     tooltip_placement: "top-start",
     if_permitted_to: [:create, Alchemy::Page]
   ) %>
-  <%= toolbar_button(
+  <%= render Alchemy::Admin::ToolbarButton.new(
     icon: clipboard_empty?('pages') ? 'clipboard' : 'paste',
     url: alchemy.admin_clipboard_path(remarkable_type: 'pages'),
     dialog_options: {

--- a/app/views/alchemy/admin/nodes/index.html.erb
+++ b/app/views/alchemy/admin/nodes/index.html.erb
@@ -6,7 +6,7 @@
   <div class="toolbar_buttons">
     <%= render 'alchemy/admin/partials/site_select' %>
     <%= render 'alchemy/admin/partials/language_tree_select' %>
-    <%= toolbar_button(
+    <%= render Alchemy::Admin::ToolbarButton.new(
       icon: 'menu-add',
       label: Alchemy.t(:create_menu),
       url: alchemy.new_admin_node_path,

--- a/app/views/alchemy/admin/pages/_toolbar.html.erb
+++ b/app/views/alchemy/admin/pages/_toolbar.html.erb
@@ -1,7 +1,7 @@
 <div class="toolbar_buttons">
   <%= render "alchemy/admin/partials/site_select" %>
   <%= render "alchemy/admin/partials/language_tree_select" %>
-  <%= toolbar_button(
+  <%= render Alchemy::Admin::ToolbarButton.new(
     icon: "file-add",
     url: alchemy.new_admin_page_path(language: @current_language),
     hotkey: 'alt+n',

--- a/app/views/alchemy/admin/resources/index.html.erb
+++ b/app/views/alchemy/admin/resources/index.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for(:toolbar) do %>
   <div class="toolbar_buttons">
-    <%= toolbar_button(
+    <%= render Alchemy::Admin::ToolbarButton.new(
       icon: "add",
       label: label_title,
       url: new_resource_path,
@@ -15,7 +15,7 @@
       },
       if_permitted_to: [:create, resource_model]
     ) %>
-    <%= toolbar_button(
+    <%= render Alchemy::Admin::ToolbarButton.new(
       icon: :download,
       url: resource_url_proxy.url_for(action: 'index', format: 'csv', q: search_filter_params[:q], sort: params[:sort]),
       label: Alchemy.t(:download_csv),

--- a/app/views/alchemy/admin/sites/index.html.erb
+++ b/app/views/alchemy/admin/sites/index.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :toolbar do %>
   <div class="toolbar_buttons">
-    <%= toolbar_button(
+    <%= render Alchemy::Admin::ToolbarButton.new(
       icon: :plus,
       label: label_title,
       url: new_resource_path,

--- a/app/views/alchemy/admin/styleguide/index.html.erb
+++ b/app/views/alchemy/admin/styleguide/index.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <% content_for(:toolbar) do %>
-  <%= toolbar_button(
+  <%= render Alchemy::Admin::ToolbarButton.new(
     icon: :info,
     label: 'Info',
     url: alchemy.dashboard_info_path,

--- a/app/views/alchemy/admin/tags/index.html.erb
+++ b/app/views/alchemy/admin/tags/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :toolbar do %>
   <div class="toolbar_buttons">
-    <%= toolbar_button(
+    <%= render Alchemy::Admin::ToolbarButton.new(
       icon: :plus,
       label: Alchemy.t('New Tag'),
       url: alchemy.new_admin_tag_path,

--- a/app/views/alchemy/base/500.html.erb
+++ b/app/views/alchemy/base/500.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :toolbar do %>
-  <%= toolbar_button(
+  <%= render Alchemy::Admin::ToolbarButton.new(
     icon: 'angle-double-left',
     url: request.referer || alchemy.admin_dashboard_path,
     label: Alchemy.t(:back),


### PR DESCRIPTION
## What is this pull request for?

Use

    render Alchemy::Admin::ToolbarButton.new

instead.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
