### PR TITLE
fix(api): authorize nested pages endpoint against restricted content

### DIFF
--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -69,8 +69,7 @@ module Alchemy
         @root_page = Alchemy::PageTreePreloader.new(
           page: @current_language.root_page,
           ability: current_ability,
-          user: current_alchemy_user,
-          admin_includes: true
+          user: current_alchemy_user
         ).call
       end
 
@@ -183,8 +182,7 @@ module Alchemy
               @page = PageTreePreloader.new(
                 page: @page,
                 ability: current_ability,
-                user: current_alchemy_user,
-                admin_includes: true
+                user: current_alchemy_user
               ).call
             else
               head 200

--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -68,6 +68,7 @@ module Alchemy
       def tree
         @root_page = Alchemy::PageTreePreloader.new(
           page: @current_language.root_page,
+          ability: current_ability,
           user: current_alchemy_user,
           admin_includes: true
         ).call
@@ -181,6 +182,7 @@ module Alchemy
             if was_folded
               @page = PageTreePreloader.new(
                 page: @page,
+                ability: current_ability,
                 user: current_alchemy_user,
                 admin_includes: true
               ).call

--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -28,8 +28,14 @@ module Alchemy
     def nested
       @page = Page.find_by(id: params[:page_id]) || Language.current_root_page
 
-      # Preload the full tree from this page
-      preloaded_page = PageTreePreloader.new(page: @page, user: current_alchemy_user).call
+      authorize! :show, @page
+
+      # Preload the full tree from this page, scoped to what the user may see
+      preloaded_page = PageTreePreloader.new(
+        page: @page,
+        user: current_alchemy_user,
+        ability: current_ability
+      ).call
 
       render json: PageTreeSerializer.new(
         preloaded_page,

--- a/app/serializers/alchemy/page_tree_serializer.rb
+++ b/app/serializers/alchemy/page_tree_serializer.rb
@@ -63,6 +63,12 @@ module Alchemy
     end
 
     def page_elements(page)
+      # Pages usually arrive wrapped in a PageTreePage delegator. Unwrap it so
+      # the ability matches the Alchemy::Page rules instead of the delegator
+      # class, while still supporting a plain Alchemy::Page being passed in.
+      authorized_page = page.try(:__getobj__) || page
+      return Alchemy::Element.none unless opts[:ability].can?(:read, authorized_page)
+
       elements = page.public_version&.elements || Alchemy::Element.none
       if opts[:elements] == "true"
         elements

--- a/app/services/alchemy/page_tree_preloader.rb
+++ b/app/services/alchemy/page_tree_preloader.rb
@@ -7,15 +7,17 @@ module Alchemy
   # It handles folded pages and preloads all necessary associations.
   #
   # @example Preload subtree from a specific page
-  #   preloader = Alchemy::PageTreePreloader.new(page: page, user: current_user)
+  #   preloader = Alchemy::PageTreePreloader.new(page: page, ability: current_ability, user: current_user)
   #   page_with_descendants = preloader.call
   #
   class PageTreePreloader
     # @param page [Page] Starting page for loading descendants
+    # @param ability [CanCan::Ability] Ability used to scope descendants to readable pages
     # @param user [User, nil] User for folding support
     # @param admin_includes [Boolean] Whether to include admin-only associations like :locker
-    def initialize(page:, user: nil, admin_includes: false)
+    def initialize(page:, ability:, user: nil, admin_includes: false)
       @page = page
+      @ability = ability
       @user = user
       @admin_includes = admin_includes
     end
@@ -24,7 +26,7 @@ module Alchemy
     #
     # @return [Array<Page>] Pages with preloaded children, or array with single page when using from:
     def call
-      pages = page.self_and_descendants
+      pages = page.self_and_descendants.accessible_by(ability, :read)
       folded_page_ids = load_folded_page_ids
       if folded_page_ids.any?
         pages = pages.where(
@@ -45,7 +47,7 @@ module Alchemy
 
     private
 
-    attr_reader :page, :user, :admin_includes
+    attr_reader :page, :user, :ability, :admin_includes
 
     # Load folded page IDs for the user
     def load_folded_page_ids

--- a/app/services/alchemy/page_tree_preloader.rb
+++ b/app/services/alchemy/page_tree_preloader.rb
@@ -14,12 +14,10 @@ module Alchemy
     # @param page [Page] Starting page for loading descendants
     # @param ability [CanCan::Ability] Ability used to scope descendants to readable pages
     # @param user [User, nil] User for folding support
-    # @param admin_includes [Boolean] Whether to include admin-only associations like :locker
-    def initialize(page:, ability:, user: nil, admin_includes: false)
+    def initialize(page:, ability:, user: nil)
       @page = page
       @ability = ability
       @user = user
-      @admin_includes = admin_includes
     end
 
     # Preloads and returns the page tree
@@ -47,7 +45,7 @@ module Alchemy
 
     private
 
-    attr_reader :page, :user, :ability, :admin_includes
+    attr_reader :page, :user, :ability
 
     # Load folded page IDs for the user
     def load_folded_page_ids
@@ -95,7 +93,9 @@ module Alchemy
         },
         :public_version
       ]
