### PR TITLE
Use keywords in routes mapping

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,15 +5,15 @@ require "alchemy/routing_constraints"
 Alchemy::Engine.routes.draw do
   root to: "pages#index"
 
-  get "/sitemap.xml" => "pages#sitemap", :format => "xml"
+  get "/sitemap.xml", to: "pages#sitemap", format: "xml"
 
   scope Alchemy.admin_path, {constraints: Alchemy.admin_constraints} do
-    get "/" => redirect("#{Alchemy.admin_path}/dashboard"), :as => :admin
-    get "/dashboard" => "admin/dashboard#index", :as => :admin_dashboard
-    get "/dashboard/info" => "admin/dashboard#info", :as => :dashboard_info
-    get "/help" => "admin/dashboard#help", :as => :help
-    get "/dashboard/update_check" => "admin/dashboard#update_check", :as => :update_check
-    get "/leave" => "admin/base#leave", :as => :leave_admin
+    get "/", to: redirect("#{Alchemy.admin_path}/dashboard"), as: :admin
+    get "/dashboard", to: "admin/dashboard#index", as: :admin_dashboard
+    get "/dashboard/info", to: "admin/dashboard#info", as: :dashboard_info
+    get "/help", to: "admin/dashboard#help", as: :help
+    get "/dashboard/update_check", to: "admin/dashboard#update_check", as: :update_check
+    get "/leave", to: "admin/base#leave", as: :leave_admin
   end
 
   namespace :admin, {path: Alchemy.admin_path, constraints: Alchemy.admin_constraints} do
@@ -105,13 +105,13 @@ Alchemy::Engine.routes.draw do
 
     resources :sites
 
-    get "/styleguide" => "styleguide#index"
+    get "/styleguide", to: "styleguide#index"
   end
 
-  get "/attachment/:id/download(/:name)" => "attachments#download",
-    :as => :download_attachment
-  get "/attachment/:id/show(/:name)" => "attachments#show",
-    :as => :show_attachment
+  get "/attachment/:id/download(/:name)", to: "attachments#download",
+    as: :download_attachment
+  get "/attachment/:id/show(/:name)", to: "attachments#show",
+    as: :show_attachment
 
   resources :messages, only: [:index, :new, :create]
   resources :elements, only: :show
@@ -123,8 +123,8 @@ Alchemy::Engine.routes.draw do
     resources :elements, only: [:index, :show]
 
     resources :pages, only: [:index] do
-      get "elements" => "elements#index", :as => "elements"
-      get "elements/:named" => "elements#index", :as => "named_elements"
+      get "elements", to: "elements#index", as: "elements"
+      get "elements/:named", to: "elements#index", as: "named_elements"
       collection do
         get :nested
       end
@@ -133,8 +133,8 @@ Alchemy::Engine.routes.draw do
       end
     end
 
-    get "/pages/*urlname(.:format)" => "pages#show", :as => "page"
-    get "/admin/pages/:id(.:format)" => "pages#show", :as => "preview_page"
+    get "/pages/*urlname(.:format)", to: "pages#show", as: "page"
+    get "/admin/pages/:id(.:format)", to: "pages#show", as: "preview_page"
 
     resources :nodes, only: [:index] do
       member do
@@ -144,14 +144,14 @@ Alchemy::Engine.routes.draw do
     end
   end
 
-  get "/:locale" => "pages#index",
-    :constraints => {locale: Alchemy::RoutingConstraints::LOCALE_REGEXP},
-    :as => :show_language_root
+  get "/:locale", to: "pages#index",
+    constraints: {locale: Alchemy::RoutingConstraints::LOCALE_REGEXP},
+    as: :show_language_root
 
   # The page show action has to be last route
   constraints(locale: Alchemy::RoutingConstraints::LOCALE_REGEXP) do
-    get "(/:locale)/*urlname(.:format)" => "pages#show",
-      :constraints => Alchemy::RoutingConstraints.new,
-      :as => :show_page
+    get "(/:locale)/*urlname(.:format)", to: "pages#show",
+      constraints: Alchemy::RoutingConstraints.new,
+      as: :show_page
   end
 end

--- a/lib/alchemy/install/tasks.rb
+++ b/lib/alchemy/install/tasks.rb
@@ -18,7 +18,7 @@ module Alchemy
             mountpoint = ask("- At which path do you want to mount Alchemy CMS at?", default: mountpoint)
           end
 
