### PR TITLE
Configurable publishable resolver

### DIFF
--- a/app/models/alchemy/publishable/timestamp_resolver.rb
+++ b/app/models/alchemy/publishable/timestamp_resolver.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Alchemy
+  module Publishable
+    # Default resolver for Publishable records.
+    #
+    # Uses the +public_on+ and +public_until+ timestamp columns to determine
+    # whether a record is public, scheduled, or publishable.
+    #
+    # This class defines the interface that custom resolvers configured via
+    # +Alchemy.config.publishable_resolver+ must implement.
+    #
+    class TimestampResolver
+      class << self
+        # Returns records without a +public_on+ date set.
+        def draft(publishables)
+          publishables.where(public_on: nil)
+        end
+
+        # Returns records with a +public_on+ date set.
+        def scheduled(publishables)
+          publishables.where.not(public_on: nil)
+        end
+
+        # Returns records that are public at the given time.
+        def published(publishables, at:)
+          scheduled(publishables)
+            .where("#{publishables.table_name}.public_on <= :at", at:)
+            .where(public_until: nil).or(
+              publishables.where("#{publishables.table_name}.public_until > :at", at:)
+            )
+        end
+      end
+
+      def initialize(publishable)
+        @publishable = publishable
+      end
+
+      # Determines if the record is public at the given time.
+      def public?(at: Current.preview_time)
+        already_public_for?(at:) && still_public_for?(at:)
+      end
+
+      # Determines if the record has a future publication or expiration event.
+      def scheduled?(at: Current.preview_time)
+        (publishable.public_on.present? && publishable.public_on > at) ||
+          (publishable.public_until.present? && publishable.public_until > at)
+      end
+
+      # Determines if the record is publishable.
+      #
+      # A record is publishable if a +public_on+ timestamp is set and not
+      # expired yet.
+      def publishable?
+        !publishable.public_on.nil? && still_public_for?
+      end
+
+      private
+
+      attr_reader :publishable
+
+      def already_public_for?(at:)
+        !publishable.public_on.nil? && publishable.public_on <= at
+      end
+
+      def still_public_for?(at: Current.preview_time)
+        publishable.public_until.nil? || publishable.public_until > at
+      end
+    end
+  end
+end

--- a/app/models/concerns/alchemy/publishable.rb
+++ b/app/models/concerns/alchemy/publishable.rb
@@ -3,15 +3,10 @@ module Alchemy
     extend ActiveSupport::Concern
 
     included do
-      scope :draft, -> { where(public_on: nil) }
-      scope :scheduled, -> { where.not(public_on: nil) }
-
+      scope :draft, -> { Alchemy.config.publishable_resolver.draft(all) }
+      scope :scheduled, -> { Alchemy.config.publishable_resolver.scheduled(all) }
       scope :published, ->(at: Current.preview_time) {
-        scheduled
-          .where("#{table_name}.public_on <= :at", at:)
-          .where(public_until: nil).or(
-            where("#{table_name}.public_until > :at", at:)
-          )
+        Alchemy.config.publishable_resolver.published(all, at:)
       }
 
       validate do
@@ -25,42 +20,32 @@ module Alchemy
 
     # Determines if this record is public
     #
-    # Takes the two timestamps +public_on+ and +public_until+
-    # and returns true if the time given (+Time.current+ per default)
-    # is in this timespan.
-    #
-    # @param at [DateTime] (Time.current)
+    # @param at [DateTime] (Current.preview_time)
     # @returns Boolean
     def public?(at: Current.preview_time)
-      already_public_for?(at:) && still_public_for?(at:)
+      publishable_resolver.public?(at:)
     end
     alias_method :public, :public?
 
+    # Determines if this record has a future publication or expiration event
+    #
+    # @param at [DateTime] (Current.preview_time)
+    # @returns Boolean
     def scheduled?(at: Current.preview_time)
-      (public_on.present? && public_on > at) || (public_until.present? && public_until > at)
+      publishable_resolver.scheduled?(at:)
     end
 
     # Determines if this record is publishable
     #
-    # A record is publishable if a +public_on+ timestamp is set and not expired yet.
-    #
     # @returns Boolean
     def publishable?
-      !public_on.nil? && still_public_for?
+      publishable_resolver.publishable?
     end
 
-    # Determines if this record is already public for given time
-    # @param at [DateTime] (Time.current)
-    # @returns Boolean
-    def already_public_for?(at: Current.preview_time)
-      !public_on.nil? && public_on <= at
-    end
+    private
 
-    # Determines if this record is still public for given time
-    # @param at [DateTime] (Time.current)
-    # @returns Boolean
-    def still_public_for?(at: Current.preview_time)
-      public_until.nil? || public_until > at
+    def publishable_resolver
+      Alchemy.config.publishable_resolver.new(self)
     end
   end
 end

