### PR TITLE
chore(docker): slim and share the dev Docker image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -59,14 +59,11 @@ ENV LISTEN_GEM_ADAPTER_WARN_BEHAVIOR=silent
 COPY --from=builder --chown=alchemy:alchemy /usr/local/bundle /usr/local/bundle
 COPY --from=builder --chown=alchemy:alchemy /workspace/node_modules /workspace/node_modules
 
-# Create the directories Compose mounts named volumes onto, owned by the alchemy
-# user. A fresh volume seeds from the image directory it covers, so this makes
-# the storage (which also holds the sqlite database), pictures and uploads
-# volumes writable instead of root-owned.
-RUN mkdir -p \
-      /workspace/spec/dummy/storage \
-      /workspace/spec/dummy/public/pictures \
-      /workspace/spec/dummy/uploads \
+# Create the storage directory Compose mounts the storage volume onto, owned by
+# the alchemy user. A fresh volume seeds from the image directory it covers, so
+# this makes the storage volume (which holds active_storage files and the sqlite
+# database) writable instead of root-owned.
+RUN mkdir -p /workspace/spec/dummy/storage \
     && chown -R alchemy:alchemy /workspace/spec
 
 USER alchemy

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -44,9 +44,29 @@ RUN pnpm install
 # the active_storage adapter).
 FROM base
 
+# Run as a non-root user. USER_ID/GROUP_ID are build args so the UID can be
+# matched to the host on plain-Linux setups; on OrbStack the Mac bind mount is
+# writable regardless of the container UID.
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+RUN groupadd -g ${GROUP_ID} alchemy \
+    && useradd -u ${USER_ID} -g alchemy -m alchemy
+
 ENV LD_PRELOAD=libjemalloc.so.2
 ENV RUBY_YJIT_ENABLE=1
 ENV LISTEN_GEM_ADAPTER_WARN_BEHAVIOR=silent
 
