### PR TITLE
Use image_file_extension in picture validation

### DIFF
--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -281,8 +281,7 @@ module Alchemy
     private
 
     def image_file_type_allowed
-      symbol = Mime::Type.lookup_by_extension(image_file_format)&.symbol&.to_s.presence
-      unless symbol&.in?(self.class.allowed_filetypes)
+      unless image_file_extension&.in?(self.class.allowed_filetypes)
         errors.add(:image_file, Alchemy.t("not a valid image"))
       end
     end


### PR DESCRIPTION
## What is this pull request for?

We already have the `image_file_extension` method
that we can use to validate the file format with.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
