### PR TITLE
[6.1] Allow to set input_type on Datetime ingredient editor

### DIFF
--- a/app/views/alchemy/ingredients/_datetime_editor.html.erb
+++ b/app/views/alchemy/ingredients/_datetime_editor.html.erb
@@ -7,7 +7,8 @@
       datetime_editor, :value, {
         name: datetime_editor.form_field_name,
         id: datetime_editor.form_field_id,
-        value: datetime_editor.value
+        value: datetime_editor.value,
+        type: datetime_editor.settings[:input_type]
       }
     ) %>
   <% end %>

--- a/spec/dummy/config/alchemy/elements.yml
+++ b/spec/dummy/config/alchemy/elements.yml
@@ -167,6 +167,8 @@
     - role: datetime
       type: Datetime
       hint: true
+      settings:
+        input_type: datetime
     - role: file
       type: File
       hint: true

--- a/spec/views/alchemy/ingredients/datetime_editor_spec.rb
+++ b/spec/views/alchemy/ingredients/datetime_editor_spec.rb
@@ -17,6 +17,6 @@ RSpec.describe "alchemy/ingredients/_datetime_editor" do
 
   it "renders a datepicker" do
     render element_editor
-    expect(rendered).to have_css('input[type="text"][data-datepicker-type="date"].date')
+    expect(rendered).to have_css('input[type="text"][data-datepicker-type="datetime"].datetime')
   end
 end


### PR DESCRIPTION
Since the Datetime ingredient stores date and time values it should be possible to set the input_type to either

- time
- date
- datetime

(cherry picked from commit 02a69a65a532e9d7233ee7cc23c96afc5a049bd7)
