### PR TITLE
Isolate dev database/storage in volumes and add alchemy-devise to dummy app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,8 @@ pnpm run build:icons      # Generate icon sprite
 ### Running the Dummy App
 
 ```bash
-# Start the development server (runs spec/dummy/bin/dev)
+# Start the full stack in Docker: builds images and runs the Rails server,
+# Sass watcher, and JS bundle watcher (docker compose up --build)
 bin/start
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,15 +34,14 @@ dependencies locally:
 
 **Using Docker (recommended):**
 
-        $ docker compose build
-        $ docker compose up
+        $ bin/start
 
-This starts the Rails dev server, Sass watcher, and JS bundle watcher.
+This builds the images and starts the Rails dev server, Sass watcher, and JS bundle watcher.
 
 **Local setup:**
 
         $ bin/setup
-        $ bin/start
+        $ bin/dev
 
 3. Run the tests. We only take pull requests with passing tests, and it's great
 to know that you have a clean slate:
@@ -77,7 +76,7 @@ If you modify JavaScript source files under `app/javascript/alchemy_admin/`, you
 
     $ pnpm run build:admin
 
-Commit the updated `app/assets/builds/alchemy/alchemy_admin.min.js` alongside your source changes. For local development, `bin/start` runs the watch process automatically.
+Commit the updated `app/assets/builds/alchemy/alchemy_admin.min.js` alongside your source changes. For local development, `bin/start` (Docker) or `bin/dev` runs the watch process automatically.
 
 Please follow these syntax guides:
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,11 @@ gem "pg", "~> 1.0" if ENV["DB"] == "postgresql"
 
 gem "alchemy_i18n", github: "AlchemyCMS/alchemy_i18n", branch: "main"
 
+# Devise based authentication for the dummy app, so auth can be exercised
+# against local Alchemy core changes. Kept out of the test env, which uses
+# the DummyUser stub instead.
+gem "alchemy-devise", github: "AlchemyCMS/alchemy-devise", branch: "main", group: :development
+
 if ENV.fetch("ALCHEMY_STORAGE_ADAPTER", "active_storage") == "active_storage"
   gem "ruby-vips"
 else

--- a/README.md
+++ b/README.md
@@ -354,10 +354,19 @@ $ bundle exec rake
 
 ### Start the dummy app
 
-You can even start the dummy app and use it to manually test your changes with:
+You can even start the dummy app and use it to manually test your changes.
+
+To run the whole stack in Docker (builds the images and starts the Rails
+server, Sass watcher, and JS bundle watcher):
 
 ```bash
 $ bin/start
