### PR TITLE
[7.4-stable] fix(picture_fields): use correct local variable

### DIFF
--- a/app/views/alchemy/admin/ingredients/_picture_fields.html.erb
+++ b/app/views/alchemy/admin/ingredients/_picture_fields.html.erb
@@ -15,7 +15,7 @@
       then css_classes
     else
       css_classes.map do |klass|
-        [Alchemy.t(klass, scope: "picture_ingredients.css_classes", default: picture_editor.css_class.camelcase), klass]
+        [Alchemy.t(klass, scope: "picture_ingredients.css_classes", default: ingredient.css_class&.camelcase), klass]
       end
     end %>
   <%= f.input :css_class, collection: css_classes_collection, include_blank: false %>

--- a/spec/dummy/config/alchemy/elements.yml
+++ b/spec/dummy/config/alchemy/elements.yml
@@ -108,6 +108,10 @@
       settings:
         size: 1200x480
         crop: true
+        css_classes:
+          - "align-right"
+          - "align-left"
+          - "align-center"
     - role: richtext
       type: Richtext
       hint: true

--- a/spec/models/alchemy/ingredients/picture_spec.rb
+++ b/spec/models/alchemy/ingredients/picture_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe Alchemy::Ingredients::Picture do
 
   it_behaves_like "having picture thumbnails" do
     let(:element) { build(:alchemy_element, name: "all_you_can_eat") }
-    let(:picture) { build(:alchemy_picture) }
+    let(:picture) { create(:alchemy_picture) }
 
     let(:record) do
       described_class.new(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.4-stable`:
 - [Merge pull request #3319 from AlchemyCMS/fix-picture-fields](https://github.com/AlchemyCMS/alchemy_cms/pull/3319)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)