### PR TITLE
feat: Conditional dashboard widgets

### DIFF
--- a/app/components/alchemy/admin/dashboard/widget.rb
+++ b/app/components/alchemy/admin/dashboard/widget.rb
@@ -12,13 +12,24 @@ module Alchemy
           </div>
         ERB
 
-        def initialize(id:, loading: "eager", style: "default")
+        def initialize(id:, loading: "eager", style: "default", condition: nil)
           @id = id
           @loading = loading
           @style = style
+          @condition = condition
+
+          if condition && !condition.respond_to?(:call)
+            raise ArgumentError, ":condition argument must be a proc or lambda"
+          end
         end
 
         private
+
+        def render?
+          return true if @condition.nil?
+
+          instance_exec(&@condition)
+        end
 
         def url = alchemy.admin_dashboard_widget_path(id: @id)
       end

--- a/app/views/alchemy/admin/dashboard/_widgets.html.erb
+++ b/app/views/alchemy/admin/dashboard/_widgets.html.erb
@@ -3,6 +3,6 @@
   <%= render Alchemy::Admin::Dashboard::Widget.new(id: "RecentPages", style: "wide") %>
   <%= render Alchemy::Admin::Dashboard::Widget.new(id: "ElementUsage", style: "usage", loading: "lazy") %>
   <%= render Alchemy::Admin::Dashboard::Widget.new(id: "PageUsage", style: "usage", loading: "lazy") %>
-  <%= render Alchemy::Admin::Dashboard::Widget.new(id: "Sites", loading: "lazy") if multi_site? %>
-  <%= render Alchemy::Admin::Dashboard::Widget.new(id: "OnlineUsers", loading: "lazy") if Alchemy.config.user_class.respond_to?(:logged_in) %>
+  <%= render Alchemy::Admin::Dashboard::Widget.new(id: "Sites", loading: "lazy", condition: -> { helpers.multi_site? }) %>
+  <%= render Alchemy::Admin::Dashboard::Widget.new(id: "OnlineUsers", loading: "lazy", condition: -> { Alchemy.config.user_class.respond_to?(:logged_in) }) %>
 </div>

--- a/spec/components/alchemy/admin/dashboard/widget_spec.rb
+++ b/spec/components/alchemy/admin/dashboard/widget_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::Admin::Dashboard::Widget, type: :component do
+  it "renders a turbo-frame with given id" do
+    render_inline(described_class.new(id: "test-widget"))
+    expect(page).to have_css(".widget turbo-frame#test-widget")
+  end
+
+  context "with style option" do
+    it "renders the widget with the given style as CSS class" do
+      render_inline(described_class.new(id: "styled-widget", style: "fancy"))
+      expect(page).to have_css(".widget.fancy")
+    end
+  end
+
+  context "with loading option" do
+    it "renders the turbo-frame with the given loading attribute" do
+      render_inline(described_class.new(id: "lazy-widget", loading: "lazy"))
+      expect(page).to have_css("turbo-frame[loading='lazy']")
+    end
+  end
+
+  context "with condition option" do
+    it "renders the widget if condition is true" do
+      render_inline(described_class.new(id: "conditional-widget", condition: -> { true }))
+      expect(page).to have_css(".widget turbo-frame")
+    end
+
+    it "does not render the widget if condition is false" do
+      render_inline(described_class.new(id: "conditional-widget", condition: -> { false }))
+      expect(rendered_content).to be_empty
+    end
+
+    it "raises error if condition is not callable" do
+      expect {
+        described_class.new(id: "invalid-widget", condition: "not a proc")
+      }.to raise_error(ArgumentError, ":condition argument must be a proc or lambda")
+    end
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

Instead of having the condition outside of the widget callside, we pass a lambda to the widget as condition argument and exec it in the widgets instance. That way we can lazy evaluate the condition and store instances of widgets in the future in order to make them configurable outside of the view context.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
