### PR TITLE
fix(routing): Ignore dotfile requests in pages routing

### DIFF
--- a/lib/alchemy/routing_constraints.rb
+++ b/lib/alchemy/routing_constraints.rb
@@ -16,10 +16,20 @@ module Alchemy
       @request = request
       @params = @request.params
 
-      handable_format? && no_rails_route?
+      handable_format? && no_dotfile_route? && no_rails_route?
     end
 
     private
+
+    # We don't want to handle requests to dotfile URLs.
+    #
+    # A page urlname never starts with a dot, so any such request
+    # (/.well-known/ ACME challenges, /.env or /.git probes, etc.)
+    # should never be served by a page.
+    #
+    def no_dotfile_route?
+      !@params["urlname"].start_with?(".")
+    end
 
     # We only want html requests to be handled by us.
     #

--- a/spec/routing/routing_spec.rb
+++ b/spec/routing/routing_spec.rb
@@ -194,6 +194,26 @@ describe "The Routing" do
     end
   end
 
+  describe "dotfile requests" do
+    it "should not be handled by alchemy/pages controller" do
+      expect({
+        get: "/.well-known/security.txt"
+      }).not_to be_routable
+
+      expect({
+        get: "/.well-known/appspecific/com.chrome.devtools.json"
+      }).not_to be_routable
+
+      expect({
+        get: "/.env"
+      }).not_to be_routable
+
+      expect({
+        get: "/.git/config"
+      }).not_to be_routable
+    end
+  end
+
   describe "Turbo stream requests" do
     it do
       expect({


### PR DESCRIPTION
## What is this pull request for?

Requests to dotfile URLs are never legitimate CMS pages. They are used for things like `/.well-known/` ACME challenges and `security.txt` or for `/.env` and `/.git` scanner probes. Since a page urlname never starts with a dot, we exclude any such request from Alchemy's catch all route in all environments.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
