### PR TITLE
Fix link dialog for links with url scheme mailto

### DIFF
--- a/app/components/alchemy/admin/link_dialog/internal_tab.rb
+++ b/app/components/alchemy/admin/link_dialog/internal_tab.rb
@@ -49,7 +49,8 @@ module Alchemy
         end
 
         def page_attributes
-          locale, urlname, _fragment = uri.path.match(PAGE_URL_PATTERN)&.captures
+          # uri.path might be nil if the protocol is mailto: or a similar scheme that cannot have paths
+          locale, urlname, _fragment = uri.path&.match(PAGE_URL_PATTERN)&.captures
 
           if locale && urlname.present?
             {language_code: locale, urlname: urlname}

--- a/spec/components/alchemy/admin/link_dialog/internal_tab_spec.rb
+++ b/spec/components/alchemy/admin/link_dialog/internal_tab_spec.rb
@@ -94,4 +94,12 @@ RSpec.describe Alchemy::Admin::LinkDialog::InternalTab, type: :component do
       expect(page.find(:css, "select[name=element_anchor]").value).to be_empty
     end
   end
+
+  context "with url being mailto" do
+    let(:url) { "mailto:foo@example.com" }
+
+    it do
+      expect { page }.to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
## What is this pull request for?

A URI that uses a `mailto:` (or similar scheme that can not have a path) url scheme Ruby returns `nil`, which cannot be called with `match`.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
