### PR TITLE
Add `image_file_format` to picture factory metadata

### DIFF
--- a/lib/alchemy/test_support/factories/picture_factory.rb
+++ b/lib/alchemy/test_support/factories/picture_factory.rb
@@ -29,6 +29,7 @@ FactoryBot.define do
         when :dragonfly
           picture.image_file = acc.image_file
           picture.image_file_size = acc.image_file.size
+          picture.image_file_format = File.extname(acc.image_file_name).delete(".").downcase
         end
       end
     end


### PR DESCRIPTION

## What is this pull request for?

With Dragonfly, I got "invalid file format" errors from the picture factory, and found that adding the file format manually did somehow fix the issue.

Closes #3316  (Remove if not related to any issue)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
