### PR TITLE
Fix re-render of layoutpages form if validation fails

### DIFF
--- a/app/controllers/alchemy/admin/layoutpages_controller.rb
+++ b/app/controllers/alchemy/admin/layoutpages_controller.rb
@@ -17,6 +17,25 @@ module Alchemy
       def edit
         @page = Page.find(params[:id])
       end
+
+      def update
+        @page = Page.find(params[:id])
+        if @page.update(page_params)
+          @notice = Alchemy.t("Page saved", name: @page.name)
+          render "alchemy/admin/pages/update"
+        else
+          render :edit, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def page_params
+        params.require(:page).permit(
+          :name,
+          :tag_list
+        )
+      end
     end
   end
 end

--- a/app/views/alchemy/admin/layoutpages/edit.html.erb
+++ b/app/views/alchemy/admin/layoutpages/edit.html.erb
@@ -1,4 +1,4 @@
-<%= alchemy_form_for [:admin, @page], class: 'edit_page' do |f| %>
+<%= alchemy_form_for [:admin, @page], url: alchemy.admin_layoutpage_path(@page), class: 'edit_page' do |f| %>
   <%= f.input :name, autofocus: true %>
   <%= render Alchemy::Admin::TagsAutocomplete.new do %>
     <%= f.input :tag_list, input_html: { value: f.object.tag_list.join(",") } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,7 +49,7 @@ Alchemy::Engine.routes.draw do
       end
     end
 
-    resources :layoutpages, only: [:index, :edit]
+    resources :layoutpages, only: [:index, :edit, :update]
 
     resources :pictures, except: [:new] do
       collection do

--- a/lib/alchemy/permissions.rb
+++ b/lib/alchemy/permissions.rb
@@ -96,7 +96,7 @@ module Alchemy
         can :leave, :alchemy_admin
         can [:info, :help], :alchemy_admin_dashboard
         can :manage, :alchemy_admin_clipboard
-        can :edit, :alchemy_admin_layoutpages
+        can :update, :alchemy_admin_layoutpages
         can :tree, :alchemy_admin_pages
 
         # Resources

--- a/spec/controllers/alchemy/admin/layoutpages_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/layoutpages_controller_spec.rb
@@ -62,5 +62,29 @@ module Alchemy
         end
       end
     end
+
+    describe "#update" do
+      let(:page) { create(:alchemy_page, :layoutpage) }
+
+      context "with passing validations" do
+        subject { put :update, params: {id: page.id, page: {name: "New Name"}}, format: :js }
+
+        it "renders update template" do
+          is_expected.to render_template("alchemy/admin/pages/update")
+        end
+      end
+
+      context "with failing validations" do
+        subject { put :update, params: {id: page.id, page: {name: ""}} }
+
+        it "renders edit form" do
+          is_expected.to render_template(:edit)
+        end
+
+        it "sets 422 status" do
+          expect(subject.status).to eq 422
+        end
+      end
+    end
   end
 end

--- a/spec/libraries/permissions_spec.rb
+++ b/spec/libraries/permissions_spec.rb
@@ -148,6 +148,10 @@ describe Alchemy::Permissions do
       is_expected.to be_able_to(:switch, Alchemy::Language)
     end
 
+    it "can update layoutpages" do
+      is_expected.to be_able_to(:update, :alchemy_admin_layoutpages)
+    end
+
     context "if page language is public" do
       let(:language) { create(:alchemy_language, :german, public: true) }
       let(:page) { create(:alchemy_page, language: language) }


### PR DESCRIPTION
## What is this pull request for?

We need to re-render the layoutpages form instead of the page form. Therefore we need to introduce an update action in the layoutpages controller, otherwise it uses the pages controller update action which renders the full page form.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
