### PR TITLE
Fix elements-editor format validations

### DIFF
--- a/app/decorators/alchemy/ingredient_editor.rb
+++ b/app/decorators/alchemy/ingredient_editor.rb
@@ -108,7 +108,15 @@ module Alchemy
     end
 
     def format_validation
-      validations.select { _1.is_a?(Hash) }.find { _1[:format] }&.fetch(:format)
+      format = validations.select { _1.is_a?(Hash) }.find { _1[:format] }&.fetch(:format)
+      return nil unless format
+
+      # If format is a string or symbol, resolve it from config format_matchers
+      if format.is_a?(String) || format.is_a?(Symbol)
+        Alchemy.config.format_matchers.get(format)
+      else
+        format
+      end
     end
 
     def length_validation

--- a/spec/decorators/alchemy/ingredient_editor_spec.rb
+++ b/spec/decorators/alchemy/ingredient_editor_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe Alchemy::IngredientEditor do
       it { is_expected.to be_nil }
     end
 
-    context "when ingredient has format validation" do
+    context "when ingredient has format validation with direct regex" do
       let(:ingredient) do
         mock_model(
           "Alchemy::Ingredients::Text",
@@ -242,6 +242,38 @@ RSpec.describe Alchemy::IngredientEditor do
       end
 
       it { is_expected.to eq(/\A[a-z]+\z/) }
+    end
+
+    context "when ingredient has format validation with config key as string" do
+      let(:ingredient) do
+        mock_model(
+          "Alchemy::Ingredients::Text",
+          definition: Alchemy::IngredientDefinition.new(
+            role: "email",
+            validate: [{format: "email"}]
+          )
+        )
+      end
+
+      it "resolves the regex from config format_matchers" do
+        expect(subject).to eq(Alchemy.config.format_matchers.email)
+      end
+    end
+
+    context "when ingredient has format validation with config key as symbol" do
+      let(:ingredient) do
+        mock_model(
+          "Alchemy::Ingredients::Text",
+          definition: Alchemy::IngredientDefinition.new(
+            role: "url",
+            validate: [{format: :url}]
+          )
+        )
+      end
+
+      it "resolves the regex from config format_matchers" do
+        expect(subject).to eq(Alchemy.config.format_matchers.url)
+      end
     end
   end
 


### PR DESCRIPTION
## What is this pull request for?

This PR fixes the format_validation method in IngredientEditor to properly resolve format matcher keys from the Alchemy configuration, ensuring consistency with how IngredientValidator handles format validations.

The Problem

Previously, when an ingredient definition used a format validation with a string or symbol key (e.g., validate: [{format: "email"}] or validate: [{format: :url}]), the format_validation method would return just the key itself instead of resolving it to the actual regex pattern defined in config.format_matchers.

This created an inconsistency: IngredientValidator#validate_format already had the logic to resolve these keys to their corresponding regex patterns from the configuration, but IngredientEditor#format_validation did not.

The Solution

Extended the format_validation method to:
1. Check if the format value is a string or symbol (indicating it's a reference to a format_matchers key)
2. Resolve it using Alchemy.config.format_matchers.get(format) to return the actual regex
3. Return the format directly if it's already a regex pattern

This mirrors the existing logic in IngredientValidator#validate_format (ingredient_validator.rb:82-91), ensuring both methods handle format validation consistently.

Example

With this configuration in config/initializers/alchemy.rb:
config.format_matchers.tap do |format|
  format.email = /\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/
  format.url = /\A[a-z0-9]+([-.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?\z/ix
end

And an ingredient definition like:
- name: contact
   ingredients:
      - role: email
         type: Text
         validate: [{format: "email"}]

Before: format_validation would return "email" (the string)After: format_validation returns /\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/ (the actual regex)

### Notable changes

No breaking changes. This fix makes the method work as it should have originally, resolving format matcher keys to their configured regex patterns.

### Screenshots

<img width="376" height="36" alt="Bildschirmfoto 2025-10-21 um 17 59 16" src="https://github.com/user-attachments/assets/b524ebe0-52f4-4155-8c5b-44f778ec6c76" />
<img width="195" height="221" alt="Bildschirmfoto 2025-10-21 um 17 58 33" src="https://github.com/user-attachments/assets/17f12864-5ae0-46b4-97b6-34e40a78e3d2" />
<img width="1728" height="960" alt="Bildschirmfoto 2025-10-21 um 17 57 27" src="https://github.com/user-attachments/assets/af6a70eb-b640-40ea-8ba1-e9401651afaf" />

## Checklist
- [X] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [X] I have added a detailed description into each commit message
- [X] I have added tests to cover this change
