### PR TITLE
Only set elementEditor dirty if present during assignment

### DIFF
--- a/app/views/alchemy/admin/attachments/assign.js.erb
+++ b/app/views/alchemy/admin/attachments/assign.js.erb
@@ -6,6 +6,9 @@
   $form_field.parent().find("> .file_icon").html("<%= j render_icon(@attachment.icon_css_class) %>")
   $form_field.parent().find("> .remove_file_link").removeClass("hidden")
   Alchemy.closeCurrentDialog(function() {
-    $form_field[0].closest("alchemy-element-editor").setDirty()
+    var elementEditor = $form_field[0].closest("alchemy-element-editor")
+    if (elementEditor) {
+      elementEditor.setDirty()
+    }
   })
 })()

--- a/app/views/alchemy/admin/pictures/assign.js.erb
+++ b/app/views/alchemy/admin/pictures/assign.js.erb
@@ -5,6 +5,9 @@
   $form_field.attr("data-image-file-width", <%= @picture.image_file_width %>)
   $form_field.attr("data-image-file-height", <%= @picture.image_file_height %>)
   Alchemy.closeCurrentDialog(function() {
-    $form_field[0].closest("alchemy-element-editor").setDirty()
+    var elementEditor = $form_field[0].closest("alchemy-element-editor")
+    if (elementEditor) {
+      elementEditor.setDirty()
+    }
   })
 })()


### PR DESCRIPTION
## What is this pull request for?

In the very uncommon situation where one uses an
ingredient editor outside of the element editor there is no elementEditor instance on the page. Since it is bad practice to not check for null here anyway we can simply do it.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
