### PR TITLE
fix(Page): Ignore deprecated meta data columns

### DIFF
--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -46,6 +46,13 @@ module Alchemy
   class Page < BaseRecord
     include Alchemy::Taggable
 
+    # These columns are deprecated in favor of page versions
+    self.ignored_columns += [
+      "meta_description",
+      "meta_keywords",
+      "title"
+    ]
+
     DEFAULT_ATTRIBUTES_FOR_COPY = {
       autogenerate_elements: false,
       public_on: nil,

--- a/spec/lib/alchemy/upgrader/eight_one_spec.rb
+++ b/spec/lib/alchemy/upgrader/eight_one_spec.rb
@@ -6,6 +6,20 @@ require "alchemy/upgrader"
 RSpec.describe Alchemy::Upgrader::EightOne do
   let(:upgrader) { Alchemy::Upgrader["8.1"] }
 
+  # Temporarily unignore the deprecated columns for testing
+  around do |example|
+    Alchemy::Shell.silence!
+    ignore_columns = Alchemy::Page.ignored_columns
+    Alchemy::Page.ignored_columns -= [
+      "meta_description",
+      "meta_keywords",
+      "title"
+    ]
+    example.run
+    Alchemy::Page.ignored_columns = ignore_columns
+    Alchemy::Shell.verbose!
+  end
+
   describe "#migrate_page_metadata" do
     context "when all page versions have metadata" do
       let!(:page) do


### PR DESCRIPTION
## What is this pull request for?

These columns are delegated to page version
and have not been deleted, so sites can migrate
the data via the alchemy upgrader. Ignoring
them from Active Records column cache, so
they are safe to delete later.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message

