### PR TITLE
fix(IngredientAnchorLink): Use alchemy-icon setAttribute

### DIFF
--- a/app/javascript/alchemy_admin/ingredient_anchor_link.js
+++ b/app/javascript/alchemy_admin/ingredient_anchor_link.js
@@ -5,10 +5,9 @@ export default class IngredientAnchorLink {
     )
     if (ingredientEditor) {
       const icon = ingredientEditor.querySelector(
-        ".edit-ingredient-anchor-link > a > .icon"
+        ".edit-ingredient-anchor-link alchemy-icon"
       )
-      icon?.classList.toggle("ri-bookmark-fill", active)
-      icon?.classList.toggle("ri-bookmark-line", !active)
+      icon.setAttribute("icon-style", active ? "fill" : "line")
     }
   }
 }

--- a/spec/javascript/alchemy_admin/ingredient_anchor_link.spec.js
+++ b/spec/javascript/alchemy_admin/ingredient_anchor_link.spec.js
@@ -1,0 +1,39 @@
+import IngredientAnchorLink from "alchemy_admin/ingredient_anchor_link"
+
+describe("IngredientAnchorLink", () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div data-ingredient-id="1">
+        <a class="edit-ingredient-anchor-link">
+          <alchemy-icon icon-style="line"></alchemy-icon>
+        </a>
+      </div>
+    `
+  })
+
+  describe(".updateIcon", () => {
+    it("sets icon-style to fill if active", () => {
+      IngredientAnchorLink.updateIcon(1, true)
+      const icon = document.querySelector(
+        ".edit-ingredient-anchor-link alchemy-icon"
+      )
+      expect(icon.getAttribute("icon-style")).toEqual("fill")
+    })
+
+    it("sets icon-style to line if not active", () => {
+      IngredientAnchorLink.updateIcon(1, false)
+      const icon = document.querySelector(
+        ".edit-ingredient-anchor-link alchemy-icon"
+      )
+      expect(icon.getAttribute("icon-style")).toEqual("line")
+    })
+
+    it("does nothing if ingredient editor is not found", () => {
+      IngredientAnchorLink.updateIcon(2, true)
+      const icon = document.querySelector(
+        ".edit-ingredient-anchor-link alchemy-icon"
+      )
+      expect(icon.getAttribute("icon-style")).toEqual("line")
+    })
+  })
+})


### PR DESCRIPTION
## What is this pull request for?

We changed `<alchemy-icon>` to use a svg icon sprite.
We cannot update the class anymore, but need to
change the `icon-style` attribute instead.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
