### PR TITLE
Fix preview window width for smaller viewports

### DIFF
--- a/app/assets/stylesheets/alchemy/preview_window.scss
+++ b/app/assets/stylesheets/alchemy/preview_window.scss
@@ -16,10 +16,10 @@
 
   .collapsed-menu.elements-window-visible & {
     width: calc(
-      100vw - #{$collapsed-main-menu-width - $default-border-width} - #{$elements-window-width}
+      100vw - #{$collapsed-main-menu-width - $default-border-width} - #{$elements-window-min-width}
     );
 
-    @media screen and (min-width: $large-screen-break-point) {
+    @media screen and (min-width: 1777px) {
       width: calc(
         100vw - #{$collapsed-main-menu-width - $default-border-width} - #{$elements-window-width}
       );


### PR DESCRIPTION
We need to adjust the media query to the value the elements window goes from fixed to a variable width.
