### PR TITLE
Use time.formats.alchemy.default for datetime view

### DIFF
--- a/app/components/alchemy/ingredients/datetime_view.rb
+++ b/app/components/alchemy/ingredients/datetime_view.rb
@@ -4,8 +4,8 @@ module Alchemy
       attr_reader :date_format
 
       # @param ingredient [Alchemy::Ingredient]
-      # @param date_format [String] The date format to use. Use either a strftime format string, a I18n format symbol or "rfc822".
-      def initialize(ingredient, date_format: nil, html_options: {})
+      # @param date_format [String] The date format to use. Use either a strftime format string, a I18n format symbol or "rfc822". Defaults to "time.formats.alchemy.default".
+      def initialize(ingredient, date_format: :"alchemy.default", html_options: {})
         super(ingredient)
         @date_format = settings_value(:date_format, value: date_format)
       end

--- a/spec/views/alchemy/ingredients/datetime_view_spec.rb
+++ b/spec/views/alchemy/ingredients/datetime_view_spec.rb
@@ -10,7 +10,7 @@ describe "alchemy/ingredients/_datetime_view" do
     context "without date_format passed" do
       it "translates the date value with default format" do
         render ingredient, options: options
-        expect(rendered).to have_content("Sun, 27 Oct 2013 20:14:16 +0000")
+        expect(rendered).to have_content("10.27.2013 20:14")
       end
     end
 


### PR DESCRIPTION
## What is this pull request for?

Using nil as default format for I18n can lead to
unpredictable results. We have a default alchemy
time format, let's use that as default format for
ingredient datetime view.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
