### PR TITLE
Replace picture css class after update 

### DIFF
--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -636,14 +636,25 @@ alchemy-publish-element-button {
 
   .picture_ingredient_css_class {
     position: absolute;
-    z-index: 1;
-    bottom: 34px;
-    background-color: rgba(255, 254, 255, 0.7);
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    z-index: 0;
+    bottom: 35px;
+    background-color: rgba(0, 0, 0, 0.15);
+    text-shadow: 0 0 2px rgba(0, 0, 0, 0.5);
+    color: var(--color-white);
     padding: 4px 8px;
     font-size: $small-font-size;
     overflow: hidden;
     max-width: 100%;
     text-overflow: ellipsis;
+
+    .icon {
+      fill: currentColor;
+      filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.25));
+    }
   }
 }
 

--- a/app/views/alchemy/admin/ingredients/_picture_fields.html.erb
+++ b/app/views/alchemy/admin/ingredients/_picture_fields.html.erb
@@ -9,9 +9,16 @@
     include_blank: false %>
 <%- end -%>
 <%- if ingredient.settings[:css_classes].present? -%>
-  <%= f.input :css_class,
-    collection: ingredient.settings[:css_classes],
-    include_blank: Alchemy.t('None') %>
+  <% css_classes = ingredient.settings[:css_classes] %>
+  <% css_classes_collection = case css_classes.first
+    when Array
+      then css_classes
+    else
+      css_classes.map do |klass|
+        [Alchemy.t(klass, scope: "picture_ingredients.css_classes", default: picture_editor.css_class.camelcase), klass]
+      end
+    end %>
+  <%= f.input :css_class, collection: css_classes_collection, include_blank: false %>
 <%- else -%>
   <% Alchemy::Deprecation.warn %(Float positioning in Picture ingredients is deprecated. If you rely on them, please use `css_classes` in your "#{ingredient.role}" settings instead.) %>
   <%= f.input :css_class,

--- a/app/views/alchemy/admin/ingredients/update.turbo_stream.erb
+++ b/app/views/alchemy/admin/ingredients/update.turbo_stream.erb
@@ -3,3 +3,10 @@
 <% if @ingredient.settings[:anchor] %>
 <alchemy-action name="updateAnchorIcon" params="<%= [@ingredient.id, @ingredient.dom_id.present?].to_json %>"></alchemy-action>
 <% end %>
+<% if @ingredient.type == "Alchemy::Ingredients::Picture" %>
+  <%= turbo_stream.replace_all "[data-ingredient-id='#{@ingredient.id}'] .picture_ingredient_css_class",
+    partial: "alchemy/ingredients/shared/picture_css_class",
+    locals: {
+      css_class: Alchemy::IngredientEditor.new(@ingredient).css_class
+    } %>
+<% end %>

--- a/app/views/alchemy/ingredients/_picture_editor.html.erb
+++ b/app/views/alchemy/ingredients/_picture_editor.html.erb
@@ -32,10 +32,9 @@
         </div>
       </div>
       <%- if picture_editor.css_class.present? -%>
-        <div class="picture_ingredient_css_class">
-          <%= Alchemy.t("alchemy.picture_ingredients.css_classes.#{picture_editor.css_class}",
-            default: picture_editor.css_class.camelcase) %>
-        </div>
+        <%= render "alchemy/ingredients/shared/picture_css_class", {
+          css_class: picture_editor.css_class
+        } %>
       <%- end -%>
       <div class="edit_images_bottom">
         <%= render "alchemy/ingredients/shared/picture_tools", {

--- a/app/views/alchemy/ingredients/shared/_picture_css_class.html.erb
+++ b/app/views/alchemy/ingredients/shared/_picture_css_class.html.erb
@@ -1,0 +1,6 @@
+<div class="picture_ingredient_css_class">
+  <%= render_icon "pencil-ruler-2", style: "line", size: "1x" %>
+  <%= Alchemy.t(css_class,
+    scope: "picture_ingredients.css_classes",
+    default: css_class.camelcase) %>
+</div>


### PR DESCRIPTION
## What is this pull request for?

We display the css class on the picture ingredient editor.
If the use updates the class, we need to update the label.

### Notable changes (remove if none)

Use translated css class for select options unless already passed as key, value pairs.

### Screenshots

Also updates the layout for better legibility 

![Alchemy CMS - Startseite 2024-06-04 22-34-49](https://github.com/AlchemyCMS/alchemy_cms/assets/42868/bf169d31-769a-4739-a037-a1bb3d35846e)
