### PR TITLE
Respect default resource filter set in controller

### DIFF
--- a/app/controllers/concerns/alchemy/admin/resource_filter.rb
+++ b/app/controllers/concerns/alchemy/admin/resource_filter.rb
@@ -81,10 +81,10 @@ module Alchemy
       end
 
       def applied_filters
-        return [] unless params[:q]
+        return [] unless search_filter_params[:q]
 
         alchemy_filters.select do |alchemy_filter|
-          params[:q][alchemy_filter.name].present?
+          search_filter_params[:q][alchemy_filter.name].present?
         end
       end
     end

--- a/app/views/alchemy/admin/resources/_filter_bar.html.erb
+++ b/app/views/alchemy/admin/resources/_filter_bar.html.erb
@@ -1,6 +1,6 @@
 <div id="filter_bar">
   <% alchemy_filters.each do |filter| %>
-    <%= render filter.input_component(params, @query) %>
+    <%= render filter.input_component(search_filter_params, @query) %>
   <% end %>
 </div>
 

--- a/spec/dummy/app/controllers/admin/events_controller.rb
+++ b/spec/dummy/app/controllers/admin/events_controller.rb
@@ -6,4 +6,12 @@ class Admin::EventsController < Alchemy::Admin::ResourcesController
     type: :select,
     options: ->(query) { Location.joins(:events).merge(query.result.reorder(nil)).distinct.map { |l| [l.name, l.id] } }
   add_alchemy_filter :starts_at_lteq, type: :datepicker
+
+  before_action :set_default_filter, only: :index
+
+  private
+
+  def set_default_filter
+    search_filter_params[:q] ||= {by_timeframe: "future"}
+  end
 end

--- a/spec/dummy/app/models/event.rb
+++ b/spec/dummy/app/models/event.rb
@@ -15,7 +15,7 @@ class Event < ActiveRecord::Base
   before_destroy :abort_if_name_is_undestructible
 
   scope :starting_today, -> { where(starts_at: Time.current.at_midnight..Date.tomorrow.at_midnight) }
-  scope :future, -> { where("starts_at > ?", Date.tomorrow.at_midnight) }
+  scope :future, -> { where("starts_at >= ?", Date.today.at_midnight) }
   scope :by_location_id, ->(id) { where(location_id: id) }
   scope :by_timeframe, ->(timeframe) {
     case timeframe

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
     name { "My Event" }
     hidden_name { "not shown" }
     location
-    starts_at { Time.local(2012, 0o3, 0o2, 8, 15) }
-    ends_at { Time.local(2012, 0o3, 0o2, 19, 30) }
+    starts_at { Date.current }
+    ends_at { Date.current + 1.day }
     lunch_starts_at { Time.local(2012, 0o3, 0o2, 12, 15) }
     lunch_ends_at { Time.local(2012, 0o3, 0o2, 13, 45) }
     description { "something\nfancy" }


### PR DESCRIPTION
## What is this pull request for?

One should be able to mange the `search_filter_params` in the controller.

Ie.

    search_filter_params[:q] ||= {by_year: "current_year"}

Also it makes sense to use the `search_filer_params` in the filter components anyway and not all (actually unpermitted) params from the request.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
