### PR TITLE
fix(alchemy_link.plugin): Avoid getting an absolute URL

### DIFF
--- a/app/assets/javascripts/tinymce/plugins/alchemy_link/plugin.min.js
+++ b/app/assets/javascripts/tinymce/plugins/alchemy_link/plugin.min.js
@@ -10,7 +10,7 @@ tinymce.PluginManager.add("alchemy_link", function (editor) {
     const anchor = getAnchor(editor.selection.getNode())
     if (anchor) {
       link = {
-        url: anchor.href,
+        url: anchor.getAttribute("href"), // avoid getting an absolute URL
         title: anchor.title,
         target: anchor.target,
         type: anchor.className


### PR DESCRIPTION
## What is this pull request for?

Suddenly the `anchor.href` attribute returns an absolute URL - at least in Firefox - with the Alchemy Admin URL as base.

We want a relative URL.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
