### PR TITLE
Add 'updated_at' to the DEFAULT_SKIPPED_ATTRIBUTES to match the documentation

### DIFF
--- a/lib/alchemy/resource.rb
+++ b/lib/alchemy/resource.rb
@@ -101,7 +101,7 @@ module Alchemy
     attr_accessor :resource_relations, :model_associations
     attr_reader :model
 
-    DEFAULT_SKIPPED_ATTRIBUTES = %w[id created_at creator_id]
+    DEFAULT_SKIPPED_ATTRIBUTES = %w[id created_at updated_at creator_id]
     DEFAULT_SKIPPED_ASSOCIATIONS = %w[creator]
     SEARCHABLE_COLUMN_TYPES = [:string, :text]
 


### PR DESCRIPTION
## What is this pull request for?

According to the documentation on this file (Line 27), the attribute 'updated_at' should be excluded by default for all resources. 

### Notable changes (remove if none)

The 'updated_at' will not be displayed in the UI when using Alchemy as admin for other models of the rails application. (But not UI changes per se)

## Checklist
- [ ] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
