### PR TITLE
[7.4] fix(api): authorize nested pages endpoint against restricted content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ end
 gem "pg", "~> 1.0" if ENV["DB"] == "postgresql"
 
 gem "alchemy_i18n", git: "https://github.com/AlchemyCMS/alchemy_i18n.git", branch: "4.2-stable"
+gem "i18n", "< 1.15" # >= 1.15 needs Ruby 3.2, but we still support Ruby 3.1
 
 group :development, :test do
   gem "execjs", "~> 2.9.1"

--- a/app/controllers/alchemy/api/pages_controller.rb
+++ b/app/controllers/alchemy/api/pages_controller.rb
@@ -28,6 +28,8 @@ module Alchemy
     def nested
       @page = Page.find_by(id: params[:page_id]) || Language.current_root_page
 
+      authorize! :show, @page
+
       render json: PageTreeSerializer.new(
         @page,
         ability: current_ability,

--- a/app/serializers/alchemy/page_tree_serializer.rb
+++ b/app/serializers/alchemy/page_tree_serializer.rb
@@ -9,7 +9,21 @@ module Alchemy
     def pages
       tree = []
       path = [{id: object.parent_id, children: tree}]
-      page_list = object.self_and_descendants.includes(:public_version, {language: :site})
+      page_list = object.self_and_descendants
+        .accessible_by(opts[:ability], :read)
+        .includes(:public_version, {language: :site})
+        .to_a
+      # Drop pages whose parent was filtered out by the ability, so a
+      # restricted or unpublished branch does not leak its accessible
+      # descendants. self_and_descendants is ordered pre-order, so a parent
+      # always precedes its children and a single pass is sufficient.
+      kept_ids = Set.new([object.id])
+      page_list = page_list.select do |page|
+        next true if page.id == object.id
+        kept_ids.include?(page.parent_id).tap do |kept|
+          kept_ids << page.id if kept
+        end
+      end
       base_level = object.level - 1
       # Load folded pages in advance
       folded_user_pages = FoldedPage.folded_for_user(opts[:user]).pluck(:page_id)
@@ -83,6 +97,8 @@ module Alchemy
     end
 
     def page_elements(page)
+      return Alchemy::Element.none unless opts[:ability].can?(:read, page)
+
       elements = page.public_version&.elements || Alchemy::Element.none
       if opts[:elements] == "true"
         elements

--- a/spec/controllers/alchemy/api/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/api/pages_controller_spec.rb
@@ -181,6 +181,113 @@ module Alchemy
           end
         end
 
+        context "with restricted and unpublished pages in the tree" do
+          let!(:restricted_page) do
+            create(:alchemy_page, :public, :restricted, name: "Restricted")
+          end
+
+          let!(:unpublished_page) do
+            create(:alchemy_page, name: "Unpublished")
+          end
+
+          def page_names(result)
+            names = []
+            collect = ->(pages) do
+              pages.each do |p|
+                names << p["name"]
+                collect.call(p["children"])
+              end
+            end
+            collect.call(result["pages"])
+            names
+          end
+
+          context "as a guest user" do
+            it "does not leak restricted pages" do
+              get :nested, params: {format: :json}
+
+              result = JSON.parse(response.body)
+              expect(page_names(result)).to_not include("Restricted")
+            end
+
+            it "does not leak unpublished pages" do
+              get :nested, params: {format: :json}
+
+              result = JSON.parse(response.body)
+              expect(page_names(result)).to_not include("Unpublished")
+            end
+
+            it "does not leak restricted page content via elements=true" do
+              element = create(
+                :alchemy_element,
+                name: "article",
+                page: restricted_page,
+                page_version: restricted_page.public_version
+              )
+              create(
+                :alchemy_ingredient_text,
+                element: element,
+                role: "intro",
+                value: "TOPSECRET_RESTRICTED_BODY_proof123"
+              )
+
+              get :nested, params: {elements: "true", format: :json}
+
+              expect(response.body).to_not include("TOPSECRET_RESTRICTED_BODY_proof123")
+            end
+
+            it "denies access to a restricted page requested by page_id" do
+              get :nested, params: {page_id: restricted_page.id, format: :json}
+
+              expect(response.status).to eq(403)
+            end
+
+            it "does not leak a published page nested under an unpublished page" do
+              # Publication is not inherited, so a published child can sit under
+              # an unpublished parent. The parent is filtered out for the guest,
+              # and its descendants must not be re-parented into the visible tree.
+              create(:alchemy_page, :public, parent: unpublished_page, name: "HiddenChild")
+
+              get :nested, params: {format: :json}
+
+              result = JSON.parse(response.body)
+              expect(page_names(result)).to_not include("HiddenChild")
+            end
+          end
+
+          context "as author" do
+            before do
+              authorize_user(build(:alchemy_dummy_user, :as_author))
+            end
+
+            it "still returns restricted and unpublished pages" do
+              get :nested, params: {format: :json}
+
+              result = JSON.parse(response.body)
+              expect(page_names(result)).to include("Restricted", "Unpublished")
+            end
+
+            it "returns restricted page content via elements=true" do
+              element = create(
+                :alchemy_element,
+                name: "article",
+                page: restricted_page,
+                page_version: restricted_page.public_version
+              )
+              create(
+                :alchemy_ingredient_text,
+                element: element,
+                role: "intro",
+                value: "TOPSECRET_RESTRICTED_BODY_proof123"
+              )
+
+              get :nested, params: {elements: "true", format: :json}
+
+              expect(response.body).to include("TOPSECRET_RESTRICTED_BODY_proof123")
+            end
+          end
+        end
+
         context "when a page_id is passed" do
           it "returns all pages as nested json from this page only" do
             get :nested, params: {page_id: page.id, format: :json}


### PR DESCRIPTION
## What is this pull request for?

The unauthenticated GET /api/pages/nested returned the full page tree including restricted and unpublished pages, and leaked their element content with ?elements=true, bypassing the access control the show and index actions enforce. Authorize the requested page and scope the serialized tree by the current ability so guests only see what they are allowed to read. Pages whose parent is filtered out are dropped so a hidden branch cannot leak its accessible descendants.

Backport of #3982

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
