### PR TITLE
Configurable `cache-control` headers

### DIFF
--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -191,7 +191,19 @@ module Alchemy
       if must_not_cache?
         expires_now
       else
-        expires_in @page.expiration_time, public: !@page.restricted, must_revalidate: true
+        expires_in @page.expiration_time, {public: !@page.restricted}.merge(caching_options)
+      end
+    end
+
+    def caching_options
+      if Alchemy.config.page_cache.stale_while_revalidate
+        {
+          stale_while_revalidate: Alchemy.config.page_cache.stale_while_revalidate
+        }
+      else
+        {
+          must_revalidate: true
+        }
       end
     end
 

--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -229,7 +229,12 @@ module Alchemy
 
     # don't cache pages if we have flash message to display or the page has caching disabled
     def must_not_cache?
-      flash.present? || !@page.cache_page?
+      !caching_enabled? || !@page.cache_page? || flash.present?
+    end
+
+    def caching_enabled?
+      Rails.application.config.action_controller.perform_caching &&
+        Alchemy.config.cache_pages
     end
 
     def page_not_found!

--- a/app/models/alchemy/page/page_natures.rb
+++ b/app/models/alchemy/page/page_natures.rb
@@ -157,7 +157,6 @@ module Alchemy
       # @returns Boolean
       #
       def cache_page?
-        # debugger
         return false if !public? || restricted?
 
         definition.cache != false && definition.searchresults != true

--- a/app/models/alchemy/page/page_natures.rb
+++ b/app/models/alchemy/page/page_natures.rb
@@ -13,8 +13,21 @@ module Alchemy
         language.public? && !!public_version&.public?
       end
 
+      # Cache-Control max-age duration in seconds.
+      #
+      # You can set this via the `ALCHEMY_PAGE_CACHE_MAX_AGE` environment variable,
+      # in the `Alchemy.config.page_cache_max_age` configuration option,
+      # or in the pages definition in `config/alchemy/page_layouts.yml` file.
+      #
+      # Defaults to 600 seconds.
       def expiration_time
-        public_until ? public_until - Time.current : nil
+        return 0 unless cache_page?
+
+        if definition.cache.to_s.match?(/\d+/)
+          definition.cache.to_i
+        else
+          Alchemy.config.page_cache.max_age
+        end
       end
 
       def rootpage?
@@ -144,17 +157,10 @@ module Alchemy
       # @returns Boolean
       #
       def cache_page?
-        return false unless caching_enabled?
+        # debugger
+        return false if !public? || restricted?
 
-        page_layout = PageDefinition.get(self.page_layout)
-        page_layout.cache != false && page_layout.searchresults != true
-      end
-
-      private
-
-      def caching_enabled?
-        Alchemy.config.cache_pages &&
-          Rails.application.config.action_controller.perform_caching
+        definition.cache != false && definition.searchresults != true
       end
     end
   end

--- a/app/models/alchemy/page_definition.rb
+++ b/app/models/alchemy/page_definition.rb
@@ -13,7 +13,7 @@ module Alchemy
     attribute :autogenerate, default: []
     attribute :layoutpage, :boolean, default: false
     attribute :unique, :boolean, default: false
-    attribute :cache, :boolean, default: true
+    attribute :cache, default: true
     attribute :insert_elements_at, :string, default: "bottom"
     attribute :fixed_attributes, default: {}
     attribute :searchable, :boolean, default: true

--- a/lib/alchemy/configurations/main.rb
+++ b/lib/alchemy/configurations/main.rb
@@ -5,6 +5,7 @@ require "alchemy/configurations/default_language"
 require "alchemy/configurations/default_site"
 require "alchemy/configurations/format_matchers"
 require "alchemy/configurations/mailer"
+require "alchemy/configurations/page_cache"
 require "alchemy/configurations/preview"
 require "alchemy/configurations/sitemap"
 require "alchemy/configurations/uploader"
