### PR TITLE
Add Language and Site serializers

### DIFF
--- a/app/serializers/alchemy/language_serializer.rb
+++ b/app/serializers/alchemy/language_serializer.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Alchemy
+  class LanguageSerializer < ActiveModel::Serializer
+    attributes :id,
+      :name
+  end
+end

--- a/app/serializers/alchemy/site_serializer.rb
+++ b/app/serializers/alchemy/site_serializer.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Alchemy
+  class SiteSerializer < ActiveModel::Serializer
+    attributes :id,
+      :name
+  end
+end

--- a/spec/requests/alchemy/api/pages_controller_spec.rb
+++ b/spec/requests/alchemy/api/pages_controller_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe "API Pages requests", type: :request do
+  describe "GET /api/pages/:id" do
+    let(:page) { create(:alchemy_page, :public) }
+
+    subject do
+      get("/api/pages/#{page.id}")
+      response
+    end
+
+    let(:json) { JSON.parse(response.body) }
+
+    context "with unauthorized user" do
+      it "returns page JSON with site not included" do
+        is_expected.to have_http_status(200)
+        expect(json).to_not include("site")
+      end
+
+      it "returns page JSON with language not included" do
+        is_expected.to have_http_status(200)
+        expect(json).to_not include("language")
+      end
+    end
+
+    context "with authorized user" do
+      before do
+        authorize_user(build(:alchemy_dummy_user, :as_author))
+      end
+
+      it "returns page JSON with site included" do
+        is_expected.to have_http_status(200)
+        expect(json).to include("site")
+        expect(json["site"]).to include("id")
+        expect(json["site"]).to include("name")
+      end
+
+      it "returns page JSON with language included" do
+        is_expected.to have_http_status(200)
+        expect(json).to include("language")
+        expect(json["language"]).to include("id")
+        expect(json["language"]).to include("name")
+      end
+    end
+  end
+end

--- a/spec/serializers/alchemy/language_serializer_spec.rb
+++ b/spec/serializers/alchemy/language_serializer_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::LanguageSerializer do
+  subject { described_class.new(language).to_json }
+
+  let(:language) { build_stubbed(:alchemy_language) }
+
+  it "includes all attributes" do
+    json = JSON.parse(subject)
+    expect(json).to eq(
+      "id" => language.id,
+      "name" => language.name
+    )
+  end
+end

--- a/spec/serializers/alchemy/page_serializer_spec.rb
+++ b/spec/serializers/alchemy/page_serializer_spec.rb
@@ -57,29 +57,11 @@ RSpec.describe Alchemy::PageSerializer do
         "elements" => [],
         "site" => {
           "id" => page.site.id,
-          "aliases" => nil,
-          "created_at" => an_instance_of(String),
-          "host" => "*",
-          "name" => "Default Site",
-          "public" => true,
-          "redirect_to_primary_host" => false,
-          "updated_at" => an_instance_of(String)
+          "name" => "Default Site"
         },
         "language" => {
-          "country_code" => "",
-          "created_at" => an_instance_of(String),
-          "creator_id" => nil,
-          "default" => true,
-          "frontpage_name" => "Intro",
           "id" => page.language_id,
-          "language_code" => "en",
-          "locale" => "en",
-          "name" => "Your Language",
-          "page_layout" => "index",
-          "public" => true,
-          "site_id" => page.site.id,
-          "updated_at" => an_instance_of(String),
-          "updater_id" => nil
+          "name" => "Your Language"
         }
       )
     end

--- a/spec/serializers/alchemy/site_serializer_spec.rb
+++ b/spec/serializers/alchemy/site_serializer_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::SiteSerializer do
+  subject { described_class.new(site).to_json }
+
+  let(:site) { build_stubbed(:alchemy_site) }
+
+  it "includes all attributes" do
+    json = JSON.parse(subject)
+    expect(json).to eq(
+      "id" => site.id,
+      "name" => site.name
+    )
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

Without those ActiveModelSerializers can't find a serializer for the site and language relations in the PageSerializer which is used in the PageSelect. It delegates serialization to Rails which takes whatever serializer is responsible for to_json, which in some cases lead to nesting the site or language with it's own root key, which is not what we want.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
