### PR TITLE
Enable element select if only one is available

### DIFF
--- a/app/views/alchemy/admin/elements/_form.html.erb
+++ b/app/views/alchemy/admin/elements/_form.html.erb
@@ -10,7 +10,7 @@
       collection: elements_for_select(@elements),
       prompt: Alchemy.t(:select_element),
       selected: (@elements.first if @elements.count == 1),
-      input_html: {is: 'alchemy-select', autofocus: true, disabled: @elements.count == 1} %>
+      input_html: {is: 'alchemy-select', autofocus: true} %>
     <% if @elements.count == 1 %>
       <%= form.hidden_field :name, value: @elements.first[:name] %>
     <% end %>


### PR DESCRIPTION
## What is this pull request for?

It seems that many users are confused if we disable the select. Since we already select the only possible element it is serving the same purpose - to save a click.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message

