### PR TITLE
[7.2-stable] Set Alchemy::Page.current in Messages Controller

### DIFF
--- a/app/controllers/alchemy/messages_controller.rb
+++ b/app/controllers/alchemy/messages_controller.rb
@@ -66,6 +66,7 @@ module Alchemy
         MessagesMailer.contact_form_mail(@message, mail_to, mail_from, subject).deliver
         redirect_to_success_page
       else
+        Current.page = @page
         render template: "alchemy/pages/show"
       end
     end

--- a/spec/controllers/alchemy/messages_controller_spec.rb
+++ b/spec/controllers/alchemy/messages_controller_spec.rb
@@ -56,6 +56,11 @@ module Alchemy
           it "should render 'alchemy/pages/show' template" do
             expect(subject).to render_template("alchemy/pages/show")
           end
+
+          it "assigns Alchemy::Page.current" do
+            expect(Alchemy::Current).to receive(:page=).with(page)
+            subject
+          end
         end
 
         context "succeeded" do


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.2-stable`:
 - [Merge pull request #3012 from tvdeyen/fix-messages-controller](https://github.com/AlchemyCMS/alchemy_cms/pull/3012)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)