### PR TITLE
Do not block database during index migration

### DIFF
--- a/db/migrate/20250626160259_add_unique_index_to_picture_descriptions.rb
+++ b/db/migrate/20250626160259_add_unique_index_to_picture_descriptions.rb
@@ -1,7 +1,15 @@
 class AddUniqueIndexToPictureDescriptions < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction! if connection.adapter_name.match?(/postgres/i)
+
   def change
     add_index :alchemy_picture_descriptions, [:picture_id, :language_id],
       name: "alchemy_picture_descriptions_on_picture_id_and_language_id",
-      unique: true
+      unique: true, algorithm: algorithm
+  end
+
+  private
+
+  def algorithm
+    connection.adapter_name.match?(/postgres/i) ? :concurrently : nil
   end
 end

--- a/spec/dummy/db/migrate/20250626160417_add_unique_index_to_picture_descriptions.alchemy.rb
+++ b/spec/dummy/db/migrate/20250626160417_add_unique_index_to_picture_descriptions.alchemy.rb
@@ -1,8 +1,16 @@
 # This migration comes from alchemy (originally 20250626160259)
 class AddUniqueIndexToPictureDescriptions < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction! if connection.adapter_name.match?(/postgres/i)
+
   def change
     add_index :alchemy_picture_descriptions, [:picture_id, :language_id],
       name: "alchemy_picture_descriptions_on_picture_id_and_language_id",
-      unique: true
+      unique: true, algorithm: algorithm
+  end
+
+  private
+
+  def algorithm
+    connection.adapter_name.match?(/postgres/i) ? :concurrently : nil
   end
 end


### PR DESCRIPTION
This makes sure, that we do not block table writes during migrating this index on postgres.