-      associations.push(:locker) if admin_includes
+      # The admin sitemap (and the serializer's admin fields) render lock info,
+      # so only eager-load the locker when the user may administer pages.
+      associations.push(:locker) if ability.can?(:index, :alchemy_admin_pages)
       associations
     end
   end

--- a/spec/controllers/alchemy/api/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/api/pages_controller_spec.rb
@@ -181,6 +181,101 @@ module Alchemy
           end
         end
 
+        context "with restricted and unpublished pages in the tree" do
+          let!(:restricted_page) do
+            create(:alchemy_page, :public, :restricted, name: "Restricted")
+          end
+
+          let!(:unpublished_page) do
+            create(:alchemy_page, name: "Unpublished")
+          end
+
+          def page_names(result)
+            names = []
+            collect = ->(pages) do
+              pages.each do |p|
+                names << p["name"]
+                collect.call(p["children"])
+              end
+            end
+            collect.call(result["pages"])
+            names
+          end
+
+          context "as a guest user" do
+            it "does not leak restricted pages" do
+              get :nested, params: {format: :json}
+
+              result = JSON.parse(response.body)
+              expect(page_names(result)).to_not include("Restricted")
+            end
+
+            it "does not leak unpublished pages" do
+              get :nested, params: {format: :json}
+
+              result = JSON.parse(response.body)
+              expect(page_names(result)).to_not include("Unpublished")
+            end
+
+            it "does not leak restricted page content via elements=true" do
+              element = create(
+                :alchemy_element,
+                name: "article",
+                page: restricted_page,
+                page_version: restricted_page.public_version
+              )
+              create(
+                :alchemy_ingredient_text,
+                element: element,
+                role: "intro",
+                value: "TOPSECRET_RESTRICTED_BODY_proof123"
+              )
+
+              get :nested, params: {elements: "true", format: :json}
+
+              expect(response.body).to_not include("TOPSECRET_RESTRICTED_BODY_proof123")
+            end
+
+            it "denies access to a restricted page requested by page_id" do
+              get :nested, params: {page_id: restricted_page.id, format: :json}
+
+              expect(response.status).to eq(403)
+            end
+          end
+
+          context "as author" do
+            before do
+              authorize_user(build(:alchemy_dummy_user, :as_author))
+            end
+
+            it "still returns restricted and unpublished pages" do
+              get :nested, params: {format: :json}
+
+              result = JSON.parse(response.body)
+              expect(page_names(result)).to include("Restricted", "Unpublished")
+            end
+
+            it "returns restricted page content via elements=true" do
+              element = create(
+                :alchemy_element,
+                name: "article",
+                page: restricted_page,
+                page_version: restricted_page.public_version
+              )
+              create(
+                :alchemy_ingredient_text,
+                element: element,
+                role: "intro",
+                value: "TOPSECRET_RESTRICTED_BODY_proof123"
+              )
+
+              get :nested, params: {elements: "true", format: :json}
+
+              expect(response.body).to include("TOPSECRET_RESTRICTED_BODY_proof123")
+            end
+          end
+        end
+
         context "when a page_id is passed" do
           it "returns all pages as nested json from this page only" do
             get :nested, params: {page_id: page.id, format: :json}

--- a/spec/serializers/alchemy/page_tree_serializer_spec.rb
+++ b/spec/serializers/alchemy/page_tree_serializer_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::PageTreeSerializer do
+  let(:ability) { Alchemy::Permissions.new(nil) } # guest
+
+  # The serializer is normally fed a PageTreePage delegator from
+  # PageTreePreloader. These specs pass a plain Alchemy::Page to exercise the
+  # safeguard in #page_elements that supports an un-preloaded page.
+  describe "#page_elements with a plain Alchemy::Page" do
+    subject(:json) do
+      JSON.parse(
+        described_class.new(page, ability: ability, elements: "true").to_json
+      )
+    end
+
+    let!(:element) do
+      create(:alchemy_element, name: "article", page: page, page_version: page.public_version)
+    end
+
+    context "when the ability can read the page" do
+      let(:page) { create(:alchemy_page, :public) }
+
+      it "includes the page elements" do
+        expect(json["pages"].first["elements"]).to_not be_empty
+      end
+    end
+
+    context "when the ability cannot read the page" do
+      let(:page) { create(:alchemy_page, :public, :restricted) }
+
+      it "omits the page elements" do
+        expect(json["pages"].first["elements"]).to eq([])
+      end
+    end
+  end
+end

