### PR TITLE
fix(LocaleSelect): Only render form for auto_submit

### DIFF
--- a/app/components/alchemy/admin/locale_select.rb
+++ b/app/components/alchemy/admin/locale_select.rb
@@ -10,12 +10,12 @@ module Alchemy
       end
 
       def call
-        form_tag(helpers.url_for, method: :get) do
-          if auto_submit
+        if auto_submit
+          form_tag(helpers.url_for, method: :get) do
             content_tag("alchemy-auto-submit", locale_select)
-          else
-            locale_select
           end
+        else
+          locale_select
         end
       end
 

--- a/spec/components/alchemy/admin/locale_select_spec.rb
+++ b/spec/components/alchemy/admin/locale_select_spec.rb
@@ -41,8 +41,9 @@ RSpec.describe Alchemy::Admin::LocaleSelect, type: :component do
     context "with auto_submit false" do
       let(:render) { render_inline described_class.new(:admin_locale, auto_submit: false) }
 
-      it "should return a select without auto submit wrapper" do
+      it "should return a single select without form and auto submit wrapper" do
         expect(page).not_to have_selector("alchemy-auto-submit")
+        expect(page).not_to have_selector("form")
         expect(page).to have_selector("select[name='admin_locale']")
       end
     end


### PR DESCRIPTION
## What is this pull request for?

If we do not want the auto-submit, because it sits inside an form with submit (ie. in alchemy-devise), we do not want a form wrapper. We just need the from wrapper for the auto-submit feature.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
