### PR TITLE
[WiP] feature: restrict access to sites by user roles

### DIFF
--- a/app/controllers/alchemy/admin/base_controller.rb
+++ b/app/controllers/alchemy/admin/base_controller.rb
@@ -164,11 +164,18 @@ module Alchemy
       end
 
       # Returns the current site for admin controllers.
+      # Raises CanCan::AccessDenied if the user is not allowed to access the site.
       #
       def current_alchemy_site
         @current_alchemy_site ||= begin
           site_id = params[:site_id] || session[:alchemy_site_id]
           site = Site.find_by(id: site_id) || super
+
+          authorize! :access, site if site
+        rescue CanCan::AccessDenied
+          site = Site.accessible_by(current_alchemy_user).first
+          raise
+        ensure
           session[:alchemy_site_id] = site&.id
           site
         end

--- a/app/helpers/alchemy/admin/base_helper.rb
+++ b/app/helpers/alchemy/admin/base_helper.rb
@@ -75,7 +75,7 @@ module Alchemy
 
       # Used for site selector in Alchemy cockpit.
       def sites_for_select
-        Alchemy::Site.all.map do |site|
+        @_sites_for_select ||= Alchemy::Site.accessible_by(current_alchemy_user).map do |site|
           [site.name, site.id]
         end
       end

--- a/app/models/alchemy/permissions.rb
+++ b/app/models/alchemy/permissions.rb
@@ -111,6 +111,11 @@ module Alchemy
         can :edit_content, Alchemy::Page, Alchemy::Page.all do |page|
           page.editable_by?(@user)
         end
+
+        can :switch, Alchemy::Site
+        can(:access, Alchemy::Site) do |site|
+          site.accessible_by?(@user)
+        end
       end
     end
 

--- a/app/models/alchemy/site.rb
+++ b/app/models/alchemy/site.rb
@@ -51,6 +51,21 @@ module Alchemy
       languages.find_by(default: true)
     end
 
+    # Returns true if the given user has access to this site.
+    # A site is accessible by all users if no roles are specified.
+    #
+    def accessible_by?(user)
+      return false if user.nil?
+
+      (accessible_by & user.alchemy_roles).any? || accessible_by.empty?
+    end
+
+    # Returns an array of role names that are allowed to access this site.
+    #
+    def accessible_by
+      definition.fetch("accessible_by", [])
+    end
+
     class << self
       def find_for_host(host)
         # These are split up into two separate queries in order to run the
@@ -65,6 +80,10 @@ module Alchemy
         all.find do |site|
           site.aliases.split.include?(host) if site.aliases.present?
         end
+      end
+
+      def accessible_by(user)
+        all.select { |site| site.accessible_by?(user) }
       end
     end
   end

--- a/app/views/alchemy/admin/partials/_site_select.html.erb
+++ b/app/views/alchemy/admin/partials/_site_select.html.erb
@@ -1,4 +1,4 @@
-<%- if multi_site? -%>
+<%- if can?(:switch, Alchemy::Site) && sites_for_select.size > 1 -%>
 <div class="toolbar_button">
   <sl-tooltip content="<%= Alchemy.t("Current site") %>">
     <%= select_tag 'change_site',


### PR DESCRIPTION
This introduces role-based access control for Alchemy::Site objects. Sites can now define an accessible_by whitelist in config/alchemy/site_layouts.yml, limiting which user roles may access and edit content for each site.

If accessible_by is not set, all roles retain access (backward compatible).

Access checks integrate with CanCanCan and restrict site selection and page/content management accordingly.

## Checklist
- [ x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x ] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change

P.S. this PR covers a very simple and first version of this feature. It's currently missing tests. Issue #3421 is the starting point of the discussion on this. 
