### PR TITLE
fix(HeadlineEditor): Fix anchor position

### DIFF
--- a/app/components/alchemy/ingredients/headline_editor.rb
+++ b/app/components/alchemy/ingredients/headline_editor.rb
@@ -61,7 +61,7 @@ module Alchemy
 
       def css_classes
         super + [
-          has_level_select? ? "with-level-select" : nil,
+          level_options.any? ? "with-level-select" : nil,
           has_size_select? ? "with-size-select" : nil
         ].compact
       end

--- a/spec/components/alchemy/ingredients/headline_editor_spec.rb
+++ b/spec/components/alchemy/ingredients/headline_editor_spec.rb
@@ -41,10 +41,10 @@ RSpec.describe Alchemy::Ingredients::HeadlineEditor, type: :component do
     is_expected.to have_selector("sl-tooltip[content='Level']")
   end
 
-  context "and having many level options" do
+  context "and having any level options" do
     before do
       allow(headline_editor).to receive(:level_options) do
-        [["H1", 1], ["H2", 2]]
+        [["H1", 1]]
       end
     end
 


### PR DESCRIPTION
## What is this pull request for?

The necessary css class was not present because we asked for many instead of any.

But the level select is always present, just disabled for a single option.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change