### PR TITLE
fix(LocaleSelect): Use request.path instead of helpers.url_for

### DIFF
--- a/app/components/alchemy/admin/locale_select.rb
+++ b/app/components/alchemy/admin/locale_select.rb
@@ -11,7 +11,7 @@ module Alchemy
 
       def call
         if auto_submit
-          form_tag(helpers.url_for, method: :get) do
+          form_tag(request.path, method: :get) do
             content_tag("alchemy-auto-submit", locale_select)
           end
         else

--- a/spec/components/alchemy/admin/locale_select_spec.rb
+++ b/spec/components/alchemy/admin/locale_select_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Alchemy::Admin::LocaleSelect, type: :component do
   subject! do
     expect(Alchemy::I18n).to receive(:available_locales) { locales }
-    allow(vc_test_view_context).to receive(:url_for) { "/admin/dashboard" }
+    allow(vc_test_request).to receive(:path) { "/admin/dashboard" }
     render
   end
 
@@ -36,6 +36,10 @@ RSpec.describe Alchemy::Admin::LocaleSelect, type: :component do
 
     it "should return a select with auto submit wrapper" do
       expect(page).to have_selector("alchemy-auto-submit select[name='admin_locale']")
+    end
+
+    it "submits the form to the current request path" do
+      expect(page).to have_selector("form[action='/admin/dashboard']")
     end
 
     context "with auto_submit false" do


### PR DESCRIPTION
## What is this pull request for?

This fixes an adjacent bug to https://github.com/AlchemyCMS/alchemy_cms/pull/3974 - I didn't find this in my repro
at the time as this is only shown when more than one locale is used.

I've grepped through the code and at least in the view components there
don't seem to be any other usages of the argless `url_for`

If you want to take a look, I've updated [my repro](https://github.com/halfbyte/alchemy_repro).

### Notable changes (remove if none)

Uses `request.path` instead of an argless `url_for` to get the URL path for the current page for the form action URL in the component.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
