### PR TITLE
ci: Exclude backport-to-8.3-stable from release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -9,6 +9,7 @@ changelog:
       - backport-to-8.0-stable
       - backport-to-8.1-stable
       - backport-to-8.2-stable
+      - backport-to-8.3-stable
       - chore
 
   categories:


### PR DESCRIPTION
The 8.3-stable branch needs its own backport label, and like the other backport labels its PRs should not show up as separate entries in the generated release notes since the original PR is already listed.
