### PR TITLE
Lazy load page layouts for select

### DIFF
--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -37,7 +37,10 @@ module Alchemy
         if: :run_on_page_layout_callbacks?,
         only: [:show]
 
-      add_alchemy_filter :by_page_layout, type: :select, options: PageLayout.all.map { |p| [Alchemy.t(p["name"], scope: "page_layout_names"), p["name"]] }
+      add_alchemy_filter :by_page_layout, type: :select, options: ->(_q) do
+        PageLayout.all.map { |p| [Alchemy.t(p[:name], scope: "page_layout_names"), p[:name]] }
+      end
+
       add_alchemy_filter :updated_at_gteq, type: :datepicker
       add_alchemy_filter :updated_at_lteq, type: :datepicker
       add_alchemy_filter :published, type: :checkbox


### PR DESCRIPTION
## What is this pull request for?

We do not want to read the page layouts during app boot. They are read from a file, but they might be loaded from db (if the PageLayout repository is used)

Anyhow it is best practice to not load stuff during class load.
