### PR TITLE
Add encoding comment to gemspec

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -1,3 +1,4 @@
+# encoding: utf-8
 # frozen_string_literal: true
 
 lib = File.expand_path("lib", __dir__)


### PR DESCRIPTION

## What is this pull request for?

I've started getting decoding errors for the gemspec in environments where `LANG` is set to `C` or any other language that uses `US-ASCII` as its preferred encoding. This magic comment ensures that Ruby uses utf-8 to decode the gemspec.

```
[!] There was an error while loading `alchemy_cms.gemspec`: invalid byte sequence in US-ASCII. Bundler cannot continue.

 #  from /home/kkmonat/kinderkulturmonat/shared/bundle/ruby/3.3.0/bundler/gems/alchemy_cms-73609c2ffb1c/alchemy_cms.gemspec:19
 #  -------------------------------------------
 #    gem.license = "BSD-3-Clause"
 >    gem.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^spec/|bun\.lockdb|package\.json|^\.}) }
 #    gem.require_paths = ["lib"]
 #  -------------------------------------------
```

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
