### PR TITLE
[7.2-stable] Fallback to @page var if no Current.page is set

### DIFF
--- a/app/helpers/alchemy/elements_helper.rb
+++ b/app/helpers/alchemy/elements_helper.rb
@@ -72,7 +72,7 @@ module Alchemy
     #
     def render_elements(options = {}, &blk)
       options = {
-        from_page: Current.page,
+        from_page: Current.page || @page,
         render_format: "html"
       }.update(options)
 

--- a/spec/helpers/alchemy/elements_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_helper_spec.rb
@@ -75,9 +75,30 @@ module Alchemy
       context "without any options" do
         let(:options) { {} }
 
-        it "should render all elements from current pages public version." do
-          is_expected.to have_selector("##{element.dom_id}")
-          is_expected.to have_selector("##{another_element.dom_id}")
+        context "with Current.page set" do
+          before { Current.page = page }
+
+          it "should render all elements from current pages public version." do
+            is_expected.to have_selector("##{element.dom_id}")
+            is_expected.to have_selector("##{another_element.dom_id}")
+          end
+        end
+
+        context "with Current.page not set" do
+          before { Current.page = nil }
+
+          it "should not render any elements." do
+            is_expected.to be_empty
+          end
+
+          context "but with @page set" do
+            before { helper.instance_variable_set(:@page, page) }
+
+            it "should render all elements from current pages public version." do
+              is_expected.to have_selector("##{element.dom_id}")
+              is_expected.to have_selector("##{another_element.dom_id}")
+            end
+          end
         end
 
         context "in preview_mode" do


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.2-stable`:
 - [Merge pull request #3011 from tvdeyen/at-page-fallback](https://github.com/AlchemyCMS/alchemy_cms/pull/3011)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)