### PR TITLE
CI: Brakeman needs security-events: write permissions

### DIFF
--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -9,6 +9,7 @@ concurrency:
 
 permissions:
   contents: read
+  security-events: write
 
 on:
   push:


### PR DESCRIPTION
In order to write code scanning alerts

See https://github.com/github/codeql-action/tree/v3?tab=readme-ov-file#workflow-permissions

Fixes https://github.com/AlchemyCMS/alchemy_cms/actions/runs/12659617016/job/35279081427