### PR TITLE
Deprecate float positioning in File and Picture ingredients

### DIFF
--- a/app/views/alchemy/admin/ingredients/_file_fields.html.erb
+++ b/app/views/alchemy/admin/ingredients/_file_fields.html.erb
@@ -7,6 +7,7 @@
     collection: css_classes,
     include_blank: Alchemy.t('None') %>
 <%- else -%>
+  <% Alchemy::Deprecation.warn %(Float positioning in File ingredients is deprecated. If you rely on them, please use `css_classes` in your "#{ingredient.role}" settings instead.) %>
   <%= f.input :css_class,
     label: Alchemy.t(:position_in_text),
     collection: [

--- a/app/views/alchemy/admin/ingredients/_picture_fields.html.erb
+++ b/app/views/alchemy/admin/ingredients/_picture_fields.html.erb
@@ -13,6 +13,7 @@
     collection: ingredient.settings[:css_classes],
     include_blank: Alchemy.t('None') %>
 <%- else -%>
+  <% Alchemy::Deprecation.warn %(Float positioning in Picture ingredients is deprecated. If you rely on them, please use `css_classes` in your "#{ingredient.role}" settings instead.) %>
   <%= f.input :css_class,
     label: Alchemy.t(:position_in_text),
     collection: [


### PR DESCRIPTION
## What is this pull request for?

Deprecates float positioning in File and Picture ingredients.

If you rely on them, please use `css_classes` in your ingredient's settings instead.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message

