### PR TITLE
fix(ActiveStorage::PictureUrl): Do not transform if image is invariable

### DIFF
--- a/spec/models/alchemy/storage_adapter/active_storage/picture_url_spec.rb
+++ b/spec/models/alchemy/storage_adapter/active_storage/picture_url_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Alchemy::StorageAdapter::ActiveStorage::PictureUrl, if: Alchemy.storage_adapter.active_storage? do
-  let(:picture) { create(:alchemy_picture) }
-  let(:image_file) { picture.image_file }
+  let(:picture) { create(:alchemy_picture, image_file:) }
+  let(:image_file) { fixture_file_upload("image.png") }
 
   before do
     allow(Alchemy.config).to receive(:image_output_format) { "webp" }
@@ -12,35 +12,54 @@ RSpec.describe Alchemy::StorageAdapter::ActiveStorage::PictureUrl, if: Alchemy.s
 
   let(:options) { {} }
 
-  it "returns the url for the variant" do
-    expect(url).to match(/\/rails\/active_storage\/representations\/redirect\/.+\/image\.webp/)
+  context "when picture has no image_file" do
+    before do
+      allow(picture).to receive(:image_file).and_return(nil)
+    end
+
+    it "returns nil" do
+      expect(url).to be_nil
+    end
   end
 
-  it "returns the configured format if not 'original'" do
-    expect(url).to match(/\.webp/)
+  context "with variable image file" do
+    it "returns the url for the variant" do
+      expect(url).to match(/\/rails\/active_storage\/representations\/redirect\/.+\/image\.webp/)
+    end
+
+    it "returns the configured format if not 'original'" do
+      expect(url).to match(/\.webp/)
+    end
+
+    context "if config is 'original'" do
+      before do
+        allow(Alchemy.config).to receive(:image_output_format).and_return("original")
+      end
+
+      it "returns the image_file_extension" do
+        expect(url).to match(/\.png/)
+      end
+    end
+
+    context "with format given" do
+      let(:options) { {format: "jpg"} }
+
+      it "uses the provided format" do
+        expect(url).to match(/\/rails\/active_storage\/representations\/redirect\/.+\/image\.jpg/)
+      end
+    end
   end
 
-  it "returns nil if image_file is nil" do
-    allow(picture).to receive(:image_file).and_return(nil)
-    expect(url).to be_nil
-  end
+  context "with invariable image file" do
+    let(:picture) { create(:alchemy_picture, image_file:) }
+    let(:image_file) { fixture_file_upload("icon.svg") }
 
-  it "returns nil if variant is nil" do
-    allow(image_file).to receive(:variant).and_return(nil)
-    expect(url).to be_nil
-  end
+    it "returns the url for the original image" do
+      expect(url).to match(/\/rails\/active_storage\/blobs\/redirect\/.+\/image\.svg/)
+    end
 
-  it "returns the image_file_extension if config is 'original'" do
-    allow(Alchemy.config).to receive(:image_output_format).and_return("original")
-    allow(picture).to receive(:image_file_extension).and_return("gif")
-    expect(url).to match(/\.gif/)
-  end
-
-  context "with format given" do
-    let(:options) { {format: "jpg"} }
-
-    it "uses the provided format" do
-      expect(url).to match(/\/rails\/active_storage\/representations\/redirect\/.+\/image\.jpg/)
+    it "returns the image_file_extension" do
+      expect(url).to match(/\.svg/)
     end
   end
 


### PR DESCRIPTION
## What is this pull request for?

We cannot transform SVGs with ActiveStorage.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
