### PR TITLE
[7.3] Deprecate resources helpers

### DIFF
--- a/app/views/alchemy/admin/resources/_resource.html.erb
+++ b/app/views/alchemy/admin/resources/_resource.html.erb
@@ -1,3 +1,5 @@
+<% Alchemy::Deprecation.warn "The `alchemy/admin/resources/_resource` partial is deprecated. Please `render 'alchemy/admin/resources/_resource_table'` instead and update it to your needs." %>
+
 <tr class="<%= cycle('even', 'odd') %>">
   <% if local_assigns[:icon] %>
     <td class="icon"><%= render_icon(local_assigns[:icon], size: "xl") %></td>

--- a/lib/alchemy/resources_helper.rb
+++ b/lib/alchemy/resources_helper.rb
@@ -130,7 +130,7 @@ module Alchemy
     # Returns the attribute's column for sorting
     #
     # If the attribute contains a resource_relation, then the table and column for related model will be returned.
-    #
+    # @deprecated
     def sortable_resource_header_column(attribute)
       if (relation = attribute[:relation])
         "#{relation[:model_association].name}_#{relation[:attr_method]}"
@@ -138,6 +138,7 @@ module Alchemy
         attribute[:name]
       end
     end
+    deprecate sortable_resource_header_column: "Please `render Alchemy::Admin::Resource::Table instead`", deprecator: Alchemy::Deprecation
 
     # Renders the row for a resource record in the resources table.
     #
@@ -156,12 +157,13 @@ module Alchemy
     #   </tr>
     #
     # NOTE: Alchemy gives you a local variable named like your resource
-    #
+    # @deprecated
     def render_resources(icon: nil)
       render partial: resource_name, collection: resources_instance_variable, locals: {icon: icon}
     rescue ActionView::MissingTemplate
       render partial: "resource", collection: resources_instance_variable, locals: {icon: icon}
     end
+    deprecate render_resources: "Please `render Alchemy::Admin::Resource::Table instead`", deprecator: Alchemy::Deprecation
 
     def resource_has_tags
       resource_model.respond_to?(:tag_counts) && resource_model.tag_counts.any?

--- a/spec/libraries/resources_helper_spec.rb
+++ b/spec/libraries/resources_helper_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "../../lib/alchemy/i18n"
-require_relative "../../lib/alchemy/resource"
-require_relative "../../lib/alchemy/resources_helper"
+require "rails_helper"
 
 module Namespace
   class MyResource
@@ -269,7 +267,7 @@ describe Alchemy::ResourcesHelper do
     end
   end
 
-  describe "#render_resources" do
+  describe "#render_resources", :silence_deprecations do
     it "renders a resource collection" do
       expect(controller).to receive(:render).with(collection: [resource_item], partial: "my_resource", locals: {icon: nil})
       controller.render_resources


### PR DESCRIPTION
## What is this pull request for?

Use the new `Alchemy::Admin::Resource::Table` instead of rendering these partials or use these helpers.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
