### PR TITLE
Use .gitattributes to ignore unwanted files in gem builds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Exclude spec files
+spec/ export-ignore
+
+# Exclude bun.lockdb
+bun.lockdb export-ignore
+
+# Exclude package.json
+package.json export-ignore
+
+# Exclude all dotfiles (e.g. .gitignore, .rubocop.yml, etc.)
+.* export-ignore

--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -16,9 +16,8 @@ Gem::Specification.new do |gem|
   gem.requirements << "ImageMagick (libmagick), v6.6 or greater."
   gem.required_ruby_version = ">= 3.1.0"
   gem.license = "BSD-3-Clause"
-  gem.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^spec/|bun\.lockdb|package\.json|^\.}) }
+  gem.files = `git archive --format=tar HEAD | tar -tf -`.split("\n")
   gem.require_paths = ["lib"]
-
   gem.metadata["homepage_uri"] = gem.homepage
   gem.metadata["source_code_uri"] = "https://github.com/AlchemyCMS/alchemy_cms"
   gem.metadata["changelog_uri"] = "https://github.com/AlchemyCMS/alchemy_cms/blob/main/CHANGELOG.md"


### PR DESCRIPTION


## What is this pull request for?

Git has a feature to specify unwanted files for builds, the `gitattributes` file with the `export-ignore` directive. This uses that in order to construct the list of files for the gem. This way the `spec/` directory with its non-standard filenames won't appear anywhere in the pipeline.

Also removes a regular expression from the codebase, which is always good.

Closes #3320 

### Notable changes (remove if none)

Should be none. 

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
