### PR TITLE
Resource Controller: Allow additional Ransack filters

### DIFF
--- a/app/controllers/alchemy/admin/resources_controller.rb
+++ b/app/controllers/alchemy/admin/resources_controller.rb
@@ -200,10 +200,7 @@ module Alchemy
       def common_search_filter_includes
         search_filters = [
           {
-            q: [
-              resource_handler.search_field_name,
-              :s
-            ]
+            q: [:s] + permitted_ransack_search_fields
           },
           :tagged_with,
           :page,
@@ -217,6 +214,12 @@ module Alchemy
         end
 
         search_filters
+      end
+
+      def permitted_ransack_search_fields
+        [
+          resource_handler.search_field_name
+        ]
       end
 
       def items_per_page

--- a/spec/dummy/app/models/event.rb
+++ b/spec/dummy/app/models/event.rb
@@ -18,6 +18,12 @@ class Event < ActiveRecord::Base
   scope :future, -> { where("starts_at > ?", Date.tomorrow.at_midnight) }
   scope :by_location_name, ->(name) { joins(:location).where(locations: { name: name }) }
 
+  def self.ransackable_attributes(*)
+    [
+      "name"
+    ]
+  end
+
   def self.alchemy_resource_relations
     {
       location: { attr_method: "name", attr_type: "string" },

--- a/spec/features/admin/resources_integration_spec.rb
+++ b/spec/features/admin/resources_integration_spec.rb
@@ -120,6 +120,22 @@ RSpec.describe "Resources", type: :system do
               expect(page).not_to have_content("yesterday")
             end
           end
+
+          it "can combine ransack queries and pagination", :js do
+            allow_any_instance_of(Admin::EventsController).to receive(:permitted_ransack_search_fields).and_return([:name_start])
+            stub_alchemy_config(:items_per_page, 1)
+
+            visit "/admin/events?q[name_start]=today"
+
+            select("4", from: "per_page")
+
+            within "div#archive_all table.list tbody" do
+              expect(page).to have_selector("tr", count: 2)
+              expect(page).to have_content("today 1")
+              expect(page).to have_content("today 2")
+              expect(page).not_to have_content("yesterday")
+            end
+          end
         end
       end
 


### PR DESCRIPTION
When using custom Ransack filters, this will allow combining them with the pagination. Without this, we can only combine the one ransack field we use for searching in the top bar.

See #2978 for context.
