### PR TITLE
Only sanitize filenames if not nil

### DIFF
--- a/app/models/alchemy/storage_adapter/dragonfly.rb
+++ b/app/models/alchemy/storage_adapter/dragonfly.rb
@@ -15,7 +15,7 @@ module Alchemy
 
             has_many :thumbs, class_name: "Alchemy::PictureThumb", dependent: :destroy
 
-            before_save do
+            before_save if: :image_file_name do
               self.image_file_name = sanitized_filename(image_file_name)
             end
 
@@ -35,7 +35,7 @@ module Alchemy
               }
             end
 
-            before_save do
+            before_save if: :file_name do
               self.file_name = sanitized_filename(file_name)
             end
           end

--- a/spec/support/file_name_examples.rb
+++ b/spec/support/file_name_examples.rb
@@ -4,13 +4,24 @@ require "rails_helper"
 
 RSpec.shared_examples_for "having file name sanitization" do
   describe "file name sanitization" do
-    let(:invalid_file_name) { 'some/../path"<script>alert(1)</script>.png' }
-    let(:sanitized_file_name) { "script&gt;.png" }
+    context "with file name given" do
+      let(:invalid_file_name) { 'some/../path"<script>alert(1)</script>.png' }
+      let(:sanitized_file_name) { "script&gt;.png" }
 
-    it "sanitizes the file name before saving" do
-      subject.send("#{file_name_attribute}=", invalid_file_name)
-      subject.save
-      expect(subject.send(file_name_attribute)).to eq(sanitized_file_name)
+      it "sanitizes the file name before saving" do
+        subject.send("#{file_name_attribute}=", invalid_file_name)
+        subject.save
+        expect(subject.send(file_name_attribute)).to eq(sanitized_file_name)
+      end
+    end
+    context "with file name being nil" do
+      let(:file_name) { nil }
+
+      it "does not sanitizes the file name before saving" do
+        subject.send("#{file_name_attribute}=", file_name)
+        subject.save
+        expect(subject.send(file_name_attribute)).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
## What is this pull request for?

If one sets the image via a data binary string
there is no image_file_name and the santization
fails with a nil exception. Skipping the callback
in this case.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
