### PR TITLE
Replace HTTP status code symbols with numeric codes

### DIFF
--- a/app/controllers/alchemy/admin/attachments_controller.rb
+++ b/app/controllers/alchemy/admin/attachments_controller.rb
@@ -52,13 +52,13 @@ module Alchemy
 
       def create
         @attachment = Attachment.create(attachment_attributes)
-        handle_uploader_response(status: :created)
+        handle_uploader_response(status: 201)
       end
 
       def update
         @attachment.update(attachment_attributes)
         if attachment_attributes["file"].present?
-          handle_uploader_response(status: :accepted)
+          handle_uploader_response(status: 202)
         else
           render_errors_or_redirect(
             @attachment,

--- a/app/controllers/alchemy/admin/base_controller.rb
+++ b/app/controllers/alchemy/admin/base_controller.rb
@@ -111,7 +111,7 @@ module Alchemy
           do_redirect_to redirect_url
         else
           render action: ((params[:action] == "update") ? "edit" : "new"),
-            status: :unprocessable_entity
+            status: 422
         end
       end
 

--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -41,11 +41,11 @@ module Alchemy
           end
         end
         if @element.save
-          render :create, status: :created
+          render :create, status: 201
         else
           @element.page_version = @page_version
           @elements = @page.available_element_definitions
-          render :new, status: :unprocessable_entity
+          render :new, status: 422
         end
       end
 
@@ -74,7 +74,7 @@ module Alchemy
                 errorMessage: ingredient.errors.messages[:value].to_sentence
               }
             end
-          }, status: :unprocessable_entity
+          }, status: 422
         end
       end
 

--- a/app/controllers/alchemy/admin/layoutpages_controller.rb
+++ b/app/controllers/alchemy/admin/layoutpages_controller.rb
@@ -26,7 +26,7 @@ module Alchemy
           @while_page_edit = request.referer.include?("edit")
           render "alchemy/admin/pages/update"
         else
-          render :edit, status: :unprocessable_entity
+          render :edit, status: 422
         end
       end
 

--- a/app/controllers/alchemy/admin/legacy_page_urls_controller.rb
+++ b/app/controllers/alchemy/admin/legacy_page_urls_controller.rb
@@ -22,7 +22,7 @@ module Alchemy
         @message = message_for_resource_action
         render :update
       else
-        render :edit, status: :unprocessable_entity
+        render :edit, status: 422
       end
     end
 

--- a/app/controllers/alchemy/admin/nodes_controller.rb
+++ b/app/controllers/alchemy/admin/nodes_controller.rb
@@ -34,12 +34,12 @@ module Alchemy
               flash_notice_for_resource_action(:create)
               do_redirect_to(admin_nodes_path)
             else
-              render :new, status: :unprocessable_entity
+              render :new, status: 422
             end
           rescue => e
             flash[:error] = e.message
             new  # Reinitialize instance variables like @node
-            render :new, status: :unprocessable_entity
+            render :new, status: 422
           end
         else
           @node = Node.new(resource_params)
@@ -47,7 +47,7 @@ module Alchemy
             flash_notice_for_resource_action(:create)
             do_redirect_to(admin_nodes_path)
           else
-            render :new, status: :unprocessable_entity
+            render :new, status: 422
           end
         end
       end

--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -139,7 +139,7 @@ module Alchemy
             flash[:notice] = @notice
           end
         else
-          render :configure, status: :unprocessable_entity
+          render :configure, status: 422
         end
       end
 
@@ -175,7 +175,7 @@ module Alchemy
             if was_folded
               @page = PageTreePreloader.new(page: @page, user: current_alchemy_user).call
             else
-              head :ok
+              head 200
             end
           end
         end

--- a/app/controllers/alchemy/admin/pictures_controller.rb
+++ b/app/controllers/alchemy/admin/pictures_controller.rb
@@ -89,7 +89,7 @@ module Alchemy
             type: "error"
           }
         end
-        render :update, status: (@message[:type] == "notice") ? :ok : :unprocessable_entity
+        render :update, status: (@message[:type] == "notice") ? 200 : 422
       end
 
       def update_multiple

