### PR TITLE
Use Alchemy.config in specs

### DIFF
--- a/spec/controllers/alchemy/base_controller_spec.rb
+++ b/spec/controllers/alchemy/base_controller_spec.rb
@@ -29,7 +29,7 @@ module Alchemy
 
     describe "#configuration" do
       it "returns certain configuration options" do
-        allow(Config).to receive(:some_option).and_return(true)
+        allow(Alchemy.config).to receive(:some_option).and_return(true)
         expect(controller.configuration(:some_option)).to eq(true)
       end
     end

--- a/spec/models/alchemy/attachment_spec.rb
+++ b/spec/models/alchemy/attachment_spec.rb
@@ -128,7 +128,7 @@ module Alchemy
     describe "validations" do
       context "having a png, but only pdf allowed" do
         before do
-          allow(Config).to receive(:get) do
+          allow(Alchemy.config).to receive(:get) do
             {"allowed_filetypes" => {"alchemy/attachments" => ["pdf"]}}
           end
         end
@@ -140,7 +140,7 @@ module Alchemy
 
       context "having a png and everything allowed" do
         before do
-          allow(Config).to receive(:get) do
+          allow(Alchemy.config).to receive(:get) do
             {"allowed_filetypes" => {"alchemy/attachments" => ["*"]}}
           end
         end

--- a/spec/models/alchemy/picture_spec.rb
+++ b/spec/models/alchemy/picture_spec.rb
@@ -75,7 +75,7 @@ module Alchemy
 
       context "with > geometry string" do
         before do
-          allow(Config).to receive(:get) do |arg|
+          allow(Alchemy.config).to receive(:get) do |arg|
             if arg == :preprocess_image_resize
               "10x10>"
             end
@@ -90,7 +90,7 @@ module Alchemy
 
       context "without > geometry string" do
         before do
-          allow(Config).to receive(:get) do |arg|
+          allow(Alchemy.config).to receive(:get) do |arg|
             if arg == :preprocess_image_resize
               "10x10"
             end


### PR DESCRIPTION
The Alchemy::Config object is deprecated in Alchemy 8.


## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
