### PR TITLE
build(docker): make compose dev stack build and boot reliably

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
 
 ENV LD_PRELOAD=libjemalloc.so.2
 ENV RUBY_YJIT_ENABLE=1
+ENV LISTEN_GEM_ADAPTER_WARN_BEHAVIOR=silent
 
 RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y nodejs \
@@ -21,5 +22,5 @@ COPY Gemfile Gemfile.lock* alchemy_cms.gemspec ./
 COPY lib/alchemy/version.rb lib/alchemy/version.rb
 RUN bundle install
 
-COPY package.json pnpm-lock.yaml* ./
+COPY package.json pnpm-*.yaml ./
 RUN pnpm install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,34 @@
 name: alchemy_cms
 
 services:
+  deps:
+    build:
+      context: .
+      dockerfile: .devcontainer/Dockerfile
+    command: bash -c "bundle check || bundle install && pnpm install"
+    volumes:
+      - .:/workspace
+      - bundle:/usr/local/bundle
+      - node_modules:/workspace/node_modules
+
   web:
     build:
       context: .
       dockerfile: .devcontainer/Dockerfile
-    command: bash -c "cd spec/dummy && bin/rails db:prepare && bin/rails server -b 0.0.0.0"
+    command: bash -c "cd spec/dummy && rm -f tmp/pids/server.pid && bin/rails db:prepare && exec bin/rails server -b 0.0.0.0"
     ports:
       - "3000:3000"
     volumes:
       - .:/workspace
+      - bundle:/usr/local/bundle
       - node_modules:/workspace/node_modules
     depends_on:
-      - css
-      - js
+      deps:
+        condition: service_completed_successfully
+      css:
+        condition: service_started
+      js:
+        condition: service_started
 
   sass:
     build:
@@ -22,7 +37,11 @@ services:
     command: pnpm run build:css --watch
     volumes:
       - .:/workspace
+      - bundle:/usr/local/bundle
       - node_modules:/workspace/node_modules
+    depends_on:
+      deps:
+        condition: service_completed_successfully
 
   css:
     build:
@@ -31,7 +50,11 @@ services:
     command: bash -c "cd spec/dummy && bin/rails dartsass:watch"
     volumes:
       - .:/workspace
+      - bundle:/usr/local/bundle
       - node_modules:/workspace/node_modules
+    depends_on:
+      deps:
+        condition: service_completed_successfully
 
   js:
     build:
@@ -40,7 +63,12 @@ services:
     command: pnpm run build:admin:dev
     volumes:
       - .:/workspace
+      - bundle:/usr/local/bundle
       - node_modules:/workspace/node_modules
+    depends_on:
+      deps:
+        condition: service_completed_successfully
 
 volumes:
+  bundle:
   node_modules:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,2 @@
-# Use a flat node_modules layout (like npm/yarn/bun) instead of pnpm's
-# symlinked store. This keeps Rails' evented file watcher (listen gem) from
-# following the .pnpm symlinks and warning about directories being watched
-# through two paths.
-nodeLinker: hoisted
-
 allowBuilds:
   '@parcel/watcher': true

--- a/spec/dummy/Procfile.dev
+++ b/spec/dummy/Procfile.dev
@@ -1,4 +1,4 @@
-web: env RUBY_DEBUG_OPEN=true bin/rails server
-css: bin/rails dartsass:watch
+web: env RUBY_DEBUG_OPEN=true LISTEN_GEM_ADAPTER_WARN_BEHAVIOR=silent bin/rails server
+css: env LISTEN_GEM_ADAPTER_WARN_BEHAVIOR=silent bin/rails dartsass:watch
 sass: cd ../../ && pnpm run build:css --watch
 js: cd ../../ && pnpm run build:admin:dev


### PR DESCRIPTION
## What is this pull request for?

The compose setup failed in a few ways: pnpm install errored because the
image copied only `pnpm-lock.yaml`, leaving `pnpm-workspace.yaml` (and its
`allowBuilds` entry) out of the build. 

The listen gem flooded boot with "already being watched" warnings. Dependencies could drift from the shared source since gems and `node_modules` were baked once into the image and the web service refused to boot whenever a stale `tmp/pids/server.pid` was left behind on the shared mount.

### Notable changes

Copy `pnpm-*.yaml` so the workspace config is present, silence the listen
warnings, add a one-shot deps service with a shared bundle volume so gems
and `node_modules` are reinstalled against the current lockfiles on every up,
and have the web command clear a stale pidfile and exec the server so it
receives `SIGTERM` and shuts down cleanly.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message

