### PR TITLE
fix(InternalTab): Fix for urls with trailing slash and no locale

### DIFF
--- a/app/components/alchemy/admin/link_dialog/internal_tab.rb
+++ b/app/components/alchemy/admin/link_dialog/internal_tab.rb
@@ -4,7 +4,7 @@ module Alchemy
   module Admin
     module LinkDialog
       class InternalTab < BaseTab
-        PAGE_URL_PATTERN = /\A\/(?<locale>[a-z]{2})?(?<slash>\/)?(?<urlname>.*?)(?<trailing-slash>\/)?\z/
+        PAGE_URL_PATTERN = /^\/(?:(?<locale>[a-z]{2})(?:\/|$))?(?<urlname>.*?)(?:\/|$)?(?:#(?<fragment>.*))?$/
 
         def title
           Alchemy.t("link_overlay_tab_label.internal")
@@ -49,7 +49,7 @@ module Alchemy
         end
 
         def page_attributes
-          locale, _, urlname, _ = uri.path.match(PAGE_URL_PATTERN)&.captures
+          locale, urlname, _fragment = uri.path.match(PAGE_URL_PATTERN)&.captures
 
           if locale && urlname.present?
             {language_code: locale, urlname: urlname}

--- a/spec/components/alchemy/admin/link_dialog/internal_tab_spec.rb
+++ b/spec/components/alchemy/admin/link_dialog/internal_tab_spec.rb
@@ -4,9 +4,10 @@ require "rails_helper"
 
 RSpec.describe Alchemy::Admin::LinkDialog::InternalTab, type: :component do
   let(:site) { create(:alchemy_site) }
-  let(:alchemy_page) { create(:alchemy_page) }
-  let(:url) { alchemy_page.url_path + "#" + fragment }
-  let(:fragment) { "bar" }
+  let(:language) { create(:alchemy_language, site: site, default: true, code: "en") }
+  let(:url) { "/homepage#bar" }
+
+  let!(:alchemy_page) { create(:alchemy_page, urlname: "homepage", language: language, language_code: "en") }
 
   let(:is_selected) { false }
   let(:link_title) { nil }
@@ -22,74 +23,61 @@ RSpec.describe Alchemy::Admin::LinkDialog::InternalTab, type: :component do
 
   context "with page found by url" do
     it "has url value set" do
-      expect(page.find(:css, "input[name=internal_link]").value).to eq(url)
+      expect(page.find(:css, "input[name=internal_link]").value).to eq("/homepage#bar")
     end
 
     context "with trailing slash" do
-      let(:language) { create(:alchemy_language, default: true, site: site) }
-      let(:alchemy_page) { create(:alchemy_page, language: language) }
-      let(:url) { alchemy_page.url_path + "/" + "#" + fragment }
+      let(:url) { "/homepage/#bar" }
 
       it "has url value set" do
-        expect(page.find(:css, "input[name=internal_link]").value).to eq(url)
+        expect(page.find(:css, "input[name=internal_link]").value).to eq("/homepage/#bar")
       end
 
       it "has hash fragment set" do
-        expect(page.find(:css, "select[name=element_anchor]").value).to eq("#" + fragment)
+        expect(page.find(:css, "select[name=element_anchor]").value).to eq("#bar")
       end
     end
 
     it "has hash fragment set" do
-      expect(page.find(:css, "select[name=element_anchor]").value).to eq("#" + fragment)
+      expect(page.find(:css, "select[name=element_anchor]").value).to eq("#bar")
     end
 
     context "with locale in url" do
-      let(:url) { "/#{alchemy_page.language_code}/#{alchemy_page.urlname}" }
+      let(:url) { "/en/homepage" }
 
       it "has url value set" do
-        expect(page.find(:css, "input[name=internal_link]").value).to eq(url)
+        expect(page.find(:css, "input[name=internal_link]").value).to eq("/en/homepage")
       end
 
       context "with trailing slash" do
-        let(:language) { create(:alchemy_language, default: true, site: site) }
-        let(:alchemy_page) { create(:alchemy_page, language: language) }
-        let(:url) { "/#{alchemy_page.language_code}/#{alchemy_page.urlname}/" }
+        let(:url) { "/en/homepage/" }
 
         it "has url value set" do
-          expect(page.find(:css, "input[name=internal_link]").value).to eq(url)
+          expect(page.find(:css, "input[name=internal_link]").value).to eq("/en/homepage/")
         end
       end
     end
 
     context "with root url" do
-      let(:language) { create(:alchemy_language, default: true, site: site) }
-      let(:alchemy_page) { create(:alchemy_page, language: language) }
-
       let(:url) { alchemy_page && "/" }
 
       it "has url value set to root url" do
-        expect(page.find(:css, "input[name=internal_link]").value).to eq(url)
+        expect(page.find(:css, "input[name=internal_link]").value).to eq("/")
       end
     end
 
     context "with locale root url" do
-      let(:language) { create(:alchemy_language, default: true, site: site) }
-      let(:alchemy_page) { create(:alchemy_page, language: language) }
-
-      let(:url) { alchemy_page && "/en" }
+      let(:url) { "/en" }
 
       it "has url value set to root url" do
-        expect(page.find(:css, "input[name=internal_link]").value).to eq(url)
+        expect(page.find(:css, "input[name=internal_link]").value).to eq("/en")
       end
 
       context "with trailing slash" do
-        let(:language) { create(:alchemy_language, default: true, site: site) }
-        let(:alchemy_page) { create(:alchemy_page, language: language) }
-
-        let(:url) { alchemy_page && "/en/" }
+        let(:url) { "/en/" }
 
         it "has url value set to root url" do
-          expect(page.find(:css, "input[name=internal_link]").value).to eq(url)
+          expect(page.find(:css, "input[name=internal_link]").value).to eq("/en/")
         end
       end
     end


### PR DESCRIPTION
## What is this pull request for?

The former regexp was ignoring the second slash in urls
without locale but with trailing slash, since it was not part
of the locale group and optional. Using a non match group
for the optional locale and it's optional slash.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
