### PR TITLE
fix(TimestampResolver): Use Time.current in publishable?

### DIFF
--- a/app/models/alchemy/publishable/timestamp_resolver.rb
+++ b/app/models/alchemy/publishable/timestamp_resolver.rb
@@ -52,7 +52,7 @@ module Alchemy
       # A record is publishable if a +public_on+ timestamp is set and not
       # expired yet.
       def publishable?
-        !publishable.public_on.nil? && still_public_for?
+        !publishable.public_on.nil? && still_public_for?(at: Time.current)
       end
 
       private

--- a/spec/models/alchemy/publishable/timestamp_resolver_spec.rb
+++ b/spec/models/alchemy/publishable/timestamp_resolver_spec.rb
@@ -159,5 +159,15 @@ RSpec.describe Alchemy::Publishable::TimestampResolver do
 
       it { expect(resolver.publishable?).to be(false) }
     end
+
+    context "when Current.preview_time is set to a future time" do
+      let(:public_on) { Time.current - 1.day }
+      let(:public_until) { Time.current + 1.day }
+
+      it "uses Time.current instead of the preview_time" do
+        Alchemy::Current.preview_time = Time.current + 1.week
+        expect(resolver.publishable?).to be(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
## What is this pull request for?

`TimestampResolver#publishable?` was delegating to `still_public_for?` without an explicit `at:` argument, so the check defaulted to `Current.preview_time`. When an editor selected a future preview time and then hit Publish, any element whose `public_until` was in the future relative to *now* but *before* the previewed moment was treated as already expired and was silently excluded from the public version of the page.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change