### PR TITLE
fix(assets): Skip SassC compression for prebuilt admin CSS

### DIFF
--- a/lib/alchemy/engine.rb
+++ b/lib/alchemy/engine.rb
@@ -17,7 +17,8 @@ module Alchemy
     end
 
     initializer "alchemy.assets" do |app|
-      if defined?(Sprockets)
+      if defined?(::Sprockets)
+        require_relative "sprockets/skip_builds_compression"
         require_relative "../non_stupid_digest_assets"
         NonStupidDigestAssets.whitelist += [/^tinymce\//]
         app.config.assets.precompile << "alchemy_manifest.js"
@@ -25,7 +26,7 @@ module Alchemy
     end
 
     initializer "alchemy.admin_stylesheets" do |app|
-      if defined?(Sprockets)
+      if defined?(::Sprockets)
         Alchemy.config.admin_stylesheets.each do |stylesheet|
           app.config.assets.precompile << stylesheet
         end
@@ -33,7 +34,7 @@ module Alchemy
     end
 
     initializer "alchemy.propshaft" do |app|
-      if defined?(Propshaft)
+      if defined?(::Propshaft)
         if app.config.assets.server
           # Monkey-patch Propshaft::Asset to enable access
           # of TinyMCE assets without a hash digest.

--- a/lib/alchemy/sprockets/skip_builds_compression.rb
+++ b/lib/alchemy/sprockets/skip_builds_compression.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+begin
+  require "sprockets/sass_compressor"
+rescue LoadError
+  # Sprockets::SassCompressor is only defined if sassc-rails is present,
+  # which is not the case in all environments (for example, when using Propshaft).
+  # In that case, we can skip prepending our patch module.
+end
+
+module Alchemy
+  module Sprockets
+    # Alchemy ships pre-built, already-minified admin CSS in +app/assets/builds+
+    # that uses modern CSS syntax (relative colors, +oklch()+ and friends). The
+    # legacy SassC/libSass +css_compressor+ — the Sprockets default whenever
+    # +sassc-rails+ is present (for example through Solidus) — re-parses every
+    # +text/css+ asset as SCSS and raises on that syntax. These files are already
+    # minified, so leave them untouched; all other stylesheets still get
+    # compressed as before.
+    module SkipBuildsCompression
+      def call(input)
+        builds_path = Alchemy::Engine.root.join("app/assets/builds").to_s
+        if input[:filename].to_s.start_with?(builds_path)
+          {data: input[:data]}
+        else
+          super
+        end
+      end
+
+      ::Sprockets::SassCompressor.singleton_class.prepend(self)
+    end
+  end
+end

--- a/spec/libraries/alchemy/engine_spec.rb
+++ b/spec/libraries/alchemy/engine_spec.rb
@@ -13,8 +13,7 @@ RSpec.describe Alchemy::Engine do
 
     context "when sprockets is not defined" do
       before do
-        Object.send(:remove_const, :Sprockets)
-      rescue NameError
+        hide_const("Sprockets")
       end
 
       it "does not add alchemy/admin/custom.css" do

--- a/spec/libraries/sprockets/skip_builds_compression_spec.rb
+++ b/spec/libraries/sprockets/skip_builds_compression_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "sprockets"
+require "alchemy/sprockets/skip_builds_compression"
+
+RSpec.describe Alchemy::Sprockets::SkipBuildsCompression do
+  let(:compressor_class) do
+    Class.new do
+      def call(input)
+        {data: "compressed(#{input[:data]})"}
+      end
+      prepend Alchemy::Sprockets::SkipBuildsCompression
+    end
+  end
+
+  subject(:compress) { compressor_class.new.call(filename: filename, data: "css") }
+
+  context "for a stylesheet inside Alchemy's app/assets/builds" do
+    let(:filename) do
+      Alchemy::Engine.root.join("app/assets/builds/alchemy/admin.css").to_s
+    end
+
+    it "returns the data untouched, skipping compression" do
+      expect(compress).to eq(data: "css")
+    end
+  end
+
+  context "for any other stylesheet" do
+    let(:filename) { "/app/app/assets/stylesheets/application.css" }
+
+    it "delegates to the wrapped compressor" do
+      expect(compress).to eq(data: "compressed(css)")
+    end
+  end
+
+  it "is prepended onto Sprockets::SassCompressor" do
+    expect(::Sprockets::SassCompressor.singleton_class.ancestors).to include(described_class)
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

Alchemy ships pre-built, already-minified admin CSS in app/assets/builds that uses modern CSS syntax such as relative colors and `oklch()`. When a host app pulls in `sassc-rails` (the default in any Solidus app), Sprockets sets the `:sass` `css_compressor`, which re-parses every `text/css` asset as SCSS through the unmaintained libSass and raises on that syntax. Since these files are already minified, prepend a skip onto the SassC compressor for assets under our builds directory and leave every other stylesheet to be compressed as before.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
