### PR TITLE
Only set url on attachment select if attachment found

### DIFF
--- a/app/components/alchemy/admin/link_dialog/file_tab.rb
+++ b/app/components/alchemy/admin/link_dialog/file_tab.rb
@@ -35,7 +35,7 @@ module Alchemy
 
         def attachment_select
           label = label_tag("file_link", Alchemy.t(:file), class: "control-label")
-          input = text_field_tag("file_link", url, id: "file_link")
+          input = text_field_tag("file_link", attachment && url, id: "file_link")
           select = render Alchemy::Admin::AttachmentSelect.new(attachment).with_content(input)
           content_tag("div", label + select, class: "input select")
         end

--- a/spec/components/alchemy/admin/link_dialog/file_tab_spec.rb
+++ b/spec/components/alchemy/admin/link_dialog/file_tab_spec.rb
@@ -17,24 +17,21 @@ RSpec.describe Alchemy::Admin::LinkDialog::FileTab, type: :component do
   it_behaves_like "a link dialog tab", :file, "File"
   it_behaves_like "a link dialog - target select", :file
 
-  context "file link" do
-    it "has a file select" do
-      expect(page).to have_selector("alchemy-attachment-select [name=file_link]")
+  it "has a file select" do
+    expect(page).to have_selector("alchemy-attachment-select [name=file_link]")
+  end
+
+  context "with attachment found by url" do
+    it "has value set" do
+      expect(page).to have_selector("alchemy-attachment-select [value='#{url}']")
     end
+  end
 
-    context "tab selected" do
-      let(:is_selected) { true }
+  context "with attachment not found by url" do
+    let(:url) { Alchemy::Engine.routes.url_helpers.show_page_path(urlname: "foo") }
 
-      it "has a selected value" do
-        expect(page).to have_selector("alchemy-attachment-select [value='#{url}']")
-      end
-    end
-
-    context "tab not selected" do
-      it "has a selected value" do
-        expect(page).to have_selector("alchemy-attachment-select [value='#{url}']")
-        # expect(page).to_not have_selector("alchemy-attachment-select [name=file_link] option[selected='selected']")
-      end
+    it "has no value set" do
+      expect(page).to_not have_selector("alchemy-attachment-select [value='#{url}']")
     end
   end
 end


### PR DESCRIPTION
## What is this pull request for?

If we set the URL select2 will try to set the value but cannot find it but will hide the placeholder.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
