### PR TITLE
[7.2-stable] Fix margin of alchemy-message in alchemy-dialog

### DIFF
--- a/app/assets/stylesheets/alchemy/dialogs.scss
+++ b/app/assets/stylesheets/alchemy/dialogs.scss
@@ -82,13 +82,15 @@ $dialog-transition-duration: 150ms;
     }
 
     form,
-    .info.message {
+    .info.message,
+    alchemy-message[type="info"] {
       position: absolute;
       right: 2 * $default-padding;
       width: 256px;
     }
 
-    .info.message {
+    .info.message,
+    alchemy-message[type="info"] {
       top: 2 * $default-padding;
       margin: 0 0 0 8px;
       padding: 0 8px 0 32px;
@@ -158,14 +160,16 @@ $dialog-transition-duration: 150ms;
   position: relative;
   color: $text-color;
 
-  .message {
+  .message,
+  alchemy-message {
     margin: 8px;
   }
 
   &.padded {
     padding: 4 * $default-padding;
 
-    .message {
+    .message,
+    alchemy-message {
       margin: 0 0 8px 0;
     }
   }

--- a/app/assets/stylesheets/alchemy/errors.scss
+++ b/app/assets/stylesheets/alchemy/errors.scss
@@ -43,4 +43,8 @@ body.error {
     max-height: 100%;
     overflow-y: scroll;
   }
+
+  alchemy-message[type="error"] {
+    margin: 0;
+  }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.2-stable`:
 - [Merge pull request #2988 from tvdeyen/fix-dialog-message-margin](https://github.com/AlchemyCMS/alchemy_cms/pull/2988)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)