### PR TITLE
Fix multi language picture descriptions

### DIFF
--- a/app/controllers/alchemy/admin/picture_descriptions_controller.rb
+++ b/app/controllers/alchemy/admin/picture_descriptions_controller.rb
@@ -1,8 +1,12 @@
 module Alchemy
   module Admin
     class PictureDescriptionsController < Alchemy::Admin::ResourcesController
+      include PictureDescriptionsFormHelper
+
       def edit
-        @picture_description = @picture.descriptions.find_or_initialize_by(language_id: params[:language_id])
+        @picture_description = @picture.descriptions.find_or_initialize_by(
+          language_id: params[:language_id]
+        )
       end
 
       private

--- a/app/controllers/alchemy/admin/pictures_controller.rb
+++ b/app/controllers/alchemy/admin/pictures_controller.rb
@@ -6,6 +6,7 @@ module Alchemy
       include UploaderResponses
       include ArchiveOverlay
       include CurrentLanguage
+      include PictureDescriptionsFormHelper
 
       helper "alchemy/admin/tags"
 

--- a/app/controllers/concerns/alchemy/admin/picture_descriptions_form_helper.rb
+++ b/app/controllers/concerns/alchemy/admin/picture_descriptions_form_helper.rb
@@ -1,0 +1,16 @@
+module Alchemy
+  module Admin
+    module PictureDescriptionsFormHelper
+      extend ActiveSupport::Concern
+
+      included do
+        helper_method :description_field_name_prefix
+      end
+
+      def description_field_name_prefix
+        picture_description_counter = @picture.descriptions.index(@picture_description)
+        "picture[descriptions_attributes][#{picture_description_counter}]"
+      end
+    end
+  end
+end

--- a/app/views/alchemy/admin/picture_descriptions/_form.html.erb
+++ b/app/views/alchemy/admin/picture_descriptions/_form.html.erb
@@ -8,4 +8,4 @@
 <% end %>
 
 <%= label field_name_prefix, :text, Alchemy::PictureDescription.human_attribute_name(:text), class: "control-label" %>
-<%= text_area field_name_prefix, :text, value: picture_description.text, rows: 3 %>
+<%= text_area field_name_prefix, :text, value: picture_description.text, rows: 5 %>

--- a/app/views/alchemy/admin/picture_descriptions/_form.html.erb
+++ b/app/views/alchemy/admin/picture_descriptions/_form.html.erb
@@ -1,11 +1,9 @@
-<% field_name_prefix = "picture[descriptions_attributes][#{picture_description_counter}]" %>
-
 <% if picture_description.persisted? %>
-  <%= hidden_field field_name_prefix, :id, value: picture_description.id %>
+  <%= hidden_field description_field_name_prefix, :id, value: picture_description.id %>
 <% else %>
-  <%= hidden_field field_name_prefix, :language_id, value: picture_description.language_id %>
-  <%= hidden_field field_name_prefix, :picture_id, value: picture_description.picture_id %>
+  <%= hidden_field description_field_name_prefix, :language_id, value: picture_description.language_id %>
+  <%= hidden_field description_field_name_prefix, :picture_id, value: picture_description.picture_id %>
 <% end %>
 
-<%= label field_name_prefix, :text, Alchemy::PictureDescription.human_attribute_name(:text), class: "control-label" %>
-<%= text_area field_name_prefix, :text, value: picture_description.text, rows: 5 %>
+<%= label description_field_name_prefix, :text, Alchemy::PictureDescription.human_attribute_name(:text), class: "control-label" %>
+<%= text_area description_field_name_prefix, :text, value: picture_description.text, rows: 5 %>

--- a/app/views/alchemy/admin/picture_descriptions/edit.html.erb
+++ b/app/views/alchemy/admin/picture_descriptions/edit.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="picture_descriptions">
   <%= render "form", {
-    picture_description: @picture_description,
-    picture_description_counter: @picture.descriptions.index(@picture_description)
+    description_field_name_prefix: description_field_name_prefix,
+    picture_description: @picture_description
   } %>
 </turbo-frame>

--- a/app/views/alchemy/admin/pictures/_form.html.erb
+++ b/app/views/alchemy/admin/pictures/_form.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag(@picture) do %>
-  <%= alchemy_form_for [:admin, @picture] do |f| %>
+  <%= alchemy_form_for [alchemy, :admin, @picture] do |f| %>
     <%= f.input :name %>
-    <%= render "picture_description_field", f: f %>
+    <%= render "alchemy/admin/pictures/picture_description_field", f: f %>
     <%= render Alchemy::Admin::TagsAutocomplete.new(additional_class: "input") do %>
       <%= f.label :tag_list %>
       <%= f.text_field :tag_list, value: f.object.tag_list.join(",") %>

--- a/app/views/alchemy/admin/pictures/_picture_description_field.html.erb
+++ b/app/views/alchemy/admin/pictures/_picture_description_field.html.erb
@@ -2,30 +2,38 @@
   <% if Alchemy::Language.published.many? %>
     <label class="inline-label" style="float: right">
       <%= Alchemy::Language.model_name.human %>
