### PR TITLE
Deprecate `Alchemy.enable_searchable` for `Alchemy.config.show_page_searchable_checkbox`

### DIFF
--- a/lib/alchemy.rb
+++ b/lib/alchemy.rb
@@ -11,19 +11,6 @@ module Alchemy
 
   YAML_PERMITTED_CLASSES = %w[Symbol Date Regexp]
 
-  # Enable full text search configuration
-  #
-  # It enables a searchable checkbox in the page form to toggle
-  # the searchable field. These information can used in a search
-  # plugin (e.g. https://github.com/AlchemyCMS/alchemy-pg_search).
-  #
-  # == Example
-  #
-  #     # config/initializers/alchemy.rb
-  #     Alchemy.enable_searchable = true
-  #
-  mattr_accessor :enable_searchable, default: false
-
   # JS Importmap instance
   singleton_class.attr_accessor :importmap
   self.importmap = Importmap::Map.new
@@ -36,6 +23,15 @@ module Alchemy
     def configure(&blk)
       yield config
     end
+
+    enable_searchable_deprecation_msg = "Use `Alchemy.config.show_page_searchable_checkbox` instead."
+    def enable_searchable = config.show_page_searchable_checkbox
+    deprecate :enable_searchable= => enable_searchable_deprecation_msg, :deprecator => Alchemy::Deprecation
+
+    def enable_searchable=(other)
+      config.show_page_searchable_checkbox = other
+    end
+    deprecate enable_searchable: enable_searchable_deprecation_msg, deprecator: Alchemy::Deprecation
 
     # Define page preview sources
     #

--- a/lib/alchemy.rb
+++ b/lib/alchemy.rb
@@ -11,144 +11,6 @@ module Alchemy
 
   YAML_PERMITTED_CLASSES = %w[Symbol Date Regexp]
 
-  def self.config
-    @_config ||= Alchemy::Configurations::Main.new
-  end
-
-  def self.configure(&blk)
-    yield config
-  end
-
-  # Define page preview sources
-  #
-  # A preview source is a Ruby class returning an URL
-  # that is used as source for the preview frame in the
-  # admin UI.
-  #
-  # == Example
-  #
-  #     # lib/acme/preview_source.rb
-  #     class Acme::PreviewSource < Alchemy::Admin::PreviewUrl
-  #       def url_for(page)
-  #         if page.site.name == "Next"
-  #           "https://user:#{ENV['PREVIEW_HTTP_PASS']}@next.acme.com"
-  #         else
-  #           "https://www.acme.com"
-  #         end
-  #       end
-  #     end
-  #
-  #     # config/initializers/alchemy.rb
-  #     require "acme/preview_source"
-  #     Alchemy.preview_sources << Acme::PreviewSource
-  #
-  #     # config/locales/de.yml
-  #     de:
-  #       activemodel:
-  #         models:
-  #           acme/preview_source: Acme Vorschau
-  #
-  def self.preview_sources
-    @_preview_sources ||= Set.new << Alchemy::Admin::PreviewUrl
-  end
-
-  def self.preview_sources=(sources)
-    @_preview_sources = Array(sources)
-  end
-
-  # Additional JS modules to be imported in the Alchemy admin UI
-  #
-  # Be sure to also pin the modules with +Alchemy.importmap+.
-  #
-  # == Example
-  #
-  #    Alchemy.importmap.pin "flatpickr/de",
-  #      to: "https://ga.jspm.io/npm:flatpickr@4.6.13/dist/l10n/de.js"
-  #
-  #    Alchemy.admin_js_imports << "flatpickr/de"
-  #
-  def self.admin_js_imports
-    @_admin_js_imports ||= Set.new
-  end
-
-  def self.admin_js_imports=(sources)
-    @_admin_js_imports = Set[sources]
-  end
-
-  # Additional importmaps to be included in the Alchemy admin UI
-  #
-  # Be sure to also pin modules with +Alchemy.importmap+.
-  #
-  # == Example
-  #
-  #    # config/alchemy/importmap.rb
-  #    Alchemy.importmap.pin "alchemy_solidus", to: "alchemy_solidus.js", preload: true
-  #    Alchemy.importmap.pin_all_from Alchemy::Solidus::Engine.root.join("app/javascript/alchemy_solidus"),
-  #      under: "alchemy_solidus",
-  #      preload: true
-  #
-  #    # lib/alchemy/solidus/engine.rb
-  #    initializer "alchemy_solidus.assets", before: "alchemy.importmap" do |app|
-  #      Alchemy.admin_importmaps.add({
-  #        importmap_path: root.join("config/importmap.rb"),
-  #        source_paths: [
-  #          root.join("app/javascript")
-  #        ],
-  #        name: "alchemy_solidus"
-  #      })
-  #      app.config.assets.precompile << "alchemy_solidus/manifest.js"
-  #    end
-  #
-  # @return [Set<Hash>]
-  def self.admin_importmaps
-    @_admin_importmaps ||= Set.new([{
-      importmap_path: Engine.root.join("config/importmap.rb"),
-      source_paths: [
-        Engine.root.join("app/javascript"),
-        Engine.root.join("vendor/javascript")
-      ],
-      name: "alchemy_admin"
-    }])
-  end
-
-  # Additional stylesheets to be included in the Alchemy admin UI
-  #
-  # == Example
-  #
-  #    # lib/alchemy/devise/engine.rb
-  #    initializer "alchemy.devise.stylesheets", before: "alchemy.admin_stylesheets" do
-  #      Alchemy.admin_stylesheets << "alchemy/devise/admin.css"
-  #    end
-  #
-  # @return [Set<String>]
-  def self.admin_stylesheets
-    @_admin_stylesheets ||= Set.new(["alchemy/admin/custom.css"])
-  end
-
-  # Define page publish targets
-  #
-  # A publish target is a ActiveJob that gets performed
-  # whenever a user clicks the publish page button.
-  #
-  # Use this to trigger deployment hooks of external
-  # services in an asychronous way.
-  #
-  # == Example
-  #
-  #     # app/jobs/publish_job.rb
-  #     class PublishJob < ApplicationJob
-  #       def perform(page)
-  #         RestClient.post(ENV['BUILD_HOOK_URL'])
-  #       end
-  #     end
-  #
-  #     # config/initializers/alchemy.rb
-  #     Alchemy.publish_targets << PublishJob
-  #
-  def self.publish_targets
-    @_publish_targets ||= Set.new
-  end
-
   # Enable full text search configuration
   #
   # It enables a searchable checkbox in the page form to toggle
