### PR TITLE
[7.0-stable] CI: Set workflow permissions

### DIFF
--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -3,6 +3,13 @@
 
 name: Brakeman Scan
 
+concurrency:
+  group: brakeman-${{ github.ref_name }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -9,6 +9,7 @@ concurrency:
 
 permissions:
   contents: read
+  security-events: write
 
 on:
   push:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,13 @@ name: Lint
 
 on: [pull_request]
 
+concurrency:
+  group: lint-${{ github.ref_name }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
+permissions:
+  contents: read
+
 jobs:
   Standard:
     runs-on: ubuntu-22.04

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,10 +4,13 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  pull-requests: write
+  issues: write
+
 jobs:
   stale:
     runs-on: ubuntu-22.04
-
     steps:
       - uses: actions/stale@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
       - 7.0-stable
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   RSpec:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.0-stable`:
 - [Merge pull request #3139 from tvdeyen/set-actions-permissions](https://github.com/AlchemyCMS/alchemy_cms/pull/3139)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)