### PR TITLE
Fallback to @page var if no Current.page is set

### DIFF
--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -72,7 +72,7 @@ module Alchemy
     #
     def render_elements(options = {}, &blk)
       options = {
-        from_page: Current.page,
+        from_page: Current.page || @page,
         render_format: "html"
       }.update(options)
 

--- a/spec/helpers/alchemy/elements_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_helper_spec.rb
@@ -75,9 +75,30 @@ module Alchemy
       context "without any options" do
         let(:options) { {} }
 
-        it "should render all elements from current pages public version." do
-          is_expected.to have_selector("##{element.dom_id}")
-          is_expected.to have_selector("##{another_element.dom_id}")
+        context "with Current.page set" do
+          before { Current.page = page }
+
+          it "should render all elements from current pages public version." do
+            is_expected.to have_selector("##{element.dom_id}")
+            is_expected.to have_selector("##{another_element.dom_id}")
+          end
+        end
+
+        context "with Current.page not set" do
+          before { Current.page = nil }
+
+          it "should not render any elements." do
+            is_expected.to be_empty
+          end
+
+          context "but with @page set" do
+            before { helper.instance_variable_set(:@page, page) }
+
+            it "should render all elements from current pages public version." do
+              is_expected.to have_selector("##{element.dom_id}")
+              is_expected.to have_selector("##{another_element.dom_id}")
+            end
+          end
         end
 
         context "in preview_mode" do


### PR DESCRIPTION
## What is this pull request for?

With Alchemy 7.2 (#2701) we started to use `Alchemy::Current.page` for rendering elements of current page. If one has a custom controller to render Alchemy content with:

    render(template: "alchemy/pages/show")

it is now empty if `Alchemy::Current.page` is not set.

Someday we might deprecate the `@page` instance variable, but until then we need to fall back to it.

## Checklist
-  [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
