### PR TITLE
[7.4-stable] Only sanitize filenames if not nil

### DIFF
--- a/app/models/alchemy/attachment.rb
+++ b/app/models/alchemy/attachment.rb
@@ -96,7 +96,7 @@ module Alchemy
       message: Alchemy.t("not a valid file"),
       unless: -> { self.class.allowed_filetypes.include?("*") }
 
-    before_save :sanitize_file_name
+    before_save :sanitize_file_name, if: :file_name
     before_save :set_name, if: :file_name_changed?
 
     scope :with_file_type, ->(file_type) { where(file_mime_type: file_type) }

--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -94,7 +94,7 @@ module Alchemy
       end
     end
 
-    before_save :sanitize_image_file_name
+    before_save :sanitize_image_file_name, if: :image_file_name
     # Create important thumbnails upfront
     after_create -> { PictureThumb.generate_thumbs!(self) if has_convertible_format? }
 

--- a/spec/support/file_name_examples.rb
+++ b/spec/support/file_name_examples.rb
@@ -4,13 +4,24 @@ require "rails_helper"
 
 RSpec.shared_examples_for "having file name sanitization" do
   describe "file name sanitization" do
-    let(:invalid_file_name) { 'some/../path"<script>alert(1)</script>.png' }
-    let(:sanitized_file_name) { "script&gt;.png" }
+    context "with file name given" do
+      let(:invalid_file_name) { 'some/../path"<script>alert(1)</script>.png' }
+      let(:sanitized_file_name) { "script&gt;.png" }
 
-    it "sanitizes the file name before saving" do
-      subject.send("#{file_name_attribute}=", invalid_file_name)
-      subject.save
-      expect(subject.send(file_name_attribute)).to eq(sanitized_file_name)
+      it "sanitizes the file name before saving" do
+        subject.send("#{file_name_attribute}=", invalid_file_name)
+        subject.save
+        expect(subject.send(file_name_attribute)).to eq(sanitized_file_name)
+      end
+    end
+    context "with file name being nil" do
+      let(:file_name) { nil }
+
+      it "does not sanitizes the file name before saving" do
+        subject.send("#{file_name_attribute}=", file_name)
+        subject.save
+        expect(subject.send(file_name_attribute)).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.4-stable`:
 - [Merge pull request #3434 from AlchemyCMS/fix-picture-image-file-name-sanitize](https://github.com/AlchemyCMS/alchemy_cms/pull/3434)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)