### PR TITLE
fix(RelatableResource): Invalidate element caches on resource update

### DIFF
--- a/app/models/concerns/alchemy/relatable_resource.rb
+++ b/app/models/concerns/alchemy/relatable_resource.rb
@@ -42,7 +42,11 @@ module Alchemy
       has_many :related_elements, through: :related_ingredients, source: :element
       has_many :related_pages, through: :related_elements, source: :page
 
-      after_touch :touch_related_ingredients, if: -> { related_ingredients.exists? }
+      # Fires on both updates and touches (touch flags the update callback),
+      # so element caches are invalidated whenever the resource changes.
+      # Deferring to after_commit avoids enqueuing on rollback and coalesces
+      # repeated touches within a transaction into a single job.
+      after_commit :touch_related_ingredients, on: :update, if: -> { related_ingredients.exists? }
     end
 
     # Returns true if object is not assigned to any ingredient.

--- a/lib/alchemy/test_support/relatable_resource_examples.rb
+++ b/lib/alchemy/test_support/relatable_resource_examples.rb
@@ -3,13 +3,16 @@ RSpec.shared_examples_for "a relatable resource" do |args|
   it { is_expected.to have_many(:related_elements).through(:related_ingredients) }
   it { is_expected.to have_many(:related_pages).through(:related_elements) }
 
+  let(:resource_factory_name) { args[:resource_factory_name] || "alchemy_#{args[:resource_name]}" }
+  let(:ingredient_factory_name) { args[:ingredient_factory_name] || "alchemy_ingredient_#{args[:ingredient_type]}" }
+
   describe ".deletable" do
     subject { described_class.deletable }
 
-    let!(:assigned_resource) { create(:"alchemy_#{args[:resource_name]}") }
-    let!(:unassigned_resource) { create(:"alchemy_#{args[:resource_name]}") }
-    let!(:ingredient1) { create(:"alchemy_ingredient_#{args[:ingredient_type]}", related_object: assigned_resource) }
-    let!(:ingredient2) { create(:"alchemy_ingredient_#{args[:ingredient_type]}", related_object: nil) }
+    let!(:assigned_resource) { create(resource_factory_name) }
+    let!(:unassigned_resource) { create(resource_factory_name) }
+    let!(:ingredient1) { create(ingredient_factory_name, related_object: assigned_resource) }
+    let!(:ingredient2) { create(ingredient_factory_name, related_object: nil) }
 
     it "should return all records that are not assigned to an ingredient" do
       is_expected.to eq [unassigned_resource]
@@ -20,9 +23,9 @@ RSpec.shared_examples_for "a relatable resource" do |args|
     subject { resource.related_ingredients }
 
     context "with other related resources with same id" do
-      let!(:resource) { create(:"alchemy_#{args[:resource_name]}") }
-      let!(:ingredient1) { create(:"alchemy_ingredient_#{args[:ingredient_type]}", related_object: resource) }
-      let!(:ingredient2) { create(:"alchemy_ingredient_#{args[:ingredient_type]}", related_object_type: "Event", related_object_id: resource.id) }
+      let!(:resource) { create(resource_factory_name) }
+      let!(:ingredient1) { create(ingredient_factory_name, related_object: resource) }
+      let!(:ingredient2) { create(ingredient_factory_name, related_object_type: "Event", related_object_id: resource.id) }
 
       it "are not included" do
         is_expected.to eq [ingredient1]
@@ -30,9 +33,9 @@ RSpec.shared_examples_for "a relatable resource" do |args|
     end
 
     context "with other related resources with same type" do
-      let!(:resource) { create(:"alchemy_#{args[:resource_name]}") }
-      let!(:ingredient1) { create(:"alchemy_ingredient_#{args[:ingredient_type]}", related_object: resource) }
-      let!(:ingredient2) { create(:"alchemy_ingredient_#{args[:ingredient_type]}", related_object_type: described_class) }
+      let!(:resource) { create(resource_factory_name) }
+      let!(:ingredient1) { create(ingredient_factory_name, related_object: resource) }
+      let!(:ingredient2) { create(ingredient_factory_name, related_object_type: described_class) }
 
       it "are not included" do
         is_expected.to eq [ingredient1]
@@ -41,12 +44,12 @@ RSpec.shared_examples_for "a relatable resource" do |args|
   end
 
   describe "#deletable?" do
-    let(:resource) { create(:"alchemy_#{args[:resource_name]}") }
+    let(:resource) { create(resource_factory_name) }
 
     subject { resource.deletable? }
 
     context "if related to ingredient" do
-      let!(:ingredient) { create(:"alchemy_ingredient_#{args[:ingredient_type]}", related_object: resource) }
+      let!(:ingredient) { create(ingredient_factory_name, related_object: resource) }
 
       it { is_expected.to be(false) }
     end
@@ -57,10 +60,10 @@ RSpec.shared_examples_for "a relatable resource" do |args|
   end
 
   describe "after_commit on touch" do
-    let(:related_object) { create(:"alchemy_#{args[:resource_name]}") }
+    let(:related_object) { create(resource_factory_name) }
 
     context "when related ingredients exist" do
