### PR TITLE
Remove admin attachments download action

### DIFF
--- a/app/controllers/alchemy/admin/attachments_controller.rb
+++ b/app/controllers/alchemy/admin/attachments_controller.rb
@@ -65,14 +65,6 @@ module Alchemy
         redirect_to alchemy.admin_attachments_path(**search_filter_params)
       end
 
-      def download
-        @attachment = Attachment.find(params[:id])
-        send_file @attachment.file.path, {
-          filename: @attachment.file_name,
-          type: @attachment.file_mime_type
-        }
-      end
-
       private
 
       def search_filter_params

--- a/app/views/alchemy/admin/attachments/_files_list.html.erb
+++ b/app/views/alchemy/admin/attachments/_files_list.html.erb
@@ -49,7 +49,7 @@
     <% table.with_action(:download) do |attachment| %>
       <sl-tooltip content="<%= Alchemy.t("download_file", filename: attachment.file_name) %>">
         <%= link_to render_icon(:download),
-          alchemy.download_admin_attachment_path(attachment),
+          alchemy.download_attachment_path(attachment),
           target: "_blank",
           class: "icon_button" %>
       </sl-tooltip>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,7 +68,6 @@ Alchemy::Engine.routes.draw do
 
     resources :attachments, except: [:new] do
       member do
-        get :download
         put :assign
       end
     end

--- a/spec/controllers/alchemy/admin/attachments_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/attachments_controller_spec.rb
@@ -204,17 +204,6 @@ module Alchemy
       end
     end
 
-    describe "#download" do
-      before do
-        expect(Attachment).to receive(:find).and_return(attachment)
-      end
-
-      it "sends the file as download" do
-        get :download, params: {id: attachment.id}
-        expect(response.headers["Content-Disposition"]).to match(/attachment/)
-      end
-    end
-
     describe "#assign" do
       let(:attachment) { create(:alchemy_attachment) }
 


### PR DESCRIPTION
## What is this pull request for?

We already have a attachments download controller. No need to have a second one we need to migrate
to ActiveStorage.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
