### PR TITLE
Fix/leaf page destroy false positive descendant node check

### DIFF
--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -615,7 +615,17 @@ module Alchemy
     end
 
     def check_descendants_for_menu_nodes
-      pages_with_nodes = descendants.joins(:nodes).reorder("alchemy_pages.lft").distinct
+      # awesome_nested_set's before_destroy runs first and closes the gap left
+      # by this page, shifting the following siblings' lft/rgt leftward. For a
+      # leaf the next sibling then lands exactly on this page's lft, so the
+      # inclusive comparison the `descendants` helper uses (lft >= self.lft)
+      # would match it. Restrict to true descendants with strict bounds. Build
+      # on nested_set_scope so the acts_as_nested_set scope stays in sync.
+      pages_with_nodes = nested_set_scope
+        .where("alchemy_pages.lft > ? AND alchemy_pages.rgt < ?", lft, rgt)
+        .joins(:nodes)
+        .reorder("alchemy_pages.lft")
+        .distinct
       if pages_with_nodes.exists?
         errors.add(:descendants, :still_attached_to_nodes, page_names: pages_with_nodes.map(&:name).to_sentence)
         throw :abort

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -297,6 +297,28 @@ module Alchemy
             )
           end
         end
+
+        context "with a sibling page attached to a menu node" do
+          # Regression: awesome_nested_set's before_destroy closes the nested-set
+          # gap by shifting following siblings' lft/rgt leftward, so the next
+          # sibling lands exactly on the destroyed leaf's lft. The inclusive
+          # comparison the `descendants` helper uses then matches it as a
+          # descendant unless we restrict to strict bounds.
+          let!(:parent) { create(:alchemy_page) }
+          let!(:page) { create(:alchemy_page, parent: parent) }
+          let!(:sibling) { create(:alchemy_page, parent: parent) }
+          let!(:node) { create(:alchemy_node, page: sibling, parent: create(:alchemy_node)) }
+
+          it "allows destruction of the leaf page" do
+            expect(page.destroy).to be_truthy
+            expect(page.errors[:descendants]).to be_empty
+          end
+
+          it "does not destroy the sibling" do
+            page.destroy
+            expect(Alchemy::Page.exists?(sibling.id)).to be true
+          end
+        end
       end
     end
 


### PR DESCRIPTION
## What is this pull request for?

Destroying a leaf page whose sibling is attached to a menu node is wrongly blocked with a `descendants … still attached to nodes` error, even though the page has no descendants at all.

Root cause is on Alchemy's side, not `awesome_nested_set`. `Page` registers `acts_as_nested_set` before its own `before_destroy :check_descendants_for_menu_nodes`, so `awesome_nested_set`'s `destroy_descendants` runs first. For a leaf it closes the nested-set gap — shifting every following sibling's `lft`/`rgt` leftward and reloading `self` — *before* our check runs. The next sibling then lands exactly on the deleted leaf's `lft`, and the check's `descendants` helper (whose scope matches `lft >= self.lft AND lft < self.rgt`) can't distinguish that shifted sibling from a real descendant, so it aborts the destroy.

This is a targeted fix for that false positive. It does not change the architectural fact that a precondition guard is implemented as a callback running mid-mutation (see Notable changes).

### Notable changes (remove if none)

- `check_descendants_for_menu_nodes` now matches only true descendants using strict bounds (`alchemy_pages.lft > ? AND alchemy_pages.rgt < ?`) instead of the inclusive `descendants` helper. A sibling that has shifted onto `self.lft` no longer matches; genuine descendants (whose range is strictly inside) still do.
- The query is built on `nested_set_scope` so it keeps honoring the `acts_as_nested_set scope: [:layoutpage, :language_id]` declaration automatically, rather than re-deriving that scope by hand.
- Columns are table-qualified because `alchemy_nodes` carries its own `lft`/`rgt` from its own nested set, which would otherwise make the joined query ambiguous.
- Regression specs added for the leaf-with-node-bearing-sibling case (destruction succeeds; the sibling is not destroyed). Verified the existing "descendant attached to a menu node" guard still passes.

## Known limitation / deliberately out of scope

The check has to run *after* `awesome_nested_set`'s callback because that is what reloads `self` with current `lft`/`rgt`; reordering it (e.g. `prepend: true`) regresses the descendant guard, since the in-memory page can hold a stale `rgt`. The cleaner design — a true pre-destroy guard, or moving this validation into the deletion service/controller layer so it reads the tree before any mutation — is a larger, riskier refactor and is intentionally left out of this focused fix.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
