### PR TITLE
[7.1-stable] CI: Run actions on ubuntu-22.04

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   backport:
     name: Backport
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Only react to merged PRs for security reasons.
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
     if: >

--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   brakeman-scan:
     name: Brakeman Scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   check_yarn_lock:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Check yarn.lock
     steps:
       - uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
     outputs:
       yarn_lock_changed: ${{ steps.changed-yarn-lock.outputs.any_changed }}
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Build JS packages
     needs: check_yarn_lock
     if: ${{ needs.check_yarn_lock.outputs.yarn_lock_changed }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   Standard:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -16,7 +16,7 @@ jobs:
       - name: Lint Ruby files
         run: bundle exec standardrb
   ESLint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -36,7 +36,7 @@ jobs:
       - name: Lint code
         run: yarn eslint
   Prettier:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/stale@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,7 +105,9 @@ jobs:
         if: failure()
         with:
           name: Screenshots
-          path: spec/dummy/tmp/screenshots
+          path: |
+            spec/dummy/tmp/capybara
+            spec/dummy/tmp/screenshots
   Jest:
     runs-on: ubuntu-22.04
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   RSpec:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -107,7 +107,7 @@ jobs:
           name: Screenshots
           path: spec/dummy/tmp/screenshots
   Jest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       NODE_ENV: test
     steps:

--- a/app/models/concerns/alchemy/picture_thumbnails.rb
+++ b/app/models/concerns/alchemy/picture_thumbnails.rb
@@ -102,11 +102,10 @@ module Alchemy
 
     # Show image cropping link for ingredient
     def allow_image_cropping?
-      settings[:crop] && picture &&
-        picture.can_be_cropped_to?(
-          settings[:size],
-          settings[:upsample]
-        ) && !!picture.image_file
+      settings[:crop] && picture&.can_be_cropped_to?(
+        settings[:size],
+        settings[:upsample]
+      ) && !!picture.image_file
     end
 
     private


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.1-stable`:
 - [Merge pull request #3122 from tvdeyen/gh-ubuntu-22](https://github.com/AlchemyCMS/alchemy_cms/pull/3122)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)