### PR TITLE
CI: Stop testing Ruby 3.1 and Rails 7.1

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -77,10 +77,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - rails: "7.1"
-            ruby: "3.1"
-            database: postgresql
-            storage: active_storage
           - rails: "7.2"
             ruby: "3.2"
             database: mariadb


### PR DESCRIPTION
Ruby 3.1 is EOL since 2025-03-31 and Rails 7.1 since 2025-10-01
