### PR TITLE
[7.4-stable] CI: Run actions on ubuntu-22.04

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   backport:
     name: Backport
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Only react to merged PRs for security reasons.
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
     if: |

--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   brakeman-scan:
     name: Brakeman Scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   check_bun_lock:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Check bun.lockdb
     steps:
       - uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
       bun_lock_changed: ${{ steps.changed-bun-lock.outputs.any_changed }}
 
   build_javascript:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Build JS packages
     needs: check_bun_lock
     if: needs.check_bun_lock.outputs.bun_lock_changed == 'true'
@@ -57,7 +57,7 @@ jobs:
   RSpec:
     needs: [check_bun_lock, build_javascript]
     if: ${{ success('check_bun_lock') && !failure('build_javascript') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -153,7 +153,7 @@ jobs:
           path: spec/dummy/tmp/screenshots
 
   PushJavascript:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [check_bun_lock, RSpec]
     if: github.event_name == 'pull_request'
     steps:
@@ -185,7 +185,7 @@ jobs:
           branch: ${{ github.head_ref }}
 
   Jest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       NODE_ENV: test
     steps:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -150,7 +150,9 @@ jobs:
         if: failure()
         with:
           name: Screenshots
-          path: spec/dummy/tmp/screenshots
+          path: |
+            spec/dummy/tmp/capybara
+            spec/dummy/tmp/screenshots
 
   PushJavascript:
     runs-on: ubuntu-22.04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   Standard:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -21,7 +21,7 @@ jobs:
       - name: Lint Ruby files
         run: bundle exec standardrb
   ESLint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
       - name: Lint code
         run: bun run --bun eslint
   Prettier:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/stale@v5


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.4-stable`:
 - [Merge pull request #3122 from tvdeyen/gh-ubuntu-22](https://github.com/AlchemyCMS/alchemy_cms/pull/3122)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)