### PR TITLE
Fix admin page preview permissions

### DIFF
--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -72,6 +72,8 @@ module Alchemy
       # Used by page preview iframe in Page#edit view.
       #
       def show
+        authorize! :edit_content, @page
+
         Current.preview_page = @page
         # Setting the locale to pages language, so the page content has it's correct translations.
         ::I18n.locale = @page.language.locale

--- a/spec/requests/alchemy/admin/pages_controller_spec.rb
+++ b/spec/requests/alchemy/admin/pages_controller_spec.rb
@@ -12,6 +12,12 @@ module Alchemy
         get admin_pages_path
         expect(request).to redirect_to(Alchemy.login_path)
       end
+
+      it "can not access page preview of a public page" do
+        page = create(:alchemy_page, :public)
+        get admin_page_path(page)
+        expect(request).to redirect_to(Alchemy.login_path)
+      end
     end
 
     context "a member" do
@@ -20,6 +26,12 @@ module Alchemy
       it "can not access page tree" do
         get admin_pages_path
         expect(request).to redirect_to(root_path)
+      end
+
+      it "can not access page preview of a public page" do
+        page = create(:alchemy_page, :public)
+        get admin_page_path(page)
+        expect(request).to redirect_to("/")
       end
     end
 
@@ -273,6 +285,11 @@ module Alchemy
       describe "#show" do
         let(:language) { create(:alchemy_language, locale: "nl") }
         let!(:page) { create(:alchemy_page, language: language) }
+
+        it "can be accessed" do
+          get admin_page_path(page)
+          expect(response).to be_successful
+        end
 
         it "should assign @preview_mode with true" do
           get admin_page_path(page)


### PR DESCRIPTION
## What is this pull request for?

It was possible to show a published page draft content with the admin/pages url, becasuse anonymous users are able to view public pages. We now only allow this for users with edit_content permissions.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
