### PR TITLE
Prevent Javascript error if the page will be unlocked

### DIFF
--- a/app/views/alchemy/admin/pages/unlock.js.erb
+++ b/app/views/alchemy/admin/pages/unlock.js.erb
@@ -15,6 +15,6 @@
     }
     locked_page_icon.outerHTML = locked_page_icon_content
   }
-  document.querySelector("#page_<%= @page.id -%> .page_status.locked").remove()
+  document.querySelector("#page_<%= @page.id -%> .page_status.locked")?.remove()
   Alchemy.growl('<%= flash[:notice] -%>')
 })()


### PR DESCRIPTION
## What is this pull request for?
Make an undefined check to the locked status label which is only available in page tree view. If user is closing the tab in page edit view (or any other view) it will result in a javascript error.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
