### PR TITLE
Resources Admin: Fix editing with filters

### DIFF
--- a/app/views/alchemy/base/redirect.js.erb
+++ b/app/views/alchemy/base/redirect.js.erb
@@ -1,7 +1,7 @@
 (function() {
   var dialog = Alchemy.currentDialog();
   var callback = function() {
-    Turbo.visit('<%= url_for(@redirect_url) %>');
+    Turbo.visit('<%= url_for(@redirect_url).html_safe %>');
   };
   if (dialog) {
     Alchemy.closeCurrentDialog(callback);

--- a/spec/features/admin/resources_integration_spec.rb
+++ b/spec/features/admin/resources_integration_spec.rb
@@ -435,4 +435,36 @@ RSpec.describe "Resources", type: :system do
       end
     end
   end
+
+  context "Editing resources with filters present" do
+    let(:office) { create(:location, name: "Office") }
+    let(:showroom) { create(:location, name: "Showroom") }
+    let!(:event_1) { create(:event, name: "Meeting 1", location: office) }
+    let!(:event_2) { create(:event, name: "Meeting 2", location: showroom) }
+    let!(:event_3) { create(:event, name: "Show", location: office) }
+
+    it "allows filtering the view and keeping filters while editing" do
+      visit admin_events_path(params: {
+        q: {
+          by_location_id: office.id,
+          name_or_hidden_name_or_description_or_location_name_cont: "Meeting"
+        }
+      })
+
+      expect(page).to have_content("Meeting 1")
+      expect(page).not_to have_content("Meeting 2")
+      expect(page).not_to have_content("Show")
+
+      # Edit an event
+      within("tr", text: "Meeting 1") do
+        click_link_with_tooltip("Edit")
+      end
+      fill_in "Name", with: "Updated Meeting 1"
+      click_button "Save"
+
+      expect(page).to have_content("Updated Meeting 1")
+      expect(page).not_to have_content("Meeting 2")
+      expect(page).not_to have_content("Show")
+    end
+  end
 end


### PR DESCRIPTION

## What is this pull request for?

Without this change, admins would lose all but the first of their search filters on editing a resource, because the `&` between subsequent filters would be escaped to `&amp;`, making the values appear in the params hash as `params[amp;q]`. This parameter would not be recognized as search parameter and discarded.

### Notable changes (remove if none)

Fix only 

### Screenshots

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
