### PR TITLE
Only allow to assign contentpages in menu node form

### DIFF
--- a/app/models/alchemy/page/page_scopes.rb
+++ b/app/models/alchemy/page/page_scopes.rb
@@ -124,7 +124,7 @@ module Alchemy
         end
 
         def ransackable_scopes(_auth_object)
-          [:published, :from_current_site, :searchables, :layoutpages]
+          [:published, :contentpages, :from_current_site, :searchables, :layoutpages]
         end
       end
     end

--- a/app/views/alchemy/admin/nodes/_form.html.erb
+++ b/app/views/alchemy/admin/nodes/_form.html.erb
@@ -13,7 +13,7 @@
         value: node.page && node.read_attribute(:name).blank? ? nil : node.name,
         placeholder: node.page ? node.page.name : nil
       } %>
-      <%= render Alchemy::Admin::PageSelect.new(node.page, allow_clear: true) do %>
+      <%= render Alchemy::Admin::PageSelect.new(node.page, allow_clear: true, query_params: {contentpages: true}) do %>
         <%= f.input :page_id, label: Alchemy::Page.model_name.human %>
       <% end %>
       <%= f.input :url, input_html: { disabled: node.page }, hint: Alchemy.t(:node_url_hint) %>

--- a/lib/alchemy/test_support/capybara_helpers.rb
+++ b/lib/alchemy/test_support/capybara_helpers.rb
@@ -40,9 +40,12 @@ module Alchemy
 
         within_entire_page do
           find("input.select2-input.select2-focused").set(value)
-          expect(page).to have_selector(".select2-result-label", visible: true)
-          find("div.select2-result-label", text: /#{Regexp.escape(value)}/i, match: :prefer_exact).click
-          expect(page).not_to have_selector(".select2-result-label")
+          expect(page).to_not have_selector(".select2-searching")
+          unless options[:select] == false
+            expect(page).to have_selector(".select2-result-label", visible: true)
+            find("div.select2-result-label", text: /#{Regexp.escape(value)}/i, match: :prefer_exact).click
+            expect(page).not_to have_selector(".select2-result-label")
+          end
         end
       end
 

--- a/spec/features/admin/menus_features_spec.rb
+++ b/spec/features/admin/menus_features_spec.rb
@@ -20,6 +20,40 @@ RSpec.describe "Admin Menus Features", type: :system do
         expect(page).to have_selector(".node_name", text: "Main Menu")
       end
     end
+
+    context "with pages", :js do
+      let(:default_language) { create(:alchemy_language) }
+      let!(:contentpage) { create(:alchemy_page, language: default_language) }
+      let!(:layoutpage) { create(:alchemy_page, :layoutpage, language: default_language) }
+      let!(:main_menu) { create(:alchemy_node, name: "Main Menu") }
+
+      it "can assign contentpages" do
+        visit alchemy.admin_nodes_path
+        expect(page).to have_selector(".node_name", text: "Main Menu")
+        within ".nodes_tree" do
+          click_link_with_tooltip Alchemy.t(:create_node)
+        end
+        within ".alchemy-dialog" do
+          select2_search contentpage.name, from: "Page"
+          click_button "create"
+        end
+        expect(page).to have_selector(".node_name", text: contentpage.name)
+      end
+
+      it "can not assign layoutpages" do
+        visit alchemy.admin_nodes_path
+        expect(page).to have_selector(".node_name", text: "Main Menu")
+        within ".nodes_tree" do
+          click_link_with_tooltip Alchemy.t(:create_node)
+        end
+        within ".alchemy-dialog" do
+          select2_search layoutpage.name, from: "Page", select: false
+        end
+        within ".select2-results" do
+          expect(page).to have_content("No matches found")
+        end
+      end
+    end
   end
 
   describe "adding a new menu" do

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -669,7 +669,9 @@ module Alchemy
 
         subject { described_class.ransackable_scopes(auth_object) }
 
-        it { is_expected.to match_array([:published, :from_current_site, :layoutpages, :searchables]) }
+        it do
+          is_expected.to match_array([:published, :contentpages, :from_current_site, :layoutpages, :searchables])
+        end
       end
     end
 


### PR DESCRIPTION
## What is this pull request for?

Layoutpages are not routable (they don't have an URL and only hold content rendered elsewhere).

Since menus are meant to render a list of page urls it does not make any sense to allow to assign a layoutpage to a menu node.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
