### PR TITLE
fix(ContactMessages): Use alchemy route proxy

### DIFF
--- a/app/controllers/alchemy/messages_controller.rb
+++ b/app/controllers/alchemy/messages_controller.rb
@@ -97,7 +97,7 @@ module Alchemy
       else
         Language.current_root_page.urlname
       end
-      redirect_to show_page_path(
+      redirect_to alchemy.show_page_path(
         urlname: urlname,
         locale: prefix_locale? ? Current.language.code : nil
       )


### PR DESCRIPTION
## What is this pull request for?

Without that it happens that a controller inheriting from `MessagesController` cannot resolve that route correctly.
