### PR TITLE
Stop testing Rails 7.0

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -74,7 +74,6 @@ jobs:
       fail-fast: false
       matrix:
         rails:
-          - "7.0"
           - "7.1"
           - "7.2"
           - "8.0"
@@ -90,8 +89,7 @@ jobs:
         exclude:
           - rails: "8.0"
             ruby: "3.1"
-          - rails: "7.0"
-            ruby: "3.4"
+
     env:
       DB: ${{ matrix.database }}
       DB_USER: alchemy_user


### PR DESCRIPTION
## What is this pull request for?

Rails 7.0 is going out of security maintenance a week from now. We don't need to be testing it (and we're making heavy use of the `view_component` library, which is already issueing warnings).


