### PR TITLE
Remove to_jq_upload

### DIFF
--- a/app/controllers/concerns/alchemy/admin/uploader_responses.rb
+++ b/app/controllers/concerns/alchemy/admin/uploader_responses.rb
@@ -11,7 +11,7 @@ module Alchemy
           name: file.name)
 
         {
-          json: uploader_response(file: file, message: message),
+          json: {message: message},
           status: status
         }
       end
@@ -23,17 +23,8 @@ module Alchemy
           name: file.name)
 
         {
-          json: uploader_response(file: file, message: message),
+          json: {message: message},
           status: :unprocessable_entity
-        }
-      end
-
-      private
-
-      def uploader_response(file:, message:)
-        {
-          files: [file.to_jq_upload],
-          message: message
         }
       end
     end

--- a/app/models/alchemy/attachment.rb
+++ b/app/models/alchemy/attachment.rb
@@ -102,14 +102,6 @@ module Alchemy
 
     # Instance methods
 
-    def to_jq_upload
-      {
-        "name" => read_attribute(:file_name),
-        "size" => read_attribute(:file_size),
-        "error" => errors[:file].join
-      }
-    end
-
     def url(options = {})
       if file
         self.class.url_class.new(self).call(options)

--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -224,16 +224,6 @@ module Alchemy
       save!
     end
 
-    # Returns a Hash suitable for jquery fileupload json.
-    #
-    def to_jq_upload
-      {
-        name: image_file_name,
-        size: image_file_size,
-        error: errors[:image_file].join
-      }
-    end
-
     # Returns the picture description for a given language.
     def description_for(language)
       descriptions.find_by(language: language)&.text

--- a/lib/alchemy/test_support/shared_uploader_examples.rb
+++ b/lib/alchemy/test_support/shared_uploader_examples.rb
@@ -7,6 +7,5 @@ RSpec.shared_examples_for "having a json uploader error message" do
     expect(response.status).to eq(422)
     json = JSON.parse(response.body)
     expect(json).to have_key("message")
-    expect(json).to have_key("files")
   end
 end

--- a/spec/controllers/alchemy/admin/attachments_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/attachments_controller_spec.rb
@@ -88,7 +88,6 @@ module Alchemy
           expect(response.status).to eq(201)
           json = JSON.parse(response.body)
           expect(json).to have_key("message")
-          expect(json).to have_key("files")
         end
       end
 
@@ -135,7 +134,6 @@ module Alchemy
             expect(response.status).to eq(202)
             json = JSON.parse(response.body)
             expect(json).to have_key("message")
-            expect(json).to have_key("files")
           end
 
           it "replaces the file" do

--- a/spec/controllers/alchemy/admin/pictures_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/pictures_controller_spec.rb
@@ -134,7 +134,7 @@ module Alchemy
       subject { post :create, params: params }
 
       let(:params) { {picture: {name: ""}} }
-      let(:picture) { mock_model("Picture", humanized_name: "Cute kittens", to_jq_upload: {}) }
+      let(:picture) { mock_model("Picture", humanized_name: "Cute kittens") }
 
       context "with passing validations" do
         before do
@@ -150,7 +150,6 @@ module Alchemy
           expect(response.status).to eq(201)
           json = JSON.parse(response.body)
           expect(json).to have_key("message")
-          expect(json).to have_key("files")
         end
       end
 

--- a/spec/models/alchemy/picture_spec.rb
+++ b/spec/models/alchemy/picture_spec.rb
@@ -396,31 +396,6 @@ module Alchemy
       end
     end
 
-    describe "#to_jq_upload" do
-      subject { picture.to_jq_upload }
-
-      let(:picture) { build_stubbed(:alchemy_picture, image_file_name: "cute-kittens.jpg", image_file_size: 1024) }
-
-      it "returns a hash containing data for jquery fileuploader" do
-        is_expected.to be_an_instance_of(Hash)
-        is_expected.to include(name: picture.image_file_name)
-        is_expected.to include(size: picture.image_file_size)
-      end
-
-      context "with error" do
-        let(:picture) { build_stubbed(:alchemy_picture) }
-
-        before do
-          expect(picture).to receive(:errors).and_return({image_file: %w[stupid_cats]})
-        end
-
-        it "returns hash with error message" do
-          is_expected.to be_an_instance_of(Hash)
-          is_expected.to include(error: "stupid_cats")
-        end
-      end
-    end
-
     describe "#restricted?" do
       subject { picture.restricted? }
 


### PR DESCRIPTION
## What is this pull request for?

We do not use the response files in the new Uploader just the message. Since this is a private method we can simply remove it.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
