### PR TITLE
Fix element position not persisting after drag and drop for new elements

### DIFF
--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -100,13 +100,14 @@ module Alchemy
 
       def order
         @element = Element.find(params[:element_id])
-        @element.update(
-          parent_element_id: params[:parent_element_id],
-          position: params[:position]
-        )
-        if params[:parent_element_id].present?
-          @parent_element = Element.find_by(id: params[:parent_element_id])
-        end
+
+        # Update position
+        @element.parent_element_id = params[:parent_element_id] if params.key?(:parent_element_id)
+        @element.position = params[:position]
+
+        # Skip validations when updating position, since new records may not yet meet all
+        # validation requirements.
+        @element.save(validate: false)
 
         render json: {
           message: Alchemy.t(:successfully_saved_element_position),

--- a/spec/controllers/alchemy/admin/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/elements_controller_spec.rb
@@ -55,6 +55,19 @@ module Alchemy
         ])
       end
 
+      it "saves position without validation" do
+        # Create an element that would fail validation if validated
+        element = create(:alchemy_element, page_version: page_version)
+
+        # Stub validation to fail
+        allow_any_instance_of(Element).to receive(:valid?).and_return(false)
+
+        # Position should still be saved
+        expect {
+          post :order, params: {element_id: element.id, position: 2}
+        }.to change { element.reload.position }.to(2)
+      end
+
       context "when nested inside parent element" do
         let(:parent) { create(:alchemy_element) }
 


### PR DESCRIPTION
## What is this pull request for?

This PR fixes an issue where newly created elements would lose their position after being reordered via drag and drop. When a user added a new element and immediately moved it to a different position before filling in the ingredient fields, the position would reset to the bottom when saving the element.

The root cause was that the order action was calling update() which would fail validation on newly created elements that don't yet have all required ingredient values filled in.

### Notable changes

Changed ElementsController#order to skip validations:
- Replaced @element.update() with manual attribute assignment and save(validate: false)
- This allows position updates to persist even when the element doesn't yet meet all validation requirements (e.g., empty required ingredient fields)
- Added inline comment explaining why validations are skipped

Added test coverage:
- New spec verifies that position is saved even when element has validation errors
- Ensures the fix continues to work correctly

### Screenshots

No visual changes - this is a behavioral fix for element reordering.

## Checklist
- [X] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [X] I have added a detailed description into each commit message
- [X] I have added tests to cover this change
