### PR TITLE
Add ingredient length validation

### DIFF
--- a/app/models/alchemy/ingredient_validator.rb
+++ b/app/models/alchemy/ingredient_validator.rb
@@ -86,6 +86,16 @@ module Alchemy
       end
     end
 
+    def validate_length(opts = {})
+      value_length = ingredient.value.to_s.length
+      if value_length < opts[:minimum]
+        ingredient.errors.add(:value, :too_short, count: opts[:minimum])
+      end
+      if value_length > opts[:maximum]
+        ingredient.errors.add(:value, :too_long, count: opts[:maximum])
+      end
+    end
+
     def duplicates
       ingredient.class
         .joins(:element).merge(Alchemy::Element.published)

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -161,6 +161,7 @@ en:
         blank: "%{field} can't be blank"
         invalid: "%{field} has wrong format"
         taken: "%{field} has already been taken"
+        too_short: "%{field} is too short"
 
     default_ingredient_texts:
       lorem: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."

--- a/spec/dummy/config/alchemy/elements.yml
+++ b/spec/dummy/config/alchemy/elements.yml
@@ -91,6 +91,9 @@
       hint: true
       validate:
         - presence
+        - length:
+            minimum: 3
+            maximum: 50
     - role: text
       type: Text
       hint: true

--- a/spec/models/alchemy/element_ingredients_spec.rb
+++ b/spec/models/alchemy/element_ingredients_spec.rb
@@ -164,6 +164,7 @@ RSpec.describe Alchemy::Element do
     it "returns translated ingredient error messages" do
       expect(element.ingredient_error_messages).to eq([
         "Please enter a headline for all you can eat",
+        "Headline is too short",
         "Text is invalid"
       ])
     end

--- a/spec/models/alchemy/ingredient_validator_spec.rb
+++ b/spec/models/alchemy/ingredient_validator_spec.rb
@@ -23,13 +23,12 @@ RSpec.describe Alchemy::IngredientValidator do
     context "and the value is blank" do
       before { validate }
 
-      it { expect(ingredient.errors).to be_present }
-      it { expect(ingredient.errors.messages).to eq(value: ["can't be blank"]) }
+      it { expect(ingredient.errors[:value]).to include("can't be blank") }
     end
 
     context "and the value is present" do
       before do
-        expect(ingredient).to receive(:value) { "Foo" }
+        expect(ingredient).to receive(:value).at_least(:once) { "Foo" }
         validate
       end
 
@@ -56,6 +55,38 @@ RSpec.describe Alchemy::IngredientValidator do
       let(:value) { "!" }
 
       it { expect(ingredient.errors).to be_present }
+    end
+  end
+
+  context "with an ingredient having length validation" do
+    let(:element) { create(:alchemy_element, :with_ingredients, name: "all_you_can_eat") }
+    let(:ingredient) { element.ingredient_by_role(:headline) }
+
+    before do
+      expect(ingredient).to receive(:value).at_least(:once) { value }
+      validate
+    end
+
+    context "and the value is too short" do
+      let(:value) { "Fo" }
+
+      it "has error" do
+        expect(ingredient.errors[:value]).to include("is too short (minimum is 3 characters)")
+      end
+    end
+
+    context "and the value is too long" do
+      let(:value) { "a" * 51 }
+
+      it "has error" do
+        expect(ingredient.errors[:value]).to include "is too long (maximum is 50 characters)"
+      end
+    end
+
+    context "and the value is just right" do
+      let(:value) { "applejuice" }
+
+      it { expect(ingredient).to be_valid }
     end
   end
 


### PR DESCRIPTION
## What is this pull request for?

You can now add a length validation to any ingredient

```yml
- name: article
  ingredients:
    - name: headline
      role: Headline
      validate:
        length:
          minimum: 3
          maximum: 50
```

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
