### PR TITLE
Refactor module_definition_for to be module method

### DIFF
--- a/spec/libraries/modules_spec.rb
+++ b/spec/libraries/modules_spec.rb
@@ -2,23 +2,15 @@
 
 require "rails_helper"
 
-class ::RegisterModuleDummyController
-  ### mock the existence of the controller
-end
+class ::RegisterModuleDummyController; end
 
 module Alchemy
-  class ModulesTestController < ApplicationController
-    include Modules
-  end
-
   describe Modules do
-    let(:controller) { ModulesTestController.new }
-
     describe "#module_definition_for" do
-      subject { controller.module_definition_for(params_or_name) }
+      subject { described_class.module_definition_for(params_or_name) }
 
       before do
-        allow(controller).to receive(:alchemy_modules) { [dashboard_module] }
+        allow(described_class).to receive(:alchemy_modules) { [dashboard_module] }
       end
 
       let(:dashboard_module) do


### PR DESCRIPTION
It's static, and we can just use it like that.

Extracted  from #3215 

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
