### PR TITLE
Resources Admin: Display search string in search field

### DIFF
--- a/app/views/alchemy/admin/partials/_search_form.html.erb
+++ b/app/views/alchemy/admin/partials/_search_form.html.erb
@@ -8,6 +8,7 @@
       <%= render_icon('search') %>
     </button>
     <%= f.search_field resource_handler.search_field_name,
+      value: params.dig(:q, resource_handler.search_field_name),
       class: 'search_input_field',
       placeholder: Alchemy.t(:search) %>
     <%= link_to render_icon(:times, size: '1x'), url,

--- a/spec/features/admin/resources_integration_spec.rb
+++ b/spec/features/admin/resources_integration_spec.rb
@@ -441,7 +441,7 @@ RSpec.describe "Resources", type: :system do
     let(:showroom) { create(:location, name: "Showroom") }
     let!(:event_1) { create(:event, name: "Meeting 1", location: office) }
     let!(:event_2) { create(:event, name: "Meeting 2", location: showroom) }
-    let!(:event_3) { create(:event, name: "Show", location: office) }
+    let!(:event_3) { create(:event, name: "Karaoke", location: office) }
 
     it "allows filtering the view and keeping filters while editing" do
       visit admin_events_path(params: {
@@ -450,10 +450,11 @@ RSpec.describe "Resources", type: :system do
           name_or_hidden_name_or_description_or_location_name_cont: "Meeting"
         }
       })
+      expect(page).to have_selector(".search_field input[value='Meeting']")
 
       expect(page).to have_content("Meeting 1")
       expect(page).not_to have_content("Meeting 2")
-      expect(page).not_to have_content("Show")
+      expect(page).not_to have_content("Karaoke")
 
       # Edit an event
       within("tr", text: "Meeting 1") do
@@ -464,7 +465,7 @@ RSpec.describe "Resources", type: :system do
 
       expect(page).to have_content("Updated Meeting 1")
       expect(page).not_to have_content("Meeting 2")
-      expect(page).not_to have_content("Show")
+      expect(page).not_to have_content("Karaoke")
     end
   end
 end


### PR DESCRIPTION

## What is this pull request for?

When navigating around the resources admin for e.g. events, and having searched in the standard search field, it's nice to have that search field's value prefilled with whatever has been searched for before so that one does not lose the search term on the next navigation.

This also changes the spec to use "Karaoke" instead of "Show" because there's a lot of "Show" in a CRUD admin.


### Screenshots

The "Meeting" here is the string in question:

<img width="222" height="86" alt="grafik" src="https://github.com/user-attachments/assets/263801cd-ab08-4cf9-8a57-6859a20bc345" />

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
