### PR TITLE
Use Alchemy `ajax` helper for delete button

### DIFF
--- a/app/javascript/alchemy_admin/components/element_editor/delete_element_button.js
+++ b/app/javascript/alchemy_admin/components/element_editor/delete_element_button.js
@@ -1,3 +1,4 @@
+import ajax from "alchemy_admin/utils/ajax"
 import { removeTab } from "alchemy_admin/fixed_elements"
 import { growl } from "alchemy_admin/growler"
 import { reloadPreview } from "alchemy_admin/components/preview_window"
@@ -12,8 +13,8 @@ export class DeleteElementButton extends HTMLElement {
   async handleEvent() {
     const confirmed = await openConfirmDialog(this.message)
     if (confirmed) {
-      const response = await fetch(this.url, { method: "DELETE" })
-      this.#removeElement(await response.json())
+      const response = await ajax("DELETE", this.url)
+      this.#removeElement(response.data)
     }
   }
 


### PR DESCRIPTION

## What is this pull request for?

Using a plain `fetch` here results in a CSRF token error (because the `X-CSRF-Token` header is not sent), which results in a NullSession, which makes Alchemy return a 401.

The helper behaves slightly differently, so we had to modify the response handling as well.

Note: The error has been reproduced using Rails 8, with `alchemy-devise` present. The Dummy app probably just automatically authenticates every request willy-nilly. 

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
