### PR TITLE
Remove `render_flash_notice` helper

### DIFF
--- a/app/helpers/alchemy/base_helper.rb
+++ b/app/helpers/alchemy/base_helper.rb
@@ -46,15 +46,6 @@ module Alchemy
       render Alchemy::Admin::Message.new(msg || capture(&blk), type: type)
     end
 
-    # Renders a dismissable growl message.
-    #
-    # @param [String] notice - The notice you want to display
-    # @param [Symbol] type - The type of this flash. Valid values are +:notice+ (default), +:warn+, +:info+ and +:error+
-    #
-    def render_flash_notice(notice, type = :notice)
-      render Alchemy::Admin::Message.new(notice, type: type, dismissable: true)
-    end
-
     # Checks if the given argument is a String or a Page object.
     # If a String is given, it tries to find the page via page_layout
     # Logs a warning if no page is given.

--- a/app/views/alchemy/admin/partials/_flash_notices.html.erb
+++ b/app/views/alchemy/admin/partials/_flash_notices.html.erb
@@ -1,7 +1,7 @@
 <div id="flash_notices">
 <% flash.keys.each do |flash_type| %>
   <% if flash[flash_type.to_sym].present? %>
-    <%= render_flash_notice(flash[flash_type.to_sym], flash_type) %>
+    <%= render Alchemy::Admin::Message.new(flash[flash_type.to_sym], type: flash_type, dismissable: true) %>
   <% end %>
 <% end %>
 </div>

--- a/spec/helpers/alchemy/base_helper_spec.rb
+++ b/spec/helpers/alchemy/base_helper_spec.rb
@@ -44,28 +44,6 @@ module Alchemy
       end
     end
 
-    describe "#render_flash_notice" do
-      context "if no argument is passed" do
-        it "should render an alchemy-message with an check icon and the given content" do
-          expect(helper.render_flash_notice("my notice")).to eq <<~HTML
-            <alchemy-message type="notice" dismissable>
-              my notice
-            </alchemy-message>
-          HTML
-        end
-      end
-
-      context "if an argument is passed" do
-        it "should render the passed argument as the type for the message" do
-          expect(helper.render_flash_notice("A error", :error)).to eq <<~HTML
-            <alchemy-message type="error" dismissable>
-              A error
-            </alchemy-message>
-          HTML
-        end
-      end
-    end
-
     describe "#page_or_find" do
       let(:page) { create(:alchemy_page, :public) }
 


### PR DESCRIPTION
## What is this pull request for?

Since we only used this internally we can simply remove this, instead of deprecating it.

If you used this helper anyway, please

    render Alchemy::Admin::Message.new(message, type: flash_type, dismissable: true)

instead.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
