### PR TITLE
fix(dialog-link): Do not addEventListener on every DOM insert

### DIFF
--- a/app/javascript/alchemy_admin/components/dialog_link.js
+++ b/app/javascript/alchemy_admin/components/dialog_link.js
@@ -10,13 +10,16 @@ export const DEFAULTS = {
 }
 
 export class DialogLink extends HTMLAnchorElement {
-  connectedCallback() {
-    this.addEventListener("click", (evt) => {
-      if (!this.disabled) {
-        this.openDialog()
-      }
-      evt.preventDefault()
-    })
+  constructor() {
+    super()
+    this.addEventListener("click", this)
+  }
+
+  handleEvent(evt) {
+    if (!this.disabled) {
+      this.openDialog()
+    }
+    evt.preventDefault()
   }
 
   openDialog() {


### PR DESCRIPTION
Doing that we get an additional event handler whenever we move the element in the DOM. Via dragndrop of an element editor for example.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207323156087536