### PR TITLE
Add element-level opt-out for page caching

### DIFF
--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -194,11 +194,10 @@ module Alchemy
     end
 
     def set_expiration_headers
-      if page_cache_disabled_by_elements?
-        # no-cache still allows storage and conditional 304 responses, which would skip element-level cache variants.
+      if must_not_cache?
+        # no-cache still allows storage and conditional 304 responses, which would serve
+        # stale content (e.g. flash messages) and skip element-level cache variants.
         no_store
-      elsif must_not_cache?
-        expires_now
       else
         expires_in @page.expiration_time, {public: !@page.restricted}.merge(caching_options)
       end

--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -194,7 +194,10 @@ module Alchemy
     end
 
     def set_expiration_headers
-      if must_not_cache?
+      if page_cache_disabled_by_elements?
+        # no-cache still allows storage and conditional 304 responses, which would skip element-level cache variants.
+        no_store
+      elsif must_not_cache?
         expires_now
       else
         expires_in @page.expiration_time, {public: !@page.restricted}.merge(caching_options)
@@ -252,7 +255,11 @@ module Alchemy
 
     # don't cache pages if we have flash message to display or the page has caching disabled
     def must_not_cache?
-      !caching_enabled? || !@page.cache_page? || flash.present?
+      !caching_enabled? || !@page.cache_page? || flash.present? || page_cache_disabled_by_elements?
+    end
+
+    def page_cache_disabled_by_elements?
+      @page&.find_elements&.any? { |element| element.definition.page_cache == false } || false
     end
 
     def caching_enabled?

--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -195,8 +195,9 @@ module Alchemy
 
     def set_expiration_headers
       if must_not_cache?
-        # no-cache still allows storage and conditional 304 responses, which would serve
-        # stale content (e.g. flash messages) and skip element-level cache variants.
+        # no-store, not no-cache: no-cache still lets caches store the response and
+        # reuse it after a 304, which serves stale content (e.g. flash messages) and
+        # skips re-rendering elements that opted out of page caching.
         no_store
       else
         expires_in @page.expiration_time, {public: !@page.restricted}.merge(caching_options)

--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -259,7 +259,13 @@ module Alchemy
     end
 
     def page_cache_disabled_by_elements?
-      @page&.find_elements&.any? { |element| element.definition.page_cache == false } || false
+      return @page_cache_disabled_by_elements if defined?(@page_cache_disabled_by_elements)
+
+      opt_out_names = Alchemy::Element.definitions.filter_map { |d| d.name if d.page_cache == false }
+      @page_cache_disabled_by_elements = !!(
+        opt_out_names.any? &&
+          @page&.public_version&.elements&.published&.exists?(name: opt_out_names)
+      )
     end
 
     def caching_enabled?

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -49,6 +49,7 @@ module Alchemy
       "ingredients",
       "message",
       "nestable_elements",
+      "page_cache",
       "searchable",
       "taggable",
       "warning"

--- a/app/models/alchemy/element_definition.rb
+++ b/app/models/alchemy/element_definition.rb
@@ -13,6 +13,7 @@ module Alchemy
     attribute :taggable, :boolean, default: false
     attribute :compact, :boolean, default: false
     attribute :fixed, :boolean, default: false
+    attribute :page_cache, :boolean, default: true
     attribute :ingredients, default: []
     attribute :nestable_elements, default: []
     attribute :autogenerate, default: []

--- a/spec/models/alchemy/element_definition_spec.rb
+++ b/spec/models/alchemy/element_definition_spec.rb
@@ -25,6 +25,7 @@ module Alchemy
       it { is_expected.to have_key(:taggable) }
       it { is_expected.to have_key(:compact) }
       it { is_expected.to have_key(:fixed) }
+      it { is_expected.to have_key(:page_cache) }
       it { is_expected.to have_key(:ingredients) }
       it { is_expected.to have_key(:nestable_elements) }
       it { is_expected.to have_key(:autogenerate) }
@@ -33,6 +34,16 @@ module Alchemy
       it { is_expected.to have_key(:warning) }
       it { is_expected.to have_key(:hint) }
       it { is_expected.to have_key(:searchable) }
+    end
+
+    describe "#page_cache" do
+      it "defaults to true" do
+        expect(described_class.new.page_cache).to be(true)
+      end
+
+      it "can be disabled" do
+        expect(described_class.new(page_cache: false).page_cache).to be(false)
+      end
     end
 
     describe "validations" do

--- a/spec/requests/alchemy/page_request_caching_spec.rb
+++ b/spec/requests/alchemy/page_request_caching_spec.rb
@@ -124,6 +124,46 @@ RSpec.describe "Page request caching" do
         end
       end
 
