### PR TITLE
Remove three letter urlname restriction

### DIFF
--- a/app/models/alchemy/page/page_naming.rb
+++ b/app/models/alchemy/page/page_naming.rb
@@ -16,8 +16,7 @@ module Alchemy
           presence: true, uniqueness: {scope: [:parent_id], case_sensitive: false, unless: -> { parent_id.nil? }}
         validates :urlname,
           uniqueness: {scope: [:language_id, :layoutpage], if: -> { urlname.present? }, case_sensitive: false},
-          exclusion: {in: RESERVED_URLNAMES},
-          length: {minimum: 3, if: -> { urlname.present? }}
+          exclusion: {in: RESERVED_URLNAMES}
 
         before_save :set_title,
           if: -> { title.blank? }
@@ -73,17 +72,10 @@ module Alchemy
         self[:title] = name
       end
 
-      # Converts the given name into an url friendly string.
+      # Returns the full nested urlname.
       #
-      # Names shorter than 3 will be filled up with dashes,
-      # so it does not collidate with the language code.
-      #
-      def converted_url_name
-        url_name = convert_to_urlname(slug.blank? ? name : slug)
-        url_name.rjust(3, "-")
-      end
-
       def nested_url_name
+        converted_url_name = convert_to_urlname(slug.blank? ? name : slug)
         if parent&.language_root?
           converted_url_name
         else

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -456,9 +456,9 @@ module Alchemy
           end
         end
 
-        it "should generate a three letter urlname from two letter name" do
+        it "should generate a two letter urlname from two letter name" do
           page = create(:alchemy_page, name: "Au", language: language, parent: language_root)
-          expect(page.urlname).to eq("-au")
+          expect(page.urlname).to eq("au")
         end
 
         it "should generate a three letter urlname from two letter name with umlaut" do
@@ -466,9 +466,9 @@ module Alchemy
           expect(page.urlname).to eq("aue")
         end
 
-        it "should generate a three letter urlname from one letter name" do
+        it "should generate a one letter urlname from one letter name" do
           page = create(:alchemy_page, name: "A", language: language, parent: language_root)
-          expect(page.urlname).to eq("--a")
+          expect(page.urlname).to eq("a")
         end
 
         it "should add a user stamper" do


### PR DESCRIPTION
## What is this pull request for?

This was implemented to make sure the root url language code requests are not overwritten by any page requested with short urlnames. This is handled by the router already and only leads to problems on nested urls, where a page with short names get urlnames with dashes in the url. In the age of AI this might not what we want. We want `example.com/services/ai` instead of `example.com/services/-ai` ;)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have adjsuted tests to cover this change
