### PR TITLE
fix(seeder): Use YAML.safe_load to load users.yml

### DIFF
--- a/lib/alchemy/seeder.rb
+++ b/lib/alchemy/seeder.rb
@@ -68,7 +68,7 @@ module Alchemy
               "Please use `rake db:reset' if you want to rebuild your database.", :skip
           false
         else
-          users = YAML.load_file(user_seeds_file)
+          users = load_yaml_file(user_seeds_file)
           users.each do |draft|
             user = Alchemy.user_class.create!(draft)
             log "Created user: #{user.try(:email) || user.try(:login) || user.id}"
@@ -83,9 +83,15 @@ module Alchemy
       end
 
       def page_yml
-        @_page_yml ||= YAML.safe_load(
-          page_seeds_file.read,
-          permitted_classes: [Date],
+        @_page_yml ||= load_yaml_file(
+          page_seeds_file
+        )
+      end
+
+      def load_yaml_file(file)
+        YAML.safe_load_file(
+          file,
+          permitted_classes: [Date, Symbol],
           aliases: true
         )
       end

--- a/spec/features/user_seeder_spec.rb
+++ b/spec/features/user_seeder_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "User seeding", type: :system do
     before do
       FileUtils.mkdir_p(Rails.root.join("db/seeds/alchemy"))
       FileUtils.cp(seeds_file, Rails.root.join("db/seeds/alchemy/users.yml"))
+      allow_any_instance_of(DummyUser).to receive(:confirmed_at=)
     end
 
     it "seeds users" do

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -1,9 +1,11 @@
 - email: admin@example.com
   password: test123
+  confirmed_at: 2025-01-01
   alchemy_roles:
     - admin
 
 - email: member@example.com
   password: test123
+  confirmed_at: 2025-01-01
   alchemy_roles:
     - member


### PR DESCRIPTION
## What is this pull request for?

We need to permit `Date` and `Symbol`, if we want to
load the `seeds/users.yml` file in Psych >= 4

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message

