### PR TITLE
feat: add `Alchemy::PublishElement` class

### DIFF
--- a/app/models/alchemy/page/publisher.rb
+++ b/app/models/alchemy/page/publisher.rb
@@ -30,7 +30,7 @@ module Alchemy
             ActiveRecord::Base.no_touching do
               Element.acts_as_list_no_update do
                 repository.publishable.not_nested.each.with_index(1) do |element, position|
-                  Alchemy::DuplicateElement.new(element, repository: repository, publishable_only: true).call(
+                  Alchemy.config.element_publisher.new(element, repository: repository).call(
                     page_version_id: version.id,
                     position: position
                   )

--- a/app/models/concerns/alchemy/duplicates_elements.rb
+++ b/app/models/concerns/alchemy/duplicates_elements.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Alchemy
+  # Shared element-copying logic for +Alchemy::DuplicateElement+ (a pure copy of
+  # an element and all of its nested elements) and +Alchemy::PublishElement+ (a
+  # copy of an element and only its publishable nested elements onto a public
+  # page version).
+  #
+  # Including classes must implement +#nested_elements+, returning the child
+  # elements to copy.
+  module DuplicatesElements
+    SKIPPED_ATTRIBUTES_ON_COPY = [
+      "cached_tag_list",
+      "created_at",
+      "creator_id",
+      "position",
+      "id",
+      "folded",
+      "updated_at",
+      "updater_id"
+    ]
+
+    def initialize(source_element, repository: source_element.page_version.element_repository)
+      @source_element = source_element
+      @repository = repository
+    end
+
+    # Copies the source element (and its nested elements) into a new element.
+    #
+    # Pass a +differences+ Hash to override attributes on the copy.
+    def call(differences = {})
+      new_element = build_new_element(differences)
+      new_element.save!
+      duplicate_nested_elements(new_element)
+      new_element
+    end
+
+    protected
+
+    attr_reader :source_element, :repository
+
+    # Builds (but does not save) the copy of the source element. Override this
+    # to set attributes on the copy before it is persisted.
+    def build_new_element(differences)
+      attributes = source_element.attributes.with_indifferent_access
+        .except(*SKIPPED_ATTRIBUTES_ON_COPY)
+        .merge(differences)
+        .merge(
+          autogenerate_ingredients: false,
+          autogenerate_nested_elements: false,
+          tags: source_element.tags
+        )
+
+      new_element = Element.new(attributes)
+      new_element.ingredients = source_element.ingredients.map(&:dup)
+      new_element
+    end
+
+    # The nested (child) elements to copy.
+    def nested_elements
+      repository.children_of(source_element)
+    end
+
+    private
+
+    def duplicate_nested_elements(new_element)
+      Element.acts_as_list_no_update do
+        nested_elements.each.with_index(1) do |nested_element, position|
+          self.class.new(nested_element, repository: repository).call(
+            parent_element: new_element,
+            page_version: new_element.page_version,
+            position: position
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/alchemy/duplicate_element.rb
+++ b/app/services/alchemy/duplicate_element.rb
@@ -1,53 +1,10 @@
 # frozen_string_literal: true
 
 module Alchemy
+  # Copies an element and all of its nested elements.
+  #
+  # Used to duplicate elements (e.g. when pasting from the clipboard or copying a page).
   class DuplicateElement
-    SKIPPED_ATTRIBUTES_ON_COPY = [
-      "cached_tag_list",
-      "created_at",
-      "creator_id",
-      "position",
-      "id",
-      "folded",
-      "updated_at",
-      "updater_id"
-    ].freeze
-
-    attr_reader :source_element, :repository, :publishable_only
-
-    def initialize(source_element, repository: source_element.page_version.element_repository, publishable_only: false)
-      @source_element = source_element
-      @repository = repository
-      @publishable_only = publishable_only
-    end
-
-    def call(differences = {})
-      attributes = source_element.attributes.with_indifferent_access
-        .except(*SKIPPED_ATTRIBUTES_ON_COPY)
-        .merge(differences)
-        .merge(
-          autogenerate_ingredients: false,
-          autogenerate_nested_elements: false,
-          tags: source_element.tags
-        )
-
-      new_element = Element.new(attributes)
-      new_element.ingredients = source_element.ingredients.map(&:dup)
-      new_element.save!
-
-      nested_elements = repository.children_of(source_element)
-      nested_elements = nested_elements.publishable if publishable_only
-      Element.acts_as_list_no_update do
-        nested_elements.each.with_index(1) do |nested_element, position|
-          self.class.new(nested_element, repository: repository, publishable_only: publishable_only).call(
-            parent_element: new_element,
-            page_version: new_element.page_version,
-            position: position
-          )
-        end
-      end
-
-      new_element
-    end
+    include DuplicatesElements
   end
 end

--- a/app/services/alchemy/publish_element.rb
+++ b/app/services/alchemy/publish_element.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Alchemy
+  # Copies a publishable element onto a public page version.
+  #
+  # Copies only the source element's *publishable* nested elements, since
+  # non-publishable elements must not appear on the public version.
+  #
+  # This is the default +Alchemy.config.element_publisher+.
+  class PublishElement
+    include DuplicatesElements
+
+    protected
+
+    def nested_elements
+      repository.children_of(source_element).publishable
+    end
+  end
+end

--- a/lib/alchemy/configurations/main.rb
+++ b/lib/alchemy/configurations/main.rb
@@ -477,6 +477,20 @@ module Alchemy
       # == Example
       #     Alchemy.config.publishable_resolver = "MyApp::CustomResolver"
       option :publishable_resolver, :class, default: "Alchemy::Publishable::TimestampResolver"
+
+      # === Element publisher
+      #
+      # The service class used to copy a publishable element onto a page's
+      # public version when publishing.
+      #
+      # The default (+Alchemy::PublishElement+) copies the element and its
+      # publishable nested elements. Extension gems can provide a subclass that
+      # overrides +#build_new_element+ to set attributes on the public copy
+      # before it is saved.
+      #
+      # == Example
+      #     Alchemy.config.element_publisher = "MyApp::CustomElementPublisher"
+      option :element_publisher, :class, default: "Alchemy::PublishElement"
     end
   end
 end

--- a/spec/services/alchemy/duplicate_element_spec.rb
+++ b/spec/services/alchemy/duplicate_element_spec.rb
@@ -70,43 +70,5 @@ RSpec.describe Alchemy::DuplicateElement do
         end
       end
     end
-
-    context "with publishable_only option" do
-      let(:element) { create(:alchemy_element) }
-
-      let!(:current_nested) do
-        create(:alchemy_element, parent_element: element, page_version: element.page_version, public_on: 1.day.ago)
-      end
-
-      let!(:future_nested) do
-        create(:alchemy_element, parent_element: element, page_version: element.page_version, public_on: 1.day.from_now)
-      end
-
-      let!(:draft_nested) do
-        create(:alchemy_element, parent_element: element, page_version: element.page_version, public_on: nil)
-      end
-
-      let!(:expired_nested) do
-        create(:alchemy_element, parent_element: element, page_version: element.page_version, public_on: 2.days.ago, public_until: 1.day.ago)
-      end
-
-      subject do
-        described_class.new(element, publishable_only: true).call(differences)
-      end
-
-      it "only copies publishable nested elements" do
-        expect(subject.all_nested_elements.count).to eq(2)
-      end
-
-      it "does not copy draft nested elements" do
-        public_ons = subject.all_nested_elements.map(&:public_on)
-        expect(public_ons).to all(be_present)
-      end
-
-      it "does not copy expired nested elements" do
-        public_untils = subject.all_nested_elements.map(&:public_until)
-        expect(public_untils).to all(be_nil)
-      end
-    end
   end
 end

--- a/spec/services/alchemy/publish_element_spec.rb
+++ b/spec/services/alchemy/publish_element_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::PublishElement do
+  let(:element) do
+    create(:alchemy_element, :with_ingredients, tag_list: "red, yellow")
+  end
+
+  let(:differences) { {} }
+
+  subject { described_class.new(element).call(differences) }
+
+  it "copies the element with its ingredients and tags" do
+    expect(subject).to be_persisted
+    expect(subject.ingredients.count).to eq(element.ingredients.count)
+    expect(subject.ingredients.pluck(:id)).not_to eq(element.ingredients.pluck(:id))
+    expect(subject.tag_list).to eq(element.tag_list)
+  end
+
+  context "with differences" do
+    let(:new_page_version) { create(:alchemy_page_version, :published) }
+    let(:differences) { {page_version_id: new_page_version.id} }
+
+    it "applies the given differences to the copy" do
+      expect(subject.page_version_id).to eq(new_page_version.id)
+    end
+  end
+
+  context "with nested elements" do
+    let(:element) { create(:alchemy_element) }
+
+    let!(:current_nested) do
+      create(:alchemy_element, parent_element: element, page_version: element.page_version, public_on: 1.day.ago)
+    end
+
+    let!(:future_nested) do
+      create(:alchemy_element, parent_element: element, page_version: element.page_version, public_on: 1.day.from_now)
+    end
+
+    let!(:draft_nested) do
+      create(:alchemy_element, parent_element: element, page_version: element.page_version, public_on: nil)
+    end
+
+    let!(:expired_nested) do
+      create(:alchemy_element, parent_element: element, page_version: element.page_version, public_on: 2.days.ago, public_until: 1.day.ago)
+    end
+
+    it "only copies publishable nested elements" do
+      expect(subject.all_nested_elements.count).to eq(2)
+    end
+
+    it "does not copy draft nested elements" do
+      expect(subject.all_nested_elements.map(&:public_on)).to all(be_present)
+    end
+
+    it "does not copy expired nested elements" do
+      expect(subject.all_nested_elements.map(&:public_until)).to all(be_nil)
+    end
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

Extract the element-copying responsibilities from `Alchemy::DuplicateElement` into a module, 
so we can have a way to separate the concerns for publishing and copying elements from a page version to another.

Full duplicates including the unpublished elements for a usual copy-paste operation. And the newly
introduced `element_publishe`r that only copies published elements and their public children.

### Notable changes

Removes the `publishable_only` argument from DuplicateElement

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
