### PR TITLE
Allow is_safe_redirect_path to recognize customized admin path

### DIFF
--- a/app/controllers/alchemy/admin/base_controller.rb
+++ b/app/controllers/alchemy/admin/base_controller.rb
@@ -43,7 +43,7 @@ module Alchemy
 
       def is_safe_redirect_path?(path)
         mount_path = alchemy.root_path
-        path.to_s.match? %r{^#{mount_path}admin/}
+        path.to_s.match? %r{^#{mount_path}#{Alchemy.admin_path}/}
       end
 
       def relative_referer_path(referer = request.referer)

--- a/spec/controllers/alchemy/admin/base_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/base_controller_spec.rb
@@ -338,5 +338,57 @@ describe Alchemy::Admin::BaseController do
         it { is_expected.to be(false) }
       end
     end
+
+    context "admin path is customized" do
+      before(:all) do
+        Alchemy.admin_path = "backend"
+        Rails.application.reload_routes!
+      end
+
+      context "path is not an external URL" do
+        let(:path) { "/backend/pages" }
+
+        it { is_expected.to be(true) }
+      end
+
+      context "path is an external URL" do
+        let(:path) { "https://evil.com" }
+
+        it { is_expected.to be(false) }
+      end
+
+      after(:all) do
+        Alchemy.admin_path = "admin"
+        Rails.application.reload_routes!
+      end
+    end
+
+    context "admin path is customized and alchemy is mounted under a path" do
+      before do
+        Alchemy.admin_path = "backend"
+        Rails.application.reload_routes!
+
+        allow(controller).to receive(:alchemy) do
+          double(root_path: "/cms/")
+        end
+      end
+
+      context "path is not an external URL" do
+        let(:path) { "/cms/backend/pages" }
+
+        it { is_expected.to be(true) }
+      end
+
+      context "path is an external URL" do
+        let(:path) { "https://evil.com" }
+
+        it { is_expected.to be(false) }
+      end
+
+      after do
+        Alchemy.admin_path = "admin"
+        Rails.application.reload_routes!
+      end
+    end
   end
 end


### PR DESCRIPTION
## What is this pull request for?

`Alchemy.admin_path` enables a customized admin interface route. However, the `is_safe_redirect_path?` method, introduced in #3129, does not currently recognize the customized admin path. As a result, many actions trigger redirects to the default admin route, leading to usability issues.

This PR addresses the issue by ensuring that `is_safe_redirect_path?` properly accounts for the customized admin path.

### Context
I'm currently integrating Alchemy into a Solidus store, migrating away from a self-built headless CMS integration. Alchemy is proving to be a much better solution in almost all areas such as editing, previewing, publishing, and caching. Excited to get this live in production soon. Thank you!

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
