### PR TITLE
Update deprecation horizon to 9.0

### DIFF
--- a/lib/alchemy/deprecation.rb
+++ b/lib/alchemy/deprecation.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Alchemy
-  Deprecation = ActiveSupport::Deprecation.new("8.0", "Alchemy")
+  Deprecation = ActiveSupport::Deprecation.new("9.0", "Alchemy")
 end


### PR DESCRIPTION
We've just introduced some new deprecation warnings that should take effect after we release Alchemy 8.0, not when it is released.

We can also use 9.0, just comment.

I've looked for deleteable deprecated code and couldn't find any.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
