### PR TITLE
fix(layoutpage): Display page icon for not locked pages

### DIFF
--- a/app/views/alchemy/admin/layoutpages/_layoutpage.html.erb
+++ b/app/views/alchemy/admin/layoutpages/_layoutpage.html.erb
@@ -8,7 +8,7 @@
         <%= render_icon "file-edit", size: "xl" %>
       </sl-tooltip>
     <% else %>
-      <%= render_icon "file-edit", size: "xl" %>
+      <%= render_icon "file", size: "xl" %>
     <% end %>
     </div>
     <div class="sitemap_sitename without-status">


### PR DESCRIPTION
## What is this pull request for?

We must not use the same icon for locked and not-locked layoutpages.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message

