### PR TITLE
Relax dragonfly constraint to fix CVE-2021-33564

### DIFF
--- a/alchemy_cms.gemspec
+++ b/alchemy_cms.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'bourbon',                          ['~> 4.2']
   gem.add_runtime_dependency 'cancancan',                        ['~> 1.9']
   gem.add_runtime_dependency 'coffee-rails',                     ['~> 4.0']
-  gem.add_runtime_dependency 'dragonfly',                        ['~> 1.0.1']
+  gem.add_runtime_dependency 'dragonfly',                        ['>= 1.0.1']
   gem.add_runtime_dependency 'dragonfly_svg',                    ['~> 0.0.4']
   gem.add_runtime_dependency 'jquery-rails',                     ['~> 4.0']
   gem.add_runtime_dependency 'jquery-ui-rails',                  ['~> 5.0.0']


### PR DESCRIPTION
## Summary
- Relaxes the dragonfly gem dependency from `~> 1.0.1` to `>= 1.0.1` to allow upgrading to versions that include a fix for [CVE-2021-33564](https://nvd.nist.gov/vuln/detail/CVE-2021-33564) (ReDoS vulnerability in dragonfly)

## Test plan
- [ ] Verify `bundle install` resolves successfully with the relaxed constraint
- [ ] Run existing test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)