-COPY --from=builder /usr/local/bundle /usr/local/bundle
-COPY --from=builder /workspace/node_modules /workspace/node_modules
+COPY --from=builder --chown=alchemy:alchemy /usr/local/bundle /usr/local/bundle
+COPY --from=builder --chown=alchemy:alchemy /workspace/node_modules /workspace/node_modules
+
+# Create the directories Compose mounts named volumes onto, owned by the alchemy
+# user. A fresh volume seeds from the image directory it covers, so this makes
+# the storage (which also holds the sqlite database), pictures and uploads
+# volumes writable instead of root-owned.
+RUN mkdir -p \
+      /workspace/spec/dummy/storage \
+      /workspace/spec/dummy/public/pictures \
+      /workspace/spec/dummy/uploads \
+    && chown -R alchemy:alchemy /workspace/spec
+
+USER alchemy

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update && apt-get install -y \
     libvips \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+ARG NODE_VERSION=24
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/* \
     && corepack enable

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,36 +1,9 @@
 ARG RUBY_VERSION=4.0.5
 
-# Builder stage: compiles native gem extensions and installs JS dependencies.
-# The compiler toolchain lives here only, so it never ends up in the final image.
-FROM docker.io/library/ruby:${RUBY_VERSION}-slim AS builder
-
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    curl \
-    git \
-    libsqlite3-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
-    && apt-get install -y nodejs \
-    && rm -rf /var/lib/apt/lists/* \
-    && corepack enable
-
-WORKDIR /workspace
-
-# Gemfile.lock is a dev artifact; the gemspec is the source of truth. Resolve
-# the whole dependency tree fresh to the latest allowed versions on every build.
-COPY Gemfile alchemy_cms.gemspec ./
-COPY lib/alchemy/version.rb lib/alchemy/version.rb
-RUN bundle update --all
-
-COPY package.json pnpm-*.yaml ./
-RUN pnpm install
-
-# Runtime stage: only the libraries the app needs to run. No compiler toolchain
-# and no ImageMagick (image processing uses libvips via the active_storage
-# adapter). Gems and node_modules are copied from the builder.
-FROM docker.io/library/ruby:${RUBY_VERSION}-slim
+# Base stage: the runtime environment shared by the builder and the final image
+# (Node for pnpm, plus the libraries the app links at runtime). Installing these
+# once here avoids repeating them in both stages.
+FROM docker.io/library/ruby:${RUBY_VERSION}-slim AS base
 
 RUN apt-get update && apt-get install -y \
     curl \
@@ -44,11 +17,35 @@ RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && rm -rf /var/lib/apt/lists/* \
     && corepack enable
 
+WORKDIR /workspace
+
+# Builder stage: the base plus the compiler toolchain needed to build native gem
+# extensions. Nothing from this stage reaches the final image except the compiled
+# gems and installed node_modules.
+FROM base AS builder
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    libsqlite3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Gemfile.lock is a dev artifact; the gemspec is the source of truth. Resolve
+# the whole dependency tree fresh to the latest allowed versions on every build.
+COPY Gemfile alchemy_cms.gemspec ./
+COPY lib/alchemy/version.rb lib/alchemy/version.rb
+RUN bundle update --all
+
+COPY package.json pnpm-*.yaml ./
+RUN pnpm install
+
+# Final stage: the base environment with the built gems and node_modules copied
+# in. No compiler toolchain and no ImageMagick (image processing uses libvips via
+# the active_storage adapter).
+FROM base
+
 ENV LD_PRELOAD=libjemalloc.so.2
 ENV RUBY_YJIT_ENABLE=1
 ENV LISTEN_GEM_ADAPTER_WARN_BEHAVIOR=silent
-
-WORKDIR /workspace
 
 COPY --from=builder /usr/local/bundle /usr/local/bundle
 COPY --from=builder /workspace/node_modules /workspace/node_modules

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,9 +18,11 @@ RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
 
 WORKDIR /workspace
 
-COPY Gemfile Gemfile.lock* alchemy_cms.gemspec ./
+# Gemfile.lock is a dev artifact; the gemspec is the source of truth. Resolve
+# the whole dependency tree fresh to the latest allowed versions on every build.
+COPY Gemfile alchemy_cms.gemspec ./
 COPY lib/alchemy/version.rb lib/alchemy/version.rb
-RUN bundle install
+RUN bundle update --all
 
 COPY package.json pnpm-*.yaml ./
 RUN pnpm install

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -67,3 +67,8 @@ RUN mkdir -p /workspace/spec/dummy/storage \
     && chown -R alchemy:alchemy /workspace/spec
 
 USER alchemy
+
+# Bake the pinned pnpm into the alchemy user's corepack cache so it is not
+# downloaded at runtime in every service container. Keep the version in sync
+# with the packageManager field in package.json.
+RUN corepack prepare pnpm@11.5.2 --activate

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,19 +1,15 @@
 ARG RUBY_VERSION=4.0.5
-FROM docker.io/library/ruby:${RUBY_VERSION}-slim
+
+# Builder stage: compiles native gem extensions and installs JS dependencies.
+# The compiler toolchain lives here only, so it never ends up in the final image.
+FROM docker.io/library/ruby:${RUBY_VERSION}-slim AS builder
 
 RUN apt-get update && apt-get install -y \
     build-essential \
     curl \
     git \
     libsqlite3-dev \
-    libjemalloc2 \
-    libvips \
-    imagemagick \
     && rm -rf /var/lib/apt/lists/*
-
-ENV LD_PRELOAD=libjemalloc.so.2
-ENV RUBY_YJIT_ENABLE=1
-ENV LISTEN_GEM_ADAPTER_WARN_BEHAVIOR=silent
 
 RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y nodejs \
@@ -28,3 +24,29 @@ RUN bundle install
 
 COPY package.json pnpm-*.yaml ./
 RUN pnpm install
+
+# Runtime stage: only the libraries the app needs to run. No compiler toolchain
+# and no ImageMagick (image processing uses libvips via the active_storage
+# adapter). Gems and node_modules are copied from the builder.
+FROM docker.io/library/ruby:${RUBY_VERSION}-slim
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    libjemalloc2 \
+    libvips \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && corepack enable
+
+ENV LD_PRELOAD=libjemalloc.so.2
+ENV RUBY_YJIT_ENABLE=1
+ENV LISTEN_GEM_ADAPTER_WARN_BEHAVIOR=silent
+
+WORKDIR /workspace
+
+COPY --from=builder /usr/local/bundle /usr/local/bundle
+COPY --from=builder /workspace/node_modules /workspace/node_modules

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -68,7 +68,8 @@ RUN mkdir -p /workspace/spec/dummy/storage \
 
 USER alchemy
 
-# Bake the pinned pnpm into the alchemy user's corepack cache so it is not
-# downloaded at runtime in every service container. Keep the version in sync
-# with the packageManager field in package.json.
-RUN corepack prepare pnpm@11.5.2 --activate
+# Bake the pnpm version pinned in package.json's packageManager field into the
+# alchemy user's corepack cache, so it is not downloaded at runtime in every
+# service container.
+COPY package.json ./
+RUN corepack install

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,10 @@
-FROM ruby:4.0
+ARG RUBY_VERSION=4.0.5
+FROM docker.io/library/ruby:${RUBY_VERSION}-slim
 
 RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    git \
     libsqlite3-dev \
     libjemalloc2 \
     libvips \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "dockerComposeFile": "../docker-compose.yml",
   "service": "web",
   "workspaceFolder": "/workspace",
-  "postCreateCommand": "bundle install && pnpm install && cd spec/dummy && bin/rails db:prepare",
+  "postCreateCommand": "rm -f Gemfile.lock && bundle install --local && pnpm install && cd spec/dummy && bin/rails db:prepare",
   "forwardPorts": [3000],
   "customizations": {
     "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
   "dockerComposeFile": "../docker-compose.yml",
   "service": "web",
   "workspaceFolder": "/workspace",
+  "remoteUser": "alchemy",
   "postCreateCommand": "rm -f Gemfile.lock && bundle install --local && pnpm install && cd spec/dummy && bin/rails db:prepare",
   "forwardPorts": [3000],
   "customizations": {

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 nodejs 24
 ruby 4.0
-pnpm 11.4.0
+pnpm 11.11.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,14 @@ x-app: &app
   image: alchemy-dummy-app
   pull_policy: never
 
+# Gems and node_modules are baked into the image. Gems live outside the
+# `.:/workspace` bind mount, so they are served straight from the image with no
+# volume. node_modules sits under the bind mount, so an anonymous volume
+# (`- /workspace/node_modules`) shadows the host directory and surfaces the
+# image's copy instead of the host's (which has platform-specific binaries).
+# After changing dependencies, rebuild the image; refresh node_modules with
+# `docker compose up --build --renew-anon-volumes`.
+
 services:
   setup:
     image: alchemy-dummy-app
@@ -17,8 +25,7 @@ services:
     command: bash -c "bundle check || bundle install && pnpm install"
     volumes:
       - .:/workspace
-      - bundle:/usr/local/bundle
-      - node_modules:/workspace/node_modules
+      - /workspace/node_modules
 
   web:
     <<: *app
@@ -27,8 +34,7 @@ services:
       - "3000:3000"
     volumes:
       - .:/workspace
-      - bundle:/usr/local/bundle
-      - node_modules:/workspace/node_modules
+      - /workspace/node_modules
       - storage:/workspace/spec/dummy/storage
       - pictures:/workspace/spec/dummy/public/pictures
       - uploads:/workspace/spec/dummy/uploads
@@ -45,8 +51,7 @@ services:
     command: pnpm run build:css --watch
     volumes:
       - .:/workspace
-      - bundle:/usr/local/bundle
-      - node_modules:/workspace/node_modules
+      - /workspace/node_modules
     depends_on:
       setup:
         condition: service_completed_successfully
@@ -56,8 +61,7 @@ services:
     command: bash -c "cd spec/dummy && bin/rails dartsass:watch"
     volumes:
       - .:/workspace
-      - bundle:/usr/local/bundle
-      - node_modules:/workspace/node_modules
+      - /workspace/node_modules
     depends_on:
       setup:
         condition: service_completed_successfully
@@ -67,15 +71,12 @@ services:
     command: pnpm run build:admin:dev
     volumes:
       - .:/workspace
-      - bundle:/usr/local/bundle
-      - node_modules:/workspace/node_modules
+      - /workspace/node_modules
     depends_on:
       setup:
         condition: service_completed_successfully
 
 volumes:
-  bundle:
-  node_modules:
   storage:
   pictures:
   uploads:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,6 @@ services:
       - .:/workspace
       - /workspace/node_modules
       - storage:/workspace/spec/dummy/storage
-      - pictures:/workspace/spec/dummy/public/pictures
-      - uploads:/workspace/spec/dummy/uploads
     depends_on:
       setup:
         condition: service_completed_successfully
@@ -81,5 +79,3 @@ services:
 
 volumes:
   storage:
-  pictures:
-  uploads:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,10 @@ services:
     build:
       context: .
       dockerfile: .devcontainer/Dockerfile
-    command: bash -c "bundle check || bundle install && pnpm install"
+    # The image resolves the whole bundle fresh (bundle update --all). Regenerate
+    # the disposable host Gemfile.lock from the baked gems so it matches the image
+    # without needing a compiler at runtime, then install JS deps.
+    command: bash -c "rm -f Gemfile.lock && bundle install --local && pnpm install"
     volumes:
       - .:/workspace
       - /workspace/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,16 @@
 name: alchemy_cms
 
+# All services run the same image, which is built once by the `setup` service.
+# The other services reference it via this anchor and set `pull_policy: never`
+# so Compose uses the locally built image instead of trying to pull it from a
+# registry on a cold start (which it does concurrently with the build).
+x-app: &app
+  image: alchemy-dummy-app
+  pull_policy: never
+
 services:
-  deps:
+  setup:
+    image: alchemy-dummy-app
     build:
       context: .
       dockerfile: .devcontainer/Dockerfile
@@ -12,9 +21,7 @@ services:
       - node_modules:/workspace/node_modules
 
   web:
-    build:
-      context: .
-      dockerfile: .devcontainer/Dockerfile
+    <<: *app
     command: bash -c "cd spec/dummy && rm -f tmp/pids/server.pid && bin/rails db:prepare && exec bin/rails server -b 0.0.0.0"
     ports:
       - "3000:3000"
@@ -26,7 +33,7 @@ services:
       - pictures:/workspace/spec/dummy/public/pictures
       - uploads:/workspace/spec/dummy/uploads
     depends_on:
-      deps:
+      setup:
         condition: service_completed_successfully
       css:
         condition: service_started
@@ -34,42 +41,36 @@ services:
         condition: service_started
 
   sass:
-    build:
-      context: .
-      dockerfile: .devcontainer/Dockerfile
+    <<: *app
     command: pnpm run build:css --watch
     volumes:
       - .:/workspace
       - bundle:/usr/local/bundle
       - node_modules:/workspace/node_modules
     depends_on:
-      deps:
+      setup:
         condition: service_completed_successfully
 
   css:
-    build:
-      context: .
-      dockerfile: .devcontainer/Dockerfile
+    <<: *app
     command: bash -c "cd spec/dummy && bin/rails dartsass:watch"
     volumes:
       - .:/workspace
       - bundle:/usr/local/bundle
       - node_modules:/workspace/node_modules
     depends_on:
-      deps:
+      setup:
         condition: service_completed_successfully
 
   js:
-    build:
-      context: .
-      dockerfile: .devcontainer/Dockerfile
+    <<: *app
     command: pnpm run build:admin:dev
     volumes:
       - .:/workspace
       - bundle:/usr/local/bundle
       - node_modules:/workspace/node_modules
     depends_on:
-      deps:
+      setup:
         condition: service_completed_successfully
 
 volumes:

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "keywords": [],
   "author": "Thomas von Deyen",
   "license": "BSD-3-Clause",
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.11.0",
   "engines": {
     "node": "24.x"
   },

--- a/spec/dummy/db/seeds.rb
+++ b/spec/dummy/db/seeds.rb
@@ -1,3 +1,13 @@
 # frozen_string_literal: true
 
 Alchemy::Seeder.seed!
+
+# Development admin so you can log into the dummy app right away (admin/test1234).
+if defined?(Alchemy::User)
+  Alchemy::User.find_or_create_by!(login: "admin") do |user|
+    user.email = "admin@example.com"
+    user.password = "test1234"
+    user.password_confirmation = "test1234"
+    user.alchemy_roles = ["admin"]
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

The development Docker setup had grown heavy and a little inconsistent: every compose service built its own copy of the image (five ~2 GB images for a single app), and those images carried the full compiler toolchain and ImageMagick even though nothing needed them at runtime. This reworks the setup so the whole stack shares one much smaller image, runs as a non-root user, and behaves predictably on a cold start.

All services now reference a single image built once by a `setup` service; the others set `pull_policy: never` so Compose reuses the local build instead of racing it with a registry pull. The image is built in two stages — native gems compile in a builder stage and only the resulting gems and `node_modules` are copied into a compiler-free runtime — and image processing relies on libvips (the active_storage default) so ImageMagick is dropped. Together this takes the image from ~1.7 GB to ~1.1 GB.

Because the gems and node_modules are baked in, the named `bundle`/`node_modules` volumes are gone: gems are served straight from the image, and node_modules uses an anonymous volume to shadow the host's platform-specific copy. The `Gemfile.lock` is treated as the disposable dev artifact it is — the image resolves the whole tree fresh from the gemspec with `bundle update --all`, and the setup step regenerates a matching lock from the baked gems without needing a compiler at runtime. The Dragonfly-era `pictures` and `uploads` volumes are dropped too, since the active_storage adapter keeps everything under the remaining `storage` volume.

The container now runs as a non-root `alchemy` user. Since a fresh Docker volume seeds from the image directory it covers, the gems, node_modules and storage directories are created and owned by that user so the volumes come up writable instead of root-owned. `USER_ID`/`GROUP_ID` are build args so the UID can be matched to the host on plain-Linux setups.

A shared base stage removes the duplicated Node and system-library installs between the two stages, the Node major version becomes a build arg alongside Ruby, and the devcontainer runs as the same non-root user. Finally, the dummy app seeds an `admin`/`test1234` user so you can log into the admin right after `db:prepare`.

### Notable changes

After changing dependencies, rebuild the image and refresh node_modules with `docker compose up --build --renew-anon-volumes` — the anonymous volume otherwise keeps the previous copy. Gems need no extra step.

When upgrading an existing checkout, remove the old named volumes once (`docker compose down -v`) so `storage` re-seeds with the non-root user's ownership.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change (n/a — development tooling only)
