### PR TITLE
Replace MySQL build with SQLite

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -71,7 +71,7 @@ jobs:
           - "3.2"
           - "3.3"
         database:
-          - mysql
+          - sqlite
           - postgresql
           - mariadb
     env:
@@ -91,15 +91,6 @@ jobs:
           POSTGRES_DB: alchemy_cms_dummy_test
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-      mysql:
-        image: mysql:latest
-        ports: ["3306:3306"]
-        env:
-          MYSQL_USER: alchemy_user
-          MYSQL_PASSWORD: password
-          MYSQL_DATABASE: alchemy_cms_dummy_test
-          MYSQL_ROOT_PASSWORD: password
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
       mariadb:
         image: mariadb:latest
         ports: ["3307:3306"]
@@ -132,8 +123,8 @@ jobs:
           sudo apt update -qq
           sudo apt install -qq --fix-missing libpq-dev -o dir::cache::archives="/home/runner/apt/cache"
           sudo chown -R runner /home/runner/apt/cache
-      - name: Install MySQL headers
-        if: matrix.database == 'mysql' || matrix.database == 'mariadb'
+      - name: Install MariaDB headers
+        if: matrix.database == 'mariadb'
         run: |
           mkdir -p /home/runner/apt/cache
           sudo apt update -qq

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ rails_version = ENV.fetch("RAILS_VERSION", "7.2")
 gem "rails", "~> #{rails_version}.0"
 
 if ENV["DB"].nil? || ENV["DB"] == "sqlite"
-  gem "sqlite3", "~> 1.7.0"
+  gem "sqlite3", (rails_version == "7.0") ? "~> 1.7.0" : "~> 2.0.0"
 end
 if ENV["DB"] == "mysql" || ENV["DB"] == "mariadb"
   gem "mysql2", "~> 0.5.1"


### PR DESCRIPTION
## What is this pull request for?

We already test with MariaDB - the Open Source MySQL fork. Since MySQL 5.7 support has been stopped in Nov 23 we remove precious build minutes for it.

Using these build minutes for testing SQLite - a database that will have full production support with Rails 8.0

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message

