### PR TITLE
[7.2-stable] Fix filtering associated models by id

### DIFF
--- a/app/controllers/alchemy/admin/resources_controller.rb
+++ b/app/controllers/alchemy/admin/resources_controller.rb
@@ -138,7 +138,7 @@ module Alchemy
       end
 
       def eligible_resource_filter_values
-        resource_filters.map(&:values).flatten
+        resource_filters.map(&:values).flatten!.map!(&:to_s)
       end
 
       # Returns a translated +flash[:notice]+ for current controller action.

--- a/spec/dummy/app/models/event.rb
+++ b/spec/dummy/app/models/event.rb
@@ -16,7 +16,7 @@ class Event < ActiveRecord::Base
 
   scope :starting_today, -> { where(starts_at: Time.current.at_midnight..Date.tomorrow.at_midnight) }
   scope :future, -> { where("starts_at > ?", Date.tomorrow.at_midnight) }
-  scope :by_location_name, ->(name) { joins(:location).where(locations: { name: name }) }
+  scope :by_location_id, ->(id) { where(location_id: id) }
 
   def self.ransackable_attributes(*)
     [
@@ -37,9 +37,9 @@ class Event < ActiveRecord::Base
         values: %w(starting_today future),
       },
       {
-        name: :by_location_name,
-        values: Location.distinct.pluck(:name),
-      },
+        name: :by_location_id,
+        values: Location.all.map { |l| [l.name, l.id] }
+      }
     ]
   end
 

--- a/spec/dummy/config/locales/alchemy.en.yml
+++ b/spec/dummy/config/locales/alchemy.en.yml
@@ -4,7 +4,7 @@ en:
       event:
         start:
           name: Start
-        by_location_name:
+        by_location_id:
           name: Location
     element_names:
       gallery_picture: Gallery picture

--- a/spec/features/admin/resources_integration_spec.rb
+++ b/spec/features/admin/resources_integration_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe "Resources", type: :system do
           end
 
           it "can combine multiple filters" do
-            visit "/admin/events?filter[start]=starting_today&filter[by_location_name]=#{location.name}"
+            visit "/admin/events?filter[start]=starting_today&filter[by_location_id]=#{location.id}"
 
             within "div#archive_all table.list tbody" do
               expect(page).to have_selector("tr", count: 1)
@@ -134,6 +134,25 @@ RSpec.describe "Resources", type: :system do
               expect(page).to have_content("today 1")
               expect(page).to have_content("today 2")
               expect(page).not_to have_content("yesterday")
+            end
+          end
+
+          context "selecting a associated model by it's id" do
+            it "should filter the list to only show matching items", :js do
+              visit "/admin/events"
+
+              within "div#archive_all table.list tbody" do
+                expect(page).to have_selector("tr", count: 3)
+              end
+
+              within "#library_sidebar #filter_bar" do
+                select2(location.name, from: "Location")
+              end
+
+              within "div#archive_all table.list tbody" do
+                expect(page).to have_selector("tr", count: 1)
+                expect(page).to have_content("today 2")
+              end
             end
           end
         end


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.2-stable`:
 - [Merge pull request #3067 from AlchemyCMS/fix-resource-filter](https://github.com/AlchemyCMS/alchemy_cms/pull/3067)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)