### PR TITLE
Clear current language when switching sites

### DIFF
--- a/app/controllers/concerns/alchemy/admin/current_language.rb
+++ b/app/controllers/concerns/alchemy/admin/current_language.rb
@@ -6,10 +6,20 @@ module Alchemy
       extend ActiveSupport::Concern
 
       included do
+        # This needs to happen before BaseController#current_alchemy_site sets the session value.
+        prepend_before_action :clear_current_language_from_session, if: :switching_site?, only: :index
         before_action :load_current_language
       end
 
       private
+
+      def switching_site?
+        params[:site_id].present? && (params[:site_id] != session[:alchemy_site_id]&.to_s)
+      end
+
+      def clear_current_language_from_session
+        session.delete(:alchemy_language_id)
+      end
 
       def load_current_language
         @current_language = if session[:alchemy_language_id].present?

--- a/lib/alchemy/test_support/current_language_shared_examples.rb
+++ b/lib/alchemy/test_support/current_language_shared_examples.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples_for "a controller that loads current language" do |args|
+  context "when session has current language id key" do
+    let!(:site_1) { create(:alchemy_site) }
+    let!(:site_1_default_language) { create :alchemy_language, site: site_1, default: true }
+    let!(:another_site_1_language) { create :alchemy_language, site: site_1, code: :de }
+    let(:site_2) { create :alchemy_site, host: "another.host", languages: [build(:alchemy_language, code: :en), build(:alchemy_language, code: :de)] }
+
+    context "on index action" do
+      context "when switching the current site" do
+        before do
+          session[:alchemy_site_id] = site_1.id
+          session[:alchemy_language_id] = another_site_1_language.id
+        end
+
+        it "sets @current_language to the new site default language" do
+          get :index, params: {site_id: site_2.id}
+          expect(assigns(:current_language)).to eq site_2.default_language
+        end
+      end
+
+      context "when no language to set" do
+        it "shows flash warning with redirect" do
+          Alchemy::Language.destroy_all
+          get :index, params: {site_id: site_1.id}
+          expect(flash[:warning]).to eq Alchemy.t("Please create a language first.")
+          expect(response).to redirect_to admin_languages_path
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/alchemy/admin/layoutpages_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/layoutpages_controller_spec.rb
@@ -10,6 +10,8 @@ module Alchemy
       authorize_user(:as_admin)
     end
 
+    it_behaves_like "a controller that loads current language"
+
     describe "#index" do
       context "with no language present" do
         it "redirects to the languages admin" do

--- a/spec/controllers/alchemy/admin/nodes_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/nodes_controller_spec.rb
@@ -10,6 +10,8 @@ module Alchemy
       authorize_user(:as_admin)
     end
 
+    it_behaves_like "a controller that loads current language"
+
     describe "#index" do
       context "if no language is present" do
         it "redirects to the language admin" do

--- a/spec/controllers/alchemy/admin/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/pages_controller_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Alchemy::Admin::PagesController do
     authorize_user(:as_admin)
   end
 
+  it_behaves_like "a controller that loads current language"
+
   describe "#index" do
     let!(:page) { create(:alchemy_page) }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,6 +31,7 @@ require "alchemy/test_support/rspec_matchers"
 require "alchemy/test_support/shared_contexts"
 require "alchemy/test_support/shared_link_tab_examples"
 require "alchemy/test_support/shared_uploader_examples"
+require "alchemy/test_support/current_language_shared_examples"
 
 require_relative "support/calculation_examples"
 require_relative "support/hint_examples"


### PR DESCRIPTION
…is associated with the current site.

## What is this pull request for?

If at least one site has multiple languages, after the language is switched in the admin/pages view, the language ID is saved to session, and switching to another site does not change the language in session, which causes that language's pages to continue to be shown.

Closes #2956

This should be backported at least to 7.1.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
