### PR TITLE
fix(<alchemy-tinymce>): Do not expect an element editor

### DIFF
--- a/app/javascript/alchemy_admin/components/tinymce.js
+++ b/app/javascript/alchemy_admin/components/tinymce.js
@@ -76,8 +76,10 @@ class Tinymce extends AlchemyHTMLElement {
         this.getElementsByTagName("alchemy-spinner")[0].remove()
 
         // event listener to mark the editor as dirty
-        editor.on("dirty", () => this.elementEditor.setDirty())
-        editor.on("click", () => this.elementEditor.onClickElement(false))
+        if (this.elementEditor) {
+          editor.on("dirty", () => this.elementEditor.setDirty())
+          editor.on("click", () => this.elementEditor.onClickElement(false))
+        }
       })
     })
   }

--- a/spec/javascript/alchemy_admin/components/char_counter.spec.js
+++ b/spec/javascript/alchemy_admin/components/char_counter.spec.js
@@ -4,7 +4,7 @@ import { setupTranslations } from "../translations.helper.js"
 
 describe("alchemy-char-counter", () => {
   beforeEach(() => {
-    setupTranslations()
+    setupLanguage()
   })
 
   /**
@@ -22,8 +22,6 @@ describe("alchemy-char-counter", () => {
   }
 
   beforeEach(() => {
-    setupLanguage()
-
     const html = `
       <alchemy-char-counter>
         <input type="text">

--- a/spec/javascript/alchemy_admin/components/component.helper.js
+++ b/spec/javascript/alchemy_admin/components/component.helper.js
@@ -1,3 +1,5 @@
+import { setupTranslations } from "../translations.helper"
+
 /**
  * render component helper
  * @param {string} name
@@ -11,4 +13,5 @@ export const renderComponent = (name, html) => {
 
 export const setupLanguage = () => {
   document.documentElement.lang = "en"
+  setupTranslations()
 }

--- a/spec/javascript/alchemy_admin/components/tinymce.spec.js
+++ b/spec/javascript/alchemy_admin/components/tinymce.spec.js
@@ -14,7 +14,33 @@ describe("alchemy-tinymce", () => {
 
   const textareaId = "tinymce-textarea"
 
-  beforeAll(() => setupLanguage())
+  beforeAll(() => {
+    setupLanguage()
+    // The tinymce configuration is set in the global Alchemy object
+    // because we translate the configuration from the Rails backend
+    // into the JS world.
+    Alchemy.TinymceDefaults = {
+      skin: "alchemy",
+      content_css: "/assets/tinymce/skins/content/alchemy/content.min.css",
+      icons: "remixicons",
+      width: "auto",
+      resize: true,
+      min_height: 250,
+      menubar: false,
+      statusbar: true,
+      toolbar: [
+        "bold italic underline | strikethrough subscript superscript | numlist bullist indent outdent | removeformat | fullscreen",
+        "pastetext charmap hr | undo redo | alchemy_link unlink anchor | code"
+      ],
+      fix_list_elements: true,
+      convert_urls: false,
+      entity_encoding: "raw",
+      paste_as_text: true,
+      element_format: "html",
+      branding: false,
+      license_key: "gpl"
+    }
+  })
 
   describe("render", () => {
     beforeEach(() => {
@@ -32,9 +58,10 @@ describe("alchemy-tinymce", () => {
       )
     })
 
-    it.skip("should have an tinymce container after the intersection observer triggered", () => {
+    it("should have an tinymce container after the intersection observer triggered", async () => {
       expect(component.getElementsByClassName("tox-tinymce").length).toEqual(0)
       intersectionObserver.enterNode(component)
+      await new Promise(process.nextTick)
       expect(component.getElementsByClassName("tox-tinymce").length).toEqual(1)
     })
 
@@ -51,30 +78,7 @@ describe("alchemy-tinymce", () => {
       <alchemy-tinymce toolbar="bold italic" foo-bar="bar | foo">
         <textarea id="${textareaId}"></textarea>
       </alchemy-tinymce>
-    `
-      // The tinymce configuration is set in the global Alchemy object
-      // because we translate the configuration from the Rails backend
-      // into the JS world.
-      Alchemy.TinymceDefaults = {
-        skin: "alchemy",
-        content_css: "/assets/tinymce/skins/content/alchemy/content.min.css",
-        icons: "remixicons",
-        width: "auto",
-        resize: true,
-        min_height: 250,
-        menubar: false,
-        statusbar: true,
-        toolbar: [
-          "bold italic underline | strikethrough subscript superscript | numlist bullist indent outdent | removeformat | fullscreen",
-          "pastetext charmap hr | undo redo | alchemy_link unlink anchor | code"
-        ],
-        fix_list_elements: true,
-        convert_urls: false,
-        entity_encoding: "raw",
-        paste_as_text: true,
-        element_format: "html",
-        branding: false
-      }
+      `
       component = renderComponent("alchemy-tinymce", html)
     })
 


### PR DESCRIPTION
## What is this pull request for?

We might use this component outside off an `<alchemy-element-editor>`.

### Notable changes (remove if none)

Also fix JS specs: setupTranslations in setupLanguage
We need `Alchemy.translations` in the DOM in order to prevent
`console.warn` in the test log.
