### PR TITLE
Do not use select2 for ingredient style select

### DIFF
--- a/app/views/alchemy/admin/ingredients/_file_fields.html.erb
+++ b/app/views/alchemy/admin/ingredients/_file_fields.html.erb
@@ -5,8 +5,7 @@
 <%- if css_classes.present? -%>
   <%= f.input :css_class,
     collection: css_classes,
-    include_blank: Alchemy.t('None'),
-    input_html: {is: 'alchemy-select'} %>
+    include_blank: Alchemy.t('None') %>
 <%- else -%>
   <%= f.input :css_class,
     label: Alchemy.t(:position_in_text),

--- a/app/views/alchemy/admin/ingredients/_picture_fields.html.erb
+++ b/app/views/alchemy/admin/ingredients/_picture_fields.html.erb
@@ -6,14 +6,12 @@
     collection: [
       [Alchemy.t('Layout default'), ""]
     ] + ingredient.settings[:sizes].to_a,
-    include_blank: false,
-    input_html: {is: 'alchemy-select'} %>
+    include_blank: false %>
 <%- end -%>
 <%- if ingredient.settings[:css_classes].present? -%>
   <%= f.input :css_class,
     collection: ingredient.settings[:css_classes],
-    include_blank: Alchemy.t('None'),
-    input_html: {is: 'alchemy-select'} %>
+    include_blank: Alchemy.t('None') %>
 <%- else -%>
   <%= f.input :css_class,
     label: Alchemy.t(:position_in_text),


### PR DESCRIPTION
## What is this pull request for?

These selects do not have much values or a remote search, so `select2` is overhead here.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message

