### PR TITLE
chore: Lint for Ruby 3.3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
           bundler-cache: true
           rubygems: "latest"
       - name: Lint Ruby files

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,6 @@
 require: standard
 
 AllCops:
-  TargetRubyVersion: 3.1
-
+  TargetRubyVersion: 3.3
 inherit_gem:
   standard: config/base.yml

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,4 +1,4 @@
 parallel: true
-ruby_version: 3.1
+ruby_version: 3.3
 ignore:
   - "spec/dummy/**/*"


### PR DESCRIPTION
## What is this pull request for?

We dropped tests for Ruby 3.2 and since dependencies start to drop support for unmaintained Ruby 3.2, we start linting for 3.3

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
