### PR TITLE
fix(page): Add `"page_layout"` to `ransackable_attributes`

### DIFF
--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -251,7 +251,7 @@ module Alchemy
 
       # Allow all string and text attributes to be searchable by Ransack.
       def ransackable_attributes(_auth_object = nil)
-        searchable_alchemy_resource_attributes + ["updated_at"]
+        searchable_alchemy_resource_attributes + %w[updated_at page_layout]
       end
     end
 

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -682,6 +682,22 @@ module Alchemy
         end
       end
 
+      describe ".ransackable_attributes" do
+        let(:auth_object) { double }
+
+        subject { described_class.ransackable_attributes(auth_object) }
+
+        it do
+          is_expected.to contain_exactly(
+            "page_layout",
+            "updated_at",
+            "urlname",
+            "title",
+            "name"
+          )
+        end
+      end
+
       describe ".ransackable_scopes" do
         let(:auth_object) { double }
 


### PR DESCRIPTION
## What is this pull request for?

We have a `page_layout` filter and ransack needs
the attributes to be listed that we want to filter by.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
