### PR TITLE
Add index to alchemy_elements_alchemy_pages table

### DIFF
--- a/db/migrate/20260702090038_add_index_to_elements_pages_join_table.rb
+++ b/db/migrate/20260702090038_add_index_to_elements_pages_join_table.rb
@@ -1,0 +1,14 @@
+class AddIndexToElementsPagesJoinTable < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction! if connection.adapter_name.match?(/postgres/i)
+
+  def change
+    add_index :alchemy_elements_alchemy_pages, :element_id, if_not_exists: true, algorithm: algorithm
+    add_index :alchemy_elements_alchemy_pages, :page_id, if_not_exists: true, algorithm: algorithm
+  end
+
+  private
+
+  def algorithm
+    connection.adapter_name.match?(/postgres/i) ? :concurrently : nil
+  end
+end

--- a/spec/dummy/db/migrate/20260702093011_add_index_to_elements_pages_join_table.alchemy.rb
+++ b/spec/dummy/db/migrate/20260702093011_add_index_to_elements_pages_join_table.alchemy.rb
@@ -1,0 +1,15 @@
+# This migration comes from alchemy (originally 20260702090038)
+class AddIndexToElementsPagesJoinTable < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction! if connection.adapter_name.match?(/postgres/i)
+
+  def change
+    add_index :alchemy_elements_alchemy_pages, :element_id, if_not_exists: true, algorithm: algorithm
+    add_index :alchemy_elements_alchemy_pages, :page_id, if_not_exists: true, algorithm: algorithm
+  end
+
+  private
+
+  def algorithm
+    connection.adapter_name.match?(/postgres/i) ? :concurrently : nil
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

This migration is already in the Alchemy 6.1 compressed migration, but the index was never added to old installation of Alchemy. The index only applies if it wasn't added before.

Ref: https://github.com/AlchemyCMS/alchemy_cms/commit/4f0f5654a82234c404db3c3b01bad199c679bb54

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
