### PR TITLE
fix Ingredient Audio and Video boolean type casting

### DIFF
--- a/app/models/alchemy/ingredients/audio.rb
+++ b/app/models/alchemy/ingredients/audio.rb
@@ -26,6 +26,17 @@ module Alchemy
       def preview_text(max_length = 30)
         name.to_s[0..max_length - 1]
       end
+
+      %i[
+        autoplay
+        controls
+        loop
+        muted
+      ].each do |method|
+        define_method(:"#{method}=") do |value|
+          super(ActiveModel::Type::Boolean.new.cast(value))
+        end
+      end
     end
   end
 end

--- a/app/models/alchemy/ingredients/video.rb
+++ b/app/models/alchemy/ingredients/video.rb
@@ -31,6 +31,18 @@ module Alchemy
       def preview_text(max_length = 30)
         name.to_s[0..max_length - 1]
       end
+
+      %i[
+        autoplay
+        controls
+        loop
+        muted
+        playsinline
+      ].each do |method|
+        define_method(:"#{method}=") do |value|
+          super(ActiveModel::Type::Boolean.new.cast(value))
+        end
+      end
     end
   end
 end

--- a/spec/models/alchemy/ingredients/audio_spec.rb
+++ b/spec/models/alchemy/ingredients/audio_spec.rb
@@ -21,24 +21,64 @@ RSpec.describe Alchemy::Ingredients::Audio do
     subject { audio_ingredient.autoplay }
     before { audio_ingredient.autoplay = false }
     it { is_expected.to eq(false) }
+
+    context "when set to '0'" do
+      before { audio_ingredient.autoplay = "0" }
+      it { is_expected.to eq(false) }
+    end
+
+    context "when set to 't'" do
+      before { audio_ingredient.autoplay = "t" }
+      it { is_expected.to eq(true) }
+    end
   end
 
   describe "#controls" do
     subject { audio_ingredient.controls }
     before { audio_ingredient.controls = true }
     it { is_expected.to eq(true) }
+
+    context "when set to '0'" do
+      before { audio_ingredient.controls = "0" }
+      it { is_expected.to eq(false) }
+    end
+
+    context "when set to 't'" do
+      before { audio_ingredient.controls = "t" }
+      it { is_expected.to eq(true) }
+    end
   end
 
   describe "#loop" do
     subject { audio_ingredient.loop }
     before { audio_ingredient.loop = false }
     it { is_expected.to eq(false) }
+
+    context "when set to '0'" do
+      before { audio_ingredient.loop = "0" }
+      it { is_expected.to eq(false) }
+    end
+
+    context "when set to 't'" do
+      before { audio_ingredient.loop = "t" }
+      it { is_expected.to eq(true) }
+    end
   end
 
   describe "#muted" do
     subject { audio_ingredient.muted }
     before { audio_ingredient.muted = true }
     it { is_expected.to eq(true) }
+
+    context "when set to '0'" do
+      before { audio_ingredient.muted = "0" }
+      it { is_expected.to eq(false) }
+    end
+
+    context "when set to 't'" do
+      before { audio_ingredient.muted = "t" }
+      it { is_expected.to eq(true) }
+    end
   end
 
   describe "#attachment" do

--- a/spec/models/alchemy/ingredients/video_spec.rb
+++ b/spec/models/alchemy/ingredients/video_spec.rb
@@ -27,12 +27,32 @@ RSpec.describe Alchemy::Ingredients::Video do
     subject { video_ingredient.autoplay }
     before { video_ingredient.autoplay = false }
     it { is_expected.to eq(false) }
+
+    context "when set to '0'" do
+      before { video_ingredient.autoplay = "0" }
+      it { is_expected.to eq(false) }
+    end
+
+    context "when set to 't'" do
+      before { video_ingredient.autoplay = "t" }
+      it { is_expected.to eq(true) }
+    end
   end
 
   describe "#controls" do
     subject { video_ingredient.controls }
     before { video_ingredient.controls = true }
     it { is_expected.to eq(true) }
+
+    context "when set to '0'" do
+      before { video_ingredient.controls = "0" }
+      it { is_expected.to eq(false) }
+    end
+
+    context "when set to 't'" do
+      before { video_ingredient.controls = "t" }
+      it { is_expected.to eq(true) }
+    end
   end
 
   describe "#height" do
@@ -45,18 +65,48 @@ RSpec.describe Alchemy::Ingredients::Video do
     subject { video_ingredient.loop }
     before { video_ingredient.loop = false }
     it { is_expected.to eq(false) }
+
+    context "when set to '0'" do
+      before { video_ingredient.loop = "0" }
+      it { is_expected.to eq(false) }
+    end
+
+    context "when set to 't'" do
+      before { video_ingredient.loop = "t" }
+      it { is_expected.to eq(true) }
+    end
   end
 
   describe "#muted" do
     subject { video_ingredient.muted }
     before { video_ingredient.muted = true }
     it { is_expected.to eq(true) }
+
+    context "when set to '0'" do
+      before { video_ingredient.muted = "0" }
+      it { is_expected.to eq(false) }
+    end
+
+    context "when set to 't'" do
+      before { video_ingredient.muted = "t" }
+      it { is_expected.to eq(true) }
+    end
   end
 
   describe "#playsinline" do
     subject { video_ingredient.playsinline }
     before { video_ingredient.playsinline = true }
     it { is_expected.to eq(true) }
+
+    context "when set to '0'" do
+      before { video_ingredient.playsinline = "0" }
+      it { is_expected.to eq(false) }
+    end
+
+    context "when set to 't'" do
+      before { video_ingredient.playsinline = "t" }
+      it { is_expected.to eq(true) }
+    end
   end
 
   describe "#preload" do


### PR DESCRIPTION
## What is this pull request for?

Currently boolean values of ingredient video and audio are stored as strings ("0"/"1") in the data column JSON.

Cast to Boolean before we save to make this booleans.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