@@ -166,39 +28,179 @@ module Alchemy
   singleton_class.attr_accessor :importmap
   self.importmap = Importmap::Map.new
 
-  # Configure tabs in the link dialog
-  #
-  # With this configuration that tabs in the link dialog can be extended
-  # without overwriting or defacing the Admin Interface.
-  #
-  # == Example
-  #
-  #    # components/acme/link_tab.rb
-  #    module Acme
-  #      class LinkTab < ::Alchemy::Admin::LinkDialog::BaseTab
-  #        def title
-  #          "Awesome Tab Title"
-  #        end
-  #
-  #        def name
-  #          :unique_name
-  #        end
-  #
-  #        def fields
-  #           [ title_input, target_select ]
-  #        end
-  #      end
-  #    end
-  #
-  #    # config/initializers/alchemy.rb
-  #    Alchemy.link_dialog_tabs << Acme::LinkTab
-  #
-  def self.link_dialog_tabs
-    @_link_dialog_tabs ||= Set.new([
-      Alchemy::Admin::LinkDialog::InternalTab,
-      Alchemy::Admin::LinkDialog::AnchorTab,
-      Alchemy::Admin::LinkDialog::ExternalTab,
-      Alchemy::Admin::LinkDialog::FileTab
-    ])
+  class << self
+    def config
+      @_config ||= Alchemy::Configurations::Main.new
+    end
+
+    def configure(&blk)
+      yield config
+    end
+
+    # Define page preview sources
+    #
+    # A preview source is a Ruby class returning an URL
+    # that is used as source for the preview frame in the
+    # admin UI.
+    #
+    # == Example
+    #
+    #     # lib/acme/preview_source.rb
+    #     class Acme::PreviewSource < Alchemy::Admin::PreviewUrl
+    #       def url_for(page)
+    #         if page.site.name == "Next"
+    #           "https://user:#{ENV['PREVIEW_HTTP_PASS']}@next.acme.com"
+    #         else
+    #           "https://www.acme.com"
+    #         end
+    #       end
+    #     end
+    #
+    #     # config/initializers/alchemy.rb
+    #     require "acme/preview_source"
+    #     Alchemy.preview_sources << Acme::PreviewSource
+    #
+    #     # config/locales/de.yml
+    #     de:
+    #       activemodel:
+    #         models:
+    #           acme/preview_source: Acme Vorschau
+    #
+    def preview_sources
+      @_preview_sources ||= Set.new << Alchemy::Admin::PreviewUrl
+    end
+
+    def preview_sources=(sources)
+      @_preview_sources = Array(sources)
+    end
+
+    # Additional JS modules to be imported in the Alchemy admin UI
+    #
+    # Be sure to also pin the modules with +Alchemy.importmap+.
+    #
+    # == Example
+    #
+    #    Alchemy.importmap.pin "flatpickr/de",
+    #      to: "https://ga.jspm.io/npm:flatpickr@4.6.13/dist/l10n/de.js"
+    #
+    #    Alchemy.admin_js_imports << "flatpickr/de"
+    #
+    def admin_js_imports
+      @_admin_js_imports ||= Set.new
+    end
+
+    def admin_js_imports=(sources)
+      @_admin_js_imports = Set[sources]
+    end
+
+    # Additional importmaps to be included in the Alchemy admin UI
+    #
+    # Be sure to also pin modules with +Alchemy.importmap+.
+    #
+    # == Example
+    #
+    #    # config/alchemy/importmap.rb
+    #    Alchemy.importmap.pin "alchemy_solidus", to: "alchemy_solidus.js", preload: true
+    #    Alchemy.importmap.pin_all_from Alchemy::Solidus::Engine.root.join("app/javascript/alchemy_solidus"),
+    #      under: "alchemy_solidus",
+    #      preload: true
+    #
+    #    # lib/alchemy/solidus/engine.rb
+    #    initializer "alchemy_solidus.assets", before: "alchemy.importmap" do |app|
+    #      Alchemy.admin_importmaps.add({
+    #        importmap_path: root.join("config/importmap.rb"),
+    #        source_paths: [
+    #          root.join("app/javascript")
+    #        ],
+    #        name: "alchemy_solidus"
+    #      })
+    #      app.config.assets.precompile << "alchemy_solidus/manifest.js"
+    #    end
+    #
+    # @return [Set<Hash>]
+    def admin_importmaps
+      @_admin_importmaps ||= Set.new([{
+        importmap_path: Engine.root.join("config/importmap.rb"),
+        source_paths: [
+          Engine.root.join("app/javascript"),
+          Engine.root.join("vendor/javascript")
+        ],
+        name: "alchemy_admin"
+      }])
+    end
+
+    # Additional stylesheets to be included in the Alchemy admin UI
+    #
+    # == Example
+    #
+    #    # lib/alchemy/devise/engine.rb
+    #    initializer "alchemy.devise.stylesheets", before: "alchemy.admin_stylesheets" do
+    #      Alchemy.admin_stylesheets << "alchemy/devise/admin.css"
+    #    end
+    #
+    # @return [Set<String>]
+    def admin_stylesheets
+      @_admin_stylesheets ||= Set.new(["alchemy/admin/custom.css"])
+    end
+
+    # Define page publish targets
+    #
+    # A publish target is a ActiveJob that gets performed
+    # whenever a user clicks the publish page button.
+    #
+    # Use this to trigger deployment hooks of external
+    # services in an asychronous way.
+    #
+    # == Example
+    #
+    #     # app/jobs/publish_job.rb
+    #     class PublishJob < ApplicationJob
+    #       def perform(page)
+    #         RestClient.post(ENV['BUILD_HOOK_URL'])
+    #       end
+    #     end
+    #
+    #     # config/initializers/alchemy.rb
+    #     Alchemy.publish_targets << PublishJob
+    #
+    def publish_targets
+      @_publish_targets ||= Set.new
+    end
+
+    # Configure tabs in the link dialog
+    #
+    # With this configuration that tabs in the link dialog can be extended
+    # without overwriting or defacing the Admin Interface.
+    #
+    # == Example
+    #
+    #    # components/acme/link_tab.rb
+    #    module Acme
+    #      class LinkTab < ::Alchemy::Admin::LinkDialog::BaseTab
+    #        def title
+    #          "Awesome Tab Title"
+    #        end
+    #
+    #        def name
+    #          :unique_name
+    #        end
+    #
+    #        def fields
+    #           [ title_input, target_select ]
+    #        end
+    #      end
+    #    end
+    #
+    #    # config/initializers/alchemy.rb
+    #    Alchemy.link_dialog_tabs << Acme::LinkTab
+    #
+    def link_dialog_tabs
+      @_link_dialog_tabs ||= Set.new([
+        Alchemy::Admin::LinkDialog::InternalTab,
+        Alchemy::Admin::LinkDialog::AnchorTab,
+        Alchemy::Admin::LinkDialog::ExternalTab,
+        Alchemy::Admin::LinkDialog::FileTab
+      ])
+    end
   end
 end

