### PR TITLE
[7.4-stable] Deprecate frontend elements controller

### DIFF
--- a/app/controllers/alchemy/elements_controller.rb
+++ b/app/controllers/alchemy/elements_controller.rb
@@ -16,7 +16,10 @@ module Alchemy
     # * html
     # * js (Tries to replace a given +container_id+ with the elements view partial content via jQuery.)
     #
+    # @deprecated This controller action will be removed in Alchemy 8.0.
     def show
+      Alchemy::Deprecation.warn "The elements#show controller action is deprecated and will be removed in Alchemy 8.0."
+
       @page = @element.page
       @options = params[:options]
 

--- a/spec/controllers/alchemy/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/elements_controller_spec.rb
@@ -11,6 +11,12 @@ module Alchemy
     let(:restricted_page) { create(:alchemy_page, :public, restricted: true) }
     let(:restricted_element) { create(:alchemy_element, page: restricted_page, name: "download") }
 
+    around do |example|
+      Deprecation.silence do
+        example.run
+      end
+    end
+
     describe "#show" do
       it "should render available elements" do
         get :show, params: {id: element.id}


### PR DESCRIPTION
## What is this pull request for?

This is a very old feature that very likely nobody uses. Will be removed in Alchemy 8.0
