### PR TITLE
Generate a view component in ingredient generator

### DIFF
--- a/lib/generators/alchemy/ingredient/ingredient_generator.rb
+++ b/lib/generators/alchemy/ingredient/ingredient_generator.rb
@@ -14,6 +14,10 @@ module Alchemy
         @ingredients_view_path = "app/views/alchemy/ingredients"
       end
 
+      def create_view_component
+        template "view_component.rb.tt", "app/components/alchemy/ingredients/#{file_name}_view.rb"
+      end
+
       def create_model
         template "model.rb.tt", "app/models/alchemy/ingredients/#{file_name}.rb"
       end
@@ -21,6 +25,7 @@ module Alchemy
       def copy_templates
         @ingredient_editor_local = "#{file_name}_editor"
         @ingredient_view_local = "#{file_name}_view"
+        @ingredient_view_component_class = "#{@class_name}View"
         template "view.html.erb", "#{@ingredients_view_path}/_#{file_name}_view.html.erb"
         template "editor.html.erb", "#{@ingredients_view_path}/_#{file_name}_editor.html.erb"
       end

--- a/lib/generators/alchemy/ingredient/templates/view.html.erb
+++ b/lib/generators/alchemy/ingredient/templates/view.html.erb
@@ -1,1 +1,1 @@
-<%%= <%= @ingredient_view_local %>.value %>
+<%%= render Alchemy::Ingredients::<%= @ingredient_view_component_class %>.new(<%= @ingredient_view_local %>) %>

--- a/lib/generators/alchemy/ingredient/templates/view_component.rb.tt
+++ b/lib/generators/alchemy/ingredient/templates/view_component.rb.tt
@@ -1,0 +1,10 @@
+module Alchemy
+  module Ingredients
+    class <%= @class_name %>View < BaseView
+      
+      def call
+        content_tag(:div, ingredient.value)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

Alchemy is mostly using a ViewComponent to render an ingredient. Only some situations the view partial is used. If you previous used the generator you ran into the situation, that the required ingredient was missing. Now the generator is creating the ingredient view component and is referring to that component in the view.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
