### PR TITLE
Add explicit strict mode in components index file

### DIFF
--- a/app/javascript/alchemy_admin/components/index.js
+++ b/app/javascript/alchemy_admin/components/index.js
@@ -1,3 +1,6 @@
+"use strict"
+// ^ add support for top-level await in Terser
+
 import "alchemy_admin/components/action"
 import "alchemy_admin/components/attachment_select"
 import "alchemy_admin/components/button"


### PR DESCRIPTION
If this file gets compiled with terser via sprockets it complain about top-level await is not available.

This code will always ever run in context of a module, which implicitely implies strict mode, but Terser need this hint anyway.

Refs https://github.com/ahorek/terser-ruby/issues/62

Closes https://github.com/AlchemyCMS/alchemy_cms/issues/3245
