### PR TITLE
[7.1-stable] CI: Use own script to check changes files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,11 +17,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Get all changed markdown files
+      - name: Get changed files
         id: changed-yarn-lock
-        uses: tj-actions/changed-files@v41
-        with:
-          files: yarn.lock
+        run: |
+          git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} > changed_files
+          cat changed_files
+          if grep -q yarn.lock changed_files; then
+            echo "any_changed=true" > $GITHUB_OUTPUT
+          else
+            echo "any_changed=false" > $GITHUB_OUTPUT
+          fi
     outputs:
       yarn_lock_changed: ${{ steps.changed-yarn-lock.outputs.any_changed }}
   build:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.1-stable`:
 - [Merge pull request #3198 from AlchemyCMS/check-files-action](https://github.com/AlchemyCMS/alchemy_cms/pull/3198)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)