### PR TITLE
Delete multiple pictures in background

### DIFF
--- a/app/jobs/alchemy/delete_picture_job.rb
+++ b/app/jobs/alchemy/delete_picture_job.rb
@@ -1,0 +1,12 @@
+module Alchemy
+  class DeletePictureJob < BaseJob
+    queue_as :default
+
+    def perform(picture_id)
+      picture = Alchemy::Picture.find_by(id: picture_id)
+      return if picture.nil? || !picture.deletable?
+
+      picture.destroy
+    end
+  end
+end

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -340,7 +340,6 @@ en:
     "Size": "Size"
     "Successfully deleted element": "Successfully deleted %{element}"
     "Tags": "Tags"
-    "These pictures could not be deleted, because they were in use": "These pictures could not be deleted, because they were in use: %{names}"
     "This page is locked": "This page is currently locked by %{name}"
     "Title": "Title"
     "Trash": "Trash"
@@ -568,6 +567,7 @@ en:
     password: "Password"
     paste: "paste"
     pictures_in_page: "%{page} in %{pictures}"
+    pictures_will_be_deleted_now: Pictures will be deleted now
     place_link: "Add link"
     player_version: "Flash Player version"
     "please enter subject and mail address": "Please enter recipient and subject."

--- a/spec/features/admin/picture_library_integration_spec.rb
+++ b/spec/features/admin/picture_library_integration_spec.rb
@@ -102,12 +102,8 @@ RSpec.describe "Picture Library", type: :system do
       end
 
       within "#flash_notices" do
-        expect(page).to have_content("Pictures deleted successfully")
+        expect(page).to have_content("Pictures will be deleted now")
       end
-
-      expect(page).to_not have_selector("#picture_#{picture_2.id}")
-      expect(page).to_not have_selector("#picture_#{picture_1.id}")
-      expect(page).to have_selector("#picture_#{picture_3.id}")
 
       # Keeps existing params
       within "#filter_bar" do

--- a/spec/jobs/alchemy/delete_picture_job_spec.rb
+++ b/spec/jobs/alchemy/delete_picture_job_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe Alchemy::DeletePictureJob, type: :job do
+  describe "#perform" do
+    subject(:perform) { described_class.new.perform(5) }
+
+    context "when picture exists" do
+      let(:picture) { build(:alchemy_picture) }
+
+      before do
+        allow(Alchemy::Picture).to receive(:find_by).with(id: 5) { picture }
+      end
+
+      context "when picture is deletable" do
+        it "deletes the picture" do
+          expect(picture).to receive(:deletable?) { true }
+          expect(picture).to receive(:destroy)
+          perform
+        end
+      end
+
+      context "when picture is not deletable" do
+        it "does not delete the picture" do
+          expect(picture).to receive(:deletable?) { false }
+          expect(picture).to_not receive(:destroy)
+          perform
+        end
+      end
+    end
+
+    context "when picture does not exist" do
+      before do
+        allow(Alchemy::Picture).to receive(:find_by).with(id: 5) { nil }
+      end
+
+      it "does nothing" do
+        perform
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

Deleting multiple pictures can take a while, because there are multiple things that happen afterwards. It should be better to background the deletion of multiple pictures.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
