### PR TITLE
fix(CI): Build package after bun update

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -24,9 +24,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all history
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
       - name: Get changed files
         id: changed-bun-lock
         run: |
+          bun install
           git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} > changed_files
           cat changed_files
           if grep -q bun.lockdb changed_files; then
@@ -203,10 +206,18 @@ jobs:
     needs: [check_bun_lock, RSpec]
     if: github.event_name == 'pull_request' && needs.check_bun_lock.outputs.bun_lock_changed == 'true'
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.ALCHEMY_BOT_APP_ID }}
+          private-key: ${{ secrets.ALCHEMY_BOT_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
+          token: ${{ steps.generate_token.outputs.token }}
           ref: ${{ github.head_ref }}
-          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of our personal access token.
+          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
+          persist-credentials: false
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
       - uses: actions/download-artifact@v4
         with:
@@ -226,7 +237,7 @@ jobs:
         if: steps.git-status.outputs.changed == 'true'
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.ALCHEMY_CI_BOT_ACCESS_TOKEN }}
+          github_token: ${{ steps.generate_token.outputs.token }}
           branch: ${{ github.head_ref }}
 
   Vitest:


### PR DESCRIPTION
Dependabot is not able to write bun.lockb files.
We need the packages to be rewritten after a
bun update and successful specs.
