### PR TITLE
feat(Configuration): Add view_component option

### DIFF
--- a/lib/alchemy/configuration.rb
+++ b/lib/alchemy/configuration.rb
@@ -12,6 +12,7 @@ require "alchemy/configuration/pathname_option"
 require "alchemy/configuration/regexp_option"
 require "alchemy/configuration/string_option"
 require "alchemy/configuration/symbol_option"
+require "alchemy/configuration/view_component_option"
 
 module Alchemy
   class Configuration

--- a/lib/alchemy/configuration/collection_option.rb
+++ b/lib/alchemy/configuration/collection_option.rb
@@ -43,6 +43,10 @@ module Alchemy
         @value.delete to_item(value)
       end
 
+      def insert(index, value)
+        @value.insert(index, to_item(value))
+      end
+
       delegate :join, :[], to: :to_a
 
       delegate :clear, :empty?, to: :@value

--- a/lib/alchemy/configuration/view_component_option.rb
+++ b/lib/alchemy/configuration/view_component_option.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Alchemy
+  class Configuration
+    # Configuration option for ViewComponents.
+    # Validates that the value is a subclass of +ViewComponent::Base+.
+    class ViewComponentOption < BaseOption
+      def self.value_class
+        ViewComponent::Base
+      end
+    end
+  end
+end

--- a/spec/libraries/alchemy/configuration/collection_option_spec.rb
+++ b/spec/libraries/alchemy/configuration/collection_option_spec.rb
@@ -117,6 +117,29 @@ RSpec.describe Alchemy::Configuration::CollectionOption do
     end
   end
 
+  describe "#insert" do
+    context "for an array collection class" do
+      let(:collection_class) { Array }
+      let(:item_type) { :integer }
+      let(:value) { [1, 2, 3] }
+
+      it "inserts item at position in collection" do
+        option.insert(1, 20)
+        expect(option.value.to_a).to eq([1, 20, 2, 3])
+      end
+    end
+
+    context "for a collection class that does not support insert" do
+      let(:collection_class) { Set }
+      let(:item_type) { :integer }
+      let(:value) { [1, 2, 3] }
+
+      it "raises an error" do
+        expect { option.insert(1, 20) }.to raise_error(NoMethodError)
+      end
+    end
+  end
+
   describe "#clear" do
     let(:collection_class) { Set }
     let(:item_type) { :integer }

--- a/spec/libraries/alchemy/configuration/view_component_spec.rb
+++ b/spec/libraries/alchemy/configuration/view_component_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::Configuration::ViewComponentOption do
+  subject { described_class.new(value:, name: :my_option).value }
+
+  context "value is a ViewComponent" do
+    let(:value) { Class.new(ViewComponent::Base).new }
+
+    it { is_expected.to be_a ViewComponent::Base }
+  end
+
+  context "value is nil" do
+    let(:value) { nil }
+
+    it { is_expected.to be nil }
+  end
+
+  context "value is something else" do
+    let(:value) { "NotAViewComponent" }
+
+    it "raises exception" do
+      expect { subject }.to raise_exception(
+        Alchemy::Configuration::ConfigurationError,
+        'Invalid configuration value for my_option: "NotAViewComponent" (expected ViewComponent::Base)'
+      )
+    end
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

Configuration option for ViewComponents.
Validates that the value is a subclass of `ViewComponent::Base`.

Also adds `insert` to `:collection` configuration option.
Same as `Array#insert` => Allows to [insert an item at given position](https://ruby-doc.org/3.4.1/Array.html#method-i-insert).

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
