### PR TITLE
Drop Rails 7.0 support

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |gem|
     activesupport
     railties
   ].each do |rails_gem|
-    gem.add_runtime_dependency rails_gem, [">= 7.0", "< 8.1"]
+    gem.add_runtime_dependency rails_gem, [">= 7.1", "< 8.1"]
   end
 
   gem.add_runtime_dependency "active_model_serializers", ["~> 0.10.14"]


### PR DESCRIPTION
## What is this pull request for?

For upcoming ActiveStorage support we need features from that are only available in Rails 7.1 and above. 
Also Rails 7.0 is out of security maintenance since April 2025 (We have June 2025).

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] ~~I have added tests to cover this change~~ We do not run tests for Rails 7.0 anymore
