### PR TITLE
fix(pages/table): Use file icon if not locked

### DIFF
--- a/app/views/alchemy/admin/pages/_table.html.erb
+++ b/app/views/alchemy/admin/pages/_table.html.erb
@@ -6,7 +6,7 @@
           <%= render_icon "file-edit", size: "xl" %>
         </sl-tooltip>
       <% else %>
-        <%= render_icon "file-edit", size: "xl" %>
+        <%= render_icon "file", size: "xl" %>
       <% end %>
     <% else %>
       <sl-tooltip class="like-hint-tooltip" content="<%= Alchemy.t("Your user role does not allow you to edit this page") %>" placement="bottom-start">


### PR DESCRIPTION
## What is this pull request for?

Pages in the list view were always shown as being locked.
