### PR TITLE
Leave only alchemy_admin.js for Sprockets manifest, fixes #3245

### DIFF
--- a/app/assets/config/alchemy_manifest.js
+++ b/app/assets/config/alchemy_manifest.js
@@ -1,5 +1,5 @@
+//= link alchemy_admin.js
 //= link_tree ../builds/alchemy/
 //= link_tree ../builds/tinymce/
 //= link_tree ../images/alchemy/
-//= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js


### PR DESCRIPTION
## What is this pull request for?

It removes the entry relative to the `javascript` folder that was precompiled by Sprockets.
It's not needed anymore and it gives issues due to the use of new Javascript features, not supported by Sprockets.

Closes #3245



## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
