### PR TITLE
Use Alchemy.config accessors instead of hash key

### DIFF
--- a/app/controllers/alchemy/admin/languages_controller.rb
+++ b/app/controllers/alchemy/admin/languages_controller.rb
@@ -14,7 +14,7 @@ module Alchemy
       def new
         @language = Language.new(
           site: @current_site,
-          page_layout: Alchemy.config.get(:default_language)["page_layout"]
+          page_layout: Alchemy.config.default_language.page_layout
         )
       end
 

--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -75,7 +75,7 @@ module Alchemy
         Current.preview_page = @page
         # Setting the locale to pages language, so the page content has it's correct translations.
         ::I18n.locale = @page.language.locale
-        render(layout: Alchemy.config.get(:admin_page_preview_layout) || "application")
+        render(layout: Alchemy.config.admin_page_preview_layout || "application")
       end
 
       def info

--- a/app/controllers/alchemy/admin/resources_controller.rb
+++ b/app/controllers/alchemy/admin/resources_controller.rb
@@ -134,11 +134,11 @@ module Alchemy
 
       def items_per_page
         cookies[:alchemy_items_per_page] =
-          params[:per_page] || cookies[:alchemy_items_per_page] || Alchemy.config.get(:items_per_page)
+          params[:per_page] || cookies[:alchemy_items_per_page] || Alchemy.config.items_per_page
       end
 
       def items_per_page_options
-        per_page = Alchemy.config.get(:items_per_page)
+        per_page = Alchemy.config.items_per_page
         [per_page, per_page * 2, per_page * 4]
       end
 

--- a/app/controllers/alchemy/messages_controller.rb
+++ b/app/controllers/alchemy/messages_controller.rb
@@ -74,7 +74,7 @@ module Alchemy
     private
 
     def mailer_config
-      Alchemy.config.get(:mailer)
+      Alchemy.config.mailer
     end
 
     def mail_to

--- a/app/helpers/alchemy/admin/base_helper.rb
+++ b/app/helpers/alchemy/admin/base_helper.rb
@@ -276,7 +276,7 @@ module Alchemy
 
       # Returns the regular expression used for external url validation in link dialog.
       def link_url_regexp
-        Alchemy.config.get(:format_matchers)["link_url"] || /^(mailto:|\/|[a-z]+:\/\/)/
+        Alchemy.config.format_matchers.link_url || /^(mailto:|\/|[a-z]+:\/\/)/
       end
 
       # Renders a hint with tooltip

--- a/app/helpers/alchemy/admin/pages_helper.rb
+++ b/app/helpers/alchemy/admin/pages_helper.rb
@@ -10,7 +10,7 @@ module Alchemy
       # You can configure the screen sizes in your +config/alchemy/config.yml+.
       #
       def preview_sizes_for_select
-        Alchemy.config.get(:page_preview_sizes).map do |size|
+        Alchemy.config.page_preview_sizes.map do |size|
           [Alchemy.t(size, scope: "preview_sizes"), size]
         end
       end

--- a/app/models/alchemy/attachment.rb
+++ b/app/models/alchemy/attachment.rb
@@ -76,7 +76,7 @@ module Alchemy
       end
 
       def allowed_filetypes
-        Alchemy.config.get(:uploader).fetch("allowed_filetypes", {}).fetch("alchemy/attachments", [])
+        Alchemy.config.uploader.allowed_filetypes.alchemy_attachments
       end
 
       def ransackable_scopes(_auth_object = nil)
@@ -85,7 +85,7 @@ module Alchemy
     end
 
     validates_presence_of :file
-    validates_size_of :file, maximum: Alchemy.config.get(:uploader)["file_size_limit"].megabytes
+    validates_size_of :file, maximum: Alchemy.config.uploader.file_size_limit.megabytes
     validate :file_type_allowed,
       unless: -> { self.class.allowed_filetypes.include?("*") }
 

--- a/app/models/alchemy/ingredient_validator.rb
+++ b/app/models/alchemy/ingredient_validator.rb
@@ -81,7 +81,7 @@ module Alchemy
 
     def validate_format(format)
       matcher = if format.is_a?(String) || format.is_a?(Symbol)
-        Alchemy.config.get("format_matchers").get(format)
+        Alchemy.config.format_matchers.get(format)
       else
         format
       end

--- a/app/models/alchemy/message.rb
+++ b/app/models/alchemy/message.rb
@@ -17,22 +17,22 @@ module Alchemy
     include ActiveModel::Model
 
     def self.config
