### PR TITLE
chore: Fix Dependabot settings for pnpm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      # select2 is pinned to a git ref (github:select2/select2#3.5.4), which the
+      # lockfile records as a git commit SHA. Dependabot tries to resolve that
+      # SHA as an npm registry version and always fails, so skip it.
+      - dependency-name: "select2"
     groups:
       babel:
         dependency-type: "development"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,21 +10,6 @@ updates:
       # SHA as an npm registry version and always fails, so skip it.
       - dependency-name: "select2"
     groups:
-      babel:
-        dependency-type: "development"
-        patterns:
-          - "@babel/*"
-        update-types:
-          - "minor"
-          - "patch"
-      jest:
-        dependency-type: "development"
-        patterns:
-          - "jest*"
-          - "babel-jest"
-        update-types:
-          - "minor"
-          - "patch"
       rollup:
         dependency-type: "development"
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,25 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # Wait before opening update PRs so brand-new releases have time to be
+    # vetted, and so CI's minimum release age policy does not reject the
+    # freshly published versions Dependabot would otherwise propose.
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
     ignore:
       # select2 is pinned to a git ref (github:select2/select2#3.5.4), which the
       # lockfile records as a git commit SHA. Dependabot tries to resolve that
       # SHA as an npm registry version and always fails, so skip it.
       - dependency-name: "select2"
+      # jQuery 4 breaks the pinned select2 3.5.4, so stay on the 3.x line until
+      # select2 is replaced.
+      - dependency-name: "jquery"
+        update-types: ["version-update:semver-major"]
+      # cropperjs 2.x removed the bundled stylesheet imported from admin.scss;
+      # the major upgrade needs manual migration before it can be taken.
+      - dependency-name: "cropperjs"
+        update-types: ["version-update:semver-major"]
     groups:
       rollup:
         dependency-type: "development"

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -57,9 +57,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -169,7 +169,7 @@ jobs:
           rubygems: "latest"
       - name: Restore apt cache
         id: apt-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /var/cache/apt/archives
           key: ${{ runner.os }}-apt-v2-${{ matrix.database }}-${{ matrix.storage }}
@@ -235,9 +235,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,9 +36,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -54,9 +54,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -72,9 +72,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm


### PR DESCRIPTION
select2 is referenced as `github:select2/select2#3.5.4`, which the pnpm lockfile records as a git commit SHA. Dependabot resolves that SHA and then tries to fetch it as an npm registry version, which fails with `ERR_PNPM_NO_MATCHING_VERSION` on every run. The dependency is intentionally pinned to that ref, so ignoring it keeps Dependabot from erroring.
