### PR TITLE
Prevent ArgumentError in ElementPreloader

### DIFF
--- a/app/services/alchemy/element_preloader.rb
+++ b/app/services/alchemy/element_preloader.rb
@@ -61,7 +61,7 @@ module Alchemy
 
       elements_by_id.each_value do |element|
         children = elements_by_parent[element.id] || []
-        children = children.sort_by(&:position)
+        children = children.sort_by { |c| c.position.to_i }
 
         # Manually set the association target
         element.association(:all_nested_elements).target = children

--- a/spec/services/alchemy/element_preloader_spec.rb
+++ b/spec/services/alchemy/element_preloader_spec.rb
@@ -161,6 +161,22 @@ RSpec.describe Alchemy::ElementPreloader do
         }.to make_database_queries(count: 4)
       end
     end
+
+    context "with nested elements containing nil positions" do
+      let!(:parent_element) { create(:alchemy_element, :with_nestable_elements, page_version: page_version, autogenerate_nested_elements: false) }
+      let!(:nested_element) do
+        create(:alchemy_element, page_version: page_version, parent_element: parent_element).tap do |e|
+          e.update_column(:position, nil)
+        end
+      end
+      let!(:other_nested_element) { create(:alchemy_element, page_version: page_version, parent_element: parent_element, position: 1) }
+
+      it "does not raise and includes all nested elements" do
+        result = described_class.new(page_version: page_version).call
+        expect(result).to eq([parent_element])
+        expect(result.first.all_nested_elements).to match_array([nested_element, other_nested_element])
+      end
+    end
   end
 
   describe "related object preloading" do


### PR DESCRIPTION
## What is this pull request for?
On older instances of Alchemy it is possible that the position column for an element is nil. To prevent an ArgumentError for nil values it is better to cast the position to integer. A nil value would become zero and would still be sortable.

Remove if no visual changes have been made.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
