### PR TITLE
docs: remove outdated link

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -84,7 +84,6 @@ Gem::Specification.new do |gem|
     Need help? Try:
 
     * https://stackoverflow.com/questions/tagged/alchemy-cms
-    * https://slackin.alchemy-cms.com
     -------------------------------------------------------------
 
   MSG


### PR DESCRIPTION
## What is this pull request for?

For everyone who installs or updates the alchemyGem and clicks the links

### Notable changes (remove if none)

We remove a 404 link

### Screenshots

![image](https://github.com/user-attachments/assets/81670c1d-f0d9-49e0-b92d-e50fbd186405)



