### PR TITLE
Load JS translations into DOM

### DIFF
--- a/app/helpers/alchemy/admin/base_helper.rb
+++ b/app/helpers/alchemy/admin/base_helper.rb
@@ -73,6 +73,13 @@ module Alchemy
         end
       end
 
+      def alchemy_admin_js_translations(locale = ::I18n.locale)
+        render partial: "alchemy/admin/translations/#{locale}", formats: [:js]
+      rescue ActionView::MissingTemplate
+        # Fallback to default translations
+        render partial: "alchemy/admin/translations/en", formats: [:js]
+      end
+
       # Used for site selector in Alchemy cockpit.
       def sites_for_select
         Alchemy::Site.all.map do |site|

--- a/app/javascript/alchemy_admin/components/alchemy_html_element.js
+++ b/app/javascript/alchemy_admin/components/alchemy_html_element.js
@@ -26,7 +26,7 @@ export class AlchemyHTMLElement extends HTMLElement {
    * this is a default function
    * @link https://developer.mozilla.org/en-US/docs/Web/API/Web_Components#reference
    */
-  connectedCallback() {
+  async connectedCallback() {
     // parse the properties object and register property with the default values
     Object.keys(this.constructor.properties).forEach((name) => {
       // if the options was given via the constructor, they should be prefer (e.g. new <WebComponentName>({title: "Foo"}))
@@ -39,7 +39,7 @@ export class AlchemyHTMLElement extends HTMLElement {
 
     // render the component
     this._updateComponent()
-    this.connected()
+    await this.connected()
   }
 
   /**
@@ -64,7 +64,7 @@ export class AlchemyHTMLElement extends HTMLElement {
   /**
    * a connected method to make it easier to overwrite the connection callback
    */
-  connected() {}
+  async connected() {}
 
   /**
    * a disconnected method to make it easier to overwrite the disconnection callback

--- a/app/javascript/alchemy_admin/components/datepicker.js
+++ b/app/javascript/alchemy_admin/components/datepicker.js
@@ -2,6 +2,8 @@ import { AlchemyHTMLElement } from "alchemy_admin/components/alchemy_html_elemen
 import { translate, currentLocale } from "alchemy_admin/i18n"
 import flatpickr from "flatpickr"
 
+const locale = currentLocale()
+
 class Datepicker extends AlchemyHTMLElement {
   static properties = {
     inputType: { default: "date" }
@@ -12,7 +14,13 @@ class Datepicker extends AlchemyHTMLElement {
     this.flatpickr = undefined
   }
 
-  afterRender() {
+  // Load the locales for flatpickr before setting it up.
+  async connected() {
+    // English is the default locale for flatpickr, so we don't need to load it
+    if (locale !== "en") {
+      await import(`flatpickr/${locale}.js`)
+    }
+
     this.flatpickr = flatpickr(
       this.getElementsByTagName("input")[0],
       this.flatpickrOptions
@@ -27,7 +35,7 @@ class Datepicker extends AlchemyHTMLElement {
     const enableTime = /time/.test(this.inputType)
     const options = {
       // alchemy_i18n supports `zh_CN` etc., but flatpickr only has two-letter codes (`zh`)
-      locale: currentLocale().slice(0, 2),
+      locale: locale.slice(0, 2),
       altInput: true,
       altFormat: translate(`formats.${this.inputType}`),
       altInputClass: "flatpickr-input",

--- a/app/javascript/alchemy_admin/components/remote_select.js
+++ b/app/javascript/alchemy_admin/components/remote_select.js
@@ -1,4 +1,5 @@
 import { AlchemyHTMLElement } from "alchemy_admin/components/alchemy_html_element"
+import { setupSelectLocale } from "alchemy_admin/i18n"
 
 export class RemoteSelect extends AlchemyHTMLElement {
   static properties = {
@@ -9,7 +10,9 @@ export class RemoteSelect extends AlchemyHTMLElement {
     url: { default: "" }
   }
 
-  connected() {
+  async connected() {
+    await setupSelectLocale()
+
     this.input.classList.add("alchemy_selectbox")
 
     $(this.input)

--- a/app/javascript/alchemy_admin/components/tags_autocomplete.js
+++ b/app/javascript/alchemy_admin/components/tags_autocomplete.js
@@ -1,5 +1,9 @@
+import { setupSelectLocale } from "alchemy_admin/i18n"
+
 class TagsAutocomplete extends HTMLElement {
-  connectedCallback() {
+  async connectedCallback() {
+    await setupSelectLocale()
+
     this.classList.add("autocomplete_tag_list")
     $(this.input).select2(this.select2Config)
   }

--- a/app/javascript/alchemy_admin/confirm_dialog.js
+++ b/app/javascript/alchemy_admin/confirm_dialog.js
@@ -3,18 +3,19 @@ import pleaseWaitOverlay from "alchemy_admin/please_wait_overlay"
 import { createHtmlElement } from "alchemy_admin/utils/dom_helpers"
 import { translate } from "alchemy_admin/i18n"
 
-const DEFAULTS = {
+const getDefaults = () => ({
+  // The default size of the dialog
   size: "300x100",
   title: translate("Please confirm"),
   ok_label: translate("Yes"),
   cancel_label: translate("No"),
   on_ok() {}
-}
+})
 
 class ConfirmDialog {
   constructor(message, options = {}) {
     this.message = message
-    this.options = { ...DEFAULTS, ...options }
+    this.options = { ...getDefaults(), ...options }
     this.#build()
     this.#bindEvents()
   }

--- a/app/javascript/alchemy_admin/i18n.js
+++ b/app/javascript/alchemy_admin/i18n.js
@@ -1,19 +1,4 @@
-import { en } from "alchemy_admin/locales/en"
-
-Alchemy.translations = Object.assign(Alchemy.translations || {}, { en })
-
 const KEY_SEPARATOR = /\./
-
-function getTranslations() {
-  const locale = currentLocale()
-  const translations = Alchemy.translations && Alchemy.translations[locale]
-
-  if (translations) {
-    return translations
-  }
-  console.warn(`Translations for locale ${locale} not found!`)
-  return {}
-}
 
 function nestedTranslation(translations, key) {
   const keys = key.split(KEY_SEPARATOR)
@@ -25,7 +10,13 @@ function nestedTranslation(translations, key) {
 }
 
 function getTranslation(key) {
-  const translations = getTranslations()
+  const locale = currentLocale()
+  const translations = Alchemy.translations
+
+  if (!translations) {
+    console.warn(`Translations for locale ${locale} not found!`)
+    return key
+  }
 
   if (KEY_SEPARATOR.test(key)) {
     return nestedTranslation(translations, key)

--- a/app/javascript/alchemy_admin/i18n.js
+++ b/app/javascript/alchemy_admin/i18n.js
@@ -39,3 +39,11 @@ export function translate(key, replacement = undefined) {
   }
   return translation
 }
+
+export async function setupSelectLocale() {
+  const locale = currentLocale()
+  if (locale === "en") return
+
+  await import(`select2/${locale}.js`)
+  $.extend($.fn.select2.defaults, $.fn.select2.locales[locale])
+}

--- a/app/views/alchemy/admin/styleguide/index.html.erb
+++ b/app/views/alchemy/admin/styleguide/index.html.erb
@@ -49,6 +49,14 @@
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 <% end %>
 
+<h3>Tags Autocomplete</h3>
+
+<div>
+  <alchemy-tags-autocomplete>
+    <input type="text" class="full_width" />
+  </alchemy-tags-autocomplete>
+</div>
+
 <h3>Growl Messages</h3>
 
 <%= link_to render_icon(:check), 'javascript:Alchemy.growl("Success message")', class: "icon_button" %>

--- a/app/views/alchemy/admin/translations/_en.js
+++ b/app/views/alchemy/admin/translations/_en.js
@@ -1,4 +1,4 @@
-export const en = {
+Alchemy.translations = {
   allowed_chars: "of %{count} chars",
   cancel: "Cancel",
   cancelled: "Cancelled",

--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -94,10 +94,6 @@
     <div id="main_content">
       <%= yield %>
     </div>
-    <script type="module">
-      // Setting the correct locale for select2 dropdown replacement.
-      $.extend($.fn.select2.defaults, $.fn.select2.locales['<%= ::I18n.locale %>']);
-    </script>
     <%= render 'alchemy/admin/uploader/setup' %>
     <%= yield(:javascripts) %>
   <% end %>

--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -22,6 +22,8 @@
       var Alchemy = {};
       // Store regular expression for external link url matching.
       Alchemy.link_url_regexp = <%= link_url_regexp.inspect %>;
+      // JS translations
+      <%= alchemy_admin_js_translations %>
     </script>
     <%= render 'alchemy/admin/tinymce/setup' %>
     <%= render 'alchemy/admin/partials/routes' %>

--- a/spec/javascript/alchemy_admin/components/char_counter.spec.js
+++ b/spec/javascript/alchemy_admin/components/char_counter.spec.js
@@ -1,7 +1,12 @@
 import "alchemy_admin/components/char_counter"
 import { renderComponent, setupLanguage } from "./component.helper"
+import { setupTranslations } from "../translations.helper.js"
 
 describe("alchemy-char-counter", () => {
+  beforeEach(() => {
+    setupTranslations()
+  })
+
   /**
    *
    * @type {HTMLElement | undefined}

--- a/spec/javascript/alchemy_admin/i18n.spec.js
+++ b/spec/javascript/alchemy_admin/i18n.spec.js
@@ -1,6 +1,11 @@
 import { translate, currentLocale } from "alchemy_admin/i18n"
+import { setupTranslations } from "./translations.helper.js"
 
 describe("i18n", () => {
+  beforeEach(() => {
+    setupTranslations()
+  })
+
   describe("currentLocale", () => {
     afterEach(() => {
       document.documentElement.lang = ""
@@ -66,27 +71,20 @@ describe("i18n", () => {
       })
     })
 
-    describe("if lang is set to a unknown locale", () => {
-      beforeEach(() => {
-        document.documentElement.lang = "kl"
-      })
-
-      it("Returns passed string and logs a warning", () => {
-        const spy = jest.spyOn(console, "warn").mockImplementation(() => {})
-        expect(translate("help")).toEqual("help")
-        expect(spy.mock.calls).toEqual([
-          ["Translations for locale kl not found!"]
-        ])
-        spy.mockRestore()
-      })
-    })
-
     describe("if Alchemy.translations is not set", () => {
+      beforeEach(() => {
+        Alchemy.translations = undefined
+      })
+
+      afterEach(() => {
+        setupTranslations()
+      })
+
       it("Returns passed string and logs a warning", () => {
         const spy = jest.spyOn(console, "warn").mockImplementation(() => {})
         expect(translate("help")).toEqual("help")
         expect(spy.mock.calls).toEqual([
-          ["Translations for locale kl not found!"]
+          ["Translations for locale en not found!"]
         ])
         spy.mockRestore()
       })

--- a/spec/javascript/alchemy_admin/translations.helper.js
+++ b/spec/javascript/alchemy_admin/translations.helper.js
@@ -1,0 +1,10 @@
+// Run this before all tests that needs translations available
+export const setupTranslations = () => {
+  window.Alchemy.translations = {
+    allowed_chars: "of %{count} chars",
+    help: "Help",
+    formats: {
+      date: "Y-m-d"
+    }
+  }
+}


### PR DESCRIPTION
## What is this pull request for?

We do not need all JS translation in memory.
We can just load the one we need during page load.
That way we do not need to load it via dynamic imports
into our ES modules.

### Notable changes

- Define `<alchemy-datepicker>` after loading translations. We need to import flatpickr localizations via a dynamic import in order to work with ES modules and importmaps.

- Confirm Dialog: Do not call `translate()` on load. We can't call `Alchemy.translate` before we're sure that all
translations are registered.

- JS Translations are now loaded into the DOM as a single `Alchemy.translations` object. Not nested into the locale anymore. So, if you have custom JS translations for Alchemy please put a file into `app/views/alchemy/admin/_{locale}.js` instead of in `app/assets/javascripts/alchemy_i18n/{locale}.js` See https://github.com/AlchemyCMS/alchemy_i18n/pull/71 for reference.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
