### PR TITLE
[7.4] Remove `dragonfly_svg` plugin

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "cancancan", [">= 2.1", "< 4.0"]
   gem.add_runtime_dependency "csv", ["~> 3.3"]
   gem.add_runtime_dependency "dragonfly", ["~> 1.4"]
-  gem.add_runtime_dependency "dragonfly_svg", ["~> 0.0.4"]
   gem.add_runtime_dependency "gutentag", ["~> 2.2", ">= 2.2.1"]
   gem.add_runtime_dependency "importmap-rails", ["~> 1.2", ">= 1.2.1"]
   gem.add_runtime_dependency "kaminari", ["~> 1.1"]

--- a/app/models/alchemy/ingredients/headline.rb
+++ b/app/models/alchemy/ingredients/headline.rb
@@ -42,7 +42,7 @@ module Alchemy
       private
 
       def levels
-        settings.fetch(:levels, (1..6))
+        settings.fetch(:levels, 1..6)
       end
 
       def sizes

--- a/config/initializers/dragonfly.rb
+++ b/config/initializers/dragonfly.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
-require "dragonfly_svg"
+Dragonfly::App.register_plugin(:svg) do
+  ->(*) {
+    Alchemy::Deprecation.warn <<~WARN
+      The Dragonfly svg plugin is not necessary anymore! Please remove `plugin :svg` from your `config/initializers/dragonfly.rb`.
+    WARN
+  }
+end
+
 require "alchemy/dragonfly/processors/crop_resize"
 require "alchemy/dragonfly/processors/auto_orient"
 require "alchemy/dragonfly/processors/thumbnail"

--- a/lib/generators/alchemy/install/templates/dragonfly.rb.tt
+++ b/lib/generators/alchemy/install/templates/dragonfly.rb.tt
@@ -14,7 +14,6 @@
 Dragonfly.app(:alchemy_pictures).configure do
   dragonfly_url nil
   plugin :imagemagick
-  plugin :svg
   secret "<%= SecureRandom.hex(32) %>"
   url_format "/pictures/:job/:basename.:ext"
 

--- a/spec/dummy/config/initializers/dragonfly.rb
+++ b/spec/dummy/config/initializers/dragonfly.rb
@@ -16,7 +16,6 @@
 Dragonfly.app(:alchemy_pictures).configure do
   dragonfly_url nil
   plugin :imagemagick
-  plugin :svg
   secret "976ee38cf5e6d65dbf58f1d355825ba33239ab7a76a432818cd592526e9c78b5"
   url_format "/pictures/:job/:basename.:ext"
 


### PR DESCRIPTION
## What is this pull request for?

Same as #3247 but for 7.4-stable

We actually do not need this plugin to handle SVGs. Dragonfly and Imagemagick can handle them very well without.

It actually stopped working a long time ago. This fixes rendering SVGs in Alchemy pictures for some Docker based deployments.

### Notable changes

Replaced the svg dragonfly plugin with a dummy plugin.

One can safely remove `plugin :svg` from `config/initializers/dragonfly.rb` now.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
