### PR TITLE
[7.1-stable] Allow to set input_type on Datetime ingredient editor

### DIFF
--- a/app/models/alchemy/ingredients/datetime.rb
+++ b/app/models/alchemy/ingredients/datetime.rb
@@ -5,7 +5,7 @@ module Alchemy
     # A datetime value
     #
     class Datetime < Alchemy::Ingredient
-      allow_settings %i[date_format]
+      allow_settings %i[date_format input_type]
 
       def value
         ActiveRecord::Type::DateTime.new.cast(self[:value])

--- a/app/views/alchemy/ingredients/_datetime_editor.html.erb
+++ b/app/views/alchemy/ingredients/_datetime_editor.html.erb
@@ -7,7 +7,8 @@
       datetime_editor, :value, {
         name: datetime_editor.form_field_name,
         id: datetime_editor.form_field_id,
-        value: datetime_editor.value
+        value: datetime_editor.value,
+        type: datetime_editor.settings[:input_type]
       }
     ) %>
   <% end %>

--- a/spec/dummy/config/alchemy/elements.yml
+++ b/spec/dummy/config/alchemy/elements.yml
@@ -123,6 +123,8 @@
     - role: datetime
       type: Datetime
       hint: true
+      settings:
+        input_type: datetime
     - role: file
       type: File
       hint: true

--- a/spec/models/alchemy/ingredients/datetime_spec.rb
+++ b/spec/models/alchemy/ingredients/datetime_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe Alchemy::Ingredients::Datetime do
     )
   end
 
+  describe ".allowed_settings" do
+    it "sets allowed_settings" do
+      expect(described_class.allowed_settings).to eq([:date_format, :input_type])
+    end
+  end
+
   describe "value" do
     subject { datetime_ingredient.value }
 

--- a/spec/views/alchemy/ingredients/datetime_editor_spec.rb
+++ b/spec/views/alchemy/ingredients/datetime_editor_spec.rb
@@ -17,6 +17,6 @@ RSpec.describe "alchemy/ingredients/_datetime_editor" do
 
   it "renders a datepicker" do
     render element_editor
-    expect(rendered).to have_css('alchemy-datepicker[input-type="date"] input[type="text"].date')
+    expect(rendered).to have_css('alchemy-datepicker[input-type="datetime"] input[type="text"].datetime')
   end
 end


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.1-stable`:
 - [Merge pull request #3002 from AlchemyCMS/fix-datetime-editor-input_type](https://github.com/AlchemyCMS/alchemy_cms/pull/3002)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)