+```
+
+Or, to run the dummy app locally without Docker:
+
+```bash
+$ bin/dev
 ```
 
 

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+require "fileutils"
+
+# path to dummy application root.
+APP_ROOT = File.expand_path("../spec/dummy", __dir__)
+
+# path to alchemy gem
+GEM_ROOT = File.expand_path("../", __dir__)
+
+def system!(*args)
+  system(*args) || abort("\n== Command #{args} failed ==")
+end
+
+FileUtils.chdir APP_ROOT do
+  puts "\n== Starting dummy app =="
+  exec "bin/dev"
+end

--- a/bin/start
+++ b/bin/start
@@ -1,17 +1,7 @@
-#!/usr/bin/env ruby
-require "fileutils"
+#!/usr/bin/env sh
 
-# path to dummy application root.
-APP_ROOT = File.expand_path("../spec/dummy", __dir__)
-
-# path to alchemy gem
-GEM_ROOT = File.expand_path("../", __dir__)
-
-def system!(*args)
-  system(*args) || abort("\n== Command #{args} failed ==")
-end
-
-FileUtils.chdir APP_ROOT do
-  puts "\n== Starting dummy app =="
-  exec "bin/dev"
-end
+# Start the full development environment in Docker: builds the images and
+# runs the Rails dev server, Sass watcher, and JS bundle watcher.
+#
+# To run the dummy app locally without Docker, use bin/dev instead.
+exec docker compose up --build "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,9 @@ services:
       - .:/workspace
       - bundle:/usr/local/bundle
       - node_modules:/workspace/node_modules
+      - storage:/workspace/spec/dummy/storage
+      - pictures:/workspace/spec/dummy/public/pictures
+      - uploads:/workspace/spec/dummy/uploads
     depends_on:
       deps:
         condition: service_completed_successfully
@@ -72,3 +75,6 @@ services:
 volumes:
   bundle:
   node_modules:
+  storage:
+  pictures:
+  uploads:

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -7,9 +7,13 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def current_user
-    return if Rails.env.test?
+  # In development authentication is handled by the alchemy-devise engine,
+  # which provides its own +current_user+ helper, so we must not shadow it.
+  unless Rails.env.development?
+    def current_user
+      return if Rails.env.test?
 
-    @_dummy_user ||= DummyUser.find_or_create_by(email: "dummy@alchemy.com")
+      @_dummy_user ||= DummyUser.find_or_create_by(email: "dummy@alchemy.com")
+    end
   end
 end

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -1,6 +1,6 @@
 sqlite: &sqlite
   adapter: sqlite3
-  database: db/<%= Rails.env %>.sqlite3
+  database: storage/<%= Rails.env %>.sqlite3
 
 mysql: &mysql
   adapter: mysql2

--- a/spec/dummy/config/initializers/alchemy.rb
+++ b/spec/dummy/config/initializers/alchemy.rb
@@ -41,8 +41,10 @@ end
 
 Alchemy.configure do |config|
   config.abilities.add("Ability")
-  config.user_class = "DummyUser"
-  config.signup_path = "/admin/pages" unless Rails.env.test?
+  # In development the alchemy-devise engine provides authentication and sets
+  # the user_class (and signup path) to its Alchemy::User. In the test suite
+  # the dummy app uses the DummyUser stub instead.
+  config.user_class = "DummyUser" if Rails.env.test?
   # == This is the global Alchemy configuration file
   #
 

--- a/spec/dummy/config/initializers/devise.rb
+++ b/spec/dummy/config/initializers/devise.rb
@@ -1,0 +1,318 @@
+# frozen_string_literal: true
+
+# Assuming you have not yet modified this file, each configuration option below
+# is set to its default value. Note that some are commented out while others
+# are not: uncommented lines are intended to protect your configuration from
+# breaking changes in upgrades (i.e., in the event that future versions of
+# Devise change the default values for those options).
+#
+# Use this hook to configure devise mailer, warden hooks and so forth.
+# Many of these configuration options can be set straight in your model.
+
+# The alchemy-devise gem is only loaded in development, so skip this
+# initializer in the environments (test, production) where Devise is absent.
+return unless defined?(Devise)
+
+Devise.setup do |config|
+  # The secret key used by Devise. Devise uses this key to generate
+  # random tokens. Changing this key will render invalid all existing
+  # confirmation, reset password and unlock tokens in the database.
+  # Devise will use the `secret_key_base` as its `secret_key`
+  # by default. You can change it below and use your own secret key.
+  # config.secret_key = 'b06d54febc393137be2cdd390029c427a3903906c3cd9612d5d47410100b1a619d8fb6188e7e7465971589456c18aafb1790b2d8c69a90b05706e9ffb5db86e5'
+
+  # ==> Controller configuration
+  # Configure the parent class to the devise controllers.
+  config.parent_controller = "Alchemy::BaseController"
+
+  # ==> Mailer Configuration
+  # Configure the e-mail address which will be shown in Devise::Mailer,
+  # note that it will be overwritten if you use your own mailer class
+  # with default "from" parameter.
+  config.mailer_sender = Alchemy.config.mailer.mail_from
+
+  # Configure the class responsible to send e-mails.
+  config.mailer = "Alchemy::Notifications"
+
+  # Configure the parent class responsible to send e-mails.
+  # config.parent_mailer = 'ActionMailer::Base'
+
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require 'devise/orm/active_record'
+
+  # ==> Configuration for any authentication mechanism
+  # Configure which keys are used when authenticating a user. The default is
+  # just :email. You can configure it to use [:username, :subdomain], so for
+  # authenticating a user, both parameters are required. Remember that those
+  # parameters are used only when authenticating and not when retrieving from
+  # session. If you need permissions, you should implement that in a before filter.
+  # You can also supply a hash where the value is a boolean determining whether
+  # or not authentication should be aborted when the value is not present.
+  config.authentication_keys = [:login]
+
+  # Configure parameters from the request object used for authentication. Each entry
+  # given should be a request method and it will automatically be passed to the
+  # find_for_authentication method and considered in your model lookup. For instance,
+  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
+  # The same considerations mentioned for authentication_keys also apply to request_keys.
+  # config.request_keys = []
+
+  # Configure which authentication keys should be case-insensitive.
+  # These keys will be downcased upon creating or modifying a user and when used
+  # to authenticate or find a user. Default is :email.
+  config.case_insensitive_keys = [:login]
+
+  # Configure which authentication keys should have whitespace stripped.
+  # These keys will have whitespace before and after removed upon creating or
+  # modifying a user and when used to authenticate or find a user. Default is :email.
+  config.strip_whitespace_keys = [:login]
+
+  # Tell if authentication through request.params is enabled. True by default.
+  # It can be set to an array that will enable params authentication only for the
+  # given strategies, for example, `config.params_authenticatable = [:database]` will
+  # enable it only for database (email + password) authentication.
+  # config.params_authenticatable = true
+
+  # Tell if authentication through HTTP Auth is enabled. False by default.
+  # It can be set to an array that will enable http authentication only for the
+  # given strategies, for example, `config.http_authenticatable = [:database]` will
+  # enable it only for database authentication.
+  # For API-only applications to support authentication "out-of-the-box", you will likely want to
+  # enable this with :database unless you are using a custom strategy.
+  # The supported strategies are:
+  # :database      = Support basic authentication with authentication key + password
+  config.http_authenticatable = true
+
+  # If 401 status code should be returned for AJAX requests. True by default.
+  config.http_authenticatable_on_xhr = true
+
+  # The realm used in Http Basic Authentication. 'Application' by default.
+  config.http_authentication_realm = 'Alchemy CMS'
+
+  # It will change confirmation, password recovery and other workflows
+  # to behave the same regardless if the e-mail provided was right or wrong.
+  # Does not affect registerable.
+  config.paranoid = true
+
+  # By default Devise will store the user in session. You can skip storage for
+  # particular strategies by setting this option.
+  # Notice that if you are skipping storage for all authentication paths, you
+  # may want to disable generating routes to Devise's sessions controller by
+  # passing skip: :sessions to `devise_for` in your config/routes.rb
+  config.skip_session_storage = [:http_auth]
+
+  # By default, Devise cleans up the CSRF token on authentication to
+  # avoid CSRF token fixation attacks. This means that, when using AJAX
+  # requests for sign in and sign up, you need to get a new CSRF token
+  # from the server. You can disable this option at your own risk.
+  # config.clean_up_csrf_token_on_authentication = true
+
+  # When false, Devise will not attempt to reload routes on eager load.
+  # This can reduce the time taken to boot the app but if your application
+  # requires the Devise mappings to be loaded during boot time the application
+  # won't boot properly.
+  # config.reload_routes = true
+
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 12. If
+  # using other algorithms, it sets how many times you want the password to be hashed.
+  # The number of stretches used for generating the hashed password are stored
+  # with the hashed password. This allows you to change the stretches without
+  # invalidating existing passwords.
+  #
+  # Limiting the stretches to just one in testing will increase the performance of
+  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
+  # a value less than 10 in other environments. Note that, for bcrypt (the default
+  # algorithm), the cost increases exponentially with the number of stretches (e.g.
+  # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
+  config.stretches = Rails.env.test? ? 1 : 12
+
+  # Set up a pepper to generate the hashed password.
+  # config.pepper = 'b96cc2998772225bc3a44a6e59e19db6b076507898457c0583d892e5da41d2e827841be79dc3642ff58c16929242e24e1c64954108d17ae56ebc7a25a5fd1957'
+
+  # Send a notification to the original email when the user's email is changed.
+  # config.send_email_changed_notification = false
+
+  # Send a notification email when the user's password is changed.
+  # config.send_password_change_notification = false
+
+  # ==> Configuration for :confirmable
+  # A period that the user is allowed to access the website even without
+  # confirming their account. For instance, if set to 2.days, the user will be
+  # able to access the website for two days without confirming their account,
+  # access will be blocked just in the third day.
+  # You can also set it to nil, which will allow the user to access the website
+  # without confirming their account.
+  # Default is 0.days, meaning the user cannot access the website without
+  # confirming their account.
+  # config.allow_unconfirmed_access_for = 2.days
+
+  # A period that the user is allowed to confirm their account before their
+  # token becomes invalid. For example, if set to 3.days, the user can confirm
+  # their account within 3 days after the mail was sent, but on the fourth day
+  # their account can't be confirmed with the token any more.
+  # Default is nil, meaning there is no restriction on how long a user can take
+  # before confirming their account.
+  # config.confirm_within = 3.days
+
+  # If true, requires any email changes to be confirmed (exactly the same way as
+  # initial account confirmation) to be applied. Requires additional unconfirmed_email
+  # db field (see migrations). Until confirmed, new email is stored in
+  # unconfirmed_email column, and copied to email column on successful confirmation.
+  config.reconfirmable = false
+
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [:email]
+
+  # ==> Configuration for :rememberable
+  # The time the user will be remembered without asking for credentials again.
+  # config.remember_for = 2.weeks
+
+  # Invalidates all the remember me tokens when the user signs out.
+  config.expire_all_remember_me_on_sign_out = true
+
+  # If true, extends the user's remember period when remembered via cookie.
+  # config.extend_remember_period = false
+
+  # Options to be passed to the created cookie. For instance, you can set
+  # secure: true in order to force SSL only cookies.
+  # config.rememberable_options = {}
+
+  # ==> Configuration for :validatable
+  # Range for password length.
+  config.password_length = 6..128
+
+  # Email regex used to validate email formats. It simply asserts that
+  # one (and only one) @ exists in the given string. This is mainly
+  # to give user feedback and not to assert the e-mail validity.
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+
+  # ==> Configuration for :timeoutable
+  # The time you want to timeout the user session without activity. After this
+  # time the user will be asked for credentials again. Default is 30 minutes.
+  config.timeout_in = Rails.env.development? ? nil : Alchemy.config.auto_logout_time.minutes
+
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  # config.lock_strategy = :failed_attempts
+
+  # Defines which key will be used when locking and unlocking an account
+  # config.unlock_keys = [:email]
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  # config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  # config.maximum_attempts = 20
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  # config.unlock_in = 1.hour
+
+  # Warn on the last attempt before the account is locked.
+  # config.last_attempt_warning = true
+
+  # ==> Configuration for :recoverable
+  #
+  # Defines which key will be used when recovering the password for an account
+  # config.reset_password_keys = [:email]
+
+  # Time interval you can reset your password with a reset password key.
+  # Don't put a too small interval or your users won't have the time to
+  # change their passwords.
+  config.reset_password_within = 6.hours
+
+  # When set to false, does not sign a user in automatically after their password is
+  # reset. Defaults to true, so a user is signed in automatically after a reset.
+  # config.sign_in_after_reset_password = true
+
+  # ==> Configuration for :encryptable
+  # Allow you to use another hashing or encryption algorithm besides bcrypt (default).
+  # You can use :sha1, :sha512 or algorithms from others authentication tools as
+  # :clearance_sha1, :authlogic_sha512 (then you should set stretches above to 20
+  # for default behavior) and :restful_authentication_sha1 (then you should set
+  # stretches to 10, and copy REST_AUTH_SITE_KEY to pepper).
+  #
+  # Require the `devise-encryptable` gem when using anything other than bcrypt
+  # config.encryptor = :sha512
+
+  # ==> Scopes configuration
+  # Turn scoped views on. Before rendering "sessions/new", it will first check for
+  # "users/sessions/new". It's turned off by default because it's slower if you
+  # are using only default views.
+  # config.scoped_views = false
+
+  # Configure the default scope given to Warden. By default it's the first
+  # devise role declared in your routes (usually :user).
+  # config.default_scope = :user
+
+  # Set this configuration to false if you want /users/sign_out to sign out
+  # only the current scope. By default, Devise signs out all scopes.
+  # config.sign_out_all_scopes = true
+
+  # ==> Navigation configuration
+  # Lists the formats that should be treated as navigational. Formats like
+  # :html should redirect to the sign in page when the user does not have
+  # access, but formats like :xml or :json, should return 401.
+  #
+  # If you have any extra navigational formats, like :iphone or :mobile, you
+  # should add them to the navigational formats lists.
+  #
+  # The "*/*" below is required to match Internet Explorer requests.
+  # config.navigational_formats = ['*/*', :html, :turbo_stream]
+
+  # The default HTTP method used to sign out a resource. Default is :delete.
+  config.sign_out_via = :delete
+
+  # ==> OmniAuth
+  # Add a new OmniAuth provider. Check the wiki for more information on setting
+  # up on your models and hooks.
+  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+
+  # ==> Warden configuration
+  # If you want to use other strategies, that are not supported by Devise, or
+  # change the failure app, you can configure them inside the config.warden block.
+  #
+  # config.warden do |manager|
+  #   manager.intercept_401 = false
+  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
+  # end
+
+  # ==> Mountable engine configurations
+  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+  # is mountable, there are some extra configurations to be taken into account.
+  # The following options are available, assuming the engine is mounted as:
+  #
+  #     mount MyEngine, at: '/my_engine'
+  #
+  # The router that invoked `devise_for`, in the example above, would be:
+  # config.router_name = :my_engine
+  #
+  # When using OmniAuth, Devise cannot automatically set OmniAuth path,
+  # so you need to do it manually. For the users scope, it would be:
+  # config.omniauth_path_prefix = '/my_engine/users/auth'
+
+  # ==> Hotwire/Turbo configuration
+  # When using Devise with Hotwire/Turbo, the http status for error responses
+  # and some redirects must match the following. The default in Devise for existing
+  # apps is `200 OK` and `302 Found` respectively, but new apps are generated with
+  # these new defaults that match Hotwire/Turbo behavior.
+  # Note: These might become the new default in future versions of Devise.
+  config.responder.error_status = :unprocessable_content
+  config.responder.redirect_status = :see_other
+
+  # ==> Configuration for :registerable
+
+  # When set to false, does not sign a user in automatically after their password is
+  # changed. Defaults to true, so a user is signed in automatically after changing a password.
+  # config.sign_in_after_change_password = true
+end

--- a/spec/dummy/db/migrate/20260709125715_create_alchemy_users.alchemy_devise.rb
+++ b/spec/dummy/db/migrate/20260709125715_create_alchemy_users.alchemy_devise.rb
@@ -1,0 +1,33 @@
+# This migration comes from alchemy_devise (originally 20131015124700)
+class CreateAlchemyUsers < ActiveRecord::Migration[4.2]
+  def up
+    return if table_exists?(:alchemy_users)
+    create_table "alchemy_users" do |t|
+      t.string "firstname"
+      t.string "lastname"
+      t.string "login"
+      t.string "email"
+      t.string "language"
+      t.string "encrypted_password", limit: 128, default: "", null: false
+      t.string "password_salt", limit: 128, default: "", null: false
+      t.integer "sign_in_count", default: 0, null: false
+      t.integer "failed_attempts", default: 0, null: false
+      t.datetime "last_request_at"
+      t.datetime "current_sign_in_at"
+      t.datetime "last_sign_in_at"
+      t.string "current_sign_in_ip"
+      t.string "last_sign_in_ip"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.integer "creator_id"
+      t.integer "updater_id"
+      t.text "cached_tag_list"
+      t.string "reset_password_token"
+      t.datetime "reset_password_sent_at"
+    end
+
+    add_index "alchemy_users", ["email"], unique: true
+    add_index "alchemy_users", ["login"], unique: true
+    add_index "alchemy_users", ["reset_password_token"], unique: true
+  end
+end

--- a/spec/dummy/db/migrate/20260709125716_add_alchemy_roles_to_alchemy_users.alchemy_devise.rb
+++ b/spec/dummy/db/migrate/20260709125716_add_alchemy_roles_to_alchemy_users.alchemy_devise.rb
@@ -1,0 +1,23 @@
+# This migration comes from alchemy_devise (originally 20131225232042)
+class AddAlchemyRolesToAlchemyUsers < ActiveRecord::Migration[4.2]
+  def up
+    # Updating old :roles column (since Alchemy CMS v2.6)
+    if column_exists?(:alchemy_users, :roles)
+      rename_column :alchemy_users, :roles, :alchemy_roles
+      change_column :alchemy_users, :alchemy_roles, :string, default: "member"
+    end
+
+    # Creating :alchemy_roles column for new apps.
+    unless column_exists?(:alchemy_users, :alchemy_roles)
+      add_column :alchemy_users, :alchemy_roles, :string, default: "member"
+    end
+
+    # Renaming the index
+    if index_exists?(:alchemy_users, :roles)
+      remove_index :alchemy_users, :roles
+    end
+    unless index_exists?(:alchemy_users, :alchemy_roles)
+      add_index :alchemy_users, :alchemy_roles
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20260709125717_add_indexes_to_alchemy_users.alchemy_devise.rb
+++ b/spec/dummy/db/migrate/20260709125717_add_indexes_to_alchemy_users.alchemy_devise.rb
@@ -1,0 +1,12 @@
+# This migration comes from alchemy_devise (originally 20141209144532)
+class AddIndexesToAlchemyUsers < ActiveRecord::Migration[4.2]
+  def up
+    add_index :alchemy_users, :firstname
+    add_index :alchemy_users, :lastname
+  end
+
+  def down
+    remove_index :alchemy_users, :firstname
+    remove_index :alchemy_users, :lastname
+  end
+end

--- a/spec/dummy/db/migrate/20260709125718_add_rememberable_column.alchemy_devise.rb
+++ b/spec/dummy/db/migrate/20260709125718_add_rememberable_column.alchemy_devise.rb
@@ -1,0 +1,6 @@
+# This migration comes from alchemy_devise (originally 20251127170649)
+class AddRememberableColumn < ActiveRecord::Migration[7.1]
+  def change
+    add_column :alchemy_users, :remember_created_at, :datetime, if_not_exists: true
+  end
+end

--- a/spec/dummy/db/migrate/20260709125719_add_timezone_to_alchemy_users.alchemy_devise.rb
+++ b/spec/dummy/db/migrate/20260709125719_add_timezone_to_alchemy_users.alchemy_devise.rb
@@ -1,0 +1,7 @@
+# This migration comes from alchemy_devise (originally 20260410115756)
+class AddTimezoneToAlchemyUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :alchemy_users, :timezone, :string, if_not_exists: true,
+      comment: "The timezone of the user, used for displaying dates in the user's timezone"
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_20_163927) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_09_125719) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -270,6 +270,39 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_20_163927) do
     t.datetime "updated_at", null: false
     t.index ["host", "public"], name: "alchemy_sites_public_hosts_idx"
     t.index ["host"], name: "index_alchemy_sites_on_host"
+  end
+
+  create_table "alchemy_users", force: :cascade do |t|
+    t.string "alchemy_roles", default: "member"
+    t.text "cached_tag_list"
+    t.datetime "created_at", precision: nil, null: false
+    t.integer "creator_id"
+    t.datetime "current_sign_in_at", precision: nil
+    t.string "current_sign_in_ip"
+    t.string "email"
+    t.string "encrypted_password", limit: 128, default: "", null: false
+    t.integer "failed_attempts", default: 0, null: false
+    t.string "firstname"
+    t.string "language"
+    t.datetime "last_request_at", precision: nil
+    t.datetime "last_sign_in_at", precision: nil
+    t.string "last_sign_in_ip"
+    t.string "lastname"
+    t.string "login"
+    t.string "password_salt", limit: 128, default: "", null: false
+    t.datetime "remember_created_at"
+    t.datetime "reset_password_sent_at", precision: nil
+    t.string "reset_password_token"
+    t.integer "sign_in_count", default: 0, null: false
+    t.string "timezone"
+    t.datetime "updated_at", precision: nil, null: false
+    t.integer "updater_id"
+    t.index ["alchemy_roles"], name: "index_alchemy_users_on_alchemy_roles"
+    t.index ["email"], name: "index_alchemy_users_on_email", unique: true
+    t.index ["firstname"], name: "index_alchemy_users_on_firstname"
+    t.index ["lastname"], name: "index_alchemy_users_on_lastname"
+    t.index ["login"], name: "index_alchemy_users_on_login", unique: true
+    t.index ["reset_password_token"], name: "index_alchemy_users_on_reset_password_token", unique: true
   end
 
   create_table "bookings", force: :cascade do |t|


### PR DESCRIPTION
## What is this pull request for?

Refines the docker-compose development setup in two independent ways.

First, database and upload state no longer lives in the bind-mounted checkout. Because the repository is mounted into the containers, the sqlite databases and upload directories were written back to the host and shared between hosts; running the stack from more than one host (a Linux VM and macOS in my case) then corrupts the sqlite files. The sqlite databases now follow the Rails 8 convention of living under `storage/`, and `storage`, `public/pictures` and `uploads` are backed by named volumes, so this state stays inside Docker and isolated per host.

Second, the dummy app can now use alchemy-devise for authentication in development. It previously auto-signed-in a `DummyUser` stub, so real login, signup and session flows could not be exercised locally. alchemy-devise is loaded in the development group only, providing an actual `Alchemy::User` and Devise routes, so authentication can be tested against local Alchemy core changes.

### Notable changes (remove if none)

The test suite is intentionally unaffected: the gem stays out of the test group, and `config.user_class`, `config.signup_path` and the `DummyUser` `current_user` override are gated to non-development environments (test keeps `DummyUser`). The generated Devise initializer is guarded with `defined?(Devise)` so it is a no-op where the gem is absent.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change (development tooling only; verified the existing suite still passes)
