### PR TITLE
Deprecate `js_filter_field`

### DIFF
--- a/app/helpers/alchemy/admin/base_helper.rb
+++ b/app/helpers/alchemy/admin/base_helper.rb
@@ -106,10 +106,11 @@ module Alchemy
       #   The css class of the <input> tag
       # @option options [String or Hash] :data ({'alchemy-list-filter' => items})
       #   A HTML data attribute that holds the jQuery selector that represents the list to be filtered
-      #
+      # @deprecated render Alchemy::Admin::ListFilter.new(items) instead
       def js_filter_field(items, _options = {})
         render Alchemy::Admin::ListFilter.new(items)
       end
+      deprecate js_filter_field: "render Alchemy::Admin::ListFilter.new(items) instead", deprecator: Alchemy::Deprecation
 
       # Returns a link that opens a modal confirmation to delete window.
       #

--- a/app/views/alchemy/admin/attachments/_tag_list.html.erb
+++ b/app/views/alchemy/admin/attachments/_tag_list.html.erb
@@ -1,6 +1,6 @@
 <% if Alchemy::Attachment.tag_counts.any? %>
   <h3><%= Alchemy.t("Filter by tag") %></h3>
-  <%= js_filter_field '.tag-list li' %>
+  <%= render Alchemy::Admin::ListFilter.new(".tag-list li") %>
   <ul>
     <%= render_tag_list('Alchemy::Attachment') %>
   </ul>

--- a/app/views/alchemy/admin/pictures/_tag_list.html.erb
+++ b/app/views/alchemy/admin/pictures/_tag_list.html.erb
@@ -1,6 +1,6 @@
 <% if Alchemy::Picture.tag_counts.any? %>
   <h3><%= Alchemy.t("Filter by tag") %></h3>
-  <%= js_filter_field '.tag-list li' %>
+  <%= render Alchemy::Admin::ListFilter.new(".tag-list li") %>
   <ul>
     <%= render_tag_list('Alchemy::Picture') %>
   </ul>

--- a/app/views/alchemy/admin/resources/_tag_list.html.erb
+++ b/app/views/alchemy/admin/resources/_tag_list.html.erb
@@ -1,6 +1,6 @@
 <div class="tag-list<%= ' with_filter_bar' if resource_has_filters %><%= ' filtered' if search_filter_params[:tagged_with].present? %>">
   <h3><%= Alchemy.t("Filter by tag") %></h3>
-  <%= js_filter_field '.tag-list li' %>
+  <%= render Alchemy::Admin::ListFilter.new(".tag-list li") %>
   <ul>
     <%= render_tag_list(resource_model.name) %>
   </ul>

--- a/app/views/alchemy/admin/tags/edit.html.erb
+++ b/app/views/alchemy/admin/tags/edit.html.erb
@@ -13,7 +13,7 @@
     <div class="input tags">
       <label class="control-label"><%= Alchemy.t('Tags') %></label>
       <div class="control_group" id="tags_tag_list">
-        <%= js_filter_field '.tag-list li' %>
+        <%= render Alchemy::Admin::ListFilter.new(".tag-list li") %>
         <ul class="tags tag-list">
           <%= render partial: "radio_tag", collection: @tags, locals: {name: "tag"} %>
         </ul>


### PR DESCRIPTION
## What is this pull request for?

Use

    render Alchemy::Admin::ListFilter.new(items)

instead.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
