### PR TITLE
Remove non visual custom elements after connect

### DIFF
--- a/app/javascript/alchemy_admin/components/action.js
+++ b/app/javascript/alchemy_admin/components/action.js
@@ -27,6 +27,8 @@ class Action extends HTMLElement {
     } else {
       console.error(`Unknown Alchemy action: ${this.name}`)
     }
+
+    this.remove()
   }
 
   get name() {

--- a/app/javascript/alchemy_admin/components/growl.js
+++ b/app/javascript/alchemy_admin/components/growl.js
@@ -3,6 +3,7 @@ import { growl } from "alchemy_admin/growler"
 class Growl extends HTMLElement {
   connectedCallback() {
     growl(this.message, this.getAttribute("type") || "notice")
+    this.remove()
   }
 
   get message() {

--- a/spec/javascript/alchemy_admin/components/action.spec.js
+++ b/spec/javascript/alchemy_admin/components/action.spec.js
@@ -53,4 +53,12 @@ describe("alchemy-action", () => {
     )
     expect(closeCurrentDialog).toBeCalled()
   })
+
+  it("removes the element from DOM after connected to the DOM", () => {
+    renderComponent(
+      "alchemy-action",
+      `<alchemy-action name="closeCurrentDialog"></alchemy-action>`
+    )
+    expect(document.querySelector("alchemy-action")).toBeNull()
+  })
 })

--- a/spec/javascript/alchemy_admin/components/growl.spec.js
+++ b/spec/javascript/alchemy_admin/components/growl.spec.js
@@ -21,4 +21,13 @@ describe("alchemy-growl", () => {
     const message = document.querySelector("alchemy-message")
     expect(message.textContent).toMatch("Foo Bar")
   })
+
+  it("removes element from DOM after connect", () => {
+    const html = `
+      <div id="flash_notices"></div>
+      <alchemy-growl>Foo Bar</alchemy-growl>
+    `
+    renderComponent("alchemy-growl", html)
+    expect(document.querySelector("alchemy-growl")).toBeNull()
+  })
 })


### PR DESCRIPTION
## What is this pull request for?

Removes the `<alchemy-action>` and `<alchemy-growl>` custom elements
from DOM after connecting them. We render them from turbo stream responses
to trigger functions. The element itself does not have any visual content.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