--- a/lib/alchemy/configuration/base_option.rb
+++ b/lib/alchemy/configuration/base_option.rb
@@ -9,7 +9,7 @@ module Alchemy
 
       def initialize(value:, name:, **args)
         @name = name
-        @value = validate(value) if value
+        @value = validate(value) unless value.nil?
       end
       attr_reader :name, :value
 

--- a/lib/alchemy/configurations/main.rb
+++ b/lib/alchemy/configurations/main.rb
@@ -194,6 +194,18 @@ module Alchemy
 
       # The sizes for the preview size select in the page editor.
       option :page_preview_sizes, :integer_list, default: [360, 640, 768, 1024, 1280, 1440]
+
+      # Enable full text search configuration
+      #
+      # It enables a searchable checkbox in the page form to toggle
+      # the searchable field. These information can used in a search
+      # plugin (e.g. https://github.com/AlchemyCMS/alchemy-pg_search).
+      #
+      # == Example
+      #
+      #     # config/initializers/alchemy.rb
+      #     Alchemy.config.page_searchable_checkbox = true
+      option :show_page_searchable_checkbox, :boolean, default: false
     end
   end
 end

--- a/spec/libraries/alchemy/configuration/boolean_option_spec.rb
+++ b/spec/libraries/alchemy/configuration/boolean_option_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::Configuration::BooleanOption do
+  subject { described_class.new(value:, name: :my_option).value }
+
+  context "value is true" do
+    let(:value) { true }
+    it { is_expected.to be true }
+  end
+
+  context "value is nil" do
+    let(:value) { nil }
+    it { is_expected.to be nil }
+  end
+
+  context "value is false " do
+    let(:value) { false }
+    it { is_expected.to be false }
+  end
+
+  context "value is something else" do
+    let(:value) { :something }
+
+    it "raises exception" do
+      expect { subject }.to raise_exception(TypeError)
+    end
+  end
+end