-      Alchemy.config.get(:mailer)
+      Alchemy.config.mailer
     end
 
     attr_accessor :contact_form_id, :ip
 
-    config["fields"].each do |field|
+    Alchemy.config.mailer.fields.each do |field|
       attr_accessor field.to_sym
     end
 
-    config["validate_fields"].each do |field|
+    Alchemy.config.mailer.validate_fields.each do |field|
       validates_presence_of field
 
       case field.to_sym
       when /email/
         validates_format_of field,
-          with: Alchemy.config.get("format_matchers")["email"],
+          with: Alchemy.config.format_matchers.email,
           if: -> { send(field).present? }
       when :email_confirmation
         validates_confirmation_of :email

--- a/app/models/alchemy/message.rb
+++ b/app/models/alchemy/message.rb
@@ -16,10 +16,6 @@ module Alchemy
   class Message
     include ActiveModel::Model
 
-    def self.config
-      Alchemy.config.mailer
-    end
-
     attr_accessor :contact_form_id, :ip
 
     Alchemy.config.mailer.fields.each do |field|

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -244,7 +244,7 @@ module Alchemy
 
       def link_target_options
         options = [[Alchemy.t(:default, scope: "link_target_options"), ""]]
-        link_target_options = Alchemy.config.get(:link_target_options)
+        link_target_options = Alchemy.config.link_target_options
         link_target_options.each do |option|
           # add an underscore to the options to provide the default syntax
           # @link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target

--- a/app/models/alchemy/page/page_natures.rb
+++ b/app/models/alchemy/page/page_natures.rb
@@ -153,7 +153,7 @@ module Alchemy
       private
 
       def caching_enabled?
-        Alchemy.config.get(:cache_pages) &&
+        Alchemy.config.cache_pages &&
           Rails.application.config.action_controller.perform_caching
       end
     end

--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -88,12 +88,12 @@ module Alchemy
     # We need to define this method here to have it available in the validations below.
     class << self
       def allowed_filetypes
-        Alchemy.config.get(:uploader).fetch("allowed_filetypes", {}).fetch("alchemy/pictures", [])
+        Alchemy.config.uploader.allowed_filetypes.alchemy_pictures
       end
     end
 
     validates_presence_of :image_file
-    validates_size_of :image_file, maximum: Alchemy.config.get(:uploader)["file_size_limit"].megabytes
+    validates_size_of :image_file, maximum: Alchemy.config.uploader.file_size_limit.megabytes
     validate :image_file_type_allowed, if: -> { image_file.present? }
 
     stampable stamper_class_name: Alchemy.user_class_name
@@ -221,7 +221,7 @@ module Alchemy
     #
     def default_render_format
       if convertible?
-        Alchemy.config.get(:image_output_format)
+        Alchemy.config.image_output_format
       else
         image_file_extension
       end
@@ -233,8 +233,8 @@ module Alchemy
     # image has not a convertible file format (i.e. SVG) this returns +false+
     #
     def convertible?
-      Alchemy.config.get(:image_output_format) &&
-        Alchemy.config.get(:image_output_format) != "original" &&
+      Alchemy.config.image_output_format &&
+        Alchemy.config.image_output_format != "original" &&
         has_convertible_format?
     end
 

--- a/app/models/alchemy/picture/preprocessor.rb
+++ b/app/models/alchemy/picture/preprocessor.rb
@@ -14,7 +14,7 @@ module Alchemy
       #   preprocess_image_resize [String] - Downsizing example: '1000x1000>'
       #
       def call
-        max_image_size = Alchemy.config.get(:preprocess_image_resize)
+        max_image_size = Alchemy.config.preprocess_image_resize
         image_file.thumb!(max_image_size) if max_image_size.present?
         # Auto orient the image so EXIF orientation data is taken into account
         image_file.auto_orient!

--- a/app/models/alchemy/picture_variant.rb
+++ b/app/models/alchemy/picture_variant.rb
@@ -96,7 +96,7 @@ module Alchemy
       convert_format = render_format.sub("jpeg", "jpg") != picture.image_file_extension.sub("jpeg", "jpg")
 
       if encodable_image? && (convert_format || options[:quality])
-        quality = options[:quality] || Alchemy.config.get(:output_image_quality)
+        quality = options[:quality] || Alchemy.config.output_image_quality
         encoding_options << "-quality #{quality}"
       end
 