--- a/spec/services/alchemy/page_tree_preloader_spec.rb
+++ b/spec/services/alchemy/page_tree_preloader_spec.rb
@@ -3,7 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Alchemy::PageTreePreloader do
-  let(:user) { create(:alchemy_dummy_user) }
+  # An admin ability can read every page, so the structural tests below see the
+  # whole (otherwise unpublished) tree.
+  let(:user) { create(:alchemy_dummy_user, :as_admin) }
+  let(:ability) { Alchemy::Permissions.new(user) }
   let(:root_page) { create(:alchemy_page, :language_root) }
   let!(:child_page_1) { create(:alchemy_page, parent: root_page) }
   let!(:child_page_2) { create(:alchemy_page, parent: root_page) }
@@ -12,7 +15,7 @@ RSpec.describe Alchemy::PageTreePreloader do
   describe "#call" do
     # Reload root_page to ensure nested set values are current
     # (they become stale after children are added)
-    subject { described_class.new(page: root_page.reload, user: user).call }
+    subject { described_class.new(page: root_page.reload, ability: ability, user: user).call }
 
     it "returns root page" do
       expect(subject).to eq(root_page)
@@ -58,10 +61,28 @@ RSpec.describe Alchemy::PageTreePreloader do
     end
 
     context "without user" do
-      subject { described_class.new(page: root_page.reload).call }
+      subject { described_class.new(page: root_page.reload, ability: ability).call }
 
       it "returns pages with all children loaded" do
         expect(subject.children.first.children).to eq([grandchild_page])
+      end
+    end
+
+    context "with an ability" do
+      let(:root_page) { create(:alchemy_page, :language_root, :public) }
+      let!(:public_child) { create(:alchemy_page, :public, parent: root_page) }
+      let!(:restricted_child) { create(:alchemy_page, :public, :restricted, parent: root_page) }
+
+      # A guest ability can only read published, non-restricted pages
+      let(:ability) { Alchemy::Permissions.new(nil) }
+
+      subject do
+        described_class.new(page: root_page.reload, ability: ability).call
+      end
+
+      it "only includes pages the ability can read" do
+        expect(subject.children).to include(public_child)
+        expect(subject.children).to_not include(restricted_child)
       end
     end
 
@@ -69,6 +90,7 @@ RSpec.describe Alchemy::PageTreePreloader do
       subject do
         described_class.new(
           page: root_page.reload,
+          ability: ability,
           user: user,
           admin_includes: true
         ).call

--- a/spec/services/alchemy/page_tree_preloader_spec.rb
+++ b/spec/services/alchemy/page_tree_preloader_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe Alchemy::PageTreePreloader do
       expect(subject.language.association(:site)).to be_loaded
     end
 
-    it "does not preload locker association" do
-      expect(subject.association(:locker)).not_to be_loaded
+    it "preloads the locker association for an admin ability" do
+      expect(subject.association(:locker)).to be_loaded
     end
 
     context "with folded pages" do
@@ -84,20 +84,9 @@ RSpec.describe Alchemy::PageTreePreloader do
         expect(subject.children).to include(public_child)
         expect(subject.children).to_not include(restricted_child)
       end
-    end
 
-    context "with admin_includes: true" do
-      subject do
-        described_class.new(
-          page: root_page.reload,
-          ability: ability,
-          user: user,
-          admin_includes: true
-        ).call
-      end
-
-      it "preloads locker association" do
-        expect(subject.association(:locker)).to be_loaded
+      it "does not preload the locker association" do
+        expect(subject.association(:locker)).not_to be_loaded
       end
     end
   end


### PR DESCRIPTION
## What is this pull request for?

The unauthenticated `GET /api/pages/nested` returned the full page tree **including restricted and unpublished pages**, and **leaked their element content** with `?elements=true`, bypassing the access control that the `show` and `index` actions enforce.

Scope the preloaded tree by the current ability and authorize the requested page so guests only see what they are allowed to read. The ability is a required argument of `PageTreePreloader` so a consumer cannot accidentally render an unscoped, leaking tree.

**Thanks @Haxset for reporting!**

### Notable changes

`PageTreePreloader` now has a new mandatory argument (`ability:`)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
