### PR TITLE
Only mark ingredients as mandatory for presence validations

### DIFF
--- a/app/decorators/alchemy/ingredient_editor.rb
+++ b/app/decorators/alchemy/ingredient_editor.rb
@@ -124,8 +124,16 @@ module Alchemy
     end
 
     def presence_validation?
-      validations.include?("presence") ||
-        validations.any? { _1.is_a?(Hash) && _1[:presence] == true }
+      validations.any? do |validation|
+        case validation
+        when :presence, "presence"
+          true
+        when Hash
+          validation[:presence] == true || validation["presence"] == true
+        else
+          false
+        end
+      end
     end
 
     private

--- a/app/helpers/alchemy/admin/ingredients_helper.rb
+++ b/app/helpers/alchemy/admin/ingredients_helper.rb
@@ -9,7 +9,7 @@ module Alchemy
       #
       # Displays a warning icon if ingredient is missing its definition.
       #
-      # Displays a mandatory field indicator, if the ingredient has validations.
+      # Displays a mandatory field indicator, if the ingredient has a presence validation.
       #
       def render_ingredient_role(ingredient)
         if ingredient.blank?
@@ -24,7 +24,7 @@ module Alchemy
           content = "#{icon} #{content}".html_safe
         end
 
-        if ingredient.has_validations?
+        if ingredient.presence_validation?
           "#{content}<span class='validation_indicator'>*</span>".html_safe
         else
           content

--- a/app/models/alchemy/ingredient_validator.rb
+++ b/app/models/alchemy/ingredient_validator.rb
@@ -80,6 +80,8 @@ module Alchemy
     end
 
     def validate_format(format)
+      return if ingredient.value.blank?
+
       matcher = if format.is_a?(String) || format.is_a?(Symbol)
         Alchemy.config.format_matchers.get(format)
       else
@@ -91,6 +93,8 @@ module Alchemy
     end
 
     def validate_length(opts = {})
+      return if ingredient.value.blank?
+
       value_length = ingredient.value.to_s.length
       if value_length < opts[:minimum]
         ingredient.errors.add(:value, :too_short, count: opts[:minimum])

--- a/spec/decorators/alchemy/ingredient_editor_spec.rb
+++ b/spec/decorators/alchemy/ingredient_editor_spec.rb
@@ -306,6 +306,20 @@ RSpec.describe Alchemy::IngredientEditor do
       it { is_expected.to be(false) }
     end
 
