### PR TITLE
Wrap importmap drawing in `config.to_prepare` block

### DIFF
--- a/spec/libraries/alchemy/engine_spec.rb
+++ b/spec/libraries/alchemy/engine_spec.rb
@@ -51,7 +51,8 @@ RSpec.describe Alchemy::Engine do
     it "adds additional importmap to admin imports" do
       initializer = Alchemy::Engine.initializers.find { _1.name == "alchemy.importmap" }
       expect(Alchemy.config.admin_js_imports).to receive(:add).with("additional_importmap")
-      initializer.run(Rails.application)
+      prepare_blocks = initializer.run(Rails.application)
+      prepare_blocks.last.call
     end
   end
 end


### PR DESCRIPTION

## What is this pull request for?

Wrap importmap drawing in `config.to_prepare` block
Otherwise, we can't add importmaps in app initializers (those run after alchemy's initializers).


## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message

