### PR TITLE
feat(element_view_for): Add `el.ingredient` alias

### DIFF
--- a/app/helpers/alchemy/elements_block_helper.rb
+++ b/app/helpers/alchemy/elements_block_helper.rb
@@ -57,6 +57,7 @@ module Alchemy
       def ingredient_by_role(role)
         element.ingredient_by_role(role)
       end
+      alias_method :ingredient, :ingredient_by_role
     end
 
     # Block-level helper for element views. Constructs a DOM element wrapping

--- a/spec/helpers/alchemy/elements_block_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_block_helper_spec.rb
@@ -119,6 +119,15 @@ module Alchemy
           expect(subject.ingredient_by_role(:headline)).to eq(ingredient)
         end
       end
+
+      describe "#ingredient" do
+        let(:element) { create(:alchemy_element, :with_ingredients) }
+        let(:ingredient) { element.ingredient_by_role(:headline) }
+
+        it "returns the ingredient record by role" do
+          expect(subject.ingredient(:headline)).to eq(ingredient)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## What is this pull request for?

More intuitive to use `el.ingredient(:some_ingredient)` instead of `el.ingredient_by_role(:role)`, which is very technical.

We removed the `el.ingredient` helper in 7.0 in order to avoid] conflicts with the essences `ingredient` method that returned the value back in the days, but those days are over now.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
