### PR TITLE
feat(SystemInfo): Display git source info

### DIFF
--- a/app/components/alchemy/admin/dashboard/widgets/system_info.html.erb
+++ b/app/components/alchemy/admin/dashboard/widgets/system_info.html.erb
@@ -5,6 +5,7 @@
   <div class="version-info">
     <span class="version">
       <%= @alchemy_version %>
+      <%= git_source %>
     </span>
 
     <%= render Alchemy::Admin::UpdateCheck.new %>

--- a/app/components/alchemy/admin/dashboard/widgets/system_info.rb
+++ b/app/components/alchemy/admin/dashboard/widgets/system_info.rb
@@ -17,6 +17,16 @@ module Alchemy
             @_logo_file ||= File.read(logo_file_path).html_safe
           end
 
+          def git_source
+            git_info = Alchemy.git_revision_info
+            return unless git_info
+
+            branch = git_info[:branch]
+            revision = git_info[:revision]
+
+            "(#{[branch, revision[0, 7]].compact.join(" @ ")})"
+          end
+
           def logo_file_path
             Alchemy::Engine.root.join("app/assets/images/alchemy/admin/logo.svg")
           end

--- a/lib/alchemy/version.rb
+++ b/lib/alchemy/version.rb
@@ -1,13 +1,27 @@
 # frozen_string_literal: true
 
 module Alchemy
+  extend self
+
   VERSION = "8.3.0.dev"
 
-  def self.version
+  def version
     VERSION
   end
 
-  def self.gem_version
+  def gem_version
     Gem::Version.new(VERSION)
+  end
+
+  def git_revision_info
+    source = Bundler.locked_gems.sources.find { _1.name == "alchemy_cms" }
+    return unless source.respond_to?(:revision)
+
+    {
+      revision: source.revision,
+      branch: source.branch
+    }
+  rescue
+    nil
   end
 end

--- a/spec/components/alchemy/admin/dashboard/widgets/system_info_spec.rb
+++ b/spec/components/alchemy/admin/dashboard/widgets/system_info_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::Admin::Dashboard::Widgets::SystemInfo, type: :component do
+  subject(:rendered) do
+    render_inline(described_class.new)
+    page
+  end
+
+  it "displays the Alchemy version" do
+    rendered
+    expect(page).to have_css(".version", text: Alchemy.version)
+  end
+
+  context "when git revision info is available" do
+    before do
+      allow(Alchemy).to receive(:git_revision_info).and_return(
+        branch: "main",
+        revision: "abc1234def5678"
+      )
+    end
+
+    it "displays the branch and shortened revision" do
+      rendered
+      expect(page).to have_css(".version", text: "(main @ abc1234)")
+    end
+  end
+
+  context "when only a revision is available" do
+    before do
+      allow(Alchemy).to receive(:git_revision_info).and_return(
+        branch: nil,
+        revision: "abc1234def5678"
+      )
+    end
+
+    it "displays only the shortened revision" do
+      rendered
+      expect(page).to have_css(".version", text: "(abc1234)")
+    end
+  end
+
+  context "when no git revision info is available" do
+    before do
+      allow(Alchemy).to receive(:git_revision_info).and_return(nil)
+    end
+
+    it "does not display a git source" do
+      rendered
+      expect(page).to have_css(".version", text: Alchemy.version)
+      expect(page).to have_no_text("@")
+    end
+  end
+end

--- a/spec/libraries/alchemy_spec.rb
+++ b/spec/libraries/alchemy_spec.rb
@@ -1,6 +1,60 @@
 require "rails_helper"
 
 RSpec.describe Alchemy do
+  describe ".version" do
+    subject { Alchemy.version }
+
+    it { is_expected.to eq(Alchemy::VERSION) }
+  end
+
+  describe ".gem_version" do
+    subject { Alchemy.gem_version }
+
+    it { is_expected.to eq(Gem::Version.new(Alchemy::VERSION)) }
+  end
+
+  describe ".git_revision_info" do
+    subject { Alchemy.git_revision_info }
+
+    let(:sources) { [source] }
+
+    before do
+      allow(Bundler).to receive(:locked_gems).and_return(double(sources: sources))
+    end
+
+    context "when the alchemy_cms gem is locked to a git source" do
+      let(:source) do
+        double(name: "alchemy_cms", revision: "abc1234def5678", branch: "main")
+      end
+
+      it "returns the revision and branch" do
+        is_expected.to eq(revision: "abc1234def5678", branch: "main")
+      end
+    end
+
+    context "when the alchemy_cms gem is not locked to a git source" do
+      let(:source) { double(name: "alchemy_cms") }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when there is no alchemy_cms source" do
+      let(:sources) { [double(name: "another_gem")] }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when reading the lockfile raises an error" do
+      let(:sources) { [] }
+
+      before do
+        allow(Bundler).to receive(:locked_gems).and_raise(StandardError)
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe ".preview_sources" do
     subject { Alchemy.preview_sources }
 


### PR DESCRIPTION
## What is this pull request for?

If the alchemy_cms gem is bundled via a git source, we show the branch and revision.

### Notable changes

Added `Alchemy.git_revision_info`.

### Screenshots

<img width="1368" height="272" alt="CleanShot 2026-06-03 at 22 25 31@2x" src="https://github.com/user-attachments/assets/95635907-a807-4a45-93a9-d3e7bbeb61f6" />

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
