### PR TITLE
Made Note About `gem propshaft` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Visit the existing demo at https://demo.alchemy-cms.com/
 > For Rails `>= 8`, use Alchemy version `>= 8.0.0a` which comes with propshaft support.
 > If you are on Rails `>= 8` with an older Alchemy version, you will need to [temporarily comment out](https://github.com/AlchemyCMS/alchemy_cms/issues/3330) the `propshaft` gem.
 
-
 ## 💎 Ruby Version
 
 Alchemy runs with Ruby >= 3.1.0.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Visit the existing demo at https://demo.alchemy-cms.com/
 * For a Rails 3.0 compatible version use the [`2.0-stable` branch](https://github.com/AlchemyCMS/alchemy_cms/tree/2.0-stable).
 * For a Rails 2.3 compatible version use the [`1.6-stable` branch](https://github.com/AlchemyCMS/alchemy_cms/tree/1.6-stable).
 
+> For Rails `>= 8`, use Alchemy version `>= 8.0.0a` which comes with propshaft support.
+> If you are on Rails `>= 8` with an older Alchemy version, you will need to [temporarily comment out](https://github.com/AlchemyCMS/alchemy_cms/issues/3330) the `propshaft` gem.
+
 
 ## 💎 Ruby Version
 


### PR DESCRIPTION
## What is this pull request for?

Adding a note about propshaft compatibility for older rails versions, with encouragement to use `alchemy ~> 8.0.0a` if on `Rails >8. Taken from [this comment](https://github.com/AlchemyCMS/alchemy_cms/issues/3330#issuecomment-3085374050).

Closes #3330

<img width="959" height="1174" alt="image" src="https://github.com/user-attachments/assets/5e99e789-f1bc-4cef-8681-948cd4bf7fe1" />

## Checklist
- [ ] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [ ] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change --> this is a documentation only change 😃 
