### PR TITLE
CI: Use ubuntu-24 to run specs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   backport:
     name: Backport
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # Only react to merged PRs for security reasons.
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
     if: |

--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   brakeman-scan:
     name: Brakeman Scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -122,6 +122,7 @@ jobs:
       DB_USER: alchemy_user
       DB_PASSWORD: password
       DB_HOST: "127.0.0.1"
+      DEBIAN_FRONTEND: noninteractive
       RAILS_ENV: test
       RAILS_VERSION: ${{ matrix.rails }}
       ALCHEMY_STORAGE_ADAPTER: ${{ matrix.storage }}
@@ -172,15 +173,11 @@ jobs:
           sudo apt-get install -qq --fix-missing libmysqlclient-dev
       - name: Install libvips
         if: matrix.storage == 'active_storage'
-        env:
-          DEBIAN_FRONTEND: noninteractive
         run: |
           sudo apt-get update -qq
           sudo apt-get install -qq --fix-missing libvips
       - name: Install ImageMagick
         if: matrix.storage == 'dragonfly'
-        env:
-          DEBIAN_FRONTEND: noninteractive
         run: |
           sudo apt-get update -qq
           sudo apt-get install -qq --fix-missing imagemagick

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-24.04
     name: Check package.json
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history
       - name: Get changed files
@@ -52,7 +52,7 @@ jobs:
     needs: check_package_json
     if: needs.check_package_json.outputs.package_json_changed == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
       - name: Restore node_modules cache
@@ -145,7 +145,7 @@ jobs:
           MARIADB_ROOT_PASSWORD: password
         options: --health-cmd="mariadb-admin ping" --health-interval=10s --health-timeout=5s --health-retries=5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -220,7 +220,7 @@ jobs:
         with:
           app-id: ${{ vars.ALCHEMY_BOT_APP_ID }}
           private-key: ${{ secrets.ALCHEMY_BOT_APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ steps.generate_token.outputs.token }}
           ref: ${{ github.head_ref }}
@@ -260,7 +260,7 @@ jobs:
     env:
       NODE_ENV: test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
       - uses: actions/download-artifact@v4

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -79,7 +79,7 @@ jobs:
     permissions:
       contents: read
     needs: [check_package_json, build_javascript]
-    if: ${{ needs.build_javascript.result == 'success' || needs.build_javascript.result == 'skipped' }}
+    if: ${{ always() && (needs.build_javascript.result == 'success' || needs.build_javascript.result == 'skipped') }}
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -256,7 +256,7 @@ jobs:
       contents: read
     runs-on: ubuntu-24.04
     needs: [check_package_json, build_javascript]
-    if: ${{ needs.build_javascript.result == 'success' || needs.build_javascript.result == 'skipped' }}
+    if: ${{ always() && (needs.build_javascript.result == 'success' || needs.build_javascript.result == 'skipped') }}
     env:
       NODE_ENV: test
     steps:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -50,6 +50,7 @@ jobs:
     runs-on: ubuntu-24.04
     name: Build JS packages
     needs: check_package_json
+    if: needs.check_package_json.outputs.package_json_changed == 'true'
     steps:
       - uses: actions/checkout@v4
       - name: Setup Bun
@@ -64,15 +65,12 @@ jobs:
       - name: Install dependencies
         run: bun install
       - name: bun build
-        if: needs.check_package_json.outputs.package_json_changed == 'true'
         run: bun run --bun build
       - uses: actions/upload-artifact@v4
-        if: needs.check_package_json.outputs.package_json_changed == 'true'
         with:
           name: javascript-bundles
           path: vendor/javascript
       - uses: actions/upload-artifact@v4
-        if: needs.check_package_json.outputs.package_json_changed == 'true'
         with:
           name: bun-lockdb
           path: bun.lockdb
@@ -81,6 +79,7 @@ jobs:
     permissions:
       contents: read
     needs: [check_package_json, build_javascript]
+    if: ${{ needs.build_javascript.result == 'success' || needs.build_javascript.result == 'skipped' }}
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -257,6 +256,7 @@ jobs:
       contents: read
     runs-on: ubuntu-24.04
     needs: [check_package_json, build_javascript]
+    if: ${{ needs.build_javascript.result == 'success' || needs.build_javascript.result == 'skipped' }}
     env:
       NODE_ENV: test
     steps:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -20,7 +20,7 @@ jobs:
   check_package_json:
     permissions:
       contents: read
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Check package.json
     steps:
       - uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
   build_javascript:
     permissions:
       contents: read
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Build JS packages
     needs: check_package_json
     steps:
@@ -81,7 +81,7 @@ jobs:
     permissions:
       contents: read
     needs: [check_package_json, build_javascript]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -157,9 +157,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /home/runner/apt/cache
-          key: ${{ runner.os }}-apt-${{ matrix.database }}
+          key: ${{ runner.os }}-apt-${{ matrix.database }}-${{ matrix.storage }}
           restore-keys: |
-            ${{ runner.os }}-apt-
+            ${{ runner.os }}-apt-${{ matrix.database }}-
       - name: Install Postgres headers
         if: matrix.database == 'postgresql'
         run: |
@@ -182,6 +182,15 @@ jobs:
           mkdir -p /home/runner/apt/cache
           sudo apt update -qq
           sudo apt install -qq --fix-missing libvips -o dir::cache::archives="/home/runner/apt/cache"
+          sudo chown -R runner /home/runner/apt/cache
+      - name: Install ImageMagick
+        if: matrix.storage == 'dragonfly'
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          mkdir -p /home/runner/apt/cache
+          sudo apt update -qq
+          sudo apt install -qq --fix-missing imagemagick -o dir::cache::archives="/home/runner/apt/cache"
           sudo chown -R runner /home/runner/apt/cache
       - uses: actions/download-artifact@v4
         if: needs.check_package_json.outputs.package_json_changed == 'true'
@@ -213,7 +222,7 @@ jobs:
   PushJavascript:
     permissions:
       contents: write
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [check_package_json, RSpec]
     if: github.event_name == 'pull_request' && needs.check_package_json.outputs.package_json_changed == 'true'
     steps:
@@ -257,7 +266,7 @@ jobs:
   Vitest:
     permissions:
       contents: read
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [check_package_json, build_javascript]
     env:
       NODE_ENV: test

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -156,42 +156,34 @@ jobs:
         id: apt-cache
         uses: actions/cache@v4
         with:
-          path: /home/runner/apt/cache
-          key: ${{ runner.os }}-apt-${{ matrix.database }}-${{ matrix.storage }}
+          path: /var/cache/apt/archives
+          key: ${{ runner.os }}-apt-v2-${{ matrix.database }}-${{ matrix.storage }}
           restore-keys: |
-            ${{ runner.os }}-apt-${{ matrix.database }}-
+            ${{ runner.os }}-apt-v2-${{ matrix.database }}-
       - name: Install Postgres headers
         if: matrix.database == 'postgresql'
         run: |
-          mkdir -p /home/runner/apt/cache
-          sudo apt update -qq
-          sudo apt install -qq --fix-missing libpq-dev -o dir::cache::archives="/home/runner/apt/cache"
-          sudo chown -R runner /home/runner/apt/cache
+          sudo apt-get update -qq
+          sudo apt-get install -qq --fix-missing libpq-dev
       - name: Install MariaDB headers
         if: matrix.database == 'mariadb'
         run: |
-          mkdir -p /home/runner/apt/cache
-          sudo apt update -qq
-          sudo apt install -qq --fix-missing libmysqlclient-dev -o dir::cache::archives="/home/runner/apt/cache"
-          sudo chown -R runner /home/runner/apt/cache
+          sudo apt-get update -qq
+          sudo apt-get install -qq --fix-missing libmysqlclient-dev
       - name: Install libvips
         if: matrix.storage == 'active_storage'
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          mkdir -p /home/runner/apt/cache
-          sudo apt update -qq
-          sudo apt install -qq --fix-missing libvips -o dir::cache::archives="/home/runner/apt/cache"
-          sudo chown -R runner /home/runner/apt/cache
+          sudo apt-get update -qq
+          sudo apt-get install -qq --fix-missing libvips
       - name: Install ImageMagick
         if: matrix.storage == 'dragonfly'
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          mkdir -p /home/runner/apt/cache
-          sudo apt update -qq
-          sudo apt install -qq --fix-missing imagemagick -o dir::cache::archives="/home/runner/apt/cache"
-          sudo chown -R runner /home/runner/apt/cache
+          sudo apt-get update -qq
+          sudo apt-get install -qq --fix-missing imagemagick
       - uses: actions/download-artifact@v4
         if: needs.check_package_json.outputs.package_json_changed == 'true'
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
       - name: Restore node_modules cache
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
       - name: Restore node_modules cache
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
       - name: Restore node_modules cache

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   Standard:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -24,7 +24,7 @@ jobs:
       - name: Lint Ruby files
         run: bundle exec standardrb
   ESLint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -42,7 +42,7 @@ jobs:
       - name: Lint code
         run: bun run --bun eslint
   Prettier:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -60,7 +60,7 @@ jobs:
       - name: Lint code
         run: bun run --bun lint
   Herb:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/stale@v5
         with:

--- a/spec/libraries/dragonfly/processors/auto_orient_spec.rb
+++ b/spec/libraries/dragonfly/processors/auto_orient_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../../../support/dragonfly_test_app"
 
-RSpec.describe Alchemy::Dragonfly::Processors::AutoOrient do
+RSpec.describe Alchemy::Dragonfly::Processors::AutoOrient, if: Alchemy.storage_adapter.dragonfly? do
   let(:app) { dragonfly_test_app }
   let(:file) { fixture_file_upload("80x60.png") }
   let(:image) { Dragonfly::Content.new(app, file) }

--- a/spec/libraries/dragonfly/processors/crop_resize_spec.rb
+++ b/spec/libraries/dragonfly/processors/crop_resize_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../../../support/dragonfly_test_app"
 
-RSpec.describe Alchemy::Dragonfly::Processors::CropResize do
+RSpec.describe Alchemy::Dragonfly::Processors::CropResize, if: Alchemy.storage_adapter.dragonfly? do
   let(:app) { dragonfly_test_app }
   let(:file) { fixture_file_upload("80x60.png") }
   let(:image) { Dragonfly::Content.new(app, file) }

--- a/spec/libraries/dragonfly/processors/thumbnail_spec.rb
+++ b/spec/libraries/dragonfly/processors/thumbnail_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require_relative "../../../support/dragonfly_test_app"
 
-RSpec.describe Alchemy::Dragonfly::Processors::Thumbnail do
+RSpec.describe Alchemy::Dragonfly::Processors::Thumbnail, if: Alchemy.storage_adapter.dragonfly? do
   let(:app) { dragonfly_test_app }
   let(:file) { fixture_file_upload("80x60.png") }
   let(:image) { Dragonfly::Content.new(app, file) }


### PR DESCRIPTION
## What is this pull request for?

Updates the runner image from Ubuntu 22 to Ubuntu 24 and install imagemagick for Dragonfly based tests, because the default runner image does not contain imagemagick anymore.

Also fixes apt package caching.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message

