### PR TITLE
fix attribute sorting across Ruby versions

### DIFF
--- a/lib/alchemy/resource.rb
+++ b/lib/alchemy/resource.rb
@@ -188,11 +188,21 @@ module Alchemy
       end
     end
 
+    # Returns a sorted array of attributes.
+    #
+    # Attribute called "name" comes first.
+    # Attribute called "updated_at" comes last.
+    # Boolean type attributes come after non-boolean attributes but before "updated_at".
+    #
     def sorted_attributes
-      @_sorted_attributes ||= attributes
-        .sort_by { |attr| (attr[:name] == "name") ? 0 : 1 }
-        .sort_by! { |attr| (attr[:type] == :boolean) ? 1 : 0 }
-        .sort_by! { |attr| (attr[:name] == "updated_at") ? 1 : 0 }
+      @_sorted_attributes ||= attributes.sort_by! do |attr|
+        [
+          (attr[:name] == "name") ? 0 : 1,
+          (attr[:name] == "updated_at") ? 3 : 2,
+          (attr[:type] == :boolean) ? 2 : 1,
+          attr[:name]
+        ]
+      end
     end
 
     def editable_attributes

--- a/spec/libraries/resource_spec.rb
+++ b/spec/libraries/resource_spec.rb
@@ -314,19 +314,24 @@ module Alchemy
     describe "#sorted_attributes" do
       subject { resource.sorted_attributes }
 
+      let(:random_attrs) do
+        20.times.map do
+          double(:column, {name: "some_title", type: :string})
+        end
+      end
+
       let(:columns) do
-        [
-          double(:column, {name: "title", type: :string}),
+        random_attrs + [
           double(:column, {name: "name", type: :string}),
           double(:column, {name: "updated_at", type: :datetime}),
           double(:column, {name: "public", type: :boolean})
         ]
       end
 
-      it "sorts by name, and updated_at" do
-        is_expected.to eq([
+      it "sorts by name, booleans and updated_at" do
+        expect(subject.uniq!).to eq([
           {name: "name", type: :string},
-          {name: "title", type: :string},
+          {name: "some_title", type: :string},
           {name: "public", type: :boolean},
           {name: "updated_at", type: :datetime}
         ])


### PR DESCRIPTION
Chaining sort_by methods caused issues because each subsequent sort_by effectively overrides the previous sort order by re-sorting the entire array based solely on the new condition. This can disrupt the prioritization of earlier sorting criteria.

Interestingly, chaining multiple sort_by calls has been working as expected in Ruby versions prior to 3.3.1, as the underlying behavior of Array#sort_by appears to have been consistent in preserving the prioritization of earlier steps.

Switching to a single sort_by call ensures compatibility across Ruby versions, including 3.3.1 and beyond.

Fixes https://github.com/AlchemyCMS/alchemy_cms/issues/3152