### PR TITLE
[7.3-stable] fix new page form

### DIFF
--- a/app/models/alchemy/page/page_naming.rb
+++ b/app/models/alchemy/page/page_naming.rb
@@ -13,7 +13,7 @@ module Alchemy
           unless: -> { name.blank? }
 
         validates :name,
-          presence: true
+          presence: true, uniqueness: {scope: [:parent_id], case_sensitive: false, unless: -> { parent_id.nil? }}
         validates :urlname,
           uniqueness: {scope: [:language_id, :layoutpage], if: -> { urlname.present? }, case_sensitive: false},
           exclusion: {in: RESERVED_URLNAMES},

--- a/app/views/alchemy/admin/pages/_new_page_form.html.erb
+++ b/app/views/alchemy/admin/pages/_new_page_form.html.erb
@@ -14,7 +14,7 @@
     label: Alchemy.t(:page_type),
     include_blank: @page_layouts.length == 1 ? nil : Alchemy.t('Please choose'),
     required: true,
-    selected: @page_layouts.length == 1 ? @page_layouts.first : nil,
+    selected: @page_layouts.length == 1 ? @page_layouts.first : @page.page_layout,
     input_html: {is: 'alchemy-select'} %>
   <%= f.input :name %>
   <%= f.submit Alchemy.t(:create) %>

--- a/spec/features/admin/page_creation_feature_spec.rb
+++ b/spec/features/admin/page_creation_feature_spec.rb
@@ -22,6 +22,19 @@ RSpec.describe "Page creation", type: :system do
         expect(page).to_not have_css("#s2id_page_parent_id")
       end
     end
+    context "with same name " do
+      let!(:existing_page) { create(:alchemy_page, parent: homepage, name: "Unique Name") }
+      it "doesn't create a page with the same name" do
+        visit admin_pages_path
+
+        find(%(a.icon_button[href="/admin/pages/new?parent_id=#{homepage.id}"]), visible: true, match: :first).click
+        select2 "Standard", from: "Type"
+        fill_in "Name", with: "Unique Name"
+        click_button "create"
+
+        expect(page).to have_css("div.alchemy-dialog-body form small.error", text: "has already been taken")
+      end
+    end
   end
 
   describe "overlay GUI" do

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -73,6 +73,20 @@ module Alchemy
 
         it { expect(page).to_not be_valid }
       end
+      context "a page must have a unique name within the same parent" do
+        let!(:homepage) { create(:alchemy_page, :language_root) }
+        let!(:existing_page) { create(:alchemy_page, parent: homepage, name: "Unique Name") }
+        it {
+          expect {
+            create(:alchemy_page, name: existing_page.name, parent: homepage)
+          }.to raise_error(ActiveRecord::RecordInvalid, /has already been taken/)
+        }
+        it {
+          expect {
+            create(:alchemy_page, name: existing_page.name.upcase, parent: homepage)
+          }.to raise_error(ActiveRecord::RecordInvalid, /has already been taken/)
+        }
+      end
     end
 
     # Callbacks


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.3-stable`:
 - [Merge pull request #3060 from zp1984/fix_page_form](https://github.com/AlchemyCMS/alchemy_cms/pull/3060)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)