### PR TITLE
Stop testing Ruby 3.1

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -78,7 +78,6 @@ jobs:
           - "7.2"
           - "8.0"
         ruby:
-          - "3.1"
           - "3.2"
           - "3.3"
           - "3.4"
@@ -86,9 +85,6 @@ jobs:
           - sqlite
           - postgresql
           - mariadb
-        exclude:
-          - rails: "8.0"
-            ruby: "3.1"
 
     env:
       DB: ${{ matrix.database }}


### PR DESCRIPTION
Ruby 3.1 is not supported beyond next week. Let's not test it.
