### PR TITLE
Fix Propshaft >= 1.2.0 manifest format compatibility

### DIFF
--- a/lib/tasks/alchemy/assets.rake
+++ b/lib/tasks/alchemy/assets.rake
@@ -6,7 +6,7 @@ if Rake::Task.task_defined?("assets:precompile") && defined?(Propshaft)
     manifest.select { |k| k.include?("tinymce/") }.each do |k, v|
       Propshaft.logger.info "Copying #{v} to #{k}"
       FileUtils.cp(
-        assets_path.join(v.dig('digested_path') || v),
+        assets_path.join(v.dig("digested_path") || v),
         assets_path.join(k)
       )
     end


### PR DESCRIPTION
## What is this pull request for?

The format of the manifest used by Propshaft has changed with version [1.2.0](https://github.com/rails/propshaft/releases/tag/v1.2.0). This fix ensures compatibility with the new format, while maintaining backwards compatibility.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
