### PR TITLE
[7.0-stable] Render Datetime ingredient in local time zone

### DIFF
--- a/app/components/alchemy/ingredients/datetime_view.rb
+++ b/app/components/alchemy/ingredients/datetime_view.rb
@@ -11,10 +11,11 @@ module Alchemy
       end
 
       def call
+        datetime = ingredient.value.in_time_zone(Rails.application.config.time_zone)
         if date_format == "rfc822"
-          ingredient.value.to_s(:rfc822)
+          datetime.try(:to_fs, :rfc822) || datetime.to_s(:rfc822)
         else
-          ::I18n.l(ingredient.value, format: date_format)
+          ::I18n.l(datetime, format: date_format)
         end.html_safe
       end
     end

--- a/spec/models/alchemy/ingredients/datetime_spec.rb
+++ b/spec/models/alchemy/ingredients/datetime_spec.rb
@@ -17,11 +17,15 @@ RSpec.describe Alchemy::Ingredients::Datetime do
   end
 
   describe "value" do
-    subject { datetime_ingredient.value }
+    subject(:value) { datetime_ingredient.value }
 
     it "returns a time object" do
       is_expected.to be_an(Time)
       is_expected.to eq("01.04.2021")
+    end
+
+    it "timezone is UTC" do
+      expect(value.zone).to eq("UTC")
     end
 
     context "without value" do

--- a/spec/views/alchemy/ingredients/datetime_view_spec.rb
+++ b/spec/views/alchemy/ingredients/datetime_view_spec.rb
@@ -3,7 +3,17 @@
 require "rails_helper"
 
 describe "alchemy/ingredients/_datetime_view" do
-  let(:ingredient) { Alchemy::Ingredients::Datetime.new(value: "2013-10-27 21:14:16 +0100") }
+  around do |example|
+    time_zone = Rails.application.config.time_zone
+    Rails.application.config.time_zone = "Berlin"
+    example.run
+    Rails.application.config.time_zone = time_zone
+  end
+
+  let(:ingredient) do
+    Alchemy::Ingredients::Datetime.new(value: "2024-08-29T10:00:00.000Z")
+  end
+
   let(:options) { {} }
 
   before do
@@ -13,8 +23,8 @@ describe "alchemy/ingredients/_datetime_view" do
   context "with date value" do
     context "without date_format passed" do
       it "translates the date value with default format" do
-        render ingredient
-        expect(rendered).to have_content("Sun, 27 Oct 2013 20:14:16 +0000")
+        render ingredient, options: options
+        expect(rendered).to have_content("Thu, 29 Aug 2024 12:00:00 +0200")
       end
     end
 
@@ -22,8 +32,8 @@ describe "alchemy/ingredients/_datetime_view" do
       let(:options) { {date_format: "rfc822"} }
 
       it "renders the date rfc822 conform" do
-        render ingredient
-        expect(rendered).to have_content("Sun, 27 Oct 2013 20:14:16 +0000")
+        render ingredient, options: options
+        expect(rendered).to have_content("Thu, 29 Aug 2024 12:00:00 +0200")
       end
     end
   end


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.0-stable`:
 - [Merge pull request #3003 from AlchemyCMS/datetime-view-time-zone](https://github.com/AlchemyCMS/alchemy_cms/pull/3003)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)