### PR TITLE
[7.4] Sanititze filenames before upload

### DIFF
--- a/app/models/alchemy/attachment.rb
+++ b/app/models/alchemy/attachment.rb
@@ -96,6 +96,7 @@ module Alchemy
       message: Alchemy.t("not a valid file"),
       unless: -> { self.class.allowed_filetypes.include?("*") }
 
+    before_save :sanitize_file_name
     before_save :set_name, if: :file_name_changed?
 
     scope :with_file_type, ->(file_type) { where(file_mime_type: file_type) }
@@ -155,6 +156,10 @@ module Alchemy
     end
 
     private
+
+    def sanitize_file_name
+      self.file_name = sanitized_filename(file_name)
+    end
 
     def set_name
       self.name = convert_to_humanized_name(file_name, file.ext)

--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -94,6 +94,7 @@ module Alchemy
       end
     end
 
+    before_save :sanitize_image_file_name
     # Create important thumbnails upfront
     after_create -> { PictureThumb.generate_thumbs!(self) if has_convertible_format? }
 
@@ -311,6 +312,10 @@ module Alchemy
     #
     def image_file_dimensions
       "#{image_file_width}x#{image_file_height}"
+    end
+
+    def sanitize_image_file_name
+      self.image_file_name = sanitized_filename(image_file_name)
     end
   end
 end

--- a/lib/alchemy/name_conversions.rb
+++ b/lib/alchemy/name_conversions.rb
@@ -22,5 +22,11 @@ module Alchemy
     def convert_to_humanized_name(name, suffix)
       name.gsub(/\.#{::Regexp.quote(suffix)}$/i, "").tr("_", " ").strip
     end
+
+    # Sanitizes a given filename by removing directory traversal attempts and HTML entities.
+    def sanitized_filename(file_name)
+      file_name = File.basename(file_name)
+      CGI.escapeHTML(file_name)
+    end
   end
 end

--- a/spec/models/alchemy/attachment_spec.rb
+++ b/spec/models/alchemy/attachment_spec.rb
@@ -7,6 +7,11 @@ module Alchemy
     let(:file) { File.new(File.expand_path("../../fixtures/image with spaces.png", __dir__)) }
     let(:attachment) { Attachment.new(file: file) }
 
+    it_behaves_like "having file name sanitization" do
+      subject { Attachment.new(file:) }
+      let(:file_name_attribute) { :file_name }
+    end
+
     describe "after assign" do
       it "stores the file mime type into database" do
         attachment.update(file: file)

--- a/spec/models/alchemy/picture_spec.rb
+++ b/spec/models/alchemy/picture_spec.rb
@@ -12,6 +12,11 @@ module Alchemy
 
     it_behaves_like "has image calculations"
 
+    it_behaves_like "having file name sanitization" do
+      subject { Picture.new(image_file:) }
+      let(:file_name_attribute) { :image_file_name }
+    end
+
     it { is_expected.to have_many(:thumbs).class_name("Alchemy::PictureThumb") }
 
     context "with a png file" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,6 +34,7 @@ require "alchemy/test_support/shared_uploader_examples"
 require "alchemy/test_support/current_language_shared_examples"
 
 require_relative "support/calculation_examples"
+require_relative "support/file_name_examples"
 require_relative "support/hint_examples"
 require_relative "support/custom_news_elements_finder"
 

--- a/spec/support/file_name_examples.rb
+++ b/spec/support/file_name_examples.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.shared_examples_for "having file name sanitization" do
+  describe "file name sanitization" do
+    let(:invalid_file_name) { 'some/../path"<script>alert(1)</script>.png' }
+    let(:sanitized_file_name) { "script&gt;.png" }
+
+    it "sanitizes the file name before saving" do
+      subject.send("#{file_name_attribute}=", invalid_file_name)
+      subject.save
+      expect(subject.send(file_name_attribute)).to eq(sanitized_file_name)
+    end
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

Sanitizes a filenames by removing directory traversal attempts and HTML entities.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