--- a/app/views/alchemy/admin/pages/_form.html.erb
+++ b/app/views/alchemy/admin/pages/_form.html.erb
@@ -11,7 +11,7 @@
       <div class="control_group">
         <%= render 'alchemy/admin/pages/publication_fields' %>
         <%= page_status_checkbox(@page, :restricted) %>
-        <% if configuration(:sitemap)['show_flag'] %>
+        <% if Alchemy.config.sitemap.show_flag %>
           <%= page_status_checkbox(@page, :sitemap) %>
         <% end %>
       </div>

--- a/app/views/alchemy/admin/uploader/_button.html.erb
+++ b/app/views/alchemy/admin/uploader/_button.html.erb
@@ -1,4 +1,4 @@
-<% file_types = configuration(:uploader)['allowed_filetypes'][object.class.model_name.collection] || ['*'] %>
+<% file_types = Alchemy.config.uploader.allowed_filetypes[object.class.model_name.collection] || ['*'] %>
 <% accept = file_types == ["*"] ? false : file_types.map {|type| ".#{type}"}.join(", ") %>
 
 <alchemy-uploader dropzone="<%= local_assigns[:dropzone] || "#main_content" %>">

--- a/app/views/alchemy/admin/uploader/_setup.html.erb
+++ b/app/views/alchemy/admin/uploader/_setup.html.erb
@@ -1,8 +1,8 @@
 <script>
   Alchemy.uploader_defaults = {
-    file_size_limit: <%= configuration(:uploader)['file_size_limit'] || 100 -%>,
-    upload_limit: <%= configuration(:uploader)['upload_limit'] || 50 -%>,
-    allowed_filetype_pictures: "<%= configuration(:uploader)['allowed_filetypes']['alchemy/pictures']&.join(", ") || '*' -%>", 
-    allowed_filetype_attachments: "<%= configuration(:uploader)['allowed_filetypes']['alchemy/attachments']&.join(", ") || '*' -%>", 
+    file_size_limit: <%= Alchemy.config.uploader.file_size_limit -%>,
+    upload_limit: <%= Alchemy.config.uploader.upload_limit -%>,
+    allowed_filetype_pictures: "<%= Alchemy.config.uploader.allowed_filetypes.alchemy_pictures.join(", ") -%>",
+    allowed_filetype_attachments: "<%= Alchemy.config.uploader.allowed_filetypes.alchemy_attachments.join(", ") -%>",
   }
 </script>

--- a/lib/alchemy/configuration_methods.rb
+++ b/lib/alchemy/configuration_methods.rb
@@ -12,9 +12,11 @@ module Alchemy
     #
     # Config file is in +config/alchemy/config.yml+
     #
+    # @deprecated - Use Alchemy.config.get instead
     def configuration(name)
       Alchemy.config.get(name)
     end
+    deprecate configuration: "Alchemy.config.get", deprecator: Alchemy::Deprecation
 
     # Returns true if more than one language is published on current site.
     #

--- a/lib/alchemy/configurations/main.rb
+++ b/lib/alchemy/configurations/main.rb
@@ -185,7 +185,7 @@ module Alchemy
       #
       # == Example:
       #
-      #   validates_format_of :url, with: Alchemy.config.get('format_matchers')['url']
+      #   validates_format_of :url, with: Alchemy.config.format_matchers.url
       #
       configuration :format_matchers, FormatMatchers
 

--- a/lib/alchemy/seeder.rb
+++ b/lib/alchemy/seeder.rb
@@ -116,7 +116,7 @@ module Alchemy
       # If no languages are present, create a default language based
       # on the host app's Alchemy configuration.
       def create_default_language!
