### PR TITLE
Disable Turbo Cache in Admin

### DIFF
--- a/app/views/alchemy/admin/pages/edit.html.erb
+++ b/app/views/alchemy/admin/pages/edit.html.erb
@@ -131,10 +131,6 @@
 </div>
 <% end %>
 
-<% content_for :javascript_includes do %>
-  <meta name="turbo-cache-control" content="no-cache">
-<% end %>
-
 <iframe
   url="<%= @preview_url %>"
   id="alchemy_preview_window"

--- a/app/views/alchemy/admin/pages/index.html.erb
+++ b/app/views/alchemy/admin/pages/index.html.erb
@@ -1,7 +1,3 @@
-<% content_for :javascript_includes do %>
-  <meta name="turbo-cache-control" content="no-cache">
-<% end %>
-
 <% content_for :toolbar do %>
   <%= render "alchemy/admin/pages/toolbar" %>
 <% end %>

--- a/app/views/alchemy/admin/styleguide/index.html.erb
+++ b/app/views/alchemy/admin/styleguide/index.html.erb
@@ -2,10 +2,6 @@
   <%= "Styleguide" %>
 <% end %>
 
-<% content_for :javascript_includes do %>
-  <meta name="turbo-cache-control" content="no-cache">
-<% end %>
-
 <% content_for(:toolbar) do %>
   <%= render Alchemy::Admin::ToolbarButton.new(
     icon: :info,

--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -9,6 +9,7 @@
     <meta name="robots" content="noindex">
     <meta name="alchemy-icon-sprite" content="<%= asset_path("remixicon.symbol.svg") %>">
     <meta name="turbo-prefetch" content="false">
+    <meta name="turbo-cache-control" content="no-cache">
     <%= stylesheet_link_tag('alchemy/admin', media: 'screen', 'data-turbo-track' => true) %>
     <%= stylesheet_link_tag('alchemy/admin/print', media: 'print', 'data-turbo-track' => true) %>
     <%= yield :stylesheets %>


### PR DESCRIPTION
## What is this pull request for?

This feature does not provide a huge benefit and has some weird downsides. If the user is revisiting a view in Alchemy admin it will be slower, but at least the user is not seeing and old view which will updating a few moments later (e.g. already closed tabs, newly created pictures, etc.)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
