### PR TITLE
fix(page filter): Only select from content pages

### DIFF
--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -38,7 +38,9 @@ module Alchemy
         only: [:show]
 
       add_alchemy_filter :by_page_layout, type: :select, options: ->(_q) do
-        PageDefinition.all.map { |p| [Alchemy.t(p[:name], scope: "page_layout_names"), p[:name]] }
+        PageDefinition.all.reject(&:layoutpage).tap do |page_layouts|
+          page_layouts.map! { |p| [Alchemy.t(p[:name], scope: "page_layout_names"), p[:name]] }
+        end
       end
 
       add_alchemy_filter :updated_at_gteq, type: :datepicker

--- a/spec/features/admin/page_list_feature_spec.rb
+++ b/spec/features/admin/page_list_feature_spec.rb
@@ -116,5 +116,13 @@ RSpec.describe "Admin page list", type: :system do
         expect(page).to_not have_css("tr:nth-child(3)")
       end
     end
+
+    specify "page type filter only includes content pages" do
+      visit admin_pages_path(view: "list")
+      options = find_all("select#q_by_page_layout > option")
+      options.each do |option|
+        expect(option.value).to_not eq("footer")
+      end
+    end
   end
 end


### PR DESCRIPTION
## What is this pull request for?

The page list only displays content pages and no layoutpages. We should exclude them from the list.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
