### PR TITLE
Generate CSS entrypoint for Custom Admin CSS

### DIFF
--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -12,6 +12,7 @@
     <meta name="turbo-cache-control" content="no-cache">
     <%= stylesheet_link_tag('alchemy/admin', media: 'screen', 'data-turbo-track' => true) %>
     <%= stylesheet_link_tag('alchemy/admin/print', media: 'print', 'data-turbo-track' => true) %>
+    <%= stylesheet_link_tag('alchemy/admin/custom', 'data-turbo-track' => true) %>
     <%= yield :stylesheets %>
     <script>
       // Global Alchemy JavaScript object.

--- a/lib/alchemy/upgrader/seven_point_three.rb
+++ b/lib/alchemy/upgrader/seven_point_three.rb
@@ -1,13 +1,39 @@
 # frozen_string_literal: true
 
 require "fileutils"
+require "thor"
 
 module Alchemy
   class Upgrader::SevenPointThree < Upgrader
-    def self.remove_admin_stylesheets
-      if File.exist? "vendor/assets/stylesheets/alchemy/admin/all.css"
-        log "Removing Alchemy admin stylesheets."
-        FileUtils.rm_f "vendor/assets/stylesheets/alchemy/admin/all.css"
+    include Thor::Base
+    include Thor::Actions
+
+    source_root Alchemy::Engine.root.join("lib/generators/alchemy/install/files")
+
+    class << self
+      def remove_admin_stylesheets
+        if File.exist? "vendor/assets/stylesheets/alchemy/admin/all.css"
+          log "Removing Alchemy admin stylesheets."
+          FileUtils.rm_f "vendor/assets/stylesheets/alchemy/admin/all.css"
+        end
+      end
+
+      def generate_custom_css_entrypoint
+        if File.exist? "app/assets/config/manifest.js"
+          log "Generating alchemy/admin/custom.css entrypoint file."
+          task.copy_file "custom.css", "app/assets/stylesheets/alchemy/admin/custom.css"
+          task.append_to_file "app/assets/config/manifest.js", "//= link alchemy/admin/custom.css\n"
+          todo(<<~TODO, "Custom styles have been moved to `app/assets/alchemy/admin/custom.css`")
+            Check the new `app/assets/alchemy/admin/custom.css` file for any custom styles you might
+            have added to the old `vendor/assets/stylesheets/alchemy/admin/all.css` file.
+          TODO
+        end
+      end
+
+      private
+
+      def task
+        @_task || new
       end
     end
   end

--- a/lib/generators/alchemy/install/files/all.scss
+++ b/lib/generators/alchemy/install/files/all.scss
@@ -1,1 +1,0 @@
-@use "alchemy/admin";

--- a/lib/generators/alchemy/install/files/custom.css
+++ b/lib/generators/alchemy/install/files/custom.css
@@ -1,0 +1,4 @@
+/*
+ * Edit this file to add custom styles to the Alchemy admin interface.
+ * This file will be loaded after the default Alchemy admin stylesheets.
+ */

--- a/lib/generators/alchemy/install/install_generator.rb
+++ b/lib/generators/alchemy/install/install_generator.rb
@@ -65,6 +65,8 @@ module Alchemy
 
       def install_assets
         copy_file "all.js", app_vendor_assets_path.join("javascripts", "alchemy", "admin", "all.js")
+        copy_file "custom.css", app_assets_path.join("stylesheets/alchemy/admin/custom.css")
+        append_to_file Rails.root.join("app/assets/config/manifest.js"), "//= link alchemy/admin/custom.css\n"
       end
 
       def copy_demo_views

--- a/lib/tasks/alchemy/upgrade.rake
+++ b/lib/tasks/alchemy/upgrade.rake
@@ -61,12 +61,18 @@ namespace :alchemy do
 
     namespace "7.3" do
       task "run" => [
-        "alchemy:upgrade:7.3:remove_admin_stylesheets"
+        "alchemy:upgrade:7.3:remove_admin_stylesheets",
+        "alchemy:upgrade:7.3:generate_custom_css_entrypoint"
       ]
 
       desc "Remove alchemy admin stylesheets"
       task remove_admin_stylesheets: [:environment] do
         Alchemy::Upgrader::SevenPointThree.remove_admin_stylesheets
+      end
+
+      desc "Generate custom css entrypoint"
+      task generate_custom_css_entrypoint: [:environment] do
+        Alchemy::Upgrader::SevenPointThree.generate_custom_css_entrypoint
       end
     end
   end

--- a/spec/dummy/app/assets/config/manifest.js
+++ b/spec/dummy/app/assets/config/manifest.js
@@ -4,3 +4,4 @@
 //= link_tree ../images
 //= link tinymce/langs/de.js
 //= link_tree ../builds
+//= link alchemy/admin/custom.css

--- a/spec/dummy/app/assets/stylesheets/alchemy/admin/custom.css
+++ b/spec/dummy/app/assets/stylesheets/alchemy/admin/custom.css
@@ -1,0 +1,4 @@
+/*
+ * Edit this file to add custom styles to the Alchemy admin interface.
+ * This file will be loaded after the default Alchemy admin stylesheets.
+ */


### PR DESCRIPTION
We've moved the Admin CSS inside the Alchemy gem. This adds an entrypoint for custom CSS to the host app within the Alchemy 7.3 upgrader, and references that directly from the admin layout.
