### PR TITLE
Disable Turbo Prefetch in Admin

### DIFF
--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -8,6 +8,7 @@
     <%= csrf_meta_tag %>
     <meta name="robots" content="noindex">
     <meta name="alchemy-icon-sprite" content="<%= asset_path("remixicon.symbol.svg") %>">
+    <meta name="turbo-prefetch" content="false">
     <%= stylesheet_link_tag('alchemy/admin', media: 'screen', 'data-turbo-track' => true) %>
     <%= stylesheet_link_tag('alchemy/admin/print', media: 'print', 'data-turbo-track' => true) %>
     <%= yield :stylesheets %>


### PR DESCRIPTION
## What is this pull request for?

This feature was enabled by default in Turbo 8 and can cause that many "locked pages" appear, if the user is hovering over page entries in page tree. 

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
