### PR TITLE
fix(HeadlineEditor): Add css class for any level option

### DIFF
--- a/app/decorators/alchemy/ingredient_editor.rb
+++ b/app/decorators/alchemy/ingredient_editor.rb
@@ -36,7 +36,7 @@ module Alchemy
         "ingredient-editor",
         partial_name,
         deprecated? ? "deprecated" : nil,
-        (respond_to?(:level_options) && level_options.many?) ? "with-level-select" : nil,
+        (respond_to?(:level_options) && level_options.any?) ? "with-level-select" : nil,
         (respond_to?(:size_options) && size_options.many?) ? "with-size-select" : nil,
         settings[:linkable] ? "linkable" : nil,
         settings[:anchor] ? "with-anchor" : nil

--- a/spec/decorators/alchemy/ingredient_editor_spec.rb
+++ b/spec/decorators/alchemy/ingredient_editor_spec.rb
@@ -35,10 +35,10 @@ RSpec.describe Alchemy::IngredientEditor do
     end
 
     context "when responding to level_options" do
-      context "and having many level options" do
+      context "and having any level options" do
         before do
           expect(ingredient).to receive(:level_options) do
-            [["H1", 1], ["H2", 2]]
+            [["H1", 1]]
           end
         end
 


### PR DESCRIPTION
## What is this pull request for?

We changed that we always show the level select on the headline editor in bd056bd7c but have not adjusted that the css class (`with-level-select`) is always added.

### Screenshots

<img width="" alt="headline-editor before" src="https://github.com/AlchemyCMS/alchemy_cms/assets/42868/2b2c1c1f-80ba-4de5-af93-7733e9d7cf8d">

<img width="" alt="headline-editor after" src="https://github.com/AlchemyCMS/alchemy_cms/assets/42868/36fb4e30-96a7-48ed-9238-91cb5c3b40bd">


## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
