### PR TITLE
fix(Node Form): Use pattern for URL matching

### DIFF
--- a/app/views/alchemy/admin/nodes/_form.html.erb
+++ b/app/views/alchemy/admin/nodes/_form.html.erb
@@ -16,7 +16,11 @@
       <%= render Alchemy::Admin::PageSelect.new(node.page, allow_clear: true, query_params: {contentpages: true}) do %>
         <%= f.input :page_id, label: Alchemy::Page.model_name.human %>
       <% end %>
-      <%= f.input :url, input_html: { disabled: node.page }, hint: Alchemy.t(:node_url_hint) %>
+      <%= f.input :url, as: :string, input_html: {
+          disabled: node.page,
+          pattern: '/.*|[a-zA-Z][\w\+\-\.]*://.+',
+          title: Alchemy.t(:node_url_hint)
+        }, hint: Alchemy.t(:node_url_hint) %>
       <%= f.input :title %>
       <%= f.input :nofollow %>
       <%= f.input :external %>

--- a/spec/features/admin/menus_features_spec.rb
+++ b/spec/features/admin/menus_features_spec.rb
@@ -54,6 +54,38 @@ RSpec.describe "Admin Menus Features", type: :system do
         end
       end
     end
+
+    context "without pages", :js do
+      let!(:main_menu) { create(:alchemy_node, name: "Main Menu") }
+
+      it "can add node with absolute url path" do
+        visit alchemy.admin_nodes_path
+        expect(page).to have_selector(".node_name", text: "Main Menu")
+        within ".nodes_tree" do
+          click_link_with_tooltip Alchemy.t(:create_node)
+        end
+        within ".alchemy-dialog" do
+          fill_in "Name", with: "Internal Link"
+          fill_in "URL", with: "/custom-url"
+          click_button "create"
+        end
+        expect(page).to have_selector(".node_name", text: "/custom-url")
+      end
+
+      it "can add node with full external url" do
+        visit alchemy.admin_nodes_path
+        expect(page).to have_selector(".node_name", text: "Main Menu")
+        within ".nodes_tree" do
+          click_link_with_tooltip Alchemy.t(:create_node)
+        end
+        within ".alchemy-dialog" do
+          fill_in "Name", with: "External Link"
+          fill_in "URL", with: "https://example.com/index.php?page=123"
+          click_button "create"
+        end
+        expect(page).to have_selector(".node_name", text: "https://example.com/index.php?page=123")
+      end
+    end
   end
 
   describe "adding a new menu" do


### PR DESCRIPTION
## What is this pull request for?

The `type=url` input does not allow absolute
urls paths, which we still want to allow for
custom internal routes. Using a `type=text`
with a pattern which gives the user feedback
over the values allowed.

Closes #3470

## Screenshots

<img width="500" height="auto" alt="CleanShot 2025-11-06 at 16 33 01@2x" src="https://github.com/user-attachments/assets/1b8c820e-837e-4107-ab4e-c3b812d45e65" />

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
