### PR TITLE
fix(DatetimeView): Use settings value if present

### DIFF
--- a/app/components/alchemy/ingredients/datetime_view.rb
+++ b/app/components/alchemy/ingredients/datetime_view.rb
@@ -1,13 +1,15 @@
 module Alchemy
   module Ingredients
     class DatetimeView < BaseView
+      DEFAULT_DATE_FORMAT = :"alchemy.default"
+
       attr_reader :date_format
 
       # @param ingredient [Alchemy::Ingredient]
       # @param date_format [String] The date format to use. Use either a strftime format string, a I18n format symbol or "rfc822". Defaults to "time.formats.alchemy.default".
-      def initialize(ingredient, date_format: :"alchemy.default", html_options: {})
+      def initialize(ingredient, date_format: nil, html_options: {})
         super(ingredient)
-        @date_format = settings_value(:date_format, value: date_format)
+        @date_format = settings_value(:date_format, value: date_format) || DEFAULT_DATE_FORMAT
       end
 
       def call

--- a/spec/components/alchemy/ingredients/datetime_view_spec.rb
+++ b/spec/components/alchemy/ingredients/datetime_view_spec.rb
@@ -28,6 +28,26 @@ RSpec.describe Alchemy::Ingredients::DatetimeView, type: :component do
       end
     end
 
+    context "with date_format in settings" do
+      before do
+        allow(ingredient).to receive(:settings) do
+          {date_format: "%d.%m."}
+        end
+      end
+
+      it "translates the date value with format from settings" do
+        is_expected.to have_content("29.08.")
+      end
+
+      context "but with format passed as argument" do
+        let(:options) { {date_format: "%d.%m.%Y"} }
+
+        it "translates the date value with format from arguments" do
+          is_expected.to have_content("29.08.2024")
+        end
+      end
+    end
+
     context "with option date_format set to rfc822" do
       let(:options) { {date_format: "rfc822"} }
 


### PR DESCRIPTION
## What is this pull request for?

If we have an ingredient settings value we need to use that and only use the argument from the view if present.

Only fallback to the default format if neither is present.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
