### PR TITLE
Allow additional stylesheets to be included in the admin UI

### DIFF
--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -13,7 +13,9 @@
     <%= stylesheet_link_tag('alchemy/custom-properties', media: 'screen', 'data-turbo-track' => true) %>
     <%= stylesheet_link_tag('alchemy/admin', media: 'screen', 'data-turbo-track' => true) %>
     <%= stylesheet_link_tag('alchemy/admin/print', media: 'print', 'data-turbo-track' => true) %>
-    <%= stylesheet_link_tag('alchemy/admin/custom', 'data-turbo-track' => true) %>
+    <% Alchemy.admin_stylesheets.each do |stylesheet| %>
+      <%= stylesheet_link_tag(stylesheet, 'data-turbo-track' => true) %>
+    <% end %>
     <%= yield :stylesheets %>
     <script>
       // Global Alchemy JavaScript object.

--- a/lib/alchemy.rb
+++ b/lib/alchemy.rb
@@ -98,6 +98,20 @@ module Alchemy
     }])
   end
 
+  # Additional stylesheets to be included in the Alchemy admin UI
+  #
+  # == Example
+  #
+  #    # lib/alchemy/devise/engine.rb
+  #    initializer "alchemy.devise.stylesheets", before: "alchemy.admin_stylesheets" do
+  #      Alchemy.admin_stylesheets << "alchemy/devise/admin.css"
+  #    end
+  #
+  # @return [Set<String>]
+  def self.admin_stylesheets
+    @_admin_stylesheets ||= Set.new(["alchemy/admin/custom.css"])
+  end
+
   # Define page publish targets
   #
   # A publish target is a ActiveJob that gets performed

--- a/lib/alchemy/engine.rb
+++ b/lib/alchemy/engine.rb
@@ -16,11 +16,19 @@ module Alchemy
       end
     end
 
-    initializer "alchemy.assets" do
+    initializer "alchemy.assets" do |app|
       if defined?(Sprockets)
         require_relative "../non_stupid_digest_assets"
         NonStupidDigestAssets.whitelist += [/^tinymce\//]
-        Rails.application.config.assets.precompile << "alchemy_manifest.js"
+        app.config.assets.precompile << "alchemy_manifest.js"
+      end
+    end
+
+    initializer "alchemy.admin_stylesheets" do |app|
+      if defined?(Sprockets)
+        Alchemy.admin_stylesheets.each do |stylesheet|
+          app.config.assets.precompile << stylesheet
+        end
       end
     end
 

--- a/lib/generators/alchemy/install/install_generator.rb
+++ b/lib/generators/alchemy/install/install_generator.rb
@@ -65,10 +65,6 @@ module Alchemy
 
       def install_assets
         copy_file "custom.css", app_assets_path.join("stylesheets/alchemy/admin/custom.css")
-        sprockets_manifest = Rails.root.join("app/assets/config/manifest.js")
-        if File.exist?(sprockets_manifest)
-          append_to_file sprockets_manifest, "//= link alchemy/admin/custom.css\n"
-        end
       end
 
       def copy_demo_views

--- a/spec/dummy/app/assets/config/manifest.js
+++ b/spec/dummy/app/assets/config/manifest.js
@@ -4,4 +4,3 @@
 //= link_tree ../images
 //= link tinymce/langs/de.js
 //= link_tree ../builds
-//= link alchemy/admin/custom.css

--- a/spec/libraries/alchemy/engine_spec.rb
+++ b/spec/libraries/alchemy/engine_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "sprockets"
+
+RSpec.describe Alchemy::Engine do
+  describe "alchemy.admin_stylesheets" do
+    let(:initializer) do
+      Alchemy::Engine.initializers.detect do
+        _1.name == "alchemy.admin_stylesheets"
+      end
+    end
+
+    context "when sprockets is not defined" do
+      before do
+        Object.send(:remove_const, :Sprockets)
+      rescue NameError
+      end
+
+      it "does not add alchemy/admin/custom.css" do
+        initializer.run(Rails.application)
+        expect(Rails.application.config.assets.precompile).not_to include("alchemy/admin/custom.css")
+      end
+    end
+
+    context "when sprockets is defined" do
+      before do
+        stub_const("Sprockets", Class.new)
+      end
+
+      it "includes alchemy/admin/custom.css" do
+        initializer.run(Rails.application)
+        expect(Rails.application.config.assets.precompile).to include("alchemy/admin/custom.css")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

Adds `Alchemy.admin_styleheets` to set additional stylesheets to be included in the Alchemy admin UI.

### Example

```rb
# config/initializers/alchemy.rb
Alchemy.admin_stylesheets << "alchemy/devise/admin.css"
```

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
