### PR TITLE
Remove require of alchemy/admin/all file

### DIFF
--- a/app/assets/config/alchemy_manifest.js
+++ b/app/assets/config/alchemy_manifest.js
@@ -1,4 +1,3 @@
-//= link alchemy/admin/all.js
 //= link_tree ../builds/alchemy/
 //= link_tree ../builds/tinymce/
 //= link_tree ../images/alchemy/


### PR DESCRIPTION
This file is empty since Alchemy 7.4 and has been deprecated since. We should not require it anymore.
