### PR TITLE
fix(assignments): Only list draft elements

### DIFF
--- a/app/controllers/alchemy/admin/attachments_controller.rb
+++ b/app/controllers/alchemy/admin/attachments_controller.rb
@@ -37,7 +37,7 @@ module Alchemy
 
       # The resources controller renders the edit form as default for show actions.
       def show
-        @assignments = @attachment.related_ingredients.joins(element: :page)
+        @assignments = @attachment.related_ingredients.joins(element: :page).merge(PageVersion.drafts)
         render :show
       end
 

--- a/app/controllers/alchemy/admin/pictures_controller.rb
+++ b/app/controllers/alchemy/admin/pictures_controller.rb
@@ -43,7 +43,7 @@ module Alchemy
         @previous = @pictures.prev_page
         @next = @pictures.next_page
 
-        @assignments = @picture.related_ingredients.joins(element: :page)
+        @assignments = @picture.related_ingredients.joins(element: :page).merge(PageVersion.drafts)
         @picture_description = @picture.descriptions.find_or_initialize_by(
           language_id: Alchemy::Current.language.id
         )

--- a/spec/controllers/alchemy/admin/attachments_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/attachments_controller_spec.rb
@@ -95,6 +95,21 @@ module Alchemy
         get :show, params: {id: attachment.id}
         expect(response).to render_template(:show)
       end
+
+      context "with assignments" do
+        let!(:page) { create(:alchemy_page) }
+        let!(:element) { create(:alchemy_element, page: page) }
+        let!(:ingredient) { create(:alchemy_ingredient_file, element: element, related_object: attachment) }
+
+        before do
+          page.publish!
+        end
+
+        it "assigns all file ingredients having an assignment to @assignments" do
+          get :show, params: {id: attachment.id}
+          expect(assigns(:assignments)).to eq([ingredient])
+        end
+      end
     end
 
     describe "#create" do

--- a/spec/controllers/alchemy/admin/pictures_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/pictures_controller_spec.rb
@@ -179,6 +179,10 @@ module Alchemy
         let!(:element) { create(:alchemy_element, page: page) }
         let!(:ingredient) { create(:alchemy_ingredient_picture, element: element, related_object: picture) }
 
+        before do
+          page.publish!
+        end
+
         it "assigns all picture ingredients having an assignment to @assignments" do
           get :show, params: {id: picture.id}
           expect(assigns(:assignments)).to eq([ingredient])


### PR DESCRIPTION
## What is this pull request for?

We should only link to the draft version elements, because the user cannot edit the published version in the page edit mode.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
