### PR TITLE
Confirm dialog defer translate call

### DIFF
--- a/app/javascript/alchemy_admin.js
+++ b/app/javascript/alchemy_admin.js
@@ -1,9 +1,6 @@
-// We still use jQuery in some places (ie. select2)
 import "handlebars"
-import "jquery"
 import "@ungap/custom-elements"
 import "@hotwired/turbo-rails"
-import "select2"
 
 import Rails from "@rails/ujs"
 

--- a/app/javascript/alchemy_admin/confirm_dialog.js
+++ b/app/javascript/alchemy_admin/confirm_dialog.js
@@ -3,18 +3,19 @@ import pleaseWaitOverlay from "alchemy_admin/please_wait_overlay"
 import { createHtmlElement } from "alchemy_admin/utils/dom_helpers"
 import { translate } from "alchemy_admin/i18n"
 
-const DEFAULTS = {
+const getDefaults = () => ({
+  // The default size of the dialog
   size: "300x100",
   title: translate("Please confirm"),
   ok_label: translate("Yes"),
   cancel_label: translate("No"),
   on_ok() {}
-}
+})
 
 class ConfirmDialog {
   constructor(message, options = {}) {
     this.message = message
-    this.options = { ...DEFAULTS, ...options }
+    this.options = { ...getDefaults(), ...options }
     this.#build()
     this.#bindEvents()
   }

--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -25,12 +25,18 @@
     </script>
     <%= render 'alchemy/admin/tinymce/setup' %>
     <%= render 'alchemy/admin/partials/routes' %>
-    <%= javascript_importmap_tags("alchemy_admin", importmap: Alchemy.importmap) %>
-    <% Alchemy.admin_js_imports.each do |path| %>
-      <script type="module">
+    <%= javascript_inline_importmap_tag(Alchemy.importmap.to_json(resolver: self)) %>
+    <%= javascript_importmap_module_preload_tags(Alchemy.importmap, entry_point: "alchemy_admin") %>
+    <script type="module">
+      // We still use jQuery in some places (ie. select2)
+      import "jquery"
+      import "select2"
+
+      import "alchemy_admin"
+      <% Alchemy.admin_js_imports.each do |path| %>
         import "<%= path %>"
-      </script>
-    <% end %>
+      <% end %>
+    </script>
     <%= yield :javascript_includes %>
   </head>
   <%= content_tag :body, id: 'alchemy',


### PR DESCRIPTION
## What is this pull request for?

This PR changes the confirm dialog class to not call `Alchemy.translate()` at load time. Tiny wins! (Came out of a pairing session today).

It also moves the jQuery and Select2 imports into the main file for better visibility.