### PR TITLE
Copy new config initializer during upgrade

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -71,20 +71,30 @@ jobs:
     needs: [check_bun_lock, build_javascript]
     runs-on: ubuntu-22.04
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        rails:
-          - "7.1"
-          - "7.2"
-          - "8.0"
-        ruby:
-          - "3.2"
-          - "3.3"
-          - "3.4"
-        database:
-          - sqlite
-          - postgresql
-          - mariadb
+        include:
+          - rails: "7.1"
+            ruby: "3.1"
+            database: postgresql
+          - rails: "7.2"
+            ruby: "3.2"
+            database: mariadb
+          - rails: "7.2"
+            ruby: "3.3"
+            database: postgresql
+          - rails: "7.2"
+            ruby: "3.4"
+            database: sqlite
+          - rails: "8.0"
+            ruby: "3.4"
+            database: postgresql
+          - rails: "8.0"
+            ruby: "3.4"
+            database: mariadb
+          - rails: "8.0"
+            ruby: "3.4"
+            database: sqlite
 
     env:
       DB: ${{ matrix.database }}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -154,11 +154,13 @@ jobs:
         run: |
           bundle exec rspec
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
+        if: matrix.rails == '8.0' && matrix.ruby == '3.4' && matrix.database == 'postgresql'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: AlchemyCMS/alchemy_cms
-          file: ./coverage/coverage.xml
+          disable_search: true
+          files: ./coverage/coverage.xml
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/lib/alchemy/upgrader.rb
+++ b/lib/alchemy/upgrader.rb
@@ -1,11 +1,31 @@
 # frozen_string_literal: true
 
 require "alchemy/shell"
+require "thor"
 
 module Alchemy
   class Upgrader
-    extend Alchemy::Shell
+    include Alchemy::Shell
+    include Thor::Base
+    include Thor::Actions
 
-    Dir["#{File.dirname(__FILE__)}/upgrader/*.rb"].sort.each { |f| require f }
+    Dir["#{File.dirname(__FILE__)}/upgrader/*.rb"].sort.each { require(_1) }
+
+    VERSION_MODULE_MAP = {
+      "8.0" => "Alchemy::Upgrader::EightZero"
+    }
+
+    source_root Alchemy::Engine.root.join("lib/generators/alchemy/install")
+
+    def initialize(version)
+      super()
+      self.class.include VERSION_MODULE_MAP[version.to_s].constantize
+    end
+
+    def update_config
+      desc "Copy configuration file."
+
+      template("templates/alchemy.rb.tt", "config/initializers/alchemy.rb")
+    end
   end
 end

--- a/lib/alchemy/upgrader.rb
+++ b/lib/alchemy/upgrader.rb
@@ -27,5 +27,17 @@ module Alchemy
 
       template("templates/alchemy.rb.tt", "config/initializers/alchemy.rb")
     end
+
+    def run_migrations
+      ActiveRecord::Migration.check_all_pending!
+    rescue ActiveRecord::PendingMigrationError
+      desc "Pending Database migrations."
+      if yes?("Run database migrations now? (y/N)")
+        log "Migrating Database..."
+        Rake::Task["db:migrate"].invoke
+      else
+        log "Don't forget to run database migrations later with rake `db:migrate`.", :skip
+      end
+    end
   end
 end

--- a/lib/alchemy/upgrader/eight_zero.rb
+++ b/lib/alchemy/upgrader/eight_zero.rb
@@ -1,0 +1,14 @@
+module Alchemy
+  class Upgrader
+    module EightZero
+      def mention_alchemy_config_initializer
+        todo <<~TEXT, "Configuration has changed to initializer"
+          Check the new configuration file `./config/initializers/alchemy.rb` and
+          update values from your `config/alchemy/config.yml` file.
+
+          Then you can safely remove the `config/alchemy/config.yml` file.
+        TEXT
+      end
+    end
+  end
+end

--- a/lib/tasks/alchemy/upgrade.rake
+++ b/lib/tasks/alchemy/upgrade.rake
@@ -11,6 +11,7 @@ namespace :alchemy do
     "alchemy:upgrade:prepare",
     "alchemy:upgrade:8.0:run"
   ] do
+    Upgrader.run_migrations
     Upgrader.display_todos
   end
 
@@ -23,8 +24,7 @@ namespace :alchemy do
 
     desc "Alchemy Upgrader: Prepares the database."
     task database: [
-      "alchemy:install:migrations",
-      "db:migrate"
+      "alchemy:install:migrations"
     ]
 
     desc "Alchemy Upgrader: Update configuration file."

--- a/lib/tasks/alchemy/upgrade.rake
+++ b/lib/tasks/alchemy/upgrade.rake
@@ -3,12 +3,15 @@
 require "alchemy/upgrader"
 require "alchemy/version"
 
+Upgrader = Alchemy::Upgrader.new("8.0")
+
 namespace :alchemy do
   desc "Upgrades your app to AlchemyCMS v#{Alchemy::VERSION}."
   task upgrade: [
-    "alchemy:upgrade:prepare"
+    "alchemy:upgrade:prepare",
+    "alchemy:upgrade:8.0:run"
   ] do
-    Alchemy::Upgrader.display_todos
+    Upgrader.display_todos
   end
 
   namespace :upgrade do
@@ -23,5 +26,20 @@ namespace :alchemy do
       "alchemy:install:migrations",
       "db:migrate"
     ]
+
+    desc "Alchemy Upgrader: Update configuration file."
+    task config: [:environment] do
+      Upgrader.update_config
+    end
+
+    namespace "8.0" do
+      task "run" => [
+        "alchemy:upgrade:8.0:mention_alchemy_config_initializer"
+      ]
+
+      task :mention_alchemy_config_initializer do
+        Upgrader.mention_alchemy_config_initializer
+      end
+    end
   end
 end


### PR DESCRIPTION
## What is this pull request for?

We change our configuration to be an ruby file instead of
the `config/alchemy/config.yml` file. This yml file will still
be read from, but we encourage people to update their
config.

This changes how we setup the upgrader. We now instantiate
the upgrader instance in the rake task and include each version
as modules instead of individual classes. That way we can
make use of Thor actions much easier than before.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
