### PR TITLE
Pass picture to Picture.url_class

### DIFF
--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -30,17 +30,6 @@ module Alchemy
 
     CONVERTIBLE_FILE_FORMATS = %w[gif jpg jpeg png webp].freeze
 
-    TRANSFORMATION_OPTIONS = [
-      :crop,
-      :crop_from,
-      :crop_size,
-      :flatten,
-      :format,
-      :quality,
-      :size,
-      :upsample
-    ]
-
     include Alchemy::Logger
     include Alchemy::NameConversions
     include Alchemy::Taggable
@@ -160,26 +149,15 @@ module Alchemy
 
     # Returns an url (or relative path) to a processed image for use inside an image_tag helper.
     #
-    # Any additional options are passed to the url method, so you can add params to your url.
-    #
     # Example:
     #
     #   <%= image_tag picture.url(size: '320x200', format: 'png') %>
     #
-    # @see Alchemy::PictureVariant#call for transformation options
-    # @see Alchemy::Picture::Url#call for url options
     # @return [String|Nil]
     def url(options = {})
       return unless image_file
 
-      variant = PictureVariant.new(self, options.slice(*TRANSFORMATION_OPTIONS))
-      self.class.url_class.new(variant).call(
-        options.except(*TRANSFORMATION_OPTIONS).merge(
-          basename: name,
-          ext: variant.render_format,
-          name: name
-        )
-      )
+      self.class.url_class.new(self).call(options)
     rescue ::Dragonfly::Job::Fetch::NotFound => e
       log_warning(e.message)
       nil

--- a/lib/alchemy/test_support/having_picture_thumbnails_examples.rb
+++ b/lib/alchemy/test_support/having_picture_thumbnails_examples.rb
@@ -86,8 +86,8 @@ RSpec.shared_examples_for "having picture thumbnails" do
           allow(record).to receive(:settings) { {} }
         end
 
-        it "adds them to the url" do
-          expect(picture_url).to match(/\?foo=baz/)
+        it "does not add them to the url" do
+          expect(picture_url).to_not match(/\?foo=baz/)
         end
       end
     end

--- a/spec/models/alchemy/picture/url_spec.rb
+++ b/spec/models/alchemy/picture/url_spec.rb
@@ -5,31 +5,32 @@ require "rails_helper"
 RSpec.describe Alchemy::Picture::Url do
   let(:image) { fixture_file_upload("image.png") }
   let(:picture) { create(:alchemy_picture, image_file: image) }
-  let(:variant) { Alchemy::PictureVariant.new(picture) }
 
-  subject { described_class.new(variant).call(params) }
+  subject { described_class.new(picture).call(options) }
 
-  let(:params) { {} }
+  let(:options) { {} }
 
   it "returns the url to the image" do
-    is_expected.to match(/\/pictures\/.+\/image\.png\?sha=.+/)
+    is_expected.to match(/\/pictures\/.+\/image\.png\?name=image&sha=.+/)
   end
 
   context "when params are passed" do
-    let(:params) do
+    let(:options) do
       {
         page: 1,
         per_page: 10
       }
     end
 
-    it "passes them to the URL" do
-      is_expected.to match(/page=1/)
+    it "do not get passed to the URL" do
+      is_expected.to_not match(/page=1/)
     end
   end
 
   context "with a processed variant" do
-    let(:variant) { Alchemy::PictureVariant.new(picture, {size: "10x10"}) }
+    let(:options) do
+      {size: "10x10"}
+    end
 
     it "returns the url to the thumbnail" do
       is_expected.to match(/\/pictures\/\d+\/.+\/image\.png/)
@@ -39,6 +40,16 @@ RSpec.describe Alchemy::Picture::Url do
       writing_role = ActiveRecord.writing_role
       expect(ActiveRecord::Base).to receive(:connected_to).with(role: writing_role)
       subject
+    end
+  end
+
+  context "with format in options" do
+    let(:options) do
+      {format: "webp"}
+    end
+
+    it "adds format to url" do
+      is_expected.to match(/\/image\.webp$/)
     end
   end
 end

--- a/spec/models/alchemy/picture_spec.rb
+++ b/spec/models/alchemy/picture_spec.rb
@@ -294,8 +294,8 @@ module Alchemy
             }
           end
 
-          it "passes them to the URL" do
-            expect(url).to match(/page=1/)
+          it "are not passed to the URL" do
+            expect(url).to_not match(/page=1/)
           end
         end
       end


### PR DESCRIPTION
## What is this pull request for?

Moves the PictureVariant usage into the Url class. The variant is only used for the dragonfly url, so we move this implementation detail into this namespace.

This removes the debatable feature to pass additional params to the picture url. A feature that never made any sense and will not be supported in ActiveStorage.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
