### PR TITLE
Set Alchemy::Page.current in Messages Controller

### DIFF
--- a/app/controllers/alchemy/messages_controller.rb
+++ b/app/controllers/alchemy/messages_controller.rb
@@ -66,6 +66,7 @@ module Alchemy
         MessagesMailer.contact_form_mail(@message, mail_to, mail_from, subject).deliver
         redirect_to_success_page
       else
+        Current.page = @page
         render template: "alchemy/pages/show"
       end
     end

--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -72,7 +72,7 @@ module Alchemy
     #
     def render_elements(options = {}, &blk)
       options = {
-        from_page: Current.page,
+        from_page: Current.page || @page,
         render_format: "html"
       }.update(options)
 

--- a/spec/controllers/alchemy/messages_controller_spec.rb
+++ b/spec/controllers/alchemy/messages_controller_spec.rb
@@ -56,6 +56,11 @@ module Alchemy
           it "should render 'alchemy/pages/show' template" do
             expect(subject).to render_template("alchemy/pages/show")
           end
+
+          it "assigns Alchemy::Page.current" do
+            expect(Alchemy::Current).to receive(:page=).with(page)
+            subject
+          end
         end
 
         context "succeeded" do

--- a/spec/helpers/alchemy/elements_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_helper_spec.rb
@@ -75,9 +75,30 @@ module Alchemy
       context "without any options" do
         let(:options) { {} }
 
-        it "should render all elements from current pages public version." do
-          is_expected.to have_selector("##{element.dom_id}")
-          is_expected.to have_selector("##{another_element.dom_id}")
+        context "with Current.page set" do
+          before { Current.page = page }
+
+          it "should render all elements from current pages public version." do
+            is_expected.to have_selector("##{element.dom_id}")
+            is_expected.to have_selector("##{another_element.dom_id}")
+          end
+        end
+
+        context "with Current.page not set" do
+          before { Current.page = nil }
+
+          it "should not render any elements." do
+            is_expected.to be_empty
+          end
+
+          context "but with @page set" do
+            before { helper.instance_variable_set(:@page, page) }
+
+            it "should render all elements from current pages public version." do
+              is_expected.to have_selector("##{element.dom_id}")
+              is_expected.to have_selector("##{another_element.dom_id}")
+            end
+          end
         end
 
         context "in preview_mode" do


### PR DESCRIPTION
## What is this pull request for?

**Needs #3011** 

Since Alchemy 7.2 (https://github.com/AlchemyCMS/alchemy_cms/pull/2701) we need to set `Alchemy::Page.current`
if we want to render a page from another controller.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