@@ -30,6 +31,12 @@ module Alchemy
       # NOTE: You can enable/disable page caching for single Alchemy::Definitions in the page_layout.yml file.
       #
       option :cache_pages, :boolean, default: true
+
+      # === Page caching max age
+      #
+      # max-age [Integer] # The duration in seconds for which the page is cached before revalidation.
+      # stale-while-revalidate [Boolean] # If true, enables the stale-while-revalidate caching strategy.
+      configuration :page_cache, PageCache
 
       # === Sitemap
       #

--- a/lib/alchemy/configurations/page_cache.rb
+++ b/lib/alchemy/configurations/page_cache.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Alchemy
+  module Configurations
+    class PageCache < Alchemy::Configuration
+      # === Page caching max age
+      #
+      # Control the max-age duration in seconds in the cache-control header.
+      #
+      option :max_age, :integer, default: 600
+    end
+  end
+end

--- a/lib/alchemy/configurations/page_cache.rb
+++ b/lib/alchemy/configurations/page_cache.rb
@@ -8,6 +8,12 @@ module Alchemy
       # Control the max-age duration in seconds in the cache-control header.
       #
       option :max_age, :integer, default: 600
+
+      # === Page caching stale-while-revalidate
+      #
+      # Set stale-while-revalidate cache-control header.
+      #
+      option :stale_while_revalidate, :integer
     end
   end
 end

--- a/spec/dummy/config/alchemy/page_layouts.yml
+++ b/spec/dummy/config/alchemy/page_layouts.yml
@@ -21,6 +21,7 @@
 - name: standard
   elements: [article, header, slider, download]
   autogenerate: [header, article, download]
+  cache: 60
 
 - name: everything
   hint: true
@@ -43,6 +44,9 @@
   insert_elements_at: top
   elements: [headline, news]
   autogenerate: [news]
+
+- name: search
+  searchresults: true
 
 - name: contact
   unique: true

--- a/spec/libraries/alchemy/tasks/usage_spec.rb
+++ b/spec/libraries/alchemy/tasks/usage_spec.rb
@@ -60,7 +60,8 @@ RSpec.describe Alchemy::Tasks::Usage do
         {"page_layout" => "everything", "count" => 0},
         {"page_layout" => "footer", "count" => 0},
         {"page_layout" => "news", "count" => 0},
-        {"page_layout" => "readonly", "count" => 0}
+        {"page_layout" => "readonly", "count" => 0},
+        {"page_layout" => "search", "count" => 0}
       ]
     end
   end

--- a/spec/models/alchemy/site_spec.rb
+++ b/spec/models/alchemy/site_spec.rb
@@ -170,7 +170,7 @@ module Alchemy
 
         it "returns all non 'layoutpage' page layout names" do
           allow(Site).to receive(:definitions).and_return([])
-          expect(site.page_layout_names).to eq(%w[index readonly standard everything news contact erb_layout])
+          expect(site.page_layout_names).to eq(%w[index readonly standard everything news search contact erb_layout])
         end
 
         context "when layoutpages are requested" do
@@ -210,7 +210,8 @@ module Alchemy
             "news",
             "contact",
             "footer",
-            "erb_layout"
+            "erb_layout",
+            "search"
           ])
         end
       end

--- a/spec/requests/alchemy/page_request_caching_spec.rb
+++ b/spec/requests/alchemy/page_request_caching_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Page request caching" do
-  let!(:page) { create(:alchemy_page, :public) }
+  let(:page) { create(:alchemy_page, :public) }
 
   context "when caching is disabled in app" do
     before do
@@ -32,46 +32,48 @@ RSpec.describe "Page request caching" do
           allow_any_instance_of(Alchemy::Page).to receive(:restricted) { false }
         end
 
-        context "for page not having expiration time" do
-          before do
-            allow_any_instance_of(Alchemy::Page).to receive(:expiration_time) { nil }
-          end
-
+        context "for page not having expiration time configured" do
           it "sets public cache control header" do
             get "/#{page.urlname}"
             expect(response.headers).to have_key("Cache-Control")
