### PR TITLE
[7.4-stable] Fix Picture.deletable scope

### DIFF
--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -116,10 +116,12 @@ module Alchemy
 
     scope :named, ->(name) { where("#{table_name}.name LIKE ?", "%#{name}%") }
     scope :recent, -> { where("#{table_name}.created_at > ?", Time.current - 24.hours).order(:created_at) }
-    scope :deletable,
-      -> {
-        where("#{table_name}.id NOT IN (SELECT related_object_id FROM alchemy_ingredients WHERE related_object_type = 'Alchemy::Picture')")
-      }
+    scope :deletable, -> do
+      where(
+        "#{table_name}.id NOT IN (SELECT related_object_id FROM alchemy_ingredients WHERE related_object_id IS NOT NULL AND related_object_type = ?)",
+        name
+      )
+    end
     scope :without_tag, -> { left_outer_joins(:taggings).where(gutentag_taggings: {id: nil}) }
     scope :by_file_format, ->(format) { where(image_file_format: format) }
 

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -127,7 +127,7 @@ en:
             last_upload: Last upload only
             recent: Recently uploaded only
             without_tag: Without tag
-            deletable: Not linked by file content
+            deletable: Not used
       attachment:
         by_file_type:
           name: File Type

--- a/spec/models/alchemy/picture_spec.rb
+++ b/spec/models/alchemy/picture_spec.rb
@@ -194,6 +194,17 @@ module Alchemy
       end
     end
 
+    describe ".deletable" do
+      let!(:assigned_picture) { create(:alchemy_picture) }
+      let!(:unassigned_picture) { create(:alchemy_picture) }
+      let!(:ingredient1) { create(:alchemy_ingredient_picture, related_object_type: described_class) }
+      let!(:ingredient2) { create(:alchemy_ingredient_picture, related_object: assigned_picture) }
+
+      it "should return all pictures that are not assigned to an ingredient" do
+        expect(Picture.deletable).to eq [unassigned_picture]
+      end
+    end
+
     describe "#destroy" do
       context "a picture that is assigned to an ingredient" do
         let(:picture) { create(:alchemy_picture) }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.4-stable`:
 - [Merge pull request #3333 from AlchemyCMS/fix-deletable-scope](https://github.com/AlchemyCMS/alchemy_cms/pull/3333)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)