### PR TITLE
chore(PageVersion): Use instance methods of Publishable

### DIFF
--- a/app/models/alchemy/page_version.rb
+++ b/app/models/alchemy/page_version.rb
@@ -29,32 +29,6 @@ module Alchemy
 
     before_destroy :delete_elements
 
-    # Determines if this version is public
-    #
-    # Takes the two timestamps +public_on+ and +public_until+
-    # and returns true if the time given (+Time.current+ per default)
-    # is in this timespan.
-    #
-    # @param time [DateTime] (Time.current)
-    # @returns Boolean
-    def public?(time = Current.preview_time)
-      already_public_for?(time) && still_public_for?(time)
-    end
-
-    # Determines if this version is already public for given time
-    # @param time [DateTime] (Current.preview_time)
-    # @returns Boolean
-    def already_public_for?(time = Current.preview_time)
-      !public_on.nil? && public_on <= time
-    end
-
-    # Determines if this version is still public for given time
-    # @param time [DateTime] (Current.preview_time)
-    # @returns Boolean
-    def still_public_for?(time = Current.preview_time)
-      public_until.nil? || public_until >= time
-    end
-
     def element_repository
       ElementsRepository.new(elements)
     end


### PR DESCRIPTION
## What is this pull request for?

The Publishable concern provides the same instance methods, but with a slightly different signature. Since these methods are identical and only used internally we can remove them.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
