### PR TITLE
Prevent redefining 'alchemy-menubar' custom element when using Turbo

### DIFF
--- a/app/views/alchemy/_menubar.html.erb
+++ b/app/views/alchemy/_menubar.html.erb
@@ -111,7 +111,7 @@
       </div>
     </template>
 
-    <script type="module">
+    <script type="module" data-turbo-eval="false">
       class Menubar extends HTMLElement {
         constructor() {
           super()


### PR DESCRIPTION
## What is this pull request for?

This pull request adds a check to prevent redefining 'alchemy-menubar' when it is already defined.
Without this check, I am getting the following error when navigating between pages with Turbo :
```
Uncaught DOMException: CustomElementRegistry.define: 'alchemy-menubar' has already been defined as a custom element
```

## Checklist
- [ ] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [ ] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
