### PR TITLE
Resource table fixes

### DIFF
--- a/app/assets/stylesheets/alchemy/admin/tables.scss
+++ b/app/assets/stylesheets/alchemy/admin/tables.scss
@@ -142,13 +142,16 @@ td,
     width: 80px;
   }
 
-  &.date,
-  &.datetime {
+  &.date {
     width: 150px;
   }
 
+  &.datetime {
+    width: 180px;
+  }
+
   &.login {
-    width: 100px;
+    width: 150px;
   }
 
   &.email {

--- a/app/components/alchemy/admin/resource/table.rb
+++ b/app/components/alchemy/admin/resource/table.rb
@@ -120,11 +120,14 @@ module Alchemy
           end
         end
 
-        def edit_button(tooltip: Alchemy.t("Edit"), dialog_size: resource_window_size)
+        def edit_button(tooltip: Alchemy.t("Edit"), dialog_title: tooltip, dialog_size: resource_window_size)
           with_action(:edit, tooltip) do |row|
             helpers.link_to_dialog render_icon(:edit),
               edit_resource_path(row, search_filter_params),
-              {size: dialog_size},
+              {
+                size: dialog_size,
+                title: dialog_title
+              },
               class: "icon_button"
           end
         end

--- a/app/components/alchemy/admin/resource/table.rb
+++ b/app/components/alchemy/admin/resource/table.rb
@@ -120,11 +120,11 @@ module Alchemy
           end
         end
 
-        def edit_button(tooltip: Alchemy.t("Edit"), size: resource_window_size)
+        def edit_button(tooltip: Alchemy.t("Edit"), dialog_size: resource_window_size)
           with_action(:edit, tooltip) do |row|
             helpers.link_to_dialog render_icon(:edit),
               edit_resource_path(row, search_filter_params),
-              {size: size},
+              {size: dialog_size},
               class: "icon_button"
           end
         end

--- a/app/components/alchemy/admin/resource/table.rb
+++ b/app/components/alchemy/admin/resource/table.rb
@@ -114,9 +114,9 @@ module Alchemy
           end
         end
 
-        def delete_button(tooltip: Alchemy.t("Delete"), message: Alchemy.t("Are you sure?"))
+        def delete_button(tooltip: Alchemy.t("Delete"), confirm_message: Alchemy.t("Are you sure?"))
           with_action(:destroy, tooltip) do |row|
-            helpers.delete_button(resource_path(row, search_filter_params), {message: message})
+            helpers.delete_button(resource_path(row, search_filter_params), {message: confirm_message})
           end
         end
 

--- a/app/views/alchemy/admin/languages/_table.html.erb
+++ b/app/views/alchemy/admin/languages/_table.html.erb
@@ -11,8 +11,8 @@
   <% end %>
   <% table.column :public %>
   <% table.column :default %>
-  <% table.delete_button %>
-  <% table.edit_button %>
+  <% table.delete_button tooltip: Alchemy.t(:delete_language) %>
+  <% table.edit_button tooltip: Alchemy.t(:edit_language), dialog_size: "430x415" %>
 <% end %>
 
 <%= paginate @languages, theme: 'alchemy' %>

--- a/app/views/alchemy/admin/pages/_table.html.erb
+++ b/app/views/alchemy/admin/pages/_table.html.erb
@@ -87,7 +87,7 @@
           class: "icon_button"
         ) %>
   <% end %>
-  <% table.delete_button tooltip: Alchemy.t(:delete_page), message: Alchemy.t(:confirm_to_delete_page) %>
+  <% table.delete_button tooltip: Alchemy.t(:delete_page), confirm_message: Alchemy.t(:confirm_to_delete_page) %>
 <% end %>
 
 

--- a/app/views/alchemy/admin/tags/index.html.erb
+++ b/app/views/alchemy/admin/tags/index.html.erb
@@ -33,7 +33,7 @@
       <% end %>
       <% table.column :taggings_count, sortable: true, class_name: "count" %>
 
-      <% table.delete_button tooltip: Alchemy.t(:delete_tag), message: Alchemy.t(:do_you_really_want_to_delete_this_tag?) %>
+      <% table.delete_button tooltip: Alchemy.t(:delete_tag), confirm_message: Alchemy.t(:do_you_really_want_to_delete_this_tag?) %>
       <% table.edit_button tooltip: Alchemy.t(:edit_tag) %>
     <% end %>
 

--- a/app/views/alchemy/admin/tags/index.html.erb
+++ b/app/views/alchemy/admin/tags/index.html.erb
@@ -34,7 +34,7 @@
       <% table.column :taggings_count, sortable: true, class_name: "count" %>
 
       <% table.delete_button tooltip: Alchemy.t(:delete_tag), confirm_message: Alchemy.t(:do_you_really_want_to_delete_this_tag?) %>
-      <% table.edit_button tooltip: Alchemy.t(:edit_tag) %>
+      <% table.edit_button tooltip: Alchemy.t(:edit_tag), dialog_size: "360x410" %>
     <% end %>
 
   <%= paginate @tags, theme: 'alchemy' %>

--- a/lib/alchemy/resources_helper.rb
+++ b/lib/alchemy/resources_helper.rb
@@ -10,7 +10,7 @@ module Alchemy
     #
 
     def resource_window_size
-      @resource_window_size ||= "420x#{100 + resource_handler.attributes.length * 40}"
+      @resource_window_size ||= "480x#{100 + resource_handler.attributes.length * 40}"
     end
 
     def resource_instance_variable

--- a/lib/alchemy/upgrader/seven_point_three.rb
+++ b/lib/alchemy/upgrader/seven_point_three.rb
@@ -30,6 +30,18 @@ module Alchemy
         end
       end
 
+      def show_resource_table_notice
+        custom_modules = Alchemy::Modules.alchemy_modules.reject { _1["engine_name"] == "alchemy" }
+        return if custom_modules.none?
+
+        todo(<<~TODO, "Resource templates have been updated.")
+          We updated the resource templates to use the newly introduced
+          `Alchemy::Admin::Resource::Table` view component.
+
+          Please update your resource templates accordingly.
+        TODO
+      end
+
       private
 
       def task

--- a/lib/tasks/alchemy/upgrade.rake
+++ b/lib/tasks/alchemy/upgrade.rake
@@ -63,7 +63,9 @@ namespace :alchemy do
       task "run" => [
         "alchemy:upgrade:7.3:remove_admin_stylesheets",
         "alchemy:upgrade:7.3:generate_custom_css_entrypoint"
-      ]
+      ] do
+        Alchemy::Upgrader::SevenPointThree.show_resource_table_notice
+      end
 
       desc "Remove alchemy admin stylesheets"
       task remove_admin_stylesheets: [:environment] do

--- a/spec/libraries/resources_helper_spec.rb
+++ b/spec/libraries/resources_helper_spec.rb
@@ -111,7 +111,7 @@ describe Alchemy::ResourcesHelper do
   describe "#resource_window_size" do
     it "returns overlay size string depending on resource attributes length" do
       allow(controller).to receive(:resource_handler).and_return double(attributes: double(length: 4))
-      expect(controller.resource_window_size).to eq("420x260")
+      expect(controller.resource_window_size).to eq("480x260")
     end
   end
 


### PR DESCRIPTION
## What is this pull request for?

Several minor fixes for the recently introduced `Alchemy::Admin::Resource::Table` view component.

Best reviewed commit by commit

### Some highlights:

- The default resource dialog width has been adjusted from 420 to 480 pixels

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
