### PR TITLE
Explicitly specify needed files for alchemy_cms gem

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.requirements << "ImageMagick (libmagick), v6.6 or greater."
   gem.required_ruby_version = ">= 3.1.0"
   gem.license = "BSD-3-Clause"
-  gem.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^spec/|bun\.lockdb|package\.json|^\.}) }
+  gem.files = Dir["{app,config,db,lib,vendor}/**/*", "LICENSE", "README.md"]
   gem.require_paths = ["lib"]
 
   gem.metadata["homepage_uri"] = gem.homepage


### PR DESCRIPTION
We had a few issues with the NULL byte in the previous code, and while looking at the issue we found we could specify the needed files for the Alchemy gem in explicitly and in Ruby.

This removes the following files from the gem (and we're good with that):

```
["CHANGELOG.md",
 "CODE_OF_CONDUCT.md",
 "CONTRIBUTING.md",
 "Gemfile",
 "SECURITY.md",
 "alchemy_cms.gemspec",
 "bin/importmap",
 "bin/rails",
 "bin/rspec",
 "bin/setup",
 "bin/start",
 "bun.lockb",
 "bundles/remixicon.mjs",
 "bundles/shoelace.js",
 "bundles/tinymce.js",
 "eslint.config.js",
 "lib/alchemy/upgrader/.keep",
 "lib/alchemy/upgrader/tasks/.keep",
 "rollup.config.mjs",
 "vitest.config.js"]
```

Closes #3322 

### Notable changes (remove if none)

See above

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
