### PR TITLE
Use `Alchemy.config.show_page_searchable_checkbox`

### DIFF
--- a/app/views/alchemy/admin/pages/_form.html.erb
+++ b/app/views/alchemy/admin/pages/_form.html.erb
@@ -23,7 +23,7 @@
       <%= f.input :title %>
     </alchemy-char-counter>
 
-    <% if Alchemy.enable_searchable %>
+    <% if Alchemy.config.show_page_searchable_checkbox %>
       <div class="input check_boxes">
         <label class="control-label"><%= Alchemy.t(:fulltext_search) %></label>
         <div class="control_group">

--- a/spec/features/admin/page_editing_feature_spec.rb
+++ b/spec/features/admin/page_editing_feature_spec.rb
@@ -112,27 +112,27 @@ RSpec.describe "Page editing feature", type: :system do
           end
         end
 
-        context "enable_searchable" do
+        describe "the searchable checkbox" do
           before do
-            Alchemy.enable_searchable = searchable
+            Alchemy.config.show_page_searchable_checkbox = searchable
             visit alchemy.configure_admin_page_path(a_page)
           end
 
           # reset default value
-          after { Alchemy.enable_searchable = false }
+          after { Alchemy.config.show_page_searchable_checkbox = false }
 
-          context "is enabled" do
+          context "when enabled" do
             let(:searchable) { true }
 
-            it "should show searchable checkbox" do
+            it "should be visible" do
               expect(page).to have_selector('input[type="checkbox"]#page_searchable')
             end
           end
 
-          context "is disabled" do
+          context "when disabled" do
             let(:searchable) { false }
 
-            it "should not show searchable checkbox" do
+            it "should not be visible" do
               visit alchemy.configure_admin_page_path(a_page)
               expect(page).to_not have_selector('input[type="checkbox"]#page_searchable')
             end


### PR DESCRIPTION
## What is this pull request for?

`Alchemy.enable_searchable` is deprecated.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
