### PR TITLE
Render Datetime ingredient in local time zone

### DIFF
--- a/app/components/alchemy/ingredients/datetime_view.rb
+++ b/app/components/alchemy/ingredients/datetime_view.rb
@@ -11,10 +11,11 @@ module Alchemy
       end
 
       def call
+        datetime = ingredient.value.in_time_zone(Rails.application.config.time_zone)
         if date_format == "rfc822"
-          ingredient.value.to_fs(:rfc822)
+          datetime.to_fs(:rfc822)
         else
-          ::I18n.l(ingredient.value, format: date_format)
+          ::I18n.l(datetime, format: date_format)
         end.html_safe
       end
     end

--- a/spec/models/alchemy/ingredients/datetime_spec.rb
+++ b/spec/models/alchemy/ingredients/datetime_spec.rb
@@ -23,11 +23,15 @@ RSpec.describe Alchemy::Ingredients::Datetime do
   end
 
   describe "value" do
-    subject { datetime_ingredient.value }
+    subject(:value) { datetime_ingredient.value }
 
     it "returns a time object" do
       is_expected.to be_an(Time)
       is_expected.to eq("01.04.2021")
+    end
+
+    it "timezone is UTC" do
+      expect(value.zone).to eq("UTC")
     end
 
     context "without value" do

--- a/spec/views/alchemy/ingredients/datetime_view_spec.rb
+++ b/spec/views/alchemy/ingredients/datetime_view_spec.rb
@@ -3,14 +3,24 @@
 require "rails_helper"
 
 describe "alchemy/ingredients/_datetime_view" do
-  let(:ingredient) { Alchemy::Ingredients::Datetime.new(value: "2013-10-27 21:14:16 +0100") }
+  around do |example|
+    time_zone = Rails.application.config.time_zone
+    Rails.application.config.time_zone = "Berlin"
+    example.run
+    Rails.application.config.time_zone = time_zone
+  end
+
+  let(:ingredient) do
+    Alchemy::Ingredients::Datetime.new(value: "2024-08-29T10:00:00.000Z")
+  end
+
   let(:options) { {} }
 
   context "with date value" do
     context "without date_format passed" do
       it "translates the date value with default format" do
         render ingredient, options: options
-        expect(rendered).to have_content("10.27.2013 20:14")
+        expect(rendered).to have_content("08.29.2024 12:00")
       end
     end
 
@@ -19,7 +29,7 @@ describe "alchemy/ingredients/_datetime_view" do
 
       it "renders the date rfc822 conform" do
         render ingredient, options: options
-        expect(rendered).to have_content("Sun, 27 Oct 2013 20:14:16 +0000")
+        expect(rendered).to have_content("Thu, 29 Aug 2024 12:00:00 +0200")
       end
     end
   end


### PR DESCRIPTION
## What is this pull request for?

Datetime values are stored in UTC in the database.
We need to render them in the local timezone.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
