### PR TITLE
Fix XMLHttpRequest AggregateError in Vitest test suite

### DIFF
--- a/spec/javascript/alchemy_admin/setup.js
+++ b/spec/javascript/alchemy_admin/setup.js
@@ -5,8 +5,85 @@ import jQuery from "jquery"
 globalThis.$ = jQuery
 globalThis.jQuery = jQuery
 
-// Import select2 and make it available
-import("select2")
+// Mock select2 to avoid network requests in jsdom environment
+globalThis.jQuery.fn.select2 = function (options) {
+  // Mock select2 initialization
+  const $element = this
+
+  // Add basic select2 classes and structure for tests
+  if (!$element.next(".select2-container").length) {
+    const container = jQuery(
+      '<div class="select2-container alchemy_selectbox"></div>'
+    )
+
+    // Add clear button if allowClear is enabled
+    if (options?.allowClear) {
+      container.append('<span class="select2-search-choice-close"></span>')
+    }
+
+    $element.after(container)
+  }
+
+  return $element
+}
+
+// Mock select2 static methods if needed
+globalThis.jQuery.fn.select2.defaults = {}
+
+// Mock TinyMCE to avoid network requests in jsdom environment
+globalThis.tinymce = {
+  init: vi.fn().mockResolvedValue([]),
+  get: vi.fn().mockReturnValue({
+    remove: vi.fn(),
+    show: vi.fn(),
+    on: vi.fn()
+  }),
+  remove: vi.fn()
+}
+
+// Mock select2 module to avoid network requests
+vi.mock("select2", () => ({}))
+
+// Mock dynamic imports to avoid network requests
+vi.mock("flatpickr/en.js", () => ({}))
+vi.mock("flatpickr/de.js", () => ({}))
+vi.mock("flatpickr/es.js", () => ({}))
+vi.mock("flatpickr/fr.js", () => ({}))
+vi.mock("flatpickr/it.js", () => ({}))
+vi.mock("flatpickr/nl.js", () => ({}))
+vi.mock("flatpickr/pt.js", () => ({}))
+vi.mock("flatpickr/ru.js", () => ({}))
+vi.mock("flatpickr/zh.js", () => ({}))
+
+// Mock fetch to avoid network requests
+globalThis.fetch = vi.fn().mockResolvedValue({
+  ok: true,
+  status: 200,
+  json: vi.fn().mockResolvedValue({}),
+  text: vi.fn().mockResolvedValue(""),
+  headers: {
+    get: vi.fn().mockReturnValue("application/json")
+  }
+})
+
+// Mock XMLHttpRequest to avoid network requests
+globalThis.XMLHttpRequest = vi.fn(() => ({
+  open: vi.fn(),
+  send: vi.fn(),
+  setRequestHeader: vi.fn(),
+  abort: vi.fn(),
+  status: 200,
+  readyState: 4,
+  responseText: "",
+  response: "",
+  upload: {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    onprogress: vi.fn()
+  },
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn()
+}))
 
 // Mock matchMedia for components that use it
 Object.defineProperty(window, "matchMedia", {


### PR DESCRIPTION
## What is this pull request for?

Resolves XMLHttpRequest network request failures in jsdom test environment by implementing comprehensive mocking strategy and cleaning up redundant test code.

Tests were logging errors with XMLHttpRequest AggregateError due to JavaScript libraries (select2, TinyMCE, flatpickr) attempting network requests in jsdom environment, which lacks a real network stack.

Implemented a two-tier mocking strategy:

1. **Global Network Mocking** (setup.js):
   - Mock select2 module and jQuery plugin to prevent CSS/asset loading
   - Mock TinyMCE global object to prevent language file requests
   - Mock flatpickr locale imports to prevent dynamic import failures
   - Add comprehensive fetch and XMLHttpRequest mocks for any remaining requests
   - Fixed XMLHttpRequest mock to create unique instances per constructor call

2. **Preserved Component-Specific Mocks**:
   - Kept specialized XMLHttpRequest mocks in file_upload.spec.js and progress.spec.js that test actual upload lifecycle behavior
   - These mocks simulate onload, onerror, and progress events essential for testing upload functionality

3. **Cleaned Up Redundant Code** (uploader.spec.js):
   - Removed local XMLHttpRequest mock that duplicated global functionality
   - Fixed test expectations to account for actual component behavior (XMLHttpRequest created for all files, then validation occurs)
   - Added proper mock clearing between test groups

- **Global mocks** prevent network requests and errors during test execution
- **Component-specific mocks** preserve testing of actual XMLHttpRequest behavior
- **Separation of concerns** between preventing errors vs testing functionality
- **Maintains test coverage** while eliminating flaky network-dependent failures

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
