### PR TITLE
feat(LocaleSelect): Make auto_submit toggable

### DIFF
--- a/app/components/alchemy/admin/locale_select.rb
+++ b/app/components/alchemy/admin/locale_select.rb
@@ -2,22 +2,19 @@ module Alchemy
   module Admin
     # Renders a locale select tag for switching the backend locale.
     class LocaleSelect < ViewComponent::Base
-      attr_reader :name
+      attr_reader :name, :auto_submit
 
-      def initialize(name = :admin_locale)
+      def initialize(name = :admin_locale, auto_submit: true)
         @name = name
+        @auto_submit = auto_submit
       end
 
       def call
         form_tag(helpers.url_for, method: :get) do
-          content_tag("alchemy-auto-submit") do
-            select_tag(
-              name,
-              options_for_select(
-                translations_for_select,
-                ::I18n.locale
-              )
-            )
+          if auto_submit
+            content_tag("alchemy-auto-submit", locale_select)
+          else
+            locale_select
           end
         end
       end
@@ -27,6 +24,16 @@ module Alchemy
       end
 
       private
+
+      def locale_select
+        select_tag(
+          name,
+          options_for_select(
+            translations_for_select,
+            ::I18n.locale
+          )
+        )
+      end
 
       def available_locales
         @_available_locales ||= Alchemy::I18n.available_locales.sort!

--- a/spec/components/alchemy/admin/locale_select_spec.rb
+++ b/spec/components/alchemy/admin/locale_select_spec.rb
@@ -33,5 +33,18 @@ RSpec.describe Alchemy::Admin::LocaleSelect, type: :component do
         expect(page).to have_selector("select[name='language']")
       end
     end
+
+    it "should return a select with auto submit wrapper" do
+      expect(page).to have_selector("alchemy-auto-submit select[name='admin_locale']")
+    end
+
+    context "with auto_submit false" do
+      let(:render) { render_inline described_class.new(:admin_locale, auto_submit: false) }
+
+      it "should return a select without auto submit wrapper" do
+        expect(page).not_to have_selector("alchemy-auto-submit")
+        expect(page).to have_selector("select[name='admin_locale']")
+      end
+    end
   end
 end


### PR DESCRIPTION
## What is this pull request for?

We need to be able to disable the auto-submit feature if we use the LocaleSelect in a form that submits via a button (ie. the users form of alchemy-devise).

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
