### PR TITLE
Only enhance `assets:precompile` task if Propshaft is present

### DIFF
--- a/lib/tasks/alchemy/assets.rake
+++ b/lib/tasks/alchemy/assets.rake
@@ -1,4 +1,4 @@
-if Rake::Task.task_defined?("assets:precompile")
+if Rake::Task.task_defined?("assets:precompile") && defined?(Propshaft)
   Rake::Task["assets:precompile"].enhance do
     manifest_path = Rails.application.config.assets.manifest_path
     assets_path = Rails.root.join("public#{Rails.application.config.assets.prefix}")


### PR DESCRIPTION
This fails if Propshaft is not installed.

