### PR TITLE
Add server error turbo_stream template

### DIFF
--- a/app/views/alchemy/base/500.turbo_stream.erb
+++ b/app/views/alchemy/base/500.turbo_stream.erb
@@ -1,0 +1,3 @@
+<alchemy-growl type="error">
+  <%= @notice %>
+</alchemy-growl>


### PR DESCRIPTION
## What is this pull request for?

If we do a Turbo Frame request that causes
an error, we want to see the error message
in an Alchemy Alert.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
