### PR TITLE
chore: add Paseo service script to start the dummy app

### DIFF
--- a/paseo.json
+++ b/paseo.json
@@ -1,0 +1,9 @@
+{
+  "scripts": {
+    "web": {
+      "type": "service",
+      "command": "bin/start",
+      "port": 3000
+    }
+  }
+}


### PR DESCRIPTION
## What is this pull request for?

[Paseo](https://getpaseo.com) supervises long-running project services declared in a `paseo.json` at the repo root. This adds a single `web` service that starts the dummy app via `bin/start`, so contributors who use Paseo can bring up the full Docker dev environment (Rails server plus the Sass/CSS/JS watchers) as a managed service on port 3000.

It reuses the existing `bin/start` launcher rather than duplicating the Docker invocation, so it automatically inherits things like the host-UID matching added in #4051. Contributors who don't use Paseo are unaffected — the file is inert without it.

### Notable changes (remove if none)

None — additive dev tooling config only, no runtime or application changes.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change