-          inject_into_file "./config/routes.rb", "\n  mount Alchemy::Engine => '#{mountpoint}'\n",
+          inject_into_file "./config/routes.rb", "\n  mount Alchemy::Engine, at: '#{mountpoint}'\n",
             {after: SENTINEL, verbose: true}
         end
 

--- a/lib/alchemy/install/tasks.rb
+++ b/lib/alchemy/install/tasks.rb
@@ -5,6 +5,8 @@ require "thor"
 module Alchemy
   module Install
     class Tasks < Thor
+      SENTINEL = /\.routes\.draw do(?:\s*\|map\|)?\s*$/
+
       include Thor::Actions
 
       no_tasks do
@@ -15,8 +17,9 @@ module Alchemy
           unless auto_accept
             mountpoint = ask("- At which path do you want to mount Alchemy CMS at?", default: mountpoint)
           end
-          sentinel = /\.routes\.draw do(?:\s*\|map\|)?\s*$/
-          inject_into_file "./config/routes.rb", "\n  mount Alchemy::Engine => '#{mountpoint}'\n", {after: sentinel, verbose: true}
+
+          inject_into_file "./config/routes.rb", "\n  mount Alchemy::Engine => '#{mountpoint}'\n",
+            {after: SENTINEL, verbose: true}
         end
 
         def set_primary_language(code: "en", name: "English", auto_accept: false)

--- a/spec/libraries/alchemy/install/tasks_spec.rb
+++ b/spec/libraries/alchemy/install/tasks_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+require "alchemy/install/tasks"
+
+RSpec.describe Alchemy::Install::Tasks do
+  let(:tasks) { described_class.new }
+
+  describe "#inject_routes" do
+    subject { tasks.inject_routes(auto_accept) }
+
+    before do
+      allow(File).to receive(:read).and_return(routes_content)
+      allow(tasks).to receive(:inject_into_file)
+    end
+
+    context "with auto_accept" do
+      let(:auto_accept) { true }
+
+      context "when routes are already mounted" do
+        let(:routes_content) { "mount Alchemy::Engine" }
+
+        it "does not inject the routes" do
+          subject
+          expect(tasks).not_to have_received(:inject_into_file)
+        end
+      end
+
+      context "when routes are not mounted" do
+        let(:routes_content) { "get '/home', to: 'home#index'" }
+
+        it "injects the routes" do
+          subject
+          expect(tasks).to have_received(:inject_into_file).with(
+            "./config/routes.rb",
+            "\n  mount Alchemy::Engine => '/'\n",
+            {
+              after: Alchemy::Install::Tasks::SENTINEL,
+              verbose: true
+            }
+          )
+        end
+      end
+    end
+
+    context "without auto_accept" do
+      let(:auto_accept) { false }
+
+      before do
+        allow(tasks).to receive(:ask).and_return("/cms")
+      end
+
+      context "when routes are already mounted" do
+        let(:routes_content) { "mount Alchemy::Engine" }
+
+        it "does not inject the routes" do
+          subject
+          expect(tasks).not_to have_received(:inject_into_file)
+        end
+      end
+
+      context "when routes are not mounted" do
+        let(:routes_content) { "get '/home', to: 'home#index'" }
+
+        it "injects mountpoint into the routes" do
+          subject
+          expect(tasks).to have_received(:inject_into_file).with(
+            "./config/routes.rb",
+            "\n  mount Alchemy::Engine => '/cms'\n",
+            {
+              after: Alchemy::Install::Tasks::SENTINEL,
+              verbose: true
+            }
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/libraries/alchemy/install/tasks_spec.rb
+++ b/spec/libraries/alchemy/install/tasks_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Alchemy::Install::Tasks do
           subject
           expect(tasks).to have_received(:inject_into_file).with(
             "./config/routes.rb",
-            "\n  mount Alchemy::Engine => '/'\n",
+            "\n  mount Alchemy::Engine, at: '/'\n",
             {
               after: Alchemy::Install::Tasks::SENTINEL,
               verbose: true
@@ -64,7 +64,7 @@ RSpec.describe Alchemy::Install::Tasks do
           subject
           expect(tasks).to have_received(:inject_into_file).with(
             "./config/routes.rb",
-            "\n  mount Alchemy::Engine => '/cms'\n",
+            "\n  mount Alchemy::Engine, at: '/cms'\n",
             {
               after: Alchemy::Install::Tasks::SENTINEL,
               verbose: true


### PR DESCRIPTION
## What is this pull request for?

Rails deprecates hash key path mapping

See: https://github.com/rails/rails/pull/52422

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
