### PR TITLE
Remove coffee-rails dependency

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -40,7 +40,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "acts_as_list", [">= 0.3", "< 2"]
   gem.add_runtime_dependency "awesome_nested_set", ["~> 3.1", ">= 3.7.0"]
   gem.add_runtime_dependency "cancancan", [">= 2.1", "< 4.0"]
-  gem.add_runtime_dependency "coffee-rails", [">= 4.0", "< 6.0"]
   gem.add_runtime_dependency "csv", ["~> 3.3"]
   gem.add_runtime_dependency "dragonfly", ["~> 1.4"]
   gem.add_runtime_dependency "dragonfly_svg", ["~> 0.0.4"]


### PR DESCRIPTION
We do not compile coffeescript files anymore.
