### PR TITLE
fix(Uploader): Handle HTML Errors during upload

### DIFF
--- a/app/javascript/alchemy_admin/components/uploader/file_upload.js
+++ b/app/javascript/alchemy_admin/components/uploader/file_upload.js
@@ -200,7 +200,7 @@ export class FileUpload extends AlchemyHTMLElement {
       const response = JSON.parse(this.request.responseText)
       return response["message"]
     } catch (error) {
-      return translate("Could not parse JSON result")
+      return `${this.request.status}: ${this.request.statusText}`
     }
   }
 


### PR DESCRIPTION
## What is this pull request for?

If the upload fails because of Proxy errors (502, etc.) we cannot parse the html as json. We should display the actual error to the user, so they can report accordingly.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
