### PR TITLE
Add tidy task to remove legacy essence tables

### DIFF
--- a/lib/alchemy/tasks/tidy.rb
+++ b/lib/alchemy/tasks/tidy.rb
@@ -73,6 +73,24 @@ module Alchemy
         log "Deleted #{count} duplicate legacy URLs"
       end
 
+      def remove_legacy_essence_tables
+        puts "\n## Removing legacy essence tables"
+        matching_tables = ActiveRecord::Base.connection.tables.select do |table|
+          table.start_with?("alchemy_essence_")
+        end
+        if matching_tables.length.zero?
+          log "No legacy essence tables found", :skip
+          nil
+        else
+          matching_tables.each do |table|
+            ActiveRecord::Base.connection.drop_table(table, if_exists: true)
+            print "."
+          end
+          puts "\n"
+          log "Deleted #{matching_tables.length} legacy essence tables"
+        end
+      end
+
       private
 
       def destroy_orphaned_records(records, class_name)

--- a/lib/tasks/alchemy/tidy.rake
+++ b/lib/tasks/alchemy/tidy.rake
@@ -10,6 +10,7 @@ namespace :alchemy do
       Rake::Task["alchemy:tidy:remove_orphaned_records"].invoke
       Rake::Task["alchemy:tidy:remove_trashed_elements"].invoke
       Rake::Task["alchemy:tidy:remove_duplicate_legacy_urls"].invoke
+      Rake::Task["alchemy:tidy:remove_legacy_essence_tables"].invoke
     end
 
     desc "Fixes element positions."
@@ -35,6 +36,11 @@ namespace :alchemy do
     desc "Remove duplicate legacy URLs"
     task remove_duplicate_legacy_urls: [:environment] do
       Alchemy::Tidy.remove_duplicate_legacy_urls
+    end
+
+    desc "Remove all legacy essence tables"
+    task remove_legacy_essence_tables: [:environment] do
+      Alchemy::Tidy.remove_legacy_essence_tables
     end
 
     desc "List Alchemy elements usage"


### PR DESCRIPTION
## What is this pull request for?

It is time to get rid of these old data. We can assume that everybody has migrated to ingredients with 7.0

### It is an optional and a manual task you need to invoke by running

```
bin/rake alchemy:tidy:remove_legacy_essence_tables
```

or

```
bin/rake alchemy:tidy:up
```

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message