--- a/lib/alchemy/configurations/main.rb
+++ b/lib/alchemy/configurations/main.rb
@@ -453,6 +453,20 @@ module Alchemy
       # == Example
       #     Alchemy.config.abilities.add("MyCustom::Ability")
       option :abilities, :collection, item_type: :class
+
+      # === Publishable resolver
+      #
+      # The class used to resolve publication state for Publishable records
+      # (currently +Alchemy::Element+ and +Alchemy::PageVersion+).
+      #
+      # The default resolver uses the +public_on+ / +public_until+ timestamp
+      # columns. Extension gems can provide a custom resolver that implements
+      # the same interface — see +Alchemy::Publishable::TimestampResolver+
+      # for the interface.
+      #
+      # == Example
+      #     Alchemy.config.publishable_resolver = "MyApp::CustomResolver"
+      option :publishable_resolver, :class, default: "Alchemy::Publishable::TimestampResolver"
     end
   end
 end

--- a/lib/alchemy/test_support/shared_publishable_examples.rb
+++ b/lib/alchemy/test_support/shared_publishable_examples.rb
@@ -33,6 +33,11 @@ RSpec.shared_examples_for "being publishable" do |factory_name|
     it "only includes records without public_on date" do
       expect(subject).to eq [nil]
     end
+
+    it "delegates to the resolver" do
+      expect(Alchemy.config.publishable_resolver).to receive(:draft)
+      described_class.draft
+    end
   end
 
   describe ".scheduled" do
@@ -50,12 +55,22 @@ RSpec.shared_examples_for "being publishable" do |factory_name|
         public_two
       ])
     end
+
+    it "delegates to the resolver" do
+      expect(Alchemy.config.publishable_resolver).to receive(:scheduled)
+      subject
+    end
   end
 
   describe ".published" do
     let!(:public_one) { create(factory_name, public_on: Date.yesterday) }
     let!(:public_two) { create(factory_name, public_on: Date.tomorrow) }
     let!(:non_public) { create(factory_name, public_on: nil) }
+
+    it "delegates to the resolver" do
+      expect(Alchemy.config.publishable_resolver).to receive(:published)
+      described_class.published
+    end
 
     context "without time given" do
       subject { described_class.published }
@@ -87,13 +102,16 @@ RSpec.shared_examples_for "being publishable" do |factory_name|
     subject { record.scheduled? }
 
     let(:record) { build(factory_name, public_on:, public_until:) }
+    let(:public_on) { nil }
+    let(:public_until) { nil }
+
+    it "delegates to the resolver" do
+      expect_any_instance_of(Alchemy.config.publishable_resolver).to receive(:scheduled?)
+      subject
+    end
 
     context "when public_on is nil" do
-      let(:public_on) { nil }
-
       context "and public_until is nil" do
-        let(:public_until) { nil }
-
         it { expect(subject).to be(false) }
       end
 
@@ -144,6 +162,13 @@ RSpec.shared_examples_for "being publishable" do |factory_name|
 
   describe "#public?" do
     subject { page_version.public? }
+
+    let(:page_version) { build(factory_name) }
+
+    it "delegates to the resolver" do
+      expect_any_instance_of(Alchemy.config.publishable_resolver).to receive(:public?)
+      subject
+    end
 
     context "when public_on is not set" do
       let(:page_version) { build(factory_name, public_on: nil) }

