### PR TITLE
Fix image cropper

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -38,7 +38,6 @@ jobs:
     runs-on: ubuntu-22.04
     name: Build JS packages
     needs: check_bun_lock
-    if: needs.check_bun_lock.outputs.bun_lock_changed == 'true'
     steps:
       - uses: actions/checkout@v4
       - name: Setup Bun
@@ -53,8 +52,10 @@ jobs:
       - name: Install dependencies
         run: bun install
       - name: bun build
+        if: needs.check_bun_lock.outputs.bun_lock_changed == 'true'
         run: bun run --bun build
       - uses: actions/upload-artifact@v4
+        if: needs.check_bun_lock.outputs.bun_lock_changed == 'true'
         with:
           name: javascript-bundles
           path: vendor/javascript
@@ -63,7 +64,6 @@ jobs:
     permissions:
       contents: read
     needs: [check_bun_lock, build_javascript]
-    if: ${{ success('check_bun_lock') && !failure('build_javascript') }}
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false

--- a/app/javascript/alchemy_admin/image_cropper.js
+++ b/app/javascript/alchemy_admin/image_cropper.js
@@ -22,9 +22,11 @@ export default class ImageCropper {
     this.#cropSizeField = document.getElementById(formFieldIds[1])
     this.elementId = elementId
     this.dialog = Alchemy.currentDialog()
-    this.dialog.options.closed = () => this.destroy()
+    if (this.dialog) {
+      this.dialog.options.closed = () => this.destroy()
+      this.bind()
+    }
     this.init()
-    this.bind()
   }
 
   get cropperOptions() {
@@ -32,6 +34,8 @@ export default class ImageCropper {
       aspectRatio: this.aspectRatio,
       viewMode: 1,
       zoomable: false,
+      checkCrossOrigin: false, // Prevent CORS issues
+      checkOrientation: false, // Prevent loading the image via AJAX which can cause CORS issues
       minCropBoxWidth: this.minSize && this.minSize[0],
       minCropBoxHeight: this.minSize && this.minSize[1],
       ready: (event) => {

--- a/app/javascript/alchemy_admin/image_cropper.js
+++ b/app/javascript/alchemy_admin/image_cropper.js
@@ -6,16 +6,8 @@ export default class ImageCropper {
   #cropFromField = null
   #cropSizeField = null
 
-  constructor(
-    image,
-    minSize,
-    defaultBox,
-    aspectRatio,
-    formFieldIds,
-    elementId
-  ) {
+  constructor(image, defaultBox, aspectRatio, formFieldIds, elementId) {
     this.image = image
-    this.minSize = minSize
     this.defaultBox = defaultBox
     this.aspectRatio = aspectRatio
     this.#cropFromField = document.getElementById(formFieldIds[0])
@@ -36,12 +28,7 @@ export default class ImageCropper {
       zoomable: false,
       checkCrossOrigin: false, // Prevent CORS issues
       checkOrientation: false, // Prevent loading the image via AJAX which can cause CORS issues
-      minCropBoxWidth: this.minSize && this.minSize[0],
-      minCropBoxHeight: this.minSize && this.minSize[1],
-      ready: (event) => {
-        const cropper = event.target.cropper
-        cropper.setData(this.box)
-      },
+      data: this.box,
       cropend: () => {
         const data = this.#cropper.getData(true)
         this.update(data)

--- a/app/views/alchemy/admin/crop.html.erb
+++ b/app/views/alchemy/admin/crop.html.erb
@@ -26,7 +26,6 @@
   new ImageLoader(image);
   new ImageCropper(
     image,
-    <%= @settings[:min_size].to_json %>,
     <%= @settings[:default_box].to_json %>,
     <%= @settings[:ratio] %>,
     [

--- a/spec/javascript/alchemy_admin/image_cropper.spec.js
+++ b/spec/javascript/alchemy_admin/image_cropper.spec.js
@@ -1,0 +1,28 @@
+import ImageCropper from "alchemy_admin/image_cropper"
+
+describe("ImageCropper", () => {
+  describe("cropperOptions", () => {
+    beforeEach(() => {
+      document.body.innerHTML = `
+        <div id="element_id">
+          <input id="crop_from" type="hidden" value="0x423" />
+          <input id="crop_size" type="hidden" value="1200x480" />
+        </div>
+      `
+      Alchemy.currentDialog = jest.fn()
+    })
+
+    it("prevents CORS issues", () => {
+      const image = new Image()
+      const cropper = new ImageCropper(
+        image,
+        {},
+        1,
+        ["crop_from", "crop_size"],
+        "element_id"
+      )
+      expect(cropper.cropperOptions["checkCrossOrigin"]).toBe(false)
+      expect(cropper.cropperOptions["checkOrientation"]).toBe(false)
+    })
+  })
+})

--- a/spec/javascript/alchemy_admin/image_cropper.spec.js
+++ b/spec/javascript/alchemy_admin/image_cropper.spec.js
@@ -12,6 +12,36 @@ describe("ImageCropper", () => {
       Alchemy.currentDialog = jest.fn()
     })
 
+    it("is sets initial data", () => {
+      const image = new Image()
+      const cropper = new ImageCropper(
+        image,
+        {},
+        1,
+        ["crop_from", "crop_size"],
+        "element_id"
+      )
+      expect(cropper.cropperOptions["data"]).toEqual({
+        height: 480,
+        width: 1200,
+        x: 0,
+        y: 423
+      })
+    })
+
+    it("does not set min crop size", () => {
+      const image = new Image()
+      const cropper = new ImageCropper(
+        image,
+        {},
+        1,
+        ["crop_from", "crop_size"],
+        "element_id"
+      )
+      expect(cropper.cropperOptions["minCropBoxWidth"]).toBeUndefined()
+      expect(cropper.cropperOptions["minCropBoxHeight"]).toBeUndefined()
+    })
+
     it("prevents CORS issues", () => {
       const image = new Image()
       const cropper = new ImageCropper(


### PR DESCRIPTION
## What is this pull request for?

This fixes two issues with the new image cropper ([cropperjs](https://github.com/fengyuanchen/cropperjs/tree/v1)) introduced in 7.4

1. It prevents CORS issues when the image is served from a remote CDN (like CloudFront or S3)
2. It fixes restoring the cropped area on re-cropping the image*

### Notable changes

*) This made it necessary to disable the minimum crop size on the cropper. Since this is a "shoot your own foot" feature anyway, it should not be a problem to let users decide how small they want the image to be.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
