### PR TITLE
Harden picture descriptions integration spec

### DIFF
--- a/spec/features/admin/picture_library_integration_spec.rb
+++ b/spec/features/admin/picture_library_integration_spec.rb
@@ -113,6 +113,9 @@ RSpec.describe "Picture Library", type: :system do
       select(language.language_code.upcase, from: "Language")
       expect(page).to have_field("Description", with: "This is an amazing image.")
 
+      # Make sure we have the latest records before making assumptions
+      picture.descriptions.reload
+
       expect(picture.descriptions.size).to eq(2)
       expect(picture.descriptions.find_by(language: german).text).to eq("Tolles Bild.")
       expect(picture.descriptions.find_by(language: language).text).to eq("This is an amazing image.")


### PR DESCRIPTION
The spec makes assumptions about the picture record and its related objects. Since those have been mutated by the server process that rspec spawns for feature specs, we need to reload the records before trying to make any assertions on the in-memory objects.
