### PR TITLE
Allow filtering with a time/date picker

### DIFF
--- a/app/components/alchemy/admin/resource/datepicker_filter.rb
+++ b/app/components/alchemy/admin/resource/datepicker_filter.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Alchemy
+  module Admin
+    module Resource
+      class DatepickerFilter < ViewComponent::Base
+        attr_reader :name, :label, :value, :input_type
+
+        erb_template <<~ERB
+          <div class="filter-input">
+            <%= label_tag datepicker_name, label %>
+            <alchemy-datepicker input_type="<%= input_type %>">
+              <%= text_field_tag(
+                datepicker_name,
+                value,
+                form: "resource_search"
+              ) %>
+            </alchemy-datepicker>
+          </div>
+        ERB
+
+        def initialize(name:, label:, input_type: :datetime, params: {})
+          @name = name
+          @label = label
+          @input_type = input_type
+          @params = params
+          @value = get_value(params)
+        end
+
+        private
+
+        def get_value(params)
+          params.dig(:q, name)
+        end
+
+        def datepicker_name
+          "q[#{name}]"
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -38,6 +38,8 @@ module Alchemy
         only: [:show]
 
       add_alchemy_filter :by_page_layout, type: :select, options: PageLayout.all.map { |p| [Alchemy.t(p["name"], scope: "page_layout_names"), p["name"]] }
+      add_alchemy_filter :updated_at_gteq, type: :datepicker
+      add_alchemy_filter :updated_at_lteq, type: :datepicker
       add_alchemy_filter :published, type: :checkbox
       add_alchemy_filter :not_public, type: :checkbox
       add_alchemy_filter :restricted, type: :checkbox

--- a/app/models/alchemy/admin/filters/base.rb
+++ b/app/models/alchemy/admin/filters/base.rb
@@ -11,6 +11,14 @@ module Alchemy
           @resource_name = resource_name
         end
 
+        def applied_filter_component(search_filter_params:, resource_url_proxy:, query:)
+          Alchemy::Admin::Resource::AppliedFilter.new(
+            link: dismiss_filter_url(search_filter_params, resource_url_proxy),
+            applied_filter_label: translated_name,
+            applied_filter_value: translated_value(search_filter_params[:q][name], query)
+          )
+        end
+
         private
 
         def translated_name

--- a/app/models/alchemy/admin/filters/datepicker.rb
+++ b/app/models/alchemy/admin/filters/datepicker.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Alchemy
+  module Admin
+    module Filters
+      class Datepicker < Base
+        attr_reader :input_type
+        # Creates a resource filter that displays as a datepicker.
+        # @param name [String] The name of the filter.
+        # @param resource_name [String] The name of the resource.
+        # @param input_type [Symbol] The input type of the datepicker. Can be :date, :datetime, or :time.
+        # @example
+        #  Alchemy::Admin::Filters::Datepicker.new(
+        #  name: :created_at_lt,
+        #  resource_name: :events,
+        #  mode: :single,
+        #  default: "2023-01-01"
+        def initialize(name:, resource_name:, input_type: :datetime)
+          super(name:, resource_name:)
+          @input_type = input_type
+        end
+
+        # Returns a datepicker filter component.
+        # @param params [Hash] The search filter params.
+        # @param query [Ransack::Search] The current search query.
+        # @return [Alchemy::Admin::Resource::DatepickerFilter] The datepicker filter component.
+        def input_component(params, _query)
+          Alchemy::Admin::Resource::DatepickerFilter.new(
+            name:,
+            label: translated_name,
+            input_type: @input_type,
+            params:
+          )
+        end
+
+        private
+
+        def translated_value(value, query)
+          date = Time.zone.parse(value) if value.is_a?(String)
+          format = case input_type
+          when :date
+            ::I18n.t(:default, scope: [:date, :formats, :alchemy])
+          when :datetime
+            ::I18n.t(:default, scope: [:time, :formats, :alchemy])
+          when :time
+            ::I18n.t(:time, scope: [:time, :formats, :alchemy])
+          end
+          ::I18n.l(date, format: format)
+        end
+      end
+    end
+  end
+end