+      context "with an element-level page cache opt-out" do
+        around do |example|
+          Alchemy::ElementDefinition.add({"name" => "uncached_element", "page_cache" => false})
+          Alchemy::PageDefinition.add({"name" => "uncached_layout", "elements" => ["uncached_element"]})
+
+          example.run
+        ensure
+          Alchemy::ElementDefinition.reset!
+          Alchemy::PageDefinition.reset!
+        end
+
+        it "sets no-store when a published element disables page caching" do
+          create(:alchemy_element, name: "uncached_element", page_version: page.public_version)
+
+          get "/#{page.urlname}"
+
+          expect(response.headers).to have_key("Cache-Control")
+          expect(response.headers["Cache-Control"]).to eq("no-store")
+        end
+
+        it "keeps page caching when the page layout allows but does not contain an element that disables page caching" do
+          uncached_page = create(:alchemy_page, :public, page_layout: "uncached_layout")
+
+          get "/#{uncached_page.urlname}"
+
+          expect(response.headers).to have_key("Cache-Control")
+          expect(response.headers["Cache-Control"]).to eq("max-age=60, public, must-revalidate")
+        end
+
+        it "renders without conditional cache revalidation when a published element disables page caching" do
+          create(:alchemy_element, name: "uncached_element", page_version: page.public_version)
+
+          expect_any_instance_of(Alchemy::PagesController).not_to receive(:stale?)
+
+          get "/#{page.urlname}", headers: {"If-None-Match" => "\"cached-page\""}
+
+          expect(response.status).to eq(200)
+        end
+      end
+
       it "does not set last-modified header" do
         get "/#{page.urlname}"
         expect(response.headers).to_not have_key("Last-Modified")

--- a/spec/requests/alchemy/page_request_caching_spec.rb
+++ b/spec/requests/alchemy/page_request_caching_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe "Page request caching" do
       Rails.application.config.action_controller.perform_caching = false
     end
 
-    it "sets no-cache header" do
+    it "sets no-store header" do
       get "/#{page.urlname}"
       expect(response.headers).to have_key("Cache-Control")
-      expect(response.headers["Cache-Control"]).to eq("no-cache")
+      expect(response.headers["Cache-Control"]).to eq("no-store")
     end
   end
 
@@ -74,10 +74,10 @@ RSpec.describe "Page request caching" do
           allow_any_instance_of(Alchemy::Page).to receive(:cache_page?) { false }
         end
 
-        it "sets no-cache cache-control header" do
+        it "sets no-store cache-control header" do
           get "/#{page.urlname}"
           expect(response.headers).to have_key("Cache-Control")
-          expect(response.headers["Cache-Control"]).to eq("no-cache")
+          expect(response.headers["Cache-Control"]).to eq("no-store")
         end
       end
 
@@ -88,7 +88,7 @@ RSpec.describe "Page request caching" do
 
         it "returns false" do
           get "/#{page.urlname}"
-          expect(response.headers["cache-control"]).to eq("no-cache")
+          expect(response.headers["cache-control"]).to eq("no-store")
         end
       end
 
@@ -175,10 +175,10 @@ RSpec.describe "Page request caching" do
         allow_any_instance_of(Alchemy::Page).to receive(:cache_page?) { false }
       end
 
-      it "sets no-cache header" do
+      it "sets no-store header" do
         get "/#{page.urlname}"
         expect(response.headers).to have_key("Cache-Control")
-        expect(response.headers["Cache-Control"]).to eq("no-cache")
+        expect(response.headers["Cache-Control"]).to eq("no-store")
       end
 
       it "does not set last-modified header" do
@@ -194,10 +194,10 @@ RSpec.describe "Page request caching" do
         end
       end
 
-      it "sets no-cache header" do
+      it "sets no-store header" do
         get "/#{page.urlname}"
         expect(response.headers).to have_key("Cache-Control")
-        expect(response.headers["Cache-Control"]).to eq("no-cache")
+        expect(response.headers["Cache-Control"]).to eq("no-store")
       end
 
       it "does not set last-modified header" do

--- a/spec/requests/alchemy/page_request_caching_spec.rb
+++ b/spec/requests/alchemy/page_request_caching_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe "Page request caching" do
           get "/#{uncached_page.urlname}"
 
           expect(response.headers).to have_key("Cache-Control")
-          expect(response.headers["Cache-Control"]).to eq("max-age=60, public, must-revalidate")
+          expect(response.headers["Cache-Control"]).to eq("max-age=600, public, must-revalidate")
         end
 
         it "renders without conditional cache revalidation when a published element disables page caching" do


### PR DESCRIPTION
Closes #3973.

This adds a `page_cache` option to element definitions, allowing individual elements to opt a page out of HTTP page caching:

```
- name: restricted_downloads
  page_cache: false
```

When a page contains an element definition with `page_cache: false`, Alchemy now always renders the page instead of relying on the page-cache. This lets dynamic or permission-sensitive elements execute and apply their own fragment cache keys.

Uncacheable page responses now use `Cache-Control: no-store` instead of `no-cache`. `no-cache` still lets a cache store the response and reuse it after a 304, which serves stale content (this is why stale flash messages could appear) and skips re-rendering elements. `no-store` guarantees the page is rendered fresh. This applies to every reason a page is uncacheable — global config, page-layout `cache: false`, a flash message, and the new element-level opt-out.

The `page_cache` option defaults to true and is kept as definition-only metadata, so element definitions behave as before unless one explicitly opts out. Note that the `no-cache` → `no-store` switch does change the cache-control header for pages that were already uncacheable.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
