### PR TITLE
Fix `stub_alchemy_config` (and make it recursive)

### DIFF
--- a/lib/alchemy/test_support/config_stubbing.rb
+++ b/lib/alchemy/test_support/config_stubbing.rb
@@ -13,13 +13,20 @@ module Alchemy
     module ConfigStubbing
       # Stub a key from the Alchemy config
       #
-      # @param key [Symbol] The configuration key you want to stub
-      # @param value [Object] The value you want to return instead of the original one
+      # @param hash [Hash] The keys you would like to stub along with their values
       #
-      def stub_alchemy_config(key, value)
-        temp_config = Alchemy::Configurations::Main.new
-        temp_config.send("#{key}=", value)
-        allow(Alchemy).to receive(:config).and_return(temp_config)
+      def stub_alchemy_config(hash)
+        stub_config(Alchemy.config, hash)
+      end
+
+      def stub_config(config, hash)
+        hash.each do |key, value|
+          if value.is_a?(Hash)
+            stub_config(config.send(key), value)
+          else
+            allow(config).to receive(key).and_return(value)
+          end
+        end
       end
     end
   end

--- a/spec/features/admin/link_overlay_spec.rb
+++ b/spec/features/admin/link_overlay_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Link overlay", type: :system do
 
     context "add new tab" do
       before do
-        stub_alchemy_config(:link_dialog_tabs, ["TestTab"])
+        stub_alchemy_config(link_dialog_tabs: [TestTab])
       end
 
       it "has a new tab" do

--- a/spec/features/admin/page_editing_feature_spec.rb
+++ b/spec/features/admin/page_editing_feature_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Page editing feature", type: :system do
 
     describe "multiple preview sources", :js do
       before do |example|
-        stub_alchemy_config(:preview_sources, ["Alchemy::Admin::PreviewUrl", "FooPreviewSource"])
+        stub_alchemy_config(preview_sources: [Alchemy::Admin::PreviewUrl, FooPreviewSource])
       end
 
       it "show as select" do
@@ -89,9 +89,8 @@ RSpec.describe "Page editing feature", type: :system do
         end
 
         context "with sitemaps show_flag config option set to true" do
-          let(:sitemap_config) { Alchemy::Configurations::Sitemap.new(show_flag: true) }
           before do
-            stub_alchemy_config(:sitemap, sitemap_config)
+            stub_alchemy_config(sitemap: {show_flag: true})
           end
 
           it "should show sitemap checkbox" do
@@ -101,9 +100,8 @@ RSpec.describe "Page editing feature", type: :system do
         end
 
         context "with sitemaps show_flag config option set to false" do
-          let(:sitemap_config) { Alchemy::Configurations::Sitemap.new(show_flag: false) }
           before do
-            stub_alchemy_config(:sitemap, sitemap_config)
+            stub_alchemy_config(sitemap: {show_flag: false})
           end
 
           it "should not show sitemap checkbox" do

--- a/spec/features/admin/resources_integration_spec.rb
+++ b/spec/features/admin/resources_integration_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Resources", type: :system do
       end
 
       it "should limit the number of items per page based on alchemy's general configuration" do
-        stub_alchemy_config(:items_per_page, 5)
+        stub_alchemy_config(items_per_page: 5)
 
         visit "/admin/events"
         expect(page).to have_selector("div#archive_all table.list tbody tr", count: 5)
@@ -123,7 +123,7 @@ RSpec.describe "Resources", type: :system do
           end
 
           it "can combine filters and pagination", :js do
-            stub_alchemy_config(:items_per_page, 1)
+            stub_alchemy_config(items_per_page: 1)
 
             visit "/admin/events?q[by_timeframe]=starting_today"
 
@@ -139,7 +139,7 @@ RSpec.describe "Resources", type: :system do
 
           it "can combine ransack queries and pagination", :js do
             allow_any_instance_of(Admin::EventsController).to receive(:permitted_ransack_search_fields).and_return([:name_start])
-            stub_alchemy_config(:items_per_page, 1)
+            stub_alchemy_config(items_per_page: 1)
 
             visit "/admin/events?q[name_start]=today"
 

--- a/spec/helpers/alchemy/admin/base_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/base_helper_spec.rb
@@ -196,8 +196,7 @@ module Alchemy
       end
 
       context "if the expression from config is nil" do
-        let(:format_matchers_config) { Alchemy::Configurations::FormatMatchers.new(link_url: nil) }
-        before { stub_alchemy_config(:format_matchers, format_matchers_config) }
+        before { stub_alchemy_config(format_matchers: {link_url: nil}) }
 
         it "returns the default expression" do
           expect(subject).to_not be_nil

