### PR TITLE
[7.2-stable] Disable Turbo Prefetch in Admin

### DIFF
--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -8,6 +8,7 @@
     <%= csrf_meta_tag %>
     <meta name="robots" content="noindex">
     <meta name="alchemy-icon-sprite" content="<%= asset_path("remixicon.symbol.svg") %>">
+    <meta name="turbo-prefetch" content="false">
     <%= stylesheet_link_tag('alchemy/admin/all', media: 'screen', 'data-turbo-track' => true) %>
     <%= stylesheet_link_tag('alchemy/print', media: 'print', 'data-turbo-track' => true) %>
     <%= yield :stylesheets %>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.2-stable`:
 - [Merge pull request #2944 from sascha-karnatz/disable-turbo-prefetch](https://github.com/AlchemyCMS/alchemy_cms/pull/2944)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)