### PR TITLE
Add `message_for_resource_action`

### DIFF
--- a/app/controllers/alchemy/admin/resources_controller.rb
+++ b/app/controllers/alchemy/admin/resources_controller.rb
@@ -141,23 +141,28 @@ module Alchemy
         resource_filters.map(&:values).flatten
       end
 
-      # Returns a translated +flash[:notice]+.
-      # The key should look like "Modelname successfully created|updated|destroyed."
-      def flash_notice_for_resource_action(action = params[:action])
+      # Returns a translated +flash[:notice]+ for current controller action.
+      def flash_notice_for_resource_action(action = action_name)
         return if resource_instance_variable.errors.any?
 
+        flash[:notice] = message_for_resource_action(action)
+      end
+
+      # Returns a translated message for a +flash[:notice]+.
+      # The key should look like "Modelname successfully created|updated|destroyed."
+      def message_for_resource_action(action = action_name)
         case action.to_sym
         when :create
-          verb = "created"
+          verb = Alchemy.t("created", scope: "resources.actions")
         when :update
-          verb = "updated"
+          verb = Alchemy.t("updated", scope: "resources.actions")
         when :destroy
-          verb = "removed"
+          verb = Alchemy.t("removed", scope: "resources.actions")
         end
-        flash[:notice] = Alchemy.t(
-          "#{resource_handler.resource_name.classify} successfully #{verb}",
-          default: Alchemy.t("Successfully #{verb}")
-        )
+        Alchemy.t("%{resource_name} successfully %{action}",
+          resource_name: resource_handler.model.model_name.human,
+          action: verb,
+          default: Alchemy.t("Successfully #{verb}"))
       end
 
       def is_alchemy_module?

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -591,7 +591,12 @@ en:
     replace: replace
     replace_file: Replace file
     "Replaced Tag": "Tag '%{old_tag}' was replaced with '%{new_tag}'"
+    "%{resource_name} successfully %{action}": "%{resource_name} successfully %{action}."
     resources:
+      actions:
+        created: "created"
+        updated: "updated"
+        removed: "removed"
       relation_select:
         blank: "- none -"
     right: "right"

--- a/spec/features/admin/resources_integration_spec.rb
+++ b/spec/features/admin/resources_integration_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe "Resources", type: :system do
       end
 
       it "shows a success message" do
-        expect(page).to have_content("Successfully created")
+        expect(page).to have_content("Event successfully created.")
       end
     end
 
@@ -246,7 +246,7 @@ RSpec.describe "Resources", type: :system do
       end
 
       it "should not display success notice" do
-        expect(page).not_to have_content("successfully created")
+        expect(page).not_to have_content("Event successfully created.")
       end
     end
   end
@@ -263,7 +263,7 @@ RSpec.describe "Resources", type: :system do
     end
 
     it "shows a success message" do
-      expect(page).to have_content("Successfully updated")
+      expect(page).to have_content("Event successfully updated.")
     end
   end
 
@@ -283,7 +283,7 @@ RSpec.describe "Resources", type: :system do
     end
 
     it "should display success message" do
-      expect(page).to have_content("Successfully removed")
+      expect(page).to have_content("Event successfully removed.")
     end
   end
 


### PR DESCRIPTION
## What is this pull request for?

Returns a translated message for a flash notice or json response message without assigning it to `flash[:notice]`.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
