### PR TITLE
Reset Current.site between tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -82,8 +82,8 @@ RSpec.configure do |config|
 
   config.use_transactional_fixtures = true
 
-  # All specs are running in transactions, but feature specs not.
   config.before(:each) do
+    Alchemy::Current.site = nil
     ::I18n.locale = :en
   end
 


### PR DESCRIPTION
In order to prevent test pollution when a previous test sets `Current.site` to a value that differs from `Site.first`, which could cause `Language.default` to return `nil` and trigger uniqueness conflicts in factories.