### PR TITLE
fix(alchemy-select): Remove clear button of select2

### DIFF
--- a/app/javascript/alchemy_admin/components/select.js
+++ b/app/javascript/alchemy_admin/components/select.js
@@ -6,8 +6,16 @@ class Select extends HTMLSelectElement {
 
     this.#select2Element = $(this).select2({
       minimumResultsForSearch: 5,
-      dropdownAutoWidth: true
+      dropdownAutoWidth: true,
+      allowClear: !!this.allowClear
     })
+
+    if (!this.allowClear) {
+      this.#select2Element
+        .prev(".select2-container")
+        .find(".select2-search-choice-close")
+        .remove()
+    }
   }
 
   enable() {
@@ -42,6 +50,10 @@ class Select extends HTMLSelectElement {
    */
   #updateSelect2() {
     this.#select2Element.trigger("change")
+  }
+
+  get allowClear() {
+    return this.dataset.hasOwnProperty("allowClear")
   }
 }
 

--- a/spec/javascript/alchemy_admin/components/select.spec.js
+++ b/spec/javascript/alchemy_admin/components/select.spec.js
@@ -120,4 +120,28 @@ describe("alchemy-select", () => {
       expect(component.hasAttribute("disabled")).toBeTruthy()
     })
   })
+
+  describe("with data-allow-clear set", () => {
+    it("adds clear button", () => {
+      const html = `<select is="alchemy-select" data-allow-clear>
+        <option value="">Please Select</option>
+        <option value="1">First</option>
+        <option value="2">Second</option>
+      </select>`
+
+      component = renderComponent("alchemy-select", html)
+      select2Component = document.querySelector(".select2-container")
+      expect(
+        select2Component.querySelector(".select2-search-choice-close")
+      ).toBeTruthy()
+    })
+  })
+
+  describe("without data-allow-clear set", () => {
+    it("removes clear button", () => {
+      expect(
+        select2Component.querySelector(".select2-search-choice-close")
+      ).toBeFalsy()
+    })
+  })
 })


### PR DESCRIPTION
## What is this pull request for?

If allowClear is not set (the default) the clear button should not be rendered. Select2 renders it nonetheless. So, we remove it.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