--- a/spec/models/alchemy/publishable/timestamp_resolver_spec.rb
+++ b/spec/models/alchemy/publishable/timestamp_resolver_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::Publishable::TimestampResolver do
+  describe ".scheduled" do
+    let!(:draft) { create(:alchemy_page_version, public_on: nil) }
+    let!(:published) { create(:alchemy_page_version, public_on: Time.current) }
+
+    it "returns records with public_on date set" do
+      result = described_class.scheduled(Alchemy::PageVersion.where(id: [draft.id, published.id]))
+      expect(result).to eq([published])
+    end
+  end
+
+  describe ".published" do
+    let!(:past) { create(:alchemy_page_version, public_on: Date.yesterday) }
+    let!(:future) { create(:alchemy_page_version, public_on: Date.tomorrow) }
+    let!(:draft) { create(:alchemy_page_version, public_on: nil) }
+
+    it "returns records currently public" do
+      result = described_class.published(
+        Alchemy::PageVersion.where(id: [past.id, future.id, draft.id]),
+        at: Time.current
+      )
+      expect(result).to eq([past])
+    end
+
+    it "returns records public at given time" do
+      result = described_class.published(
+        Alchemy::PageVersion.where(id: [past.id, future.id, draft.id]),
+        at: Date.tomorrow + 1.day
+      )
+      expect(result).to match_array([past, future])
+    end
+  end
+
+  describe ".draft" do
+    let!(:draft) { create(:alchemy_page_version, public_on: nil) }
+    let!(:published) { create(:alchemy_page_version, public_on: Time.current) }
+
+    it "returns records without public_on date" do
+      result = described_class.draft(Alchemy::PageVersion.where(id: [draft.id, published.id]))
+      expect(result).to eq([draft])
+    end
+  end
+
+  let(:record) { build(:alchemy_page_version, public_on: public_on, public_until: public_until) }
+  let(:public_on) { nil }
+  let(:public_until) { nil }
+
+  subject(:resolver) { described_class.new(record) }
+
+  describe "#public?" do
+    context "when public_on is nil" do
+      it { expect(resolver.public?).to be(false) }
+    end
+
+    context "when public_on is in the past and public_until is nil" do
+      let(:public_on) { Time.current - 2.days }
+
+      it { expect(resolver.public?).to be(true) }
+    end
+
+    context "when public_on is in the past and public_until is in the future" do
+      let(:public_on) { Time.current - 2.days }
+      let(:public_until) { Time.current + 2.days }
+
+      it { expect(resolver.public?).to be(true) }
+    end
+
+    context "when public_on is in the past and public_until is in the past" do
+      let(:public_on) { Time.current - 2.days }
+      let(:public_until) { Time.current - 1.day }
+
+      it { expect(resolver.public?).to be(false) }
+    end
+
+    context "when public_on is in the future" do
+      let(:public_on) { Time.current + 2.days }
+
+      it { expect(resolver.public?).to be(false) }
+    end
+
+    context "when at: is given" do
+      let(:public_on) { Time.zone.parse("2025-06-01 00:00:00") }
+      let(:public_until) { Time.zone.parse("2025-06-30 23:59:59") }
+
+      it "uses the given time" do
+        expect(resolver.public?(at: Time.zone.parse("2025-06-15 12:00:00"))).to be(true)
+        expect(resolver.public?(at: Time.zone.parse("2025-07-15 12:00:00"))).to be(false)
+        expect(resolver.public?(at: Time.zone.parse("2025-05-15 12:00:00"))).to be(false)
+      end
+    end
+
+    context "when Current.preview_time is set" do
+      let(:public_on) { Time.zone.parse("2025-06-01 00:00:00") }
+      let(:public_until) { Time.zone.parse("2025-06-30 23:59:59") }
+
+      it "uses preview_time by default" do
+        Alchemy::Current.preview_time = Time.zone.parse("2025-06-15 12:00:00")
+        expect(resolver.public?).to be(true)
+      end
+    end
+  end
+
+  describe "#scheduled?" do
+    context "when public_on is nil and public_until is nil" do
+      it { expect(resolver.scheduled?).to be(false) }
+    end
+
+    context "when public_on is nil and public_until is in the future" do
+      let(:public_until) { Date.tomorrow }
+
+      it { expect(resolver.scheduled?).to be(true) }
+    end
+
+    context "when public_on is in the past and public_until is nil" do
+      let(:public_on) { Date.yesterday }
+
+      it { expect(resolver.scheduled?).to be(false) }
+    end
+
+    context "when public_on is in the past and public_until is in the future" do
+      let(:public_on) { Date.yesterday }
+      let(:public_until) { Date.tomorrow }
+
+      it { expect(resolver.scheduled?).to be(true) }
+    end
+
+    context "when public_on is in the future" do
+      let(:public_on) { Date.tomorrow }
+
+      it { expect(resolver.scheduled?).to be(true) }
+    end
+  end
+
+  describe "#publishable?" do
+    context "when public_on is nil" do
+      it { expect(resolver.publishable?).to be(false) }
+    end
+
+    context "when public_on is set and public_until is nil" do
+      let(:public_on) { Time.current }
+
+      it { expect(resolver.publishable?).to be(true) }
+    end
+
+    context "when public_on is set and public_until is in the future" do
+      let(:public_on) { Time.current }
+      let(:public_until) { Time.current + 1.day }
+
+      it { expect(resolver.publishable?).to be(true) }
+    end
+
+    context "when public_on is set and public_until is in the past" do
+      let(:public_on) { Time.current - 2.days }
+      let(:public_until) { Time.current - 1.day }
+
+      it { expect(resolver.publishable?).to be(false) }
+    end
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

Publishable delegates `public?`, `scheduled?`, `publishable?` and its scopes to a resolver class configured via `Alchemy.config.publishable_resolver`. The default `Alchemy::Publishable::TimestampResolver` preserves the existing timestamp-based behavior. Extension gems can now provide a custom resolver that implements the same interface without having to prepend `Element` or `PageVersion`.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
