### PR TITLE
fix(CollectionOption): Resolve item_type using camelcase

### DIFF
--- a/lib/alchemy/configuration/collection_option.rb
+++ b/lib/alchemy/configuration/collection_option.rb
@@ -70,7 +70,7 @@ module Alchemy
       end
 
       def get_item_class(item_type)
-        "Alchemy::Configuration::#{item_type.to_s.classify}Option".constantize
+        "Alchemy::Configuration::#{item_type.to_s.camelcase}Option".constantize
       end
     end
   end

--- a/spec/libraries/alchemy/configuration/collection_option_spec.rb
+++ b/spec/libraries/alchemy/configuration/collection_option_spec.rb
@@ -41,6 +41,28 @@ RSpec.describe Alchemy::Configuration::CollectionOption do
     end
   end
 
+  context "with an array of Data instances" do
+    let(:data_class) { Data.define(:id) }
+    let(:collection_class) { Array }
+    let(:item_type) { :data }
+    let(:value) { [data_class.new(id: "x")] }
+
+    describe "#item_class" do
+      subject { option.item_class }
+
+      before do
+        stub_const(
+          "Alchemy::Configuration::DataOption",
+          Class.new(Alchemy::Configuration::BaseOption) { def self.value_class = Data }
+        )
+      end
+
+      it "resolves :data to DataOption (not DatumOption via the inflector)" do
+        expect { option.value }.to_not raise_error
+      end
+    end
+  end
+
   describe "#<<" do
     let(:collection_class) { Set }
     let(:item_type) { :integer }


### PR DESCRIPTION
## What is this pull request for?

`String#classify` singularizes its input through the Rails inflector, which turns `:data` into `Datum` and looks up the non-existent `DatumOption`. Using camelcase preserves the symbol as-is so :`data` resolves to `DataOption` and other item types keep working.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
