### PR TITLE
Use alchemy_display_name for page actor names

### DIFF
--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -491,7 +491,7 @@ module Alchemy
     # does not respond to +#name+ it returns +'unknown'+
     #
     def creator_name
-      creator.try(:name) || Alchemy.t("unknown")
+      creator.try(:alchemy_display_name) || Alchemy.t("unknown")
     end
 
     # Returns the name of the last updater of this page.
@@ -500,7 +500,7 @@ module Alchemy
     # does not respond to +#name+ it returns +'unknown'+
     #
     def updater_name
-      updater.try(:name) || Alchemy.t("unknown")
+      updater.try(:alchemy_display_name) || Alchemy.t("unknown")
     end
 
     # Returns the name of the user currently editing this page.
@@ -509,7 +509,7 @@ module Alchemy
     # does not respond to +#name+ it returns +'unknown'+
     #
     def locker_name
-      locker.try(:name) || Alchemy.t("unknown")
+      locker.try(:alchemy_display_name) || Alchemy.t("unknown")
     end
 
     # Key hint translations by page layout, rather than the default name.

--- a/spec/dummy/app/models/dummy_user.rb
+++ b/spec/dummy/app/models/dummy_user.rb
@@ -13,11 +13,15 @@ class DummyUser < ActiveRecord::Base
   end
 
   def alchemy_roles
-    @alchemy_roles || %w(admin)
+    @alchemy_roles || %w[admin]
   end
 
   def name
     @name || email
+  end
+
+  def alchemy_display_name
+    name
   end
 
   def human_roles_string

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -1816,7 +1816,7 @@ module Alchemy
         end
       end
 
-      context "with user class having a name accessor" do
+      context "with user class having a alchemy_display_name accessor" do
         let(:user) { build(:alchemy_dummy_user, name: "Paul Page") }
 
         describe "#creator_name" do
@@ -1844,7 +1844,7 @@ module Alchemy
         end
       end
 
-      context "with user class returning nil for name" do
+      context "with user class returning nil for alchemy_display_name" do
         let(:user) { Alchemy.user_class.new }
 
         describe "#creator_name" do
@@ -1872,11 +1872,11 @@ module Alchemy
         end
       end
 
-      context "with user class not responding to name" do
+      context "with user class not responding to alchemy_display_name" do
         let(:user) { Alchemy.user_class.new }
 
         before do
-          expect(user).to receive(:respond_to?).with(:name) { false }
+          expect(user).to receive(:respond_to?).with(:alchemy_display_name) { false }
         end
 
         describe "#creator_name" do


### PR DESCRIPTION
## What is this pull request for?

If you have a user class that does not implement
name (eg. `Spree::User` or a generic `User` class) it would return `nil` for Page actor methods (creator, updater, locker).

We already use `alchemy_display_name` for the current logged in user displayed in the admin frame.

Using this for the Page actor methods to be consistant and allow custom user classes to present a user by it.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
