### PR TITLE
Re-add deprecated `translations_for_select` helper

### DIFF
--- a/app/helpers/alchemy/base_helper.rb
+++ b/app/helpers/alchemy/base_helper.rb
@@ -37,5 +37,14 @@ module Alchemy
     def render_message(type = :info, msg = nil, &)
       render Alchemy::Admin::Message.new(msg || capture(&), type: type)
     end
+
+    # Used for translations selector in Alchemy cockpit user settings.
+
+    def translations_for_select
+      Alchemy::I18n.available_locales.sort.map do |locale|
+        [Alchemy.t(locale, scope: :translations), locale]
+      end
+    end
+    deprecate translations_for_select: "Please use the new `Alchemy::Admin::LocaleSelect` component."
   end
 end


### PR DESCRIPTION


## What is this pull request for?

This helper is used in the sign-up form in `alchemy-devise` on the `8.0-stable` branch. Let's add it back in, but deprecated.


## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