--- a/spec/libraries/admin/preview_url_spec.rb
+++ b/spec/libraries/admin/preview_url_spec.rb
@@ -21,9 +21,7 @@ RSpec.describe Alchemy::Admin::PreviewUrl do
     context "with preview configured" do
       context "without protocol" do
         before do
-          stub_alchemy_config(:preview, Alchemy::Configurations::Preview.new({
-            "host" => "www.example.com"
-          }))
+          stub_alchemy_config(preview: {host: "www.example.com"})
         end
 
         it "raises error" do
@@ -33,9 +31,7 @@ RSpec.describe Alchemy::Admin::PreviewUrl do
 
       context "as http url" do
         before do
-          stub_alchemy_config(:preview, Alchemy::Configurations::Preview.new({
-            "host" => "http://www.example.com"
-          }))
+          stub_alchemy_config(preview: {host: "http://www.example.com"})
         end
 
         it "returns the configured preview url" do
@@ -45,9 +41,7 @@ RSpec.describe Alchemy::Admin::PreviewUrl do
 
       context "as https url" do
         before do
-          stub_alchemy_config(:preview, Alchemy::Configurations::Preview.new({
-            "host" => "https://www.example.com"
-          }))
+          stub_alchemy_config(preview: {host: "https://www.example.com"})
         end
 
         it "returns the configured preview url with https" do
@@ -57,13 +51,13 @@ RSpec.describe Alchemy::Admin::PreviewUrl do
 
       context "and with basic auth configured" do
         before do
