### PR TITLE
Fix redirect to recent pictures after upload

### DIFF
--- a/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
+++ b/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
@@ -8,7 +8,7 @@
         in_dialog: true,
         redirect_url: alchemy.admin_pictures_path(
           size: search_filter_params[:size],
-          filter: { misc: 'last_upload' },
+          q: { last_upload: true },
           form_field_id: @form_field_id
         ) %>
     </div>

--- a/app/views/alchemy/admin/pictures/index.html.erb
+++ b/app/views/alchemy/admin/pictures/index.html.erb
@@ -7,7 +7,7 @@
           file_attribute: 'image_file',
           redirect_url: alchemy.admin_pictures_path(
             size: @size,
-            filter: { misc: 'last_upload' }
+            q: { last_upload: true }
           ) %>
       </div>
       <div class="toolbar_spacer"></div>


### PR DESCRIPTION
This went missing after we changed the resource filters to ransackable scopes.