-        default_language = Alchemy.config.get(:default_language)
+        default_language = Alchemy.config.default_language
         if default_language
           Alchemy::Language.create!(
             name: default_language["name"],
@@ -134,7 +134,7 @@ module Alchemy
       end
 
       def create_default_site!
-        default_site = Alchemy.config.get(:default_site)
+        default_site = Alchemy.config.default_site
         if default_site
           Alchemy::Site.create!(name: default_site["name"], host: default_site["host"])
         else

--- a/lib/alchemy/test_support/factories/language_factory.rb
+++ b/lib/alchemy/test_support/factories/language_factory.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     code { ::I18n.available_locales.first.to_s }
     default { true }
     frontpage_name { "Intro" }
-    page_layout { Alchemy.config.get(:default_language)["page_layout"] }
+    page_layout { Alchemy.config.default_language.page_layout }
 
     public { true }
 

--- a/lib/alchemy/test_support/factories/site_factory.rb
+++ b/lib/alchemy/test_support/factories/site_factory.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
     trait :default do
       public { true }
 
-      name { Alchemy.config.get(:default_site)["name"] }
-      host { Alchemy.config.get(:default_site)["host"] }
+      name { Alchemy.config.default_site.name }
+      host { Alchemy.config.default_site.host }
     end
 
     trait :public do

--- a/lib/generators/alchemy/install/templates/page_layouts.yml.tt
+++ b/lib/generators/alchemy/install/templates/page_layouts.yml.tt
@@ -3,7 +3,7 @@
 # For further information please see https://guides.alchemy-cms.com/pages.html
 
 <%- unless @options[:skip_demo_files] -%>
-- name: <%= Alchemy.config.get(:default_language)['page_layout'] %>
+- name: <%= Alchemy.config.default_language.page_layout %>
   unique: true
   elements: [article]
   autogenerate: [article]

--- a/spec/controllers/alchemy/admin/languages_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/languages_controller_spec.rb
@@ -65,7 +65,7 @@ describe Alchemy::Admin::LanguagesController do
       it "has default language's page_layout set" do
         get :new
         expect(assigns(:language).page_layout)
-          .to eq(Alchemy.config.get(:default_language)["page_layout"])
+          .to eq(Alchemy.config.default_language.page_layout)
       end
     end
   end

--- a/spec/controllers/alchemy/base_controller_spec.rb
+++ b/spec/controllers/alchemy/base_controller_spec.rb
@@ -29,8 +29,10 @@ module Alchemy
 
     describe "#configuration" do
       it "returns certain configuration options" do
-        allow(Alchemy.config).to receive(:some_option).and_return(true)
-        expect(controller.configuration(:some_option)).to eq(true)
+        Deprecation.silenced do
+          allow(Alchemy.config).to receive(:some_option).and_return(true)
+          expect(controller.configuration(:some_option)).to eq(true)
+        end
       end
     end
 

--- a/spec/controllers/alchemy/messages_controller_spec.rb
+++ b/spec/controllers/alchemy/messages_controller_spec.rb
@@ -265,7 +265,7 @@ module Alchemy
 
       context "when mailer_config['fields'] does not inlcude :contact_field_id" do
         it "should permit :contact_form_id" do
-          expect(Alchemy.config.get(:mailer)["fields"]).not_to include "contact_field_id"
+          expect(Alchemy.config.mailer.fields).not_to include "contact_field_id"
           msg_params = subject.send(:message_params)
 
           expect(msg_params).to include :contact_form_id

--- a/spec/features/admin/page_editing_feature_spec.rb
+++ b/spec/features/admin/page_editing_feature_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "Page editing feature", type: :system do
 
         context "with sitemaps show_flag config option set to true" do
           before do
-            stub_alchemy_config(:sitemap, {"show_flag" => true})
+            stub_alchemy_config(:sitemap, double(show_flag: true))
           end
 
           it "should show sitemap checkbox" do
@@ -103,7 +103,7 @@ RSpec.describe "Page editing feature", type: :system do
 
         context "with sitemaps show_flag config option set to false" do
           before do
-            stub_alchemy_config(:sitemap, {"show_flag" => false})
+            stub_alchemy_config(:sitemap, double(show_flag: false))
           end
 
           it "should not show sitemap checkbox" do

--- a/spec/helpers/alchemy/admin/base_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/base_helper_spec.rb
@@ -203,7 +203,7 @@ module Alchemy
       end
 
       context "if the expression from config is nil" do
-        before { stub_alchemy_config(:format_matchers, {link_url: nil}) }
+        before { stub_alchemy_config(:format_matchers, double(link_url: nil)) }
 
         it "returns the default expression" do
           expect(subject).to_not be_nil

--- a/spec/libraries/alchemy_spec.rb
+++ b/spec/libraries/alchemy_spec.rb
@@ -57,21 +57,21 @@ RSpec.describe Alchemy do
 
     describe "format matchers" do
       describe "email" do
-        subject { Alchemy.config.get("format_matchers")["email"] }
+        subject { Alchemy.config.format_matchers.email }
 
         it { is_expected.to match("hello@gmail.com") }
         it { is_expected.not_to match("stulli@gmx") }
       end
 
       describe "url" do
-        subject { Alchemy.config.get("format_matchers")["url"] }
+        subject { Alchemy.config.format_matchers.url }
 
         it { is_expected.to match("www.example.com:80/about") }
         it { is_expected.not_to match('www.example.com:80\/about') }
       end
 
       describe "link_url" do
-        subject { Alchemy.config.get("format_matchers")["link_url"] }
+        subject { Alchemy.config.format_matchers.link_url }
 
         it { is_expected.to match("tel:12345") }
         it { is_expected.to match("mailto:stulli@gmx.de") }

--- a/spec/models/alchemy/attachment_spec.rb
+++ b/spec/models/alchemy/attachment_spec.rb
@@ -153,8 +153,8 @@ module Alchemy
     describe "validations" do
       context "having a png, but only pdf allowed" do
         before do
-          allow(Alchemy.config).to receive(:get) do
-            {"allowed_filetypes" => {"alchemy/attachments" => ["pdf"]}}
+          allow(Alchemy.config.uploader.allowed_filetypes).to receive(:alchemy_attachments) do
+            ["pdf"]
           end
         end
 
@@ -166,8 +166,8 @@ module Alchemy
 
       context "having a png and everything allowed" do
         before do
-          allow(Alchemy.config).to receive(:get) do
-            {"allowed_filetypes" => {"alchemy/attachments" => ["*"]}}
+          allow(Alchemy.config.uploader.allowed_filetypes).to receive(:alchemy_attachments) do
+            ["*"]
           end
         end
 

--- a/spec/models/alchemy/message_spec.rb
+++ b/spec/models/alchemy/message_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe "Alchemy::Message" do
 
   describe ".config" do
     it "should return the mailer config" do
-      expect(Alchemy::Message.config).to eq(Alchemy.config.get(:mailer))
+      expect(Alchemy::Message.config).to eq(Alchemy.config.mailer)
     end
   end
 
   it "has attributes writers and getters for all fields defined in mailer config" do
-    Alchemy.config.get(:mailer)["fields"].each do |field|
+    Alchemy.config.mailer.fields.each do |field|
       expect(message).to respond_to(field)
       expect(message).to respond_to("#{field}=")
     end
@@ -21,7 +21,7 @@ RSpec.describe "Alchemy::Message" do
   context "validation of" do
     context "all fields defined in mailer config" do
       it "adds errors on that fields" do
-        Alchemy.config.get(:mailer)["validate_fields"].each do |field|
+        Alchemy.config.mailer.validate_fields.each do |field|
           expect(message).to_not be_valid
           expect(message.errors[field].size).to eq(1)
         end
@@ -30,10 +30,10 @@ RSpec.describe "Alchemy::Message" do
 
     context "field containing email in its name" do
       before do
-        stub_alchemy_config(:mailer, {
+        stub_alchemy_config(:mailer, double(
           fields: %w[email_of_my_boss],
           validate_fields: %w[email_of_my_boss]
-        }.with_indifferent_access)
+        ))
         Alchemy.send(:remove_const, :Message)
         load Alchemy::Engine.root.join("app/models/alchemy/message.rb")
       end

--- a/spec/models/alchemy/message_spec.rb
+++ b/spec/models/alchemy/message_spec.rb
@@ -5,12 +5,6 @@ require "rails_helper"
 RSpec.describe "Alchemy::Message" do
   let(:message) { Alchemy::Message.new }
 
-  describe ".config" do
-    it "should return the mailer config" do
-      expect(Alchemy::Message.config).to eq(Alchemy.config.mailer)
-    end
-  end
-
   it "has attributes writers and getters for all fields defined in mailer config" do
     Alchemy.config.mailer.fields.each do |field|
       expect(message).to respond_to(field)

--- a/spec/models/alchemy/picture_spec.rb
+++ b/spec/models/alchemy/picture_spec.rb
@@ -79,10 +79,8 @@ module Alchemy
 
       context "with > geometry string" do
         before do
-          allow(Alchemy.config).to receive(:get) do |arg|
-            if arg == :preprocess_image_resize
-              "10x10>"
-            end
+          allow(Alchemy.config).to receive(:preprocess_image_resize) do
+            "10x10>"
           end
         end
 
@@ -94,10 +92,8 @@ module Alchemy
 
       context "without > geometry string" do
         before do
-          allow(Alchemy.config).to receive(:get) do |arg|
-            if arg == :preprocess_image_resize
-              "10x10"
-            end
+          allow(Alchemy.config).to receive(:preprocess_image_resize) do
+            "10x10"
           end
         end
 


### PR DESCRIPTION
## What is this pull request for?

Instead of `Alchemy.config.get(:some_config)` we use `Alchemy.config.some_config`.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
