### PR TITLE
Add index to `created_at` on attachment and pictures tables

### DIFF
--- a/db/migrate/20250905140323_add_created_at_index_to_pictures_and_attachments.rb
+++ b/db/migrate/20250905140323_add_created_at_index_to_pictures_and_attachments.rb
@@ -1,0 +1,14 @@
+class AddCreatedAtIndexToPicturesAndAttachments < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction! if connection.adapter_name.match?(/postgres/i)
+
+  def change
+    add_index :alchemy_pictures, :created_at, if_not_exists: true, algorithm: algorithm
+    add_index :alchemy_attachments, :created_at, if_not_exists: true, algorithm: algorithm
+  end
+
+  private
+
+  def algorithm
+    connection.adapter_name.match?(/postgres/i) ? :concurrently : nil
+  end
+end

--- a/spec/dummy/db/migrate/20250905140502_add_created_at_index_to_pictures_and_attachments.alchemy.rb
+++ b/spec/dummy/db/migrate/20250905140502_add_created_at_index_to_pictures_and_attachments.alchemy.rb
@@ -1,0 +1,15 @@
+# This migration comes from alchemy (originally 20250905140323)
+class AddCreatedAtIndexToPicturesAndAttachments < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction! if connection.adapter_name.match?(/postgres/i)
+
+  def change
+    add_index :alchemy_pictures, :created_at, if_not_exists: true, algorithm: algorithm
+    add_index :alchemy_attachments, :created_at, if_not_exists: true, algorithm: algorithm
+  end
+
+  private
+
+  def algorithm
+    connection.adapter_name.match?(/postgres/i) ? :concurrently : nil
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_26_160417) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_05_140502) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -49,6 +49,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_26_160417) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "file_uid"
+    t.index ["created_at"], name: "index_alchemy_attachments_on_created_at"
     t.index ["creator_id"], name: "index_alchemy_attachments_on_creator_id"
     t.index ["file_uid"], name: "index_alchemy_attachments_on_file_uid"
     t.index ["updater_id"], name: "index_alchemy_attachments_on_updater_id"
@@ -246,6 +247,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_26_160417) do
     t.string "image_file_uid"
     t.integer "image_file_size"
     t.string "image_file_format"
+    t.index ["created_at"], name: "index_alchemy_pictures_on_created_at"
     t.index ["creator_id"], name: "index_alchemy_pictures_on_creator_id"
     t.index ["image_file_name"], name: "index_alchemy_pictures_on_image_file_name"
     t.index ["name"], name: "index_alchemy_pictures_on_name"


### PR DESCRIPTION
## What is this pull request for?

We have the recent scope on the attachment and pictures models. Also the picture archive now defaults to sorting by recent images.

On large projects it should be a good idea to have an index on these columns.

It will add the index concurrently on Postgres.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
