### PR TITLE
Add turbo frame support to dialog

### DIFF
--- a/app/controllers/alchemy/admin/base_controller.rb
+++ b/app/controllers/alchemy/admin/base_controller.rb
@@ -109,11 +109,12 @@ module Alchemy
       #
       def do_redirect_to(url_or_path)
         respond_to do |format|
-          format.js {
+          format.js do
             @redirect_url = url_or_path
             render :redirect
-          }
-          format.html { redirect_to url_or_path }
+          end
+          format.turbo_stream { redirect_to(url_or_path) }
+          format.html { redirect_to(url_or_path) }
         end
       end
 

--- a/app/helpers/alchemy/admin/form_helper.rb
+++ b/app/helpers/alchemy/admin/form_helper.rb
@@ -16,7 +16,7 @@ module Alchemy
       def alchemy_form_for(object, *args, &block)
         options = args.extract_options!
         options[:builder] = Alchemy::Forms::Builder
-        options[:remote] = request.xhr?
+        options[:remote] = options.key?(:remote) ? options[:remote] : request.xhr?
         options[:html] = {
           id: options.delete(:id),
           class: ["alchemy", options.delete(:class)].compact.join(" ")

--- a/app/views/alchemy/admin/resources/_form.html.erb
+++ b/app/views/alchemy/admin/resources/_form.html.erb
@@ -1,26 +1,28 @@
-<%= alchemy_form_for resource_instance_variable, url: resource_path(resource_instance_variable, search_filter_params) do |f| %>
-  <% resource_handler.editable_attributes.each do |attribute| %>
-    <% if relation = attribute[:relation] %>
-      <%= f.association relation[:name].to_sym,
-        collection: relation[:collection],
-        label_method: relation[:attr_method],
-        include_blank: Alchemy.t(:blank, scope: 'resources.relation_select'),
-        input_html: {is: 'alchemy-select'} %>
-    <% elsif attribute[:type].in? %i[date time datetime] %>
-      <%= f.datepicker attribute[:name], resource_attribute_field_options(attribute) %>
-    <% elsif attribute[:enum].present? %>
-      <%= f.input attribute[:name],
-        collection: attribute[:enum],
-        include_blank: Alchemy.t(:blank, scope: 'resources.relation_select'),
-        input_html: {is: 'alchemy-select'} %>
-    <% else %>
-      <%= f.input attribute[:name], resource_attribute_field_options(attribute) %>
+<%= turbo_frame_tag resource_instance_variable, target: "_top" do %>
+  <%= alchemy_form_for resource_instance_variable, url: resource_path(resource_instance_variable, search_filter_params), remote: false do |f| %>
+    <% resource_handler.editable_attributes.each do |attribute| %>
+      <% if relation = attribute[:relation] %>
+        <%= f.association relation[:name].to_sym,
+          collection: relation[:collection],
+          label_method: relation[:attr_method],
+          include_blank: Alchemy.t(:blank, scope: 'resources.relation_select'),
+          input_html: {is: 'alchemy-select'} %>
+      <% elsif attribute[:type].in? %i[date time datetime] %>
+        <%= f.datepicker attribute[:name], resource_attribute_field_options(attribute) %>
+      <% elsif attribute[:enum].present? %>
+        <%= f.input attribute[:name],
+          collection: attribute[:enum],
+          include_blank: Alchemy.t(:blank, scope: 'resources.relation_select'),
+          input_html: {is: 'alchemy-select'} %>
+      <% else %>
+        <%= f.input attribute[:name], resource_attribute_field_options(attribute) %>
+      <% end %>
     <% end %>
-  <% end %>
-  <% if f.object.respond_to?(:tag_list) %>
-    <%= render Alchemy::Admin::TagsAutocomplete.new do %>
-      <%= f.input :tag_list, input_html: { value: f.object.tag_list.join(",") } %>
+    <% if f.object.respond_to?(:tag_list) %>
+      <%= render Alchemy::Admin::TagsAutocomplete.new do %>
+        <%= f.input :tag_list, input_html: { value: f.object.tag_list.join(",") } %>
+      <% end %>
     <% end %>
+    <%= f.submit Alchemy.t(:save) %>
   <% end %>
-  <%= f.submit Alchemy.t(:save) %>
 <% end %>

--- a/spec/dummy/app/models/series.rb
+++ b/spec/dummy/app/models/series.rb
@@ -2,4 +2,6 @@
 
 class Series < ActiveRecord::Base
   extend Alchemy::SearchableResource
+
+  validates :name, presence: true
 end


### PR DESCRIPTION
## What is this pull request for?

Handle Turbo related events to support `turbo_frame_tag`s
in Dialogs. Follows redirects after successful form submission,
if we use `do_redirect_to` which is called by `render_errors_or_redirect`.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
