### PR TITLE
Add name attribute to Preview IFrame

### DIFF
--- a/app/views/alchemy/admin/pages/edit.html.erb
+++ b/app/views/alchemy/admin/pages/edit.html.erb
@@ -136,6 +136,7 @@
 <iframe
   url="<%= @preview_url %>"
   id="alchemy_preview_window"
+  name="alchemy_preview_window"
   is="alchemy-preview-window"
   frameborder="0">
 </iframe>


### PR DESCRIPTION


## What is this pull request for?

In Alchemy 7.1, the preview Iframe had a name attribute that could be reference from inside the iframe by using `window.name`. With 7.2, this isn't the case anymore, and our (admittedly a bit special implementation) of previews have stopped working because of this missing attribute.
