### PR TITLE
Fix Datetime view with rfc822 format option

### DIFF
--- a/app/components/alchemy/ingredients/datetime_view.rb
+++ b/app/components/alchemy/ingredients/datetime_view.rb
@@ -12,7 +12,7 @@ module Alchemy
 
       def call
         if date_format == "rfc822"
-          ingredient.value.to_s(:rfc822)
+          ingredient.value.to_fs(:rfc822)
         else
           ::I18n.l(ingredient.value, format: date_format)
         end.html_safe

--- a/spec/views/alchemy/ingredients/datetime_view_spec.rb
+++ b/spec/views/alchemy/ingredients/datetime_view_spec.rb
@@ -6,14 +6,10 @@ describe "alchemy/ingredients/_datetime_view" do
   let(:ingredient) { Alchemy::Ingredients::Datetime.new(value: "2013-10-27 21:14:16 +0100") }
   let(:options) { {} }
 
-  before do
-    allow(view).to receive(:options).and_return(options)
-  end
-
   context "with date value" do
     context "without date_format passed" do
       it "translates the date value with default format" do
-        render ingredient
+        render ingredient, options: options
         expect(rendered).to have_content("Sun, 27 Oct 2013 20:14:16 +0000")
       end
     end
@@ -22,7 +18,7 @@ describe "alchemy/ingredients/_datetime_view" do
       let(:options) { {date_format: "rfc822"} }
 
       it "renders the date rfc822 conform" do
-        render ingredient
+        render ingredient, options: options
         expect(rendered).to have_content("Sun, 27 Oct 2013 20:14:16 +0000")
       end
     end
@@ -32,7 +28,7 @@ describe "alchemy/ingredients/_datetime_view" do
     let(:ingredient) { Alchemy::Ingredients::Datetime.new(value: nil) }
 
     it "renders nothing" do
-      render ingredient
+      render ingredient, options: options
       expect(rendered).to eq("")
     end
   end


### PR DESCRIPTION
## What is this pull request for?

[Deprecated since Rails 7.0](https://guides.rubyonrails.org/v7.0/7_0_release_notes.html#active-support-deprecations) and gets removed in Rails 7.2. Using `to_fs` instead.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
