### PR TITLE
refactor(uploader): Do not use arguments in constructor

### DIFF
--- a/app/javascript/alchemy_admin/components/uploader.js
+++ b/app/javascript/alchemy_admin/components/uploader.js
@@ -68,7 +68,8 @@ export class Uploader extends AlchemyHTMLElement {
 
     const fileUploads = files.map((file) => {
       const request = new XMLHttpRequest()
-      const fileUpload = new FileUpload(file, request)
+      const fileUpload = new FileUpload()
+      fileUpload.initialize(file, request)
 
       if (Alchemy.uploader_defaults.upload_limit - 1 < fileUploadCount) {
         fileUpload.valid = false
@@ -110,7 +111,8 @@ export class Uploader extends AlchemyHTMLElement {
       this.uploadProgress.cancel()
       document.body.removeChild(this.uploadProgress)
     }
-    this.uploadProgress = new Progress(fileUploads)
+    this.uploadProgress = new Progress()
+    this.uploadProgress.initialize(fileUploads)
     this.uploadProgress.onComplete = (status) => {
       this.dispatchCustomEvent(`upload.${status}`)
     }

--- a/app/javascript/alchemy_admin/components/uploader/file_upload.js
+++ b/app/javascript/alchemy_admin/components/uploader/file_upload.js
@@ -4,21 +4,28 @@ import { translate } from "alchemy_admin/i18n"
 import { growl } from "alchemy_admin/growler"
 
 export class FileUpload extends AlchemyHTMLElement {
-  /**
-   * @param {File} file
-   * @param {XMLHttpRequest} request
-   */
-  constructor(file, request) {
-    super({})
+  constructor() {
+    super()
 
-    this.file = file
-    this.request = request
+    this.file = null
+    this.request = null
 
     this.progressEventLoaded = 0
-    this.progressEventTotal = file ? file.size : 0
+    this.progressEventTotal = 0
     this.className = "in-progress"
     this.valid = true
     this.value = 0
+  }
+
+  /**
+   * Initialize the component with file and request
+   * @param {File} file
+   * @param {XMLHttpRequest} request
+   */
+  initialize(file, request) {
+    this.file = file
+    this.request = request
+    this.progressEventTotal = file ? file.size : 0
 
     this._validateFile()
     this._addRequestEventListener()

--- a/app/javascript/alchemy_admin/components/uploader/progress.js
+++ b/app/javascript/alchemy_admin/components/uploader/progress.js
@@ -6,17 +6,23 @@ import { translate } from "alchemy_admin/i18n"
 export class Progress extends AlchemyHTMLElement {
   #visible = false
 
-  /**
-   * @param {FileUpload[]} fileUploads
-   */
-  constructor(fileUploads = []) {
+  constructor() {
     super()
     this.buttonLabel = translate("Cancel all uploads")
-    this.fileUploads = fileUploads
-    this.fileCount = fileUploads.length
+    this.fileUploads = []
+    this.fileCount = 0
     this.className = "in-progress"
     this.visible = true
     this.handleFileChange = () => this._updateView()
+  }
+
+  /**
+   * Initialize the component with file uploads
+   * @param {FileUpload[]} fileUploads
+   */
+  initialize(fileUploads = []) {
+    this.fileUploads = fileUploads
+    this.fileCount = fileUploads.length
   }
 
   /**

--- a/spec/javascript/alchemy_admin/components/uploader/file_upload.spec.js
+++ b/spec/javascript/alchemy_admin/components/uploader/file_upload.spec.js
@@ -45,12 +45,13 @@ describe("alchemy-file-upload", () => {
   }
 
   /**
-   * initialize file progress component with the correct constructor
+   * initialize file progress component with the correct initialization
    * @param {File} file the default file has a size of 100 B
    * @param {XMLHttpRequest} request default request
    */
   const renderComponent = (file = testFile, request = mockXMLHttpRequest()) => {
-    component = new FileUpload(file, request)
+    component = new FileUpload()
+    component.initialize(file, request)
     document.body.innerHTML = "" // reset previous content to prevent raise conditions
     document.body.append(component)
 

--- a/spec/javascript/alchemy_admin/components/uploader/progress.spec.js
+++ b/spec/javascript/alchemy_admin/components/uploader/progress.spec.js
@@ -42,16 +42,25 @@ describe("alchemy-upload-progress", () => {
   }
 
   /**
-   * initialize upload progress component with the correct constructor
+   * initialize upload progress component with the correct initialization
    * @param {FileUpload[]} fileUploads
    */
   const renderComponent = (
     fileUploads = [
-      new FileUpload(firstFile, mockXMLHttpRequest()),
-      new FileUpload(secondFile, mockXMLHttpRequest())
+      (() => {
+        const upload1 = new FileUpload()
+        upload1.initialize(firstFile, mockXMLHttpRequest())
+        return upload1
+      })(),
+      (() => {
+        const upload2 = new FileUpload()
+        upload2.initialize(secondFile, mockXMLHttpRequest())
+        return upload2
+      })()
     ]
   ) => {
-    component = new Progress(fileUploads)
+    component = new Progress()
+    component.initialize(fileUploads)
 
     document.body.append(component)
 
@@ -185,13 +194,14 @@ describe("alchemy-upload-progress", () => {
       })
 
       it("should marked progress as failed if one upload was not successful", async () => {
-        const failedUpload = new FileUpload(secondFile, mockXMLHttpRequest())
+        const failedUpload = new FileUpload()
+        failedUpload.initialize(secondFile, mockXMLHttpRequest())
         failedUpload.status = "failed"
 
-        renderComponent([
-          new FileUpload(firstFile, mockXMLHttpRequest()),
-          failedUpload
-        ])
+        const successfulUpload = new FileUpload()
+        successfulUpload.initialize(firstFile, mockXMLHttpRequest())
+
+        renderComponent([successfulUpload, failedUpload])
 
         expect(component.status).toEqual("failed")
       })
@@ -321,7 +331,8 @@ describe("alchemy-upload-progress", () => {
 
   describe("cancel", () => {
     it("should call the cancel - action file upload", () => {
-      const fileUpload = new FileUpload(firstFile, mockXMLHttpRequest())
+      const fileUpload = new FileUpload()
+      fileUpload.initialize(firstFile, mockXMLHttpRequest())
       fileUpload.cancel = jest.fn()
 
       renderComponent([fileUpload])
@@ -336,8 +347,10 @@ describe("alchemy-upload-progress", () => {
     })
 
     it("should call only active file uploads", () => {
-      const activeFileUpload = new FileUpload(firstFile, mockXMLHttpRequest())
-      const uploadedFileUpload = new FileUpload(firstFile, mockXMLHttpRequest())
+      const activeFileUpload = new FileUpload()
+      activeFileUpload.initialize(firstFile, mockXMLHttpRequest())
+      const uploadedFileUpload = new FileUpload()
+      uploadedFileUpload.initialize(firstFile, mockXMLHttpRequest())
       activeFileUpload.cancel = jest.fn()
       uploadedFileUpload.cancel = jest.fn()
       uploadedFileUpload.status = "canceled"


### PR DESCRIPTION
## What is this pull request for?

Using custom elements like this is no compliant to the spec. You must not have arguments passed to the constructor as the browser won't be able to do that.

This prepares these file to be tested with Vitest instead of Jest.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
