### PR TITLE
fix(RoutingConstraints): Allow Turbo Stream requests

### DIFF
--- a/lib/alchemy/routing_constraints.rb
+++ b/lib/alchemy/routing_constraints.rb
@@ -27,7 +27,7 @@ module Alchemy
     # because it could be a legacy route that needs to be redirected.
     #
     def handable_format?
-      @request.format.symbol.nil? || (@request.format.symbol == :html)
+      @request.format.symbol.nil? || @request.format.html?
     end
 
     # We don't want to handle the Rails info routes.

--- a/spec/routing/routing_spec.rb
+++ b/spec/routing/routing_spec.rb
@@ -194,6 +194,14 @@ describe "The Routing" do
     end
   end
 
+  describe "Turbo stream requests" do
+    it do
+      expect({
+        get: "/contact/thanks.turbo_stream"
+      }).to be_routable
+    end
+  end
+
   context "for admin interface" do
     context "default" do
       it "should route to admin dashboard" do


### PR DESCRIPTION
## What is this pull request for?

`rails-turbo` [registers a new request format](https://github.com/hotwired/turbo-rails/blob/e376852bfb273f69f4ebb54cf516b99fcbaa7acb/lib/turbo/engine.rb#L82-L89)

    text/vnd.turbo-stream.html

which is used whenever Turbo redirects.

In order to handle those requests from - for example the messages controller - we need to allow this mime type to route into Alchemy as well.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
