### PR TITLE
[7.4-stable] Display current search string in resource search field

### DIFF
--- a/app/views/alchemy/admin/partials/_search_form.html.erb
+++ b/app/views/alchemy/admin/partials/_search_form.html.erb
@@ -6,6 +6,7 @@
       <%= render_icon('search') %>
     </button>
     <%= f.search_field resource_handler.search_field_name,
+      value: params.dig(:q, resource_handler.search_field_name),
       class: 'search_input_field',
       placeholder: Alchemy.t(:search) %>
     <% local_assigns.fetch(:additional_query_fields, []).each do |field| %>

--- a/spec/features/admin/resources_integration_spec.rb
+++ b/spec/features/admin/resources_integration_spec.rb
@@ -437,6 +437,7 @@ RSpec.describe "Resources", type: :system do
           by_location_id: office.id
         }
       })
+      expect(page).to have_selector(".search_field input[value='Meeting']")
 
       expect(page).to have_content("Meeting 1")
       expect(page).not_to have_content("Meeting 2")


### PR DESCRIPTION

## What is this pull request for?

When navigating around the resources admin for e.g. events, and having searched in the standard search field, it's nice to have that search field's value prefilled with whatever has been searched for before so that one does not lose the search term on the next navigation.

Backport from #3314 


## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