-          stub_alchemy_config(:preview, Alchemy::Configurations::Preview.new({
-            "host" => "https://www.example.com",
-            "auth" => {
-              "username" => "foo",
-              "password" => "baz"
+          stub_alchemy_config(preview: {
+            host: "https://www.example.com",
+            auth: {
+              username: "foo",
+              password: "baz"
             }
-          }))
+          })
         end
 
         it "returns the configured preview url with userinfo" do
@@ -73,9 +67,7 @@ RSpec.describe Alchemy::Admin::PreviewUrl do
 
       context "with a port configured" do
         before do
-          stub_alchemy_config(:preview, Alchemy::Configurations::Preview.new({
-            "host" => "https://www.example.com:8080"
-          }))
+          stub_alchemy_config(preview: {host: "https://www.example.com:8080"})
         end
 
         it "returns the configured preview url with userinfo" do
@@ -85,16 +77,16 @@ RSpec.describe Alchemy::Admin::PreviewUrl do
 
       context "for a site" do
         before do
-          stub_alchemy_config(:preview, config)
+          stub_alchemy_config(preview: config)
         end
 
         context "that matches the pages site name" do
           let(:config) do
-            Alchemy::Configurations::Preview.new({
+            Alchemy::Configurations::Preview.new(
               page.site.name => {
                 "host" => "http://new.example.com"
               }
-            })
+            )
           end
 
           it "returns the configured preview url for that site" do
@@ -105,12 +97,12 @@ RSpec.describe Alchemy::Admin::PreviewUrl do
         context "that does not match the pages site name" do
           context "with a default configured" do
             let(:config) do
-              Alchemy::Configurations::Preview.new({
+              Alchemy::Configurations::Preview.new(
                 "Not matching site name" => {
                   "host" => "http://new.example.com"
                 },
                 "host" => "http://www.example.com"
-              })
+              )
             end
 
             it "returns the default configured preview url" do
@@ -120,11 +112,11 @@ RSpec.describe Alchemy::Admin::PreviewUrl do
 
           context "without a default configured" do
             let(:config) do
-              Alchemy::Configurations::Preview.new({
+              Alchemy::Configurations::Preview.new(
                 "Not matching site name" => {
                   "host" => "http://new.example.com"
                 }
-              })
+              )
             end
 
             it "returns the internal preview url" do
@@ -138,9 +130,7 @@ RSpec.describe Alchemy::Admin::PreviewUrl do
         let(:page) { create(:alchemy_page, :language_root) }
 
         before do
-          stub_alchemy_config(:preview, Alchemy::Configurations::Preview.new({
-            "host" => "https://www.example.com"
-          }))
+          stub_alchemy_config(preview: {host: "https://www.example.com"})
         end
 
         it "returns the preview url without urlname" do

--- a/spec/libraries/alchemy/engine_spec.rb
+++ b/spec/libraries/alchemy/engine_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Alchemy::Engine do
     end
 
     before do
-      stub_alchemy_config(:admin_importmaps, [additional_importmap])
+      stub_alchemy_config(admin_importmaps: [additional_importmap])
     end
 
     it "adds additional importmap to admin imports" do

--- a/spec/libraries/controller_actions_spec.rb
+++ b/spec/libraries/controller_actions_spec.rb
@@ -17,10 +17,8 @@ describe "Alchemy::ControllerActions", type: "controller" do
     end
 
     context "with custom current_user_method" do
-      around do |example|
-        Alchemy.current_user_method = "current_admin"
-        example.run
-        Alchemy.current_user_method = "current_user"
+      before do
+        stub_config(Alchemy, {current_user_method: :current_admin})
       end
 
       it "calls the custom method" do
@@ -30,10 +28,8 @@ describe "Alchemy::ControllerActions", type: "controller" do
     end
 
     context "with not implemented current_user_method" do
-      around do |example|
-        Alchemy.current_user_method = "not_implemented_method"
-        example.run
-        Alchemy.current_user_method = "current_user"
+      before do
+        stub_config(Alchemy, {current_user_method: :not_implemented_method})
       end
 
       it "raises an error" do

--- a/spec/models/alchemy/message_spec.rb
+++ b/spec/models/alchemy/message_spec.rb
@@ -23,14 +23,11 @@ RSpec.describe "Alchemy::Message" do
     end
 
     context "field containing email in its name" do
-      let(:mailer_config) do
-        Alchemy::Configurations::Mailer.new(
+      before do
+        stub_alchemy_config(mailer: {
           fields: %w[email_of_my_boss],
           validate_fields: %w[email_of_my_boss]
-        )
-      end
-      before do
-        stub_alchemy_config(:mailer, mailer_config)
+        })
         Alchemy.send(:remove_const, :Message)
         load Alchemy::Engine.root.join("app/models/alchemy/message.rb")
       end

--- a/spec/models/alchemy/picture_spec.rb
+++ b/spec/models/alchemy/picture_spec.rb
@@ -369,7 +369,7 @@ module Alchemy
       context "when image is convertible" do
         before do
           expect(picture).to receive(:convertible?) { true }
-          stub_alchemy_config(:image_output_format, "jpg")
+          stub_alchemy_config(image_output_format: "jpg")
         end
 
         it "returns the configured image output format" do
@@ -380,7 +380,7 @@ module Alchemy
       context "when image is not convertible" do
         before do
           expect(picture).to receive(:convertible?) { false }
-          stub_alchemy_config(:image_output_format, "original")
+          stub_alchemy_config(image_output_format: "original")
         end
 
         it "returns the original file format." do
@@ -397,7 +397,7 @@ module Alchemy
 
       context "when `image_output_format` is configured to `original`" do
         before do
-          stub_alchemy_config(:image_output_format, "original")
+          stub_alchemy_config(image_output_format: "original")
         end
 
         it { is_expected.to be(false) }
@@ -405,7 +405,7 @@ module Alchemy
 
       context "when `image_output_format` is configured to jpg" do
         before do
-          stub_alchemy_config(:image_output_format, "jpg")
+          stub_alchemy_config(image_output_format: "jpg")
         end
 
         context "and the image has a convertible format" do

--- a/spec/requests/alchemy/admin/pages_controller_spec.rb
+++ b/spec/requests/alchemy/admin/pages_controller_spec.rb
@@ -313,7 +313,7 @@ module Alchemy
 
         context "when layout is set to custom" do
           before do
-            stub_alchemy_config(:admin_page_preview_layout, "custom")
+            stub_alchemy_config(admin_page_preview_layout: "custom")
           end
 
           it "it renders custom layout instead" do

--- a/spec/requests/alchemy/page_request_caching_spec.rb
+++ b/spec/requests/alchemy/page_request_caching_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "Page request caching" do
 
       context "when caching is deactivated in the Alchemy config" do
         before do
-          stub_alchemy_config(:cache_pages, false)
+          stub_alchemy_config(cache_pages: false)
         end
 
         it "returns false" do

--- a/spec/services/alchemy/dragonfly_to_image_processing_spec.rb
+++ b/spec/services/alchemy/dragonfly_to_image_processing_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Alchemy::DragonflyToImageProcessing do
 
       context "and the image output format is configured to be original" do
         before do
-          stub_alchemy_config(:image_output_format, "original")
+          stub_alchemy_config(image_output_format: "original")
         end
 
         it "does not contain the format option" do
@@ -175,7 +175,7 @@ RSpec.describe Alchemy::DragonflyToImageProcessing do
 
       context "and the image output format is configured to webp" do
         before do
-          stub_alchemy_config(:image_output_format, "webp")
+          stub_alchemy_config(image_output_format: "webp")
         end
 
         it "does not contain the format option" do


### PR DESCRIPTION


## What is this pull request for?

This allows us to deeply stub the Alchemy configuration using nested hashes as an argument. Also, stubbing `Alchemy.config` will not reset the config object any longer, as it did before. This has especially been a problem for things like the importmap configuration, as that would be added on engine load, but would not be a "default" setting, as it is with many of the scalar values in the configuration.

### Notable changes (remove if none)

The method signature for `stub_alchemy_config` changes from `:key, value` to `key: value`.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
