### PR TITLE
Fix yaml syntax in dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,27 +7,27 @@ updates:
     groups:
       babel:
         dependency-type: "development"
-          patterns:
-            - "@babel/*"
-          update-types:
-            - "minor"
-            - "patch"
+        patterns:
+          - "@babel/*"
+        update-types:
+          - "minor"
+          - "patch"
       jest:
         dependency-type: "development"
-          patterns:
-            - "jest*"
-            - "babel-jest"
-          update-types:
-            - "minor"
-            - "patch"
+        patterns:
+          - "jest*"
+          - "babel-jest"
+        update-types:
+          - "minor"
+          - "patch"
       rollup:
         dependency-type: "development"
-          patterns:
-            - "@rollup/*"
-            - "rollup"
-          update-types:
-            - "minor"
-            - "patch"
+        patterns:
+          - "@rollup/*"
+          - "rollup"
+        update-types:
+          - "minor"
+          - "patch"
       versioning-strategy: increase-if-necessary
   - package-ecosystem: "bundler"
     directory: "/"


### PR DESCRIPTION
This has been an issue since c16fbbc15febdcf11d49dd33d2823657bbe7d0ec
