### PR TITLE
[8.2-stable] fix(Publishable): Use Time.current in publishable?

### DIFF
--- a/app/models/alchemy/page_version.rb
+++ b/app/models/alchemy/page_version.rb
@@ -29,32 +29,6 @@ module Alchemy
 
     before_destroy :delete_elements
 
-    # Determines if this version is public
-    #
-    # Takes the two timestamps +public_on+ and +public_until+
-    # and returns true if the time given (+Time.current+ per default)
-    # is in this timespan.
-    #
-    # @param time [DateTime] (Time.current)
-    # @returns Boolean
-    def public?(time = Current.preview_time)
-      already_public_for?(time) && still_public_for?(time)
-    end
-
-    # Determines if this version is already public for given time
-    # @param time [DateTime] (Current.preview_time)
-    # @returns Boolean
-    def already_public_for?(time = Current.preview_time)
-      !public_on.nil? && public_on <= time
-    end
-
-    # Determines if this version is still public for given time
-    # @param time [DateTime] (Current.preview_time)
-    # @returns Boolean
-    def still_public_for?(time = Current.preview_time)
-      public_until.nil? || public_until >= time
-    end
-
     def element_repository
       ElementsRepository.new(elements)
     end

--- a/app/models/concerns/alchemy/publishable.rb
+++ b/app/models/concerns/alchemy/publishable.rb
@@ -46,7 +46,7 @@ module Alchemy
     #
     # @returns Boolean
     def publishable?
-      !public_on.nil? && still_public_for?
+      !public_on.nil? && still_public_for?(at: Time.current)
     end
 
     # Determines if this record is already public for given time

--- a/lib/alchemy/test_support/shared_publishable_examples.rb
+++ b/lib/alchemy/test_support/shared_publishable_examples.rb
@@ -212,4 +212,41 @@ RSpec.shared_examples_for "being publishable" do |factory_name|
       end
     end
   end
+
+  describe "#publishable?" do
+    context "when public_on is nil" do
+      let(:page_version) { build(factory_name, public_on: nil) }
+
+      it { expect(page_version.publishable?).to be(false) }
+    end
+
+    context "when public_on is set and public_until is nil" do
+      let(:page_version) { build(factory_name, public_on: Time.current) }
+
+      it { expect(page_version.publishable?).to be(true) }
+    end
+
+    context "when public_on is set and public_until is in the past" do
+      let(:page_version) do
+        build(factory_name,
+          public_on: Time.current - 2.days,
+          public_until: Time.current - 1.day)
+      end
+
+      it { expect(page_version.publishable?).to be(false) }
+    end
+
+    context "when Current.preview_time is set to a future time" do
+      let(:page_version) do
+        build(factory_name,
+          public_on: Time.current - 1.day,
+          public_until: Time.current + 1.day)
+      end
+
+      it "uses Time.current instead of the preview_time" do
+        Alchemy::Current.preview_time = Time.current + 1.week
+        expect(page_version.publishable?).to be(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What is this pull request for?

Backport of #3866 to `8.2-stable`.

`Publishable#publishable?` was delegating to `still_public_for?` without an explicit `at:` argument, so the check defaulted to `Current.preview_time`. When an editor selected a future preview time and then hit Publish, any element whose `public_until` was in the future relative to *now* but *before* the previewed moment was treated as already expired and was silently excluded from the public version of the page.

To keep the fix minimal and consistent with the keyword-argument signature on the `Publishable` concern, the redundant `still_public_for?` / `already_public_for?` / `public?` overrides on `PageVersion` are removed first (cherry-picked from c402e583b on `main`).

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change