--- a/app/models/alchemy/admin/filters/select.rb
+++ b/app/models/alchemy/admin/filters/select.rb
@@ -30,14 +30,6 @@ module Alchemy
           )
         end
 
-        def applied_filter_component(search_filter_params:, resource_url_proxy:, query:)
-          Alchemy::Admin::Resource::AppliedFilter.new(
-            link: dismiss_filter_url(search_filter_params, resource_url_proxy),
-            applied_filter_label: translated_name,
-            applied_filter_value: translated_value(search_filter_params[:q][name], query)
-          )
-        end
-
         private
 
         def include_blank

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -253,6 +253,11 @@ module Alchemy
         end
         options
       end
+
+      # Allow all string and text attributes to be searchable by Ransack.
+      def ransackable_attributes(_auth_object = nil)
+        searchable_alchemy_resource_attributes + ["updated_at"]
+      end
     end
 
     # Instance methods

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -117,6 +117,10 @@ en:
           name: Published
         restricted:
           name: Restricted
+        updated_at_lteq:
+          name: Updated before
+        updated_at_gteq:
+          name: Updated after
       picture:
         by_file_format:
           name: File Type

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -688,7 +688,7 @@ en:
   time:
     formats:
       alchemy:
-        default: "%m.%d.%Y %H:%M"
+        default: "%Y-%m-%d %H:%M"
         ingredient_date: "%Y-%m-%d"
         page_status: "%m.%d.%Y %H:%M"
         short_datetime: "%d %b %H:%M"

--- a/spec/components/alchemy/admin/resource/datepicker_filter_spec.rb
+++ b/spec/components/alchemy/admin/resource/datepicker_filter_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::Admin::Resource::DatepickerFilter, type: :component do
+  let(:name) { "starts_at_gteq" }
+  let(:params) { {} }
+  let(:label) { "Starts at later than " }
+  let(:input_type) { :datetime }
+  let(:component) do
+    described_class.new(name:, label:, input_type:, params:)
+  end
+
+  before do
+    render
+  end
+
+  subject(:render) do
+    render_inline component
+  end
+
+  describe "#render" do
+    it "renders a select input with the correct options" do
+      expect(page).to have_selector('input[name="q[starts_at_gteq]"][form="resource_search"]')
+      expect(page).to have_selector("label", text: "Starts at later than ")
+      expect(page).to have_selector("alchemy-datepicker[input_type='datetime']")
+    end
+
+    context "if input_type is :date" do
+      let(:input_type) { :date }
+
+      it "renders a datepicker with the correct input type" do
+        expect(page).to have_selector("alchemy-datepicker[input_type='date']")
+      end
+    end
+
+    context "if input_type is :time" do
+      let(:input_type) { :time }
+
+      it "renders a datepicker with the correct input type" do
+        expect(page).to have_selector("alchemy-datepicker[input_type='time']")
+      end
+    end
+
+    context "if params are set" do
+      let(:params) { {q: {starts_at_gteq: "2025-04-01"}.with_indifferent_access} }
+
+      it "renders the params value in the input field" do
+        expect(page).to have_selector('input[name="q[starts_at_gteq]"][value]')
+        expect(page).to have_selector("alchemy-datepicker[input_type='datetime']")
+      end
+    end
+  end
+end

--- a/spec/dummy/app/controllers/admin/events_controller.rb
+++ b/spec/dummy/app/controllers/admin/events_controller.rb
@@ -5,4 +5,5 @@ class Admin::EventsController < Alchemy::Admin::ResourcesController
   add_alchemy_filter :by_location_id,
     type: :select,
     options: ->(query) { Location.joins(:events).merge(query.result.reorder(nil)).distinct.map { |l| [l.name, l.id] } }
+  add_alchemy_filter :starts_at_lteq, type: :datepicker
 end

--- a/spec/dummy/app/models/event.rb
+++ b/spec/dummy/app/models/event.rb
@@ -28,7 +28,8 @@ class Event < ActiveRecord::Base
 
   def self.ransackable_attributes(*)
     [
-      "name"
+      "name",
+      "starts_at"
     ]
   end
 

--- a/spec/dummy/config/locales/alchemy.en.yml
+++ b/spec/dummy/config/locales/alchemy.en.yml
@@ -4,6 +4,10 @@ en:
       event:
         start:
           name: Start
+        created_at_lt:
+          name: Created before
+        starts_at_gteq:
+          name: Starts after
         by_location_id:
           name: Location
         by_timeframe:

--- a/spec/models/alchemy/admin/filters/datepicker_spec.rb
+++ b/spec/models/alchemy/admin/filters/datepicker_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::Admin::Filters::Datepicker do
+  let(:name) { "starts_at_gteq" }
+  let(:resource_name) { "event" }
+  let(:input_type) { :date }
+  let(:datepicker) { described_class.new(name:, resource_name:, input_type:) }
+
+  describe "#applied_filter_component" do
+    let(:search_filter_params) { {q: {starts_at_gteq: "2025-04-01"}}.with_indifferent_access }
+    let(:resource_url_proxy) { double(url_for: "/admin/events") }
+    let(:query) { double }
+
+    subject(:applied_filter_component) do
+      datepicker.applied_filter_component(search_filter_params:, resource_url_proxy:, query:)
+    end
+
+    it "returns a dismiss filter component" do
+      expect(applied_filter_component).to be_a(Alchemy::Admin::Resource::AppliedFilter)
+      expect(applied_filter_component.link).to eq("/admin/events")
+      expect(applied_filter_component.applied_filter_label).to eq("Starts after")
+      expect(applied_filter_component.applied_filter_value).to eq("2025-04-01")
+    end
+
+    context "when the input_type is :datetime" do
+      let(:input_type) { :datetime }
+
+      it "returns a datepicker filter input component with the correct input type and format" do
+        expect(applied_filter_component.applied_filter_value).to eq("2025-04-01 00:00")
+      end
+    end
+
+    context "when the input_type is :time" do
+      let(:input_type) { :time }
+
+      it "returns a datepicker filter input component with the correct input type and format" do
+        expect(applied_filter_component.applied_filter_value).to eq("00:00")
+      end
+    end
+  end
+
+  describe "#input_component" do
+    let(:params) { {q: {starts_at_gteq: "2025-04-01"}}.with_indifferent_access }
+    let(:query) { double }
+
+    subject(:component) do
+      datepicker.input_component(params, query)
+    end
+
+    it "returns a datepicker filter input component" do
+      expect(component).to be_a(Alchemy::Admin::Resource::DatepickerFilter)
+      expect(component.name).to eq(name)
+      expect(component.label).to eq("Starts after")
+      expect(component.value).to eq("2025-04-01")
+    end
+  end
+end

--- a/spec/views/alchemy/ingredients/datetime_view_spec.rb
+++ b/spec/views/alchemy/ingredients/datetime_view_spec.rb
@@ -20,7 +20,7 @@ describe "alchemy/ingredients/_datetime_view" do
     context "without date_format passed" do
       it "translates the date value with default format" do
         render ingredient, options: options
-        expect(rendered).to have_content("08.29.2024 12:00")
+        expect(rendered).to have_content("2024-08-29 12:00")
       end
     end
 


### PR DESCRIPTION
## What is this pull request for?

This adds a new filter type: Filtering with a datepicker. The datepicker can either display as a date, as a time and date, or a time, and will create the appropriate parameters. Out of the box, you get things like "updated_at_lteq" from Ransack, for things like "starts after x PM" you'd have to write a ransackable scope.

### Notable changes (remove if none)

Feature addition only.

### Screenshots
![grafik](https://github.com/user-attachments/assets/cd33bb05-9451-4197-851d-d60917999d15)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
