### PR TITLE
fix(PictureEditor): Use local klass to translate

### DIFF
--- a/app/views/alchemy/admin/ingredients/_picture_fields.html.erb
+++ b/app/views/alchemy/admin/ingredients/_picture_fields.html.erb
@@ -15,7 +15,7 @@
       then css_classes
     else
       css_classes.map do |klass|
-        [Alchemy.t(klass, scope: "picture_ingredients.css_classes", default: ingredient.css_class&.camelcase), klass]
+        [Alchemy.t(klass, scope: "picture_ingredients.css_classes", default: klass&.humanize), klass]
       end
     end %>
   <%= f.input :css_class, collection: css_classes_collection, include_blank: false %>

--- a/app/views/alchemy/ingredients/shared/_picture_css_class.html.erb
+++ b/app/views/alchemy/ingredients/shared/_picture_css_class.html.erb
@@ -2,5 +2,5 @@
   <%= render_icon "pencil-ruler-2", style: "line", size: "1x" %>
   <%= Alchemy.t(css_class,
     scope: "picture_ingredients.css_classes",
-    default: css_class.camelcase) %>
+    default: css_class.humanize) %>
 </div>


### PR DESCRIPTION
Otherwise all option labels are the same once we set a css_class on the ingredient.
