### PR TITLE
fix(admin): Resolve exposed components to their source files

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -15,12 +15,18 @@ pin "tinymce", to: "tinymce.min.js", preload: true
 pin "tom-select", to: "tom-select.min.js", preload: true
 
 pin "alchemy_admin", to: "alchemy/alchemy_admin.min.js", preload: true
-pin "alchemy_admin/components/remote_select", to: "alchemy/alchemy_admin.min.js"
-pin "alchemy_admin/components/page_select", to: "alchemy/alchemy_admin.min.js"
-pin "alchemy_admin/components/attachment_select", to: "alchemy/alchemy_admin.min.js"
-pin "alchemy_admin/components/element_select", to: "alchemy/alchemy_admin.min.js"
-pin "alchemy_admin/components/tags_autocomplete", to: "alchemy/alchemy_admin.min.js"
-pin "alchemy_admin/components/tinymce", to: "alchemy/alchemy_admin.min.js"
+# Individually importable admin components. These resolve to their source
+# files (not the bundle) so host engines can import a single component without
+# loading and executing the whole admin bundle. Not preloaded, so they add no
+# fetches to normal admin page loads (which import the bundle instead).
+pin "alchemy_admin/components/page_select"
+pin "alchemy_admin/components/attachment_select"
+pin "alchemy_admin/components/element_select"
+pin "alchemy_admin/components/tags_autocomplete"
+pin "alchemy_admin/components/tinymce"
+pin "alchemy_admin/components/remote_select"
+pin "alchemy_admin/components/select"
+pin "alchemy_admin/i18n"
 pin "alchemy_admin/image_cropper", to: "alchemy/alchemy_admin.min.js"
 pin "alchemy_admin/image_overlay", to: "alchemy/alchemy_admin.min.js"
 pin "alchemy_admin/picture_selector", to: "alchemy/alchemy_admin.min.js"


### PR DESCRIPTION
The individually-importable admin components were pinned to the pre-built `alchemy_admin` bundle. Because an importmap maps a name to a file with no tree-shaking, importing a single component in a host engine fetched and executed the *entire* admin bundle — including its bootstrap side effects (Rails UJS start, Turbo configuration, and defining every admin custom element). That made the exposed components effectively unusable from other engines, a regression from the pre-bundling behaviour where each module was individually importable.

This resolves the exposed component names to their source files instead, so a host engine loads only the component and its real dependency graph (`page_select`/`attachment_select` → `remote_select` → `i18n`, `element_select` → `select` → `i18n`, `tags_autocomplete`/`tinymce` → `i18n`). The vendor libraries they rely on (jQuery/Select2, Tom Select, TinyMCE, floating-ui) stay external pins that the host app provides.

The new pins are not preloaded, so the admin itself keeps loading the single bundle and normal admin page loads gain no extra fetches; only host apps that explicitly import a component pay for its small module cascade.
