### PR TITLE
Fix: Allow Multiple Select migration to work with MariaDB

### DIFF
--- a/db/migrate/20251106150010_convert_select_value_for_multiple.rb
+++ b/db/migrate/20251106150010_convert_select_value_for_multiple.rb
@@ -1,11 +1,18 @@
 class ConvertSelectValueForMultiple < ActiveRecord::Migration[7.1]
   def up
     say_with_time "Converting Alchemy::Ingredients::Select values to multiple" do
-      update <<-SQL.squish
-        UPDATE alchemy_ingredients
-        SET value = '["' || value || '"]'
-        WHERE type = 'Alchemy::Ingredients::Select' AND value NOT LIKE '["%"]';
-      SQL
+      Alchemy::Ingredients::Select
+        .where.not("value LIKE ?", '["%')
+        .update_all(
+          Arel.sql(
+            case ActiveRecord::Base.connection.adapter_name
+            when /mysql|mariadb/i
+              "value = CONCAT('[\"', value, '\"]')"
+            else
+              "value = '[\"' || value || '\"]'"
+            end
+          )
+        )
     end
   end
 end


### PR DESCRIPTION


## What is this pull request for?

MariaDB/MySQL do not support the `||` operator for string concatenation (they treat it as a logical "or"). This commit converts the syntax to ActiveRecord and uses `CONCAT` for MariaDB and MySQL. Apparently, SQlite does not support `CONCAT`, and needs the pipes.


### Notable changes (remove if none)

None, bugfix

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
