### PR TITLE
fix: Dragging nested element out of nesting element

### DIFF
--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -101,7 +101,7 @@ module Alchemy
         @element = Element.find(params[:element_id])
 
         # Update position
-        @element.parent_element_id = params[:parent_element_id] if params.key?(:parent_element_id)
+        @element.parent_element_id = params[:parent_element_id]
         @element.position = params[:position]
 
         # Skip validations when updating position, since new records may not yet meet all

--- a/spec/controllers/alchemy/admin/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/elements_controller_spec.rb
@@ -88,6 +88,20 @@ module Alchemy
           }
           expect(element_3.reload.parent_element_id).to eq parent.id
         end
+
+        context "and dragged outside of parent element" do
+          before do
+            element_3.update(parent_element: parent)
+          end
+
+          it "nils parent_element_id" do
+            expect {
+              post :order, params: {
+                element_id: element_3.id
+              }
+            }.to change { element_3.reload.parent_element_id }.to(nil)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
## What is this pull request for?

We need to be able to nil the `parent_element_id`.

This fixes a regression introduced in 63e0a23b0d53be276199fede81553dc17952e57b

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