+    context "when ingredient has presence validation as symbol" do
+      let(:ingredient) do
+        mock_model(
+          "Alchemy::Ingredients::Text",
+          definition: Alchemy::IngredientDefinition.new(
+            role: "foo",
+            validate: [:presence]
+          )
+        )
+      end
+
+      it { is_expected.to be(true) }
+    end
+
     context "when ingredient has presence validation as string" do
       let(:ingredient) do
         mock_model(
@@ -320,13 +334,83 @@ RSpec.describe Alchemy::IngredientEditor do
       it { is_expected.to be(true) }
     end
 
-    context "when ingredient has presence validation as hash" do
+    context "when ingredient has presence validation as hash with symbol key" do
       let(:ingredient) do
         mock_model(
           "Alchemy::Ingredients::Text",
           definition: Alchemy::IngredientDefinition.new(
             role: "foo",
             validate: [{presence: true}]
+          )
+        )
+      end
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when ingredient has presence validation as hash with string key" do
+      let(:ingredient) do
+        mock_model(
+          "Alchemy::Ingredients::Text",
+          definition: Alchemy::IngredientDefinition.new(
+            role: "foo",
+            validate: [{"presence" => true}]
+          )
+        )
+      end
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when ingredient has presence: false with symbol key" do
+      let(:ingredient) do
+        mock_model(
+          "Alchemy::Ingredients::Text",
+          definition: Alchemy::IngredientDefinition.new(
+            role: "foo",
+            validate: [{presence: false}]
+          )
+        )
+      end
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when ingredient has presence: false with string key" do
+      let(:ingredient) do
+        mock_model(
+          "Alchemy::Ingredients::Text",
+          definition: Alchemy::IngredientDefinition.new(
+            role: "foo",
+            validate: [{"presence" => false}]
+          )
+        )
+      end
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when ingredient has only format validation" do
+      let(:ingredient) do
+        mock_model(
+          "Alchemy::Ingredients::Text",
+          definition: Alchemy::IngredientDefinition.new(
+            role: "foo",
+            validate: [{format: "email"}]
+          )
+        )
+      end
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when ingredient has format and presence validation" do
+      let(:ingredient) do
+        mock_model(
+          "Alchemy::Ingredients::Text",
+          definition: Alchemy::IngredientDefinition.new(
+            role: "foo",
+            validate: [:presence, {format: "email"}]
           )
         )
       end

--- a/spec/features/admin/edit_elements_feature_spec.rb
+++ b/spec/features/admin/edit_elements_feature_spec.rb
@@ -181,9 +181,6 @@ RSpec.describe "The edit elements feature", type: :system do
         within ".element_errors" do
           expect(page).to have_content(/Please check marked fields below/)
         end
-        within first("small.error", minimum: 1) do
-          expect(page).to have_content(/is invalid/)
-        end
       end
     end
   end

--- a/spec/helpers/alchemy/admin/ingredients_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/ingredients_helper_spec.rb
@@ -60,7 +60,7 @@ describe Alchemy::Admin::IngredientsHelper do
       let(:ingredient) do
         mock_model "Alchemy::Ingredients::Text",
           role: "intro",
-          definition: {},
+          definition: Alchemy::IngredientDefinition.new,
           translated_role: "Intro",
           has_validations?: false,
           deprecated?: false,
@@ -97,7 +97,7 @@ describe Alchemy::Admin::IngredientsHelper do
     end
 
     context "with validations" do
-      before { expect(ingredient).to receive(:has_validations?).and_return(true) }
+      before { expect(ingredient_editor).to receive(:presence_validation?).and_return(true) }
 
       it "show a validation indicator" do
         is_expected.to have_selector(".validation_indicator")

--- a/spec/models/alchemy/ingredient_validator_spec.rb
+++ b/spec/models/alchemy/ingredient_validator_spec.rb
@@ -73,6 +73,14 @@ RSpec.describe Alchemy::IngredientValidator do
         it { expect(ingredient.errors).to be_present }
       end
     end
+
+    context "and the value is blank" do
+      let(:value) { "" }
+
+      it "does not add format validation errors" do
+        expect(ingredient.errors).to be_blank
+      end
+    end
   end
 
   context "an element with url format validation" do
@@ -126,6 +134,15 @@ RSpec.describe Alchemy::IngredientValidator do
       let(:value) { "applejuice" }
 
       it { expect(ingredient).to be_valid }
+    end
+
+    context "and the value is blank" do
+      let(:value) { "" }
+
+      it "does not add length validation errors" do
+        expect(ingredient.errors[:value]).not_to include("is too short (minimum is 3 characters)")
+        expect(ingredient.errors[:value]).not_to include("is too long (maximum is 50 characters)")
+      end
     end
   end
 


### PR DESCRIPTION
## What is this pull request for?

This PR fixes an issue where format and length validations were incorrectly applied to blank values in optional ingredient fields. Now, validation is only triggered when a value is present, preventing validation errors on optional fields that are intentionally left empty.

Additionally, the mandatory field indicator (*) in the Alchemy editor now correctly shows only for fields with presence validation, rather than for any validation type.

### Notable changes

**Validation behavior:**
- Format validation (`validate_format`) now skips blank values
- Length validation (`validate_length`) now skips blank values
- This ensures optional fields (without presence validation) don't show errors when left empty

**UI indicator:**
- The mandatory field indicator (*) in `app/helpers/alchemy/admin/ingredients_helper.rb:27` now uses `presence_validation?` instead of `has_validations?`
- This means only fields with presence validation show the asterisk, not fields with only format or length validation

**Code improvements:**
- Enhanced `presence_validation?` method in `app/decorators/alchemy/ingredient_editor.rb:126-136` to handle all validation format variations (symbols, strings, and hashes with both symbol and string keys)
- Added comprehensive test coverage for various validation scenarios

## Checklist
- [X] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [X] I have added a detailed description into each commit message
- [X] I have added tests to cover this change
