### PR TITLE
Prevent jumping of toggle button in element window

### DIFF
--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -78,7 +78,7 @@ alchemy-tinymce {
   line-height: 1;
   max-width: 85%;
 
-  .element-hidden & {
+  .element-hidden > & {
     max-width: 65%;
   }
 
@@ -113,10 +113,6 @@ alchemy-tinymce {
   box-shadow: none;
   padding: 0;
   margin: 0 0 0 auto;
-
-  .element-hidden & {
-    margin-left: unset;
-  }
 
   &:hover {
     &:not(:focus):not(:active) {


### PR DESCRIPTION
## What is this pull request for?

The toggle button was jumping if a parent element was marked as hidden and the nested element was not marked as hidden. Now the toggle stays in its position, if a other element above is switched to hidden.

### Screenshots

![Aufnahme 2024-05-23 at 11 09 30@2x](https://github.com/AlchemyCMS/alchemy_cms/assets/122262394/8f459b3c-6e57-45e0-8072-f6d5537d8b57)

![Aufnahme 2024-05-23 at 11 09 24@2x](https://github.com/AlchemyCMS/alchemy_cms/assets/122262394/3b5dbd89-45ef-4822-b90b-2a6bfcb39ead)


## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
