### PR TITLE
Filter Bar: Submit form on any "change" event in #filter_bar

### DIFF
--- a/app/views/alchemy/admin/resources/_filter_bar.html.erb
+++ b/app/views/alchemy/admin/resources/_filter_bar.html.erb
@@ -5,13 +5,13 @@
 </div>
 
 <script type="module">
-  $(function() {
-    $('input, select', '#filter_bar').on('change', function(e) {
-      // We need to dispatch a submit event, so that Turbo that listens
-      // to it submits the search form us.
-      const event = new Event("submit", { bubbles: true, cancelable: true });
-      this.form.dispatchEvent(event);
-      return false;
-    });
+  // Still using jQuery here, because select2 does emit the event from
+  // the correct element.
+  $('#filter_bar').on('change', function(event) {
+    // We need to dispatch a submit event, so that Turbo that listens
+    // to it submits the search form us.
+    const submitEvent = new Event("submit", { bubbles: true, cancelable: true });
+    event.target.form.dispatchEvent(submitEvent);
+    return false;
   });
 </script>


### PR DESCRIPTION
Previously, we targeted the individual inputs within the filter bar. This led to a race condition between adding the event handler and initializing datepickers, which would change the input elements. Handling the change event on the `filter_bar` element and all its children makes us immune to that problem.