-      <%= select_tag :language_id, options_from_collection_for_select(
+      <%= select description_field_name_prefix, :language_id, options_from_collection_for_select(
           Alchemy::Language.published, :id, ->(l) { l.code.upcase },
           selected: @picture_description.language_id,
-        ), data: {
-          url: alchemy.edit_admin_picture_description_url(id: "__ID__", picture_id: @picture)
+        ),
+        {},
+        id: "picture_description_select",
+        data: {
+          url: alchemy.edit_admin_picture_description_url(
+            id: @picture_description.id || "__ID__",
+            picture_id: @picture
+          )
         } %>
     </label>
   <% end %>
 
   <turbo-frame id="picture_descriptions">
     <%= render "alchemy/admin/picture_descriptions/form",
-      picture_description_counter: @picture.descriptions.index(@picture_description),
+      description_field_name_prefix: description_field_name_prefix,
       picture_description: @picture_description %>
   </turbo-frame>
 </div>
 
-<script type="module">
-  const select = document.querySelector("#language_id")
+<script>
+  (function ($) {
+    const select = $.getElementById("picture_description_select")
 
-  if (select) {
-    select.addEventListener("change", () => {
-      const url = new URL(select.dataset.url)
-      url.searchParams.set("language_id", select.value)
-      Turbo.visit(url, { frame: "picture_descriptions" })
-    })
-  }
+    if (select) {
+      select.addEventListener("change", () => {
+        const url = new URL(select.dataset.url)
+        url.searchParams.set("language_id", select.value)
+        Turbo.visit(url, { frame: "picture_descriptions" })
+      })
+    }
+  })(document)
 </script>

--- a/db/migrate/20250626160259_add_unique_index_to_picture_descriptions.rb
+++ b/db/migrate/20250626160259_add_unique_index_to_picture_descriptions.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexToPictureDescriptions < ActiveRecord::Migration[7.0]
+  def change
+    add_index :alchemy_picture_descriptions, [:picture_id, :language_id],
+      name: "alchemy_picture_descriptions_on_picture_id_and_language_id",
+      unique: true
+  end
+end

--- a/spec/dummy/db/migrate/20250626160417_add_unique_index_to_picture_descriptions.alchemy.rb
+++ b/spec/dummy/db/migrate/20250626160417_add_unique_index_to_picture_descriptions.alchemy.rb
@@ -1,0 +1,8 @@
+# This migration comes from alchemy (originally 20250626160259)
+class AddUniqueIndexToPictureDescriptions < ActiveRecord::Migration[7.0]
+  def change
+    add_index :alchemy_picture_descriptions, [:picture_id, :language_id],
+      name: "alchemy_picture_descriptions_on_picture_id_and_language_id",
+      unique: true
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_04_11_155901) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_26_160417) do
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string "name"
     t.string "file_name"
@@ -193,6 +193,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_04_11_155901) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["language_id"], name: "index_alchemy_picture_descriptions_on_language_id"
+    t.index ["picture_id", "language_id"], name: "alchemy_picture_descriptions_on_picture_id_and_language_id", unique: true
     t.index ["picture_id"], name: "index_alchemy_picture_descriptions_on_picture_id"
   end
 

--- a/spec/features/admin/picture_library_integration_spec.rb
+++ b/spec/features/admin/picture_library_integration_spec.rb
@@ -112,6 +112,10 @@ RSpec.describe "Picture Library", type: :system do
       end
       select(language.language_code.upcase, from: "Language")
       expect(page).to have_field("Description", with: "This is an amazing image.")
+
+      expect(picture.descriptions.size).to eq(2)
+      expect(picture.descriptions.find_by(language: german).text).to eq("Tolles Bild.")
+      expect(picture.descriptions.find_by(language: language).text).to eq("This is an amazing image.")
     end
   end
 

--- a/spec/views/admin/pictures/show_spec.rb
+++ b/spec/views/admin/pictures/show_spec.rb
@@ -29,6 +29,7 @@ describe "alchemy/admin/pictures/show.html.erb" do
     allow(view).to receive(:admin_picture_path).and_return("/path")
     allow(view).to receive(:edit_admin_page_path).and_return("/path")
     allow(view).to receive(:render_message)
+    allow(view).to receive(:description_field_name_prefix) { "prefix" }
     allow(view).to receive(:search_filter_params) { {} }
     view.extend Alchemy::Admin::FormHelper
     view.extend Alchemy::BaseHelper


### PR DESCRIPTION
## What is this pull request for?

Several fixes and tweaks to make multi language picture descriptions actually work like expected.

1. Make picture form partial be reusable
2. Add more rows to the picture description textarea
3. Fix persisting multi language picture descriptions
4. Add a uniqueness constraint to the `alchemy_picture_descriptions` table on `picture_id` and `language_id` columns

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
