### PR TITLE
New filters: Translate `include_blank` per filter

### DIFF
--- a/app/models/alchemy/admin/filters/select.rb
+++ b/app/models/alchemy/admin/filters/select.rb
@@ -33,7 +33,7 @@ module Alchemy
         private
 
         def include_blank
-          Alchemy.t(:all, scope: [:resources, resource_name, :filters])
+          Alchemy.t(:all, scope: [:filters, resource_name, name])
         end
 
         def options_to_proc(options)

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -104,8 +104,10 @@ en:
     filters:
       page:
         by_page_layout:
+          all: All page types
           name: Page Type
         status:
+          all: Do not filter
           name: Status
           values:
             not_public: Unpublished
@@ -123,6 +125,7 @@ en:
           name: Updated after
       picture:
         by_file_format:
+          all: Show all file types
           name: File Type
           values:
             gif: GIF Image
@@ -144,6 +147,7 @@ en:
           name: File Type
           values:
             <<: *mime_types
+          all: Show all file types
         last_upload:
           name: Last upload only
         recent:


### PR DESCRIPTION
Select filters start out with a string that currently always says "All". This commit allows developers to set a nice string that indicates the absence of the filter. If the string is not set, we'll still see "All", which makes sense in many cases.

The previous translation has not been used once I believe.
