### PR TITLE
feat(ClassOption): Allow array with arguments as value

### DIFF
--- a/lib/alchemy/configuration/class_option.rb
+++ b/lib/alchemy/configuration/class_option.rb
@@ -5,11 +5,54 @@ require "alchemy/configuration/base_option"
 module Alchemy
   class Configuration
     class ClassOption < BaseOption
-      def self.value_class
-        String
+      def allowed_classes
+        [String, Array]
       end
 
-      def value = @value&.constantize
+      def validate(value)
+        super
+
+        if value.is_a?(Array)
+          validate_array!(value)
+        end
+      end
+
+      def value
+        @_cached_value ||= case @value
+        when Array
+          @value[0] = @value[0]&.constantize
+          @value
+        when String
+          @value&.constantize
+        end
+      end
+
+      private
+
+      def validate_array!(value)
+        @array = value
+        has_length_two! && first_value_is_string! && second_value_is_hash!
+      end
+
+      def has_length_two!
+        return true if @array.length == 2
+
+        raise(ConfigurationError.new(name, @array, [
+          Class.new(Array) { def self.name = "an Array of length two" }
+        ]))
+      end
+
+      def first_value_is_string!
+        return true if @array[0].is_a?(String)
+
+        raise(ConfigurationError.new(name, @array[0], [String]))
+      end
+
+      def second_value_is_hash!
+        return true if @array[1].is_a?(Hash)
+
+        raise(ConfigurationError.new(name, @array[1], [Hash]))
+      end
     end
   end
 end

--- a/spec/libraries/alchemy/configuration/class_option_spec.rb
+++ b/spec/libraries/alchemy/configuration/class_option_spec.rb
@@ -2,14 +2,12 @@
 
 require "rails_helper"
 
-MyClass = Class.new do
-  def self.name
-    "MyClass"
-  end
-end
-
 RSpec.describe Alchemy::Configuration::ClassOption do
   subject { described_class.new(value:, name: :my_class).value }
+
+  before do
+    stub_const("MyClass", Class.new)
+  end
 
   context "value is 'MyClass'" do
     let(:value) { "MyClass" }
@@ -34,9 +32,44 @@ RSpec.describe Alchemy::Configuration::ClassOption do
     end
   end
 
-  after do
-    if defined?(MyClass)
-      Object.send(:remove_const, :MyClass)
+  context "value is an Array" do
+    let(:value) { ["MyClass", {foo: "bar"}] }
+
+    context "with two items" do
+      it "value is the constantized class with arguments" do
+        is_expected.to eq [MyClass, {foo: "bar"}]
+      end
+
+      context "first item is not a String" do
+        let(:value) { [123, {foo: "bar"}] }
+
+        it "raises exception" do
+          expect { subject }.to raise_exception(
+            Alchemy::Configuration::ConfigurationError,
+            "Invalid configuration value for my_class: 123 (expected String)"
+          )
+        end
+      end
+
+      context "second item is not a Hash" do
+        it "raises an exception" do
+          expect { described_class.new(value: ["MyClass", "not a hash"], name: :my_class) }.to raise_exception(
+            Alchemy::Configuration::ConfigurationError,
+            'Invalid configuration value for my_class: "not a hash" (expected Hash)'
+          )
+        end
+      end
+    end
+
+    context "with just one item" do
+      let(:value) { ["MyClass"] }
+
+      it "raises exception" do
+        expect { subject }.to raise_exception(
+          Alchemy::Configuration::ConfigurationError,
+          'Invalid configuration value for my_class: ["MyClass"] (expected an Array of length two)'
+        )
+      end
     end
   end
 end

--- a/spec/libraries/alchemy/configuration_spec.rb
+++ b/spec/libraries/alchemy/configuration_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Alchemy::Configuration do
         configuration.picture_thumb_storage_class = String
       end.to raise_exception(
         Alchemy::Configuration::ConfigurationError,
-        "Invalid configuration value for picture_thumb_storage_class: String (expected String)"
+        "Invalid configuration value for picture_thumb_storage_class: String (expected String or Array)"
       )
     end
     it "allows getting the raw string" do
@@ -327,7 +327,7 @@ RSpec.describe Alchemy::Configuration do
         configuration.preview_sources = [Alchemy::Admin::PreviewUrl, Alchemy::Admin::PreviewUrl]
       end.to raise_exception(
         Alchemy::Configuration::ConfigurationError,
-        "Invalid configuration value for preview_sources: Alchemy::Admin::PreviewUrl (expected String)"
+        "Invalid configuration value for preview_sources: Alchemy::Admin::PreviewUrl (expected String or Array)"
       )
     end
   end


### PR DESCRIPTION
## What is this pull request for?

Allow to pass an array to a `:class` configuration option, that is exactly two items long. The first
has to be the class name as string and the second
argument a hash. The value is then the array with
the constantized class and its arguments.

This can be used, if we need to pass arguments to
the class instantized later.

### Example

```rb
Alchemy.configure do |config|
  config.dashboard.stats << [
    "Alchemy::Admin::Dashboard::Widget", {
      id: "MyStatistic", 
      style: "stat"
    }
  ]
end
```

```erb
<% Alchemy.config.dashboard.stats.each do |widget, args| %>
  <%= render widget.new(**args) %>
<% end %>
```

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