--- a/app/controllers/alchemy/base_controller.rb
+++ b/app/controllers/alchemy/base_controller.rb
@@ -54,7 +54,7 @@ module Alchemy
         WARN
       end
       if request.format.json?
-        render json: {message: Alchemy.t("You are not authorized")}, status: :unauthorized
+        render json: {message: Alchemy.t("You are not authorized")}, status: 401
       elsif current_alchemy_user
         handle_redirect_for_user
       else

--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -157,7 +157,7 @@ module Alchemy
 
     # Redirects to given url with 301 status
     def redirect_permanently_to(url)
-      redirect_to url, status: :moved_permanently
+      redirect_to url, status: 301
     end
 
     # Returns url parameters that are not internal show page params.

--- a/app/controllers/concerns/alchemy/admin/uploader_responses.rb
+++ b/app/controllers/concerns/alchemy/admin/uploader_responses.rb
@@ -5,7 +5,7 @@ module Alchemy
     module UploaderResponses
       extend ActiveSupport::Concern
 
-      def successful_uploader_response(file:, status: :created)
+      def successful_uploader_response(file:, status: 201)
         message = Alchemy.t(:upload_success,
           scope: [:uploader, file.class.model_name.i18n_key],
           name: file.name)
@@ -24,7 +24,7 @@ module Alchemy
 
         {
           json: {message: message},
-          status: :unprocessable_entity
+          status: 422
         }
       end
     end

--- a/app/controllers/concerns/alchemy/site_redirects.rb
+++ b/app/controllers/concerns/alchemy/site_redirects.rb
@@ -12,7 +12,7 @@ module Alchemy
     private
 
     def enforce_primary_host_for_site
-      redirect_to url_for(host: current_alchemy_site.host), status: :moved_permanently, allow_other_host: true
+      redirect_to url_for(host: current_alchemy_site.host), status: 301, allow_other_host: true
     end
 
     def needs_redirect_to_primary_host?

--- a/spec/controllers/alchemy/admin/base_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/base_controller_spec.rb
@@ -86,7 +86,7 @@ describe Alchemy::Admin::BaseController do
           controller.send(:permission_denied, CanCan::AccessDenied.new)
           expect(controller).to have_received(:render).with(
             json: {message: Alchemy.t("You are not authorized")},
-            status: :unauthorized
+            status: 401
           )
         end
       end

--- a/spec/controllers/alchemy/admin/nodes_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/nodes_controller_spec.rb
@@ -94,7 +94,7 @@ module Alchemy
           }
 
           expect(response).to render_template(:new)
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(422)
           expect(flash[:error]).to eq("Copy failed")
         end
 
@@ -139,7 +139,7 @@ module Alchemy
           }
 
           expect(response).to render_template(:new)
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(422)
         end
       end
 
@@ -164,7 +164,7 @@ module Alchemy
           post :create, params: {node: invalid_params}
 
           expect(response).to render_template(:new)
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(422)
         end
 
         it "loads clipboard items for error rendering" do

--- a/spec/controllers/alchemy/on_page_layout_mixin_spec.rb
+++ b/spec/controllers/alchemy/on_page_layout_mixin_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe ApplicationController, "OnPageLayout mixin", type: :controller do
   controller do
     def index
       @another_controller = true
-      head :ok
+      head 200
     end
   end
 


### PR DESCRIPTION
## What is this pull request for?

Replace all HTTP status code symbols with numeric codes to avoid Rack 3.1+ deprecation warnings.

Rack 3.1 renamed `:unprocessable_entity` to `:unprocessable_content`, which causes deprecation warnings. Since AlchemyCMS supports Rails 7.1+ (which can use Rack 2.x, 3.0, or 3.1+), using numeric codes ensures compatibility across all Rack versions without warnings.

For consistency, all status code symbols have been replaced:
- `:unprocessable_entity` → 422
- `:created` → 201
- `:accepted` → 202
- `:unauthorized` → 401
- `:moved_permanently` → 301
- `:ok` → 200

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change