### PR TITLE
Fix combining search filters and pagination

### DIFF
--- a/app/views/alchemy/admin/resources/_per_page_select.html.erb
+++ b/app/views/alchemy/admin/resources/_per_page_select.html.erb
@@ -1,6 +1,6 @@
 <%= form_tag url_for, method: :get, class: 'per-page-select-form' do |f| %>
   <% search_filter_params.reject { |k, _| k == 'page' || k == 'per_page' }.each do |key, value| %>
-    <% if value.is_a? ActionController::Parameters %>
+    <% if value.respond_to?(:keys) %>
       <% value.each do |k, v| %>
         <%= hidden_field_tag "#{key}[#{k}]", v, id: nil %>
       <% end %>

--- a/spec/features/admin/resources_integration_spec.rb
+++ b/spec/features/admin/resources_integration_spec.rb
@@ -105,6 +105,21 @@ RSpec.describe "Resources", type: :system do
               expect(page).to_not have_content("today 1")
             end
           end
+
+          it "can combine filters and pagination", :js do
+            stub_alchemy_config(:items_per_page, 1)
+
+            visit "/admin/events?filter[start]=starting_today"
+
+            select("4", from: "per_page")
+
+            within "div#archive_all table.list tbody" do
+              expect(page).to have_selector("tr", count: 2)
+              expect(page).to have_content("today 1")
+              expect(page).to have_content("today 2")
+              expect(page).not_to have_content("yesterday")
+            end
+          end
         end
       end
 


### PR DESCRIPTION
The `search_filter_params` method in Alchemy's Resource Controller converts the permitted attributes to a Hash, stopping them from being recognized as something like a nested Hash in our per page select. This commit uses duck-typing in order to find out whether we're looking at a nested Hash. This should work with both ActionController::Parameters and with a Hash.
