### PR TITLE
Fix preview window resize transition

### DIFF
--- a/app/assets/stylesheets/alchemy/preview_window.scss
+++ b/app/assets/stylesheets/alchemy/preview_window.scss
@@ -7,7 +7,7 @@
   border: 0 none;
   background: #fff;
   border-right: $default-border;
-  transition: $transition-duration ease-in-out;
+  transition: width $transition-duration ease-in-out;
 
   .collapsed-menu & {
     left: $collapsed-main-menu-width;
@@ -15,10 +15,14 @@
   }
 
   .collapsed-menu.elements-window-visible & {
-    width: calc(100vw - #{$collapsed-main-menu-width - $default-border-width} - #{$elements-window-width});
+    width: calc(
+      100vw - #{$collapsed-main-menu-width - $default-border-width} - #{$elements-window-width}
+    );
 
     @media screen and (min-width: $large-screen-break-point) {
-      max-width: calc(100vw - #{$collapsed-main-menu-width - $default-border-width} - #{$elements-window-min-width});
+      width: calc(
+        100vw - #{$collapsed-main-menu-width - $default-border-width} - #{$elements-window-min-width}
+      );
     }
   }
 }


### PR DESCRIPTION
We had a mixture of `width` and `max-width`. By using
just `width` fixes the resize `transition` of the preview window when the elements window gets hidden.
