### PR TITLE
[7.4] CI: Use unique screenshots name

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -164,7 +164,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: Screenshots
+          name: Screenshots-${{ matrix.database }}-${{ matrix.ruby }}-${{ matrix.rails }}
           path: |
             spec/dummy/tmp/capybara
             spec/dummy/tmp/screenshots


### PR DESCRIPTION
**Extracted from https://github.com/AlchemyCMS/alchemy_cms/pull/3224 for `7.4-stable` branch.**

Since upload-artifacts v4 we need to use a conflict free name, otherwise it will error.
