### PR TITLE
Fix tinymce fullscreen mode

### DIFF
--- a/app/assets/stylesheets/alchemy/elements.scss
+++ b/app/assets/stylesheets/alchemy/elements.scss
@@ -15,7 +15,7 @@
   }
 
   // Fix for Tinymce fullscreen window positioning issues (GH#1511)
-  .mce-fullscreen & {
+  .tox-fullscreen & {
     width: calc(100vw - #{$collapsed-main-menu-width - $default-border-width});
   }
 


### PR DESCRIPTION
Back ports 095a9faf3 into 7.1

Tinymce has a new css class prefix, that
broke the fullscreen mode.
