### PR TITLE
fix language scope in picture description field

### DIFF
--- a/app/views/alchemy/admin/pictures/_picture_description_field.html.erb
+++ b/app/views/alchemy/admin/pictures/_picture_description_field.html.erb
@@ -1,5 +1,5 @@
 <div class="input">
-  <% if Alchemy::Language.many? %>
+  <% if Alchemy::Language.published.many? %>
     <label class="inline-label" style="float: right">
       <%= Alchemy::Language.model_name.human %>
       <%= select_tag :language_id, options_from_collection_for_select(


### PR DESCRIPTION
We only allow to select from published languages,
so we should only display the select if there are
at least two published languages.
