### PR TITLE
fix(PictureThumbnails): Do not fail if size is nil

### DIFF
--- a/app/models/concerns/alchemy/picture_thumbnails.rb
+++ b/app/models/concerns/alchemy/picture_thumbnails.rb
@@ -114,7 +114,11 @@ module Alchemy
       return true if settings[:upsample]
 
       dimensions = inferred_dimensions_from_string(settings[:size])
-      picture.image_file_width > dimensions[0] && picture.image_file_height > dimensions[1]
+      if dimensions
+        picture.image_file_width > dimensions[0] && picture.image_file_height > dimensions[1]
+      else
+        false
+      end
     end
 
     def default_crop_size

--- a/lib/alchemy/test_support/having_picture_thumbnails_examples.rb
+++ b/lib/alchemy/test_support/having_picture_thumbnails_examples.rb
@@ -689,6 +689,12 @@ RSpec.shared_examples_for "having picture thumbnails" do
             let(:picture) { build(:alchemy_picture) }
 
             it { is_expected.to be(true) }
+
+            context "with size setting being nil" do
+              let(:size) { nil }
+
+              it { is_expected.to be_falsey }
+            end
           end
         end
       end


### PR DESCRIPTION
## What is this pull request for?

If `settings[:size]` is nil we must not allow image cropping, instead of causing a NilClass exception.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