--- a/spec/libraries/alchemy/configurations/main_spec.rb
+++ b/spec/libraries/alchemy/configurations/main_spec.rb
@@ -33,4 +33,13 @@ RSpec.describe Alchemy::Configurations::Main do
       end.to change { subject.output_image_quality }.from(85).to(90)
     end
   end
+
+  describe "default values" do
+    let(:configuration) { described_class.new }
+
+    describe "#page_searchable_checkbox" do
+      subject { configuration.show_page_searchable_checkbox }
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/libraries/alchemy_spec.rb
+++ b/spec/libraries/alchemy_spec.rb
@@ -109,4 +109,21 @@ RSpec.describe Alchemy do
       expect(Alchemy::Config).to eq(Alchemy.config)
     end
   end
+
+  describe "legacy configuration methods" do
+    around do |example|
+      Alchemy::Deprecation.silence { example.run }
+    end
+    describe ".enable_searchable" do
+      it "forwards to config.page_searchable_checkbox" do
+        expect do
+          Alchemy.enable_searchable = true
+        end.to change(Alchemy.config, :show_page_searchable_checkbox).to(true)
+        # Reset
+        expect do
+          Alchemy.enable_searchable = false
+        end.to change(Alchemy, :enable_searchable).to(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What is this pull request for?

This moves one configuration option from the `Alchemy` module to the `Alchemy.config` object. It renames the option from `Alchemy.enable_searchable` which doesn't provide a lot of clarity to `Alchemy.show_page_searchable_checkbox` which is somewhat clearer I think.

There's also a refactoring in this PR that should prepare the work on the other configuration options in `lib/alchemy.rb`.

### Notable changes (remove if none)

- Deprecates `Alchemy.enable_searchable`.
- Introduces `Alchemy.config.show_page_searchable_checkbox`. 

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
