### PR TITLE
feat: Invalidate elements cache if related object changes

### DIFF
--- a/app/jobs/alchemy/base_job.rb
+++ b/app/jobs/alchemy/base_job.rb
@@ -3,9 +3,9 @@
 module Alchemy
   class BaseJob < ActiveJob::Base
     # Automatically retry jobs that encountered a deadlock
-    # retry_on ActiveRecord::Deadlocked
+    retry_on ActiveRecord::Deadlocked
 
     # Most jobs are safe to ignore if the underlying records are no longer available
-    # discard_on ActiveJob::DeserializationError
+    discard_on ActiveJob::DeserializationError
   end
 end

--- a/app/jobs/alchemy/invalidate_elements_cache_job.rb
+++ b/app/jobs/alchemy/invalidate_elements_cache_job.rb
@@ -1,0 +1,33 @@
+module Alchemy
+  class InvalidateElementsCacheJob < BaseJob
+    queue_as :default
+
+    def perform(related_object_type, related_object_id)
+      element_ids = Ingredient
+        .where(related_object_type:, related_object_id:)
+        .joins(:element)
+        .pluck(:element_id)
+      elements = Element.where(id: element_ids)
+
+      all_element_ids = get_all_element_ids(elements, element_ids)
+      Element.where(id: all_element_ids).touch_all
+
+      page_ids = elements.joins(page_version: :page).select("DISTINCT alchemy_pages.id")
+      Page.where(id: page_ids).touch_all
+    end
+
+    private
+
+    def get_all_element_ids(elements, element_ids)
+      parent_element_ids = elements.where.not(parent_element_id: nil).pluck(:parent_element_id)
+      parent_elements = Element.distinct.where(id: parent_element_ids)
+
+      if parent_elements.any?
+        element_ids += parent_element_ids
+        get_all_element_ids(parent_elements, element_ids)
+      else
+        element_ids
+      end
+    end
+  end
+end

--- a/app/models/concerns/alchemy/relatable_resource.rb
+++ b/app/models/concerns/alchemy/relatable_resource.rb
@@ -41,12 +41,20 @@ module Alchemy
 
       has_many :related_elements, through: :related_ingredients, source: :element
       has_many :related_pages, through: :related_elements, source: :page
+
+      after_touch :touch_related_ingredients, if: -> { related_ingredients.exists? }
     end
 
     # Returns true if object is not assigned to any ingredient.
     #
     def deletable?
       related_ingredients.none?
+    end
+
+    private
+
+    def touch_related_ingredients
+      InvalidateElementsCacheJob.perform_later(self.class.name, id)
     end
   end
 end

--- a/lib/alchemy/test_support/relatable_resource_examples.rb
+++ b/lib/alchemy/test_support/relatable_resource_examples.rb
@@ -55,4 +55,24 @@ RSpec.shared_examples_for "a relatable resource" do |args|
       it { is_expected.to be(true) }
     end
   end
+
+  describe "after_touch" do
+    let(:related_object) { create(:"alchemy_#{args[:resource_name]}") }
+
+    context "when related ingredients exist" do
+      let!(:ingredient) { create(:"alchemy_ingredient_#{args[:ingredient_type]}", related_object:) }
+
+      it "enqueues InvalidateElementsCacheJob" do
+        expect {
+          related_object.touch
+        }.to have_enqueued_job(Alchemy::InvalidateElementsCacheJob).with(described_class.name, related_object.id)
+      end
+    end
+
+    context "when no related ingredients exist" do
+      it "does not enqueue InvalidateElementsCacheJob" do
+        expect { related_object.touch }.to_not have_enqueued_job(Alchemy::InvalidateElementsCacheJob)
+      end
+    end
+  end
 end

--- a/spec/jobs/alchemy/invalidate_elements_cache_job_spec.rb
+++ b/spec/jobs/alchemy/invalidate_elements_cache_job_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe Alchemy::InvalidateElementsCacheJob, type: :job do
+  let(:job) { described_class.new }
+
+  subject { job.perform("Alchemy::Page", related_object.id) }
+
+  let(:page) { create(:alchemy_page, :public, updated_at: 1.week.ago) }
+
+  let!(:element) do
+    create(:alchemy_element, page_version: page.draft_version, ingredients: [ingredient], updated_at: 1.day.ago)
+  end
+
+  describe "#perform" do
+    let(:related_object) { create(:alchemy_page) }
+    let(:ingredient) { Alchemy::Ingredients::Page.create(related_object:, role: "page") }
+
+    it "touches the element" do
+      expect { subject }.to change { element.reload.updated_at }
+    end
+
+    context "when the element has a parent" do
+      let!(:parent_element) do
+        create(:alchemy_element, page_version: page.draft_version, updated_at: 1.day.ago).tap do |parent|
+          element.update_column(:parent_element_id, parent.id)
+        end
+      end
+
+      it "touches the parent element" do
+        expect { subject }.to change { parent_element.reload.updated_at }
+      end
+
+      context "that has a parent" do
+        let!(:grand_parent_element) do
+          create(:alchemy_element, page_version: page.draft_version, updated_at: 1.day.ago).tap do |grand_parent|
+            parent_element.update_column(:parent_element_id, grand_parent.id)
+          end
+        end
+
+        it "touches the grand parent element" do
+          expect { subject }.to change { grand_parent_element.reload.updated_at }
+        end
+      end
+    end
+
+    it "touches the page" do
+      expect { subject }.to change { page.reload.updated_at }
+    end
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

Add a after_touch callback to RelatableResurce that enqueues a job that invalidates the element and page caches for
ingredients having this object assigned as related_object.

So, when a page or node changes the elements and pages get touched as well.

[Taken from alchemy-solidus extension](https://github.com/AlchemyCMS/alchemy-solidus/pull/147), but actually useful for all related objects.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
