### PR TITLE
fix(TimezoneSelect): Use request path over url helper

### DIFF
--- a/app/components/alchemy/admin/timezone_select.rb
+++ b/app/components/alchemy/admin/timezone_select.rb
@@ -22,7 +22,7 @@ module Alchemy
 
       def popover_content
         content_tag(:div, class: "alchemy-popover") do
-          form_tag(helpers.url_for, method: :get, class: "timezone-select") do
+          form_tag(request.path, method: :get, class: "timezone-select") do
             label_tag(:admin_timezone, Alchemy.t(:timezone)) +
               content_tag("alchemy-auto-submit") do
                 select_tag(

--- a/spec/components/alchemy/admin/timezone_select_spec.rb
+++ b/spec/components/alchemy/admin/timezone_select_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe Alchemy::Admin::TimezoneSelect, type: :component do
   subject! do
-    allow(vc_test_view_context).to receive(:url_for) { "/admin/dashboard" }
+    allow(vc_test_request).to receive(:path) { "/admin/dashboard" }
     render_inline described_class.new
   end
 
@@ -24,5 +24,9 @@ RSpec.describe Alchemy::Admin::TimezoneSelect, type: :component do
     expect(page).to have_selector(
       "select[name='admin_timezone'] option[selected][value='#{Time.zone.name}']"
     )
+  end
+
+  it "submits the form to the current request path" do
+    expect(page).to have_selector("form.timezone-select[action='/admin/dashboard']")
   end
 end


### PR DESCRIPTION
## What is this pull request for?

Rails' `url_for` helper needs a route to be set up in the alchemy engine scope. If an app or extension gem has it's own path outside of the Alchemy engine it fails with a routing error. Since we just need to redirect to current path in the timezone select, we can simply use that instead of going through the router.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