-      let!(:ingredient) { create(:"alchemy_ingredient_#{args[:ingredient_type]}", related_object:) }
+      let!(:ingredient) { create(ingredient_factory_name, related_object:) }
 
       it "enqueues InvalidateElementsCacheJob" do
         expect {
@@ -77,10 +80,10 @@ RSpec.shared_examples_for "a relatable resource" do |args|
   end
 
   describe "after_commit on update" do
-    let(:related_object) { create(:"alchemy_#{args[:resource_name]}") }
+    let(:related_object) { create(resource_factory_name) }
 
     context "when related ingredients exist" do
-      let!(:ingredient) { create(:"alchemy_ingredient_#{args[:ingredient_type]}", related_object:) }
+      let!(:ingredient) { create(ingredient_factory_name, related_object:) }
 
       it "enqueues InvalidateElementsCacheJob" do
         expect {

--- a/lib/alchemy/test_support/relatable_resource_examples.rb
+++ b/lib/alchemy/test_support/relatable_resource_examples.rb
@@ -5,6 +5,7 @@ RSpec.shared_examples_for "a relatable resource" do |args|
 
   let(:resource_factory_name) { args[:resource_factory_name] || "alchemy_#{args[:resource_name]}" }
   let(:ingredient_factory_name) { args[:ingredient_factory_name] || "alchemy_ingredient_#{args[:ingredient_type]}" }
+  let(:update_attribute) { args[:update_attribute] || :name }
 
   describe ".deletable" do
     subject { described_class.deletable }
@@ -15,7 +16,8 @@ RSpec.shared_examples_for "a relatable resource" do |args|
     let!(:ingredient2) { create(ingredient_factory_name, related_object: nil) }
 
     it "should return all records that are not assigned to an ingredient" do
-      is_expected.to eq [unassigned_resource]
+      is_expected.to include(unassigned_resource)
+      is_expected.to_not include(assigned_resource)
     end
   end
 
@@ -87,14 +89,14 @@ RSpec.shared_examples_for "a relatable resource" do |args|
 
       it "enqueues InvalidateElementsCacheJob" do
         expect {
-          related_object.update(name: "Updated name")
+          related_object.update(update_attribute => "Updated name")
         }.to have_enqueued_job(Alchemy::InvalidateElementsCacheJob).with(described_class.name, related_object.id)
       end
     end
 
     context "when no related ingredients exist" do
       it "does not enqueue InvalidateElementsCacheJob" do
-        expect { related_object.update(name: "Updated name") }.to_not have_enqueued_job(Alchemy::InvalidateElementsCacheJob)
+        expect { related_object.update(update_attribute => "Updated name") }.to_not have_enqueued_job(Alchemy::InvalidateElementsCacheJob)
       end
     end
   end

--- a/lib/alchemy/test_support/relatable_resource_examples.rb
+++ b/lib/alchemy/test_support/relatable_resource_examples.rb
@@ -56,7 +56,7 @@ RSpec.shared_examples_for "a relatable resource" do |args|
     end
   end
 
-  describe "after_touch" do
+  describe "after_commit on touch" do
     let(:related_object) { create(:"alchemy_#{args[:resource_name]}") }
 
     context "when related ingredients exist" do
@@ -72,6 +72,26 @@ RSpec.shared_examples_for "a relatable resource" do |args|
     context "when no related ingredients exist" do
       it "does not enqueue InvalidateElementsCacheJob" do
         expect { related_object.touch }.to_not have_enqueued_job(Alchemy::InvalidateElementsCacheJob)
+      end
+    end
+  end
+
+  describe "after_commit on update" do
+    let(:related_object) { create(:"alchemy_#{args[:resource_name]}") }
+
+    context "when related ingredients exist" do
+      let!(:ingredient) { create(:"alchemy_ingredient_#{args[:ingredient_type]}", related_object:) }
+
+      it "enqueues InvalidateElementsCacheJob" do
+        expect {
+          related_object.update(name: "Updated name")
+        }.to have_enqueued_job(Alchemy::InvalidateElementsCacheJob).with(described_class.name, related_object.id)
+      end
+    end
+
+    context "when no related ingredients exist" do
+      it "does not enqueue InvalidateElementsCacheJob" do
+        expect { related_object.update(name: "Updated name") }.to_not have_enqueued_job(Alchemy::InvalidateElementsCacheJob)
       end
     end
   end

--- a/spec/models/alchemy/attachment_spec.rb
+++ b/spec/models/alchemy/attachment_spec.rb
@@ -18,8 +18,8 @@ module Alchemy
     end
 
     it_behaves_like "a relatable resource",
-      resource_name: :attachment,
-      ingredient_type: :file
+      resource_factory_name: "alchemy_attachment",
+      ingredient_factory_name: "alchemy_ingredient_file"
 
     describe ".deletable" do
       let!(:richtext_linked_attachment) { create(:alchemy_attachment) }

--- a/spec/models/alchemy/picture_spec.rb
+++ b/spec/models/alchemy/picture_spec.rb
@@ -18,8 +18,8 @@ module Alchemy
     end
 
     it_behaves_like "a relatable resource",
-      resource_name: :picture,
-      ingredient_type: :picture
+      resource_factory_name: "alchemy_picture",
+      ingredient_factory_name: "alchemy_ingredient_picture"
 
     it "is valid with valid attributes" do
       expect(picture).to be_valid


### PR DESCRIPTION
## What is this pull request for?

`InvalidateElementsCacheJob` was only enqueued from an `after_touch` callback on relatable resources (`Picture`, `Attachment`). As a result, editing one of these records directly — re-uploading, cropping or renaming — left the rendered caches of every element referencing it stale until the record happened to be touched.

This switches the callback to `after_commit on: :update`, which fires on both real updates and touches (a touch flags the update callback), so the caches are invalidated whenever the resource actually changes. Deferring to `after_commit` also means the job is never enqueued for a rolled-back transaction, and repeated touches within a single transaction are coalesced into one job.

### Notable changes (remove if none)

Cache invalidation now also runs on a direct update of a relatable resource, not only when it is touched. The element and page hierarchy is still invalidated via `touch_all`, which fires no further callbacks, so there is no cascade of jobs from element or ingredient saves — those never touch their related resource.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change