-            expect(response.headers["Cache-Control"]).to eq("public, must-revalidate")
+            expect(response.headers["Cache-Control"]).to eq("max-age=60, public, must-revalidate")
           end
         end
 
-        context "for page having expiration time" do
-          let!(:public_until) { 10.days.from_now }
-          let!(:now) { Time.current }
-          let!(:expiration_time) { public_until - now }
-
+        context "for page having expiration time configured" do
           before do
-            allow(Time).to receive(:current) { now }
-            page.public_version.update(public_until: public_until)
+            allow_any_instance_of(Alchemy::Page).to receive(:expiration_time) { 3600 }
           end
 
           it "sets max-age cache control header" do
             get "/#{page.urlname}"
             expect(response.headers).to have_key("Cache-Control")
             expect(response.headers["Cache-Control"]).to \
-              eq("max-age=#{expiration_time.to_i}, public, must-revalidate")
+              eq("max-age=3600, public, must-revalidate")
           end
         end
       end
 
-      context "when page is restricted" do
+      context "when page must not be cached" do
         before do
-          allow_any_instance_of(Alchemy::Page).to receive(:restricted) { true }
+          allow_any_instance_of(Alchemy::Page).to receive(:cache_page?) { false }
         end
 
-        it "sets private cache control header" do
+        it "sets no-cache cache-control header" do
           get "/#{page.urlname}"
           expect(response.headers).to have_key("Cache-Control")
-          expect(response.headers["Cache-Control"]).to eq("private, must-revalidate")
+          expect(response.headers["Cache-Control"]).to eq("no-cache")
+        end
+      end
+
+      context "when caching is deactivated in the Alchemy config" do
+        before do
+          stub_alchemy_config(:cache_pages, false)
+        end
+
+        it "returns false" do
+          get "/#{page.urlname}"
+          expect(response.headers["cache-control"]).to eq("no-cache")
         end
       end
 

--- a/spec/requests/alchemy/page_request_caching_spec.rb
+++ b/spec/requests/alchemy/page_request_caching_spec.rb
@@ -40,6 +40,21 @@ RSpec.describe "Page request caching" do
           end
         end
 
+        context "when stale_while_revalidate is enabled" do
+          before do
+            allow(Alchemy.config).to receive(:page_cache) do
+              double(stale_while_revalidate: 3600, max_age: 600)
+            end
+          end
+
+          it "sets cache-control header stale-while-revalidate" do
+            get "/#{page.urlname}"
+            expect(response.headers).to have_key("Cache-Control")
+            expect(response.headers["Cache-Control"]).to \
+              eq("max-age=60, public, stale-while-revalidate=3600")
+          end
+        end
+
         context "for page having expiration time configured" do
           before do
             allow_any_instance_of(Alchemy::Page).to receive(:expiration_time) { 3600 }


### PR DESCRIPTION
## What is this pull request for?

### 1. Configurable page cache `max-age` header

Introduces two ways to configure the `cache-control` `max-age` header.

You can set a number on a pages definition to control the
`cache-control` `max-age` value of all pages of this type.

You can also set this value for all pages in the new

```rb
Alchemy.config.page_cache.max_age
```

configuration option. It defaults to 600 seconds (10 minutes).

### 2. Allow `stale-while-revalidate` `cache-control` header

If you have a CDN that supports the `stale-while-revalidate` header
(like Cloudflare [^1]) - you can enable this header for better CDN
performance.

Set this value pages in the new

```rb
Alchemy.config.page_cache.stale_while_revalidate
```

configuration option to any integer value in seconds.

It is disabled by default, because this only works with CDNs. Browsers will
ignore this caching rule and we use `must-revalidate` as rule by default.

[^1]: https://developers.cloudflare.com/cache/concepts/cache-control/#revalidation


## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
