### PR TITLE
Use editable resource attributes for resource_params

### DIFF
--- a/app/controllers/alchemy/admin/resources_controller.rb
+++ b/app/controllers/alchemy/admin/resources_controller.rb
@@ -181,16 +181,15 @@ module Alchemy
         authorize!(action_name.to_sym, resource_instance_variable || resource_handler.model)
       end
 
-      # Permits all parameters as default!
+      # Permits all editable resource attributes as default.
       #
-      # THIS IS INSECURE! Although only signed in admin users can send requests anyway, but we should change this.
+      # Define this method in your inheriting controller if you want to permit additional attributes.
       #
-      # Please define this method in your inheriting controller and set the parameters you want to permit.
-      #
-      # TODO: Hook this into authorization provider.
-      #
+      # @see Alchemy::Resource#editable_attributes
       def resource_params
-        params.require(resource_handler.namespaced_resource_name).permit!
+        params.require(resource_handler.namespaced_resource_name).permit(
+          resource_handler.editable_attributes.map { _1[:name] }
+        )
       end
 
       def search_filter_params

--- a/spec/controllers/alchemy/admin/resources_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/resources_controller_spec.rb
@@ -2,7 +2,9 @@
 
 require "rails_helper"
 
-describe Admin::EventsController do
+RSpec.describe Alchemy::Admin::ResourcesController do
+  controller(Admin::EventsController) {}
+
   it "should include ResourcesHelper" do
     expect(controller.respond_to?(:resource_window_size)).to be_truthy
   end
@@ -98,8 +100,9 @@ describe Admin::EventsController do
       let!(:peter) { create(:series, name: "Peter") }
       let(:params) { {q: {name_cont: "some_query"}, page: 6} }
 
+      controller(Admin::SeriesController) {}
+
       it "redirects to index, keeping the current location parameters" do
-        expect(controller).to receive(:controller_path).twice { "admin/series" }
         post :update, params: {id: peter.id, series: {name: "Hans"}}.merge(params)
         expect(response.redirect_url).to eq("http://test.host/admin/series?page=6&q%5Bname_cont%5D=some_query")
       end
@@ -132,8 +135,9 @@ describe Admin::EventsController do
     context "with zero plural noun model name" do
       let(:params) { {q: {name_cont: "some_query"}, page: 6} }
 
+      controller(Admin::SeriesController) {}
+
       it "redirects to index, keeping the current location parameters" do
-        expect(controller).to receive(:controller_path).twice { "admin/series" }
         post :create, params: {series: {name: "Hans"}}.merge(params)
         expect(response.redirect_url).to eq("http://test.host/admin/series?page=6&q%5Bname_cont%5D=some_query")
       end

--- a/spec/controllers/alchemy/admin/resources_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/resources_controller_spec.rb
@@ -119,6 +119,17 @@ RSpec.describe Alchemy::Admin::ResourcesController do
         expect(subject.status).to eq 422
       end
     end
+
+    describe "params security" do
+      subject { put :update, params: {id: peter.id, event: {name: "Fox", foo: "bar"}} }
+
+      it "only accepts editable attributes" do
+        expect_any_instance_of(Event).to receive(:update).with(
+          ActionController::Parameters.new(name: "Fox").permit!
+        )
+        subject
+      end
+    end
   end
 
   describe "#create" do
@@ -140,6 +151,17 @@ RSpec.describe Alchemy::Admin::ResourcesController do
       it "redirects to index, keeping the current location parameters" do
         post :create, params: {series: {name: "Hans"}}.merge(params)
         expect(response.redirect_url).to eq("http://test.host/admin/series?page=6&q%5Bname_cont%5D=some_query")
+      end
+    end
+
+    describe "params security" do
+      subject { post :create, params: {event: {name: "Fox", foo: "bar"}} }
+
+      it "only accepts editable attributes" do
+        expect(Event).to receive(:new).with(
+          ActionController::Parameters.new(name: "Fox").permit!
+        ).and_call_original
+        subject
       end
     end
   end


### PR DESCRIPTION
## What is this pull request for?

Instead of permitting all params we make use of the editable
attributes which are used to populate the resource form.

This is potentially breaking if you have a resource form
with more attributes than defined in
`Alchemy::Resource#editable_attributes` for your model.

Please override `resource_params` and adjust accordingly.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
