### PR TITLE
fix(Ingredient::Picture): Do not try to localize CSS class if empty

### DIFF
--- a/app/views/alchemy/admin/ingredients/update.turbo_stream.erb
+++ b/app/views/alchemy/admin/ingredients/update.turbo_stream.erb
@@ -3,7 +3,7 @@
 <% if @ingredient.settings[:anchor] %>
 <alchemy-action name="updateAnchorIcon" params="<%= [@ingredient.id, @ingredient.dom_id.present?].to_json %>"></alchemy-action>
 <% end %>
-<% if @ingredient.type == "Alchemy::Ingredients::Picture" %>
+<% if @ingredient.type == "Alchemy::Ingredients::Picture" && @ingredient.css_class.present? %>
   <%= turbo_stream.replace_all "[data-ingredient-id='#{@ingredient.id}'] .picture_ingredient_css_class",
     partial: "alchemy/ingredients/shared/picture_css_class",
     locals: {

--- a/spec/controllers/alchemy/admin/ingredients_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/ingredients_controller_spec.rb
@@ -84,6 +84,28 @@ RSpec.describe Alchemy::Admin::IngredientsController do
           expect(ingredient.size).to eq "3"
           expect(ingredient.dom_id).to eq "se-id"
         end
+
+        context "with a picture ingredient having empty css class" do
+          let(:ingredient) do
+            stub_model(
+              Alchemy::Ingredients::Picture,
+              type: "Alchemy::Ingredients::Picture",
+              element: element,
+              role: "picture",
+              data: {
+                css_class: ""
+              }
+            )
+          end
+
+          render_views
+
+          it "does not raise I18n ArgumentError" do
+            expect {
+              patch :update, params: params, format: :turbo_stream
+            }.to_not raise_error
+          end
+        end
       end
 
       context "with unpermitted attributes" do


### PR DESCRIPTION
An empty css class leads to a ArgumentError in I18n.
