### PR TITLE
feat(Page): Add all_ingredients association

### DIFF
--- a/app/models/alchemy/page/page_elements.rb
+++ b/app/models/alchemy/page/page_elements.rb
@@ -20,6 +20,8 @@ module Alchemy
         end
 
         has_many :ingredients, through: :elements
+        has_many :all_ingredients, through: :all_elements, source: :ingredients
+
         has_and_belongs_to_many :to_be_swept_elements, -> { distinct },
           class_name: "Alchemy::Element",
           join_table: ElementToPage.table_name

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -7,6 +7,10 @@ module Alchemy
     it { is_expected.to have_many(:folded_pages).dependent(:destroy) }
     it { is_expected.to have_many(:legacy_urls).dependent(:destroy) }
     it { is_expected.to have_many(:versions) }
+    it { is_expected.to have_many(:elements) }
+    it { is_expected.to have_many(:all_elements) }
+    it { is_expected.to have_many(:ingredients) }
+    it { is_expected.to have_many(:all_ingredients) }
     it { is_expected.to have_one(:draft_version) }
     it { is_expected.to have_one(:public_version) }
 


### PR DESCRIPTION
## What is this pull request for?

The `Page#ingredients` association only returns
first level ingredients (via the `elements` association).

Adding `all_ingredients` similar the `all_elements` allows to access all ingredients a page has.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
