### PR TITLE
fix(docker): pass the host uid into the image build

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -4,4 +4,13 @@
 # runs the Rails dev server, Sass watcher, and JS bundle watcher.
 #
 # To run the dummy app locally without Docker, use bin/dev instead.
+
+# The container user must own the bind mounted workspace to write into it. On
+# macOS the bind mount is writable whatever the container uid is, but on Linux a
+# uid mismatch makes the workspace read-only, so build the image with the host's
+# ids. An explicitly exported USER_ID/GROUP_ID wins.
+USER_ID="${USER_ID:-$(id -u)}"
+GROUP_ID="${GROUP_ID:-$(id -g)}"
+export USER_ID GROUP_ID
+
 exec docker compose up --build "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,10 @@ x-app: &app
 # image's copy instead of the host's (which has platform-specific binaries).
 # After changing dependencies, rebuild the image; refresh node_modules with
 # `docker compose up --build --renew-anon-volumes`.
+#
+# USER_ID/GROUP_ID select the uid/gid of the image's `alchemy` user, which has to
+# own the `.:/workspace` bind mount to be able to write into it. `bin/start` sets
+# them from the host user, so the documented entry point needs no configuration.
 
 services:
   setup:
@@ -22,6 +26,9 @@ services:
     build:
       context: .
       dockerfile: .devcontainer/Dockerfile
+      args:
+        USER_ID: ${USER_ID:-1000}
+        GROUP_ID: ${GROUP_ID:-1000}
     # The image resolves the whole bundle fresh (bundle update --all). Regenerate
     # the disposable host Gemfile.lock from the baked gems so it matches the image
     # without needing a compiler at runtime, then install JS deps.


### PR DESCRIPTION
## What is this pull request for?

`.devcontainer/Dockerfile` accepts `USER_ID`/`GROUP_ID` build args precisely so the container's `alchemy` user can be matched to the host user, but `docker-compose.yml` never forwarded them. The image therefore always ended up on uid/gid 1000.

That is invisible on macOS, where the bind mount is writable no matter which uid the container runs as. On a plain-Linux host whose user is not uid 1000, the `.:/workspace` bind mount stays owned by the host user while the container runs as 1000, which makes the workspace effectively read-only. `bin/start` — the entry point we document — then dies immediately in the `setup` service:

```
setup-1  | rm: cannot remove 'Gemfile.lock': Permission denied
setup-1 exited with code 1
service "setup" didn't complete successfully: exit 1
```

Rollup and sass writes into `app/assets/builds` fail the same way with `EACCES`.

So compose now forwards the two args, and `bin/start` fills them from `id -u`/`id -g` so the documented entry point works out of the box on any host. Both default back to 1000 when unset, leaving behaviour unchanged for everyone already on uid 1000, and an explicitly exported `USER_ID`/`GROUP_ID` still wins.

### Notable changes (remove if none)

`.devcontainer/devcontainer.json` builds through this same compose file, but it does not go through `bin/start`, so VS Code devcontainer users fall back to the 1000 defaults. Linux users on a different uid can export `USER_ID`/`GROUP_ID` before launching the devcontainer. Solving that properly is out of scope here.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change
