### PR TITLE
feat(sitemap): cache the XML sitemap

### DIFF
--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -74,13 +74,67 @@ module Alchemy
 
     # Renders a search engine compatible xml sitemap.
     def sitemap
-      @pages = Page.sitemap
       respond_to do |format|
-        format.xml { render layout: "alchemy/sitemap" }
+        format.xml do
+          if sitemap_caching_enabled?
+            render_cached_sitemap
+          else
+            render_sitemap
+          end
+        end
       end
     end
 
     private
+
+    # Renders the sitemap and stores it in the cache.
+    #
+    # The etag is checked before the pages are loaded, so a revalidating client
+    # only costs us the aggregate cache key queries, not a full render.
+    #
+    def render_cached_sitemap
+      cache_key = sitemap_cache_key
+      expires_in sitemap_max_age, public: true
+
+      return unless stale?(etag: cache_key, public: true)
+
+      # The time bucket in the cache key already rotates every max_age seconds.
+      # The expiry is only here so that stale buckets do not pile up in cache
+      # stores that do not evict on their own.
+      xml = Rails.cache.fetch(cache_key, expires_in: sitemap_max_age) do
+        render_sitemap_to_string
+      end
+
+      render xml: xml
+    end
+
+    def render_sitemap
+      @pages = Page.sitemap
+      render layout: "alchemy/sitemap"
+    end
+
+    def render_sitemap_to_string
+      @pages = Page.sitemap
+      render_to_string(layout: "alchemy/sitemap", formats: [:xml])
+    end
+
+    def sitemap_cache_key
+      Page::SitemapCacheKey.new(
+        site: Current.site,
+        base_url: request.base_url,
+        max_age: sitemap_max_age
+      ).call
+    end
+
+    def sitemap_max_age
+      Alchemy.config.sitemap.max_age
+    end
+
+    # A max_age of zero (or less) disables sitemap caching, because it would
+    # leave the time bucket undefined.
+    def sitemap_caching_enabled?
+      caching_enabled? && sitemap_max_age.to_i.positive?
+    end
 
     # Redirects to requested action without locale prefixed
     def enforce_no_locale

--- a/app/models/alchemy/page/sitemap_cache_key.rb
+++ b/app/models/alchemy/page/sitemap_cache_key.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Alchemy
+  # Builds the cache key for the XML sitemap.
+  #
+  # The key combines three independent sources of change:
+  #
+  # 1. The contents of the +Alchemy::Page.sitemap+ scope, as page count and
+  #    latest +updated_at+.
+  # 2. The requested base url (protocol, host and port), because
+  #    +show_alchemy_page_url+ builds absolute urls from +request.base_url+ and
+  #    a site can be served under several of them (see +Alchemy::Site.find_for_host+).
+  # 3. A coarse time bucket of +max_age+ seconds.
+  #
+  # The time bucket is what makes scheduled publishing work. Pages enter and
+  # leave the sitemap when +public_on+ / +public_until+ pass, without any record
+  # being touched, so no content based key can notice that transition. Rotating
+  # the key every +max_age+ seconds bounds how long such a page can be missing.
+  # It also keeps the ETag from freezing: without it, a revalidating client
+  # would receive +304 Not Modified+ forever.
+  class Page::SitemapCacheKey
+    attr_reader :site, :base_url, :max_age
+
+    # @param site [Alchemy::Site] The site the sitemap is rendered for.
+    # @param base_url [String] The requested base url (e.g. +request.base_url+).
+    # @param max_age [Integer] Length of the time bucket in seconds.
+    def initialize(site:, base_url:, max_age: Alchemy.config.sitemap.max_age)
+      @site = site
+      @base_url = base_url
+      @max_age = max_age
+    end
+
+    # @return [Array<Object>]
+    def call
+      [site&.id, base_url, content_version, time_bucket]
+    end
+
+    private
+
+    # Page count and latest +updated_at+ of the sitemap scope.
+    #
+    # We can not use +ActiveRecord::Relation#cache_key_with_version+ here. The
+    # +published+ scope inlines +Time.current+ into its SQL, so the query digest
+    # that +cache_key+ is built from would differ on every single call and the
+    # key would never be stable.
+    def content_version
+      pages = Page.sitemap
+      timestamp = pages.maximum(Page.arel_table[:updated_at])
+      "#{pages.count}-#{timestamp&.to_fs(:usec)}"
+    end
+
+    def time_bucket
+      Time.current.to_i / max_age
+    end
+  end
+end

--- a/config/alchemy/config.yml
+++ b/config/alchemy/config.yml
@@ -27,10 +27,12 @@ cache_pages: true
 #
 #   show_root [Boolean] # Show language root page in sitemap?
 #   show_flag [Boolean] # Enables the Checkbox in Page#update overlay. So your customer can set the visibility of pages in the sitemap.
+#   max_age [Integer]   # How long the sitemap is cached, in seconds. Set to 0 to disable sitemap caching.
 #
 sitemap:
   show_root: true
   show_flag: false
+  max_age: 3600
 
 # === Default items per page in admin views
 #

--- a/lib/alchemy/configurations/main.rb
+++ b/lib/alchemy/configurations/main.rb
@@ -50,6 +50,7 @@ module Alchemy
       #
       #   show_root [Boolean] # Show language root page in sitemap?
       #   show_flag [Boolean] # Enables the Checkbox in Page#update overlay. So your customer can set the visibility of pages in the sitemap.
+      #   max_age [Integer]   # How long the sitemap is cached, in seconds. Set to 0 to disable sitemap caching.
       configuration :sitemap, Sitemap
 
       # === Default items per page in admin views

--- a/lib/alchemy/configurations/sitemap.rb
+++ b/lib/alchemy/configurations/sitemap.rb
@@ -5,6 +5,7 @@ module Alchemy
     class Sitemap < Alchemy::Configuration
       option :show_root, :boolean, default: true
       option :show_flag, :boolean, default: false
+      option :max_age, :integer, default: 3600
     end
   end
 end

--- a/lib/generators/alchemy/install/templates/alchemy.rb.tt
+++ b/lib/generators/alchemy/install/templates/alchemy.rb.tt
@@ -28,10 +28,12 @@ Alchemy.configure do |config|
   #
   #   show_root [Boolean] # Show language root page in sitemap?
   #   show_flag [Boolean] # Enables the Checkbox in Page#update overlay. So your customer can set the visibility of pages in the sitemap.
+  #   max_age [Integer]   # How long the sitemap is cached, in seconds. Set to 0 to disable sitemap caching.
   #
   # config.sitemap.tap do |sitemap|
   #   sitemap.show_root = <%= @default_config.sitemap.show_root.inspect %>
   #   sitemap.show_flag = <%= @default_config.sitemap.show_flag.inspect %>
+  #   sitemap.max_age = <%= @default_config.sitemap.max_age.inspect %>
   # end
 
   # === Default items per page in admin views

--- a/spec/libraries/alchemy/configuration_spec.rb
+++ b/spec/libraries/alchemy/configuration_spec.rb
@@ -351,7 +351,7 @@ RSpec.describe Alchemy::Configuration do
 
     it "can be converted to a Hash" do
       expect(configuration.to_h).to eq(
-        sitemap_configs: [{show_root: true, show_flag: false}]
+        sitemap_configs: [{show_root: true, show_flag: false, max_age: 3600}]
       )
     end
   end

--- a/spec/models/alchemy/page/sitemap_cache_key_spec.rb
+++ b/spec/models/alchemy/page/sitemap_cache_key_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::Page::SitemapCacheKey do
+  let!(:page) { create(:alchemy_page, :public, sitemap: true) }
+  let(:site) { page.site }
+
+  let(:max_age) { 3600 }
+
+  # Not a memoized +subject+ on purpose. The whole point of these examples is
+  # that a second call returns a different key.
+  def cache_key(site: self.site, base_url: "https://example.com")
+    described_class.new(
+      site: site,
+      base_url: base_url,
+      max_age: max_age
+    ).call
+  end
+
+  before { Alchemy::Current.site = site }
+
+  it "returns an array" do
+    expect(cache_key).to be_an(Array)
+  end
+
+  it "is stable for repeated calls within the same time bucket" do
+    expect(cache_key).to eq(cache_key)
+  end
+
+  describe "content invalidation" do
+    it "changes when a sitemap page is added" do
+      before_key = cache_key
+      create(:alchemy_page, :public, sitemap: true)
+      expect(cache_key).to_not eq(before_key)
+    end
+
+    it "changes when a sitemap page is updated" do
+      before_key = cache_key
+      travel 1.second do
+        page.touch
+        expect(cache_key).to_not eq(before_key)
+      end
+    end
+
+    it "changes when a page leaves the sitemap scope" do
+      before_key = cache_key
+      page.update!(sitemap: false)
+      expect(cache_key).to_not eq(before_key)
+    end
+  end
+
+  describe "time bucketing" do
+    # Buckets are aligned to absolute time, so we pin the clock to the start of
+    # a bucket. Otherwise an example starting near a boundary would cross it.
+    let(:bucket_start) { Time.at((Time.utc(2026, 1, 1).to_i / max_age) * max_age).utc }
+
+    after { travel_back }
+
+    it "does not change before max_age has elapsed" do
+      travel_to(bucket_start)
+      before_key = cache_key
+
+      travel_to(bucket_start + max_age - 10)
+      expect(cache_key).to eq(before_key)
+    end
+
+    # Regression test: without a time bucket the ETag would never change,
+    # so revalidating clients would receive 304 forever and scheduled pages
+    # would never enter the sitemap.
+    it "changes once max_age has elapsed" do
+      travel_to(bucket_start)
+      before_key = cache_key
+
+      travel_to(bucket_start + max_age + 10)
+      expect(cache_key).to_not eq(before_key)
+    end
+  end
+
+  describe "request scoping" do
+    it "differs by host" do
+      expect(cache_key(base_url: "https://example.com"))
+        .to_not eq(cache_key(base_url: "https://www.example.org"))
+    end
+
+    it "differs by protocol" do
+      expect(cache_key(base_url: "https://example.com"))
+        .to_not eq(cache_key(base_url: "http://example.com"))
+    end
+
+    it "differs by port" do
+      expect(cache_key(base_url: "http://example.com:8080"))
+        .to_not eq(cache_key(base_url: "http://example.com:9090"))
+    end
+
+    it "differs by site" do
+      other_site = create(:alchemy_site, host: "other.com")
+      expect(cache_key(site: site)).to_not eq(cache_key(site: other_site))
+    end
+  end
+
+  context "when no site is present" do
+    let(:site) { nil }
+
+    it "still returns a key" do
+      expect(cache_key).to be_an(Array)
+    end
+  end
+end

--- a/spec/requests/alchemy/sitemap_caching_spec.rb
+++ b/spec/requests/alchemy/sitemap_caching_spec.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "XML sitemap caching" do
+  let!(:page) { create(:alchemy_page, :public, sitemap: true) }
+
+  let(:max_age) { Alchemy.config.sitemap.max_age }
+
+  # The test environment uses a :null_store, which would make every
+  # Rails.cache.fetch a miss and render the cache assertions meaningless.
+  let(:cache_store) { ActiveSupport::Cache::MemoryStore.new }
+
+  before { allow(Rails).to receive(:cache).and_return(cache_store) }
+
+  # Counts template renders so we can tell a cache hit from a re-render.
+  def rendered_templates
+    templates = []
+    subscriber = ->(*, payload) { templates << payload[:identifier] }
+    ActiveSupport::Notifications.subscribed(subscriber, "render_template.action_view") do
+      yield
+    end
+    templates
+  end
+
+  context "when caching is enabled" do
+    before { Rails.application.config.action_controller.perform_caching = true }
+    after { Rails.application.config.action_controller.perform_caching = false }
+
+    it "sets a public cache-control header with the configured max-age" do
+      get "/sitemap.xml"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Cache-Control"]).to include("max-age=#{max_age}")
+      expect(response.headers["Cache-Control"]).to include("public")
+    end
+
+    it "sets an ETag" do
+      get "/sitemap.xml"
+      expect(response.headers["ETag"]).to be_present
+    end
+
+    it "renders valid xml on a cache miss and on a cache hit" do
+      2.times do
+        get "/sitemap.xml"
+
+        expect(response.media_type).to eq("application/xml")
+        xml_doc = Nokogiri::XML(response.body)
+        expect(xml_doc.namespaces["xmlns"]).to eq("http://www.sitemaps.org/schemas/sitemap/0.9")
+        expect(xml_doc.css("urlset url loc").length).to eq(2)
+      end
+    end
+
+    it "responds with 304 when revalidating with a matching ETag" do
+      get "/sitemap.xml"
+      etag = response.headers["ETag"]
+
+      get "/sitemap.xml", headers: {"If-None-Match" => etag}
+
+      expect(response).to have_http_status(:not_modified)
+      expect(response.body).to be_empty
+    end
+
+    it "renders the sitemap only once for repeated requests" do
+      templates = rendered_templates do
+        get "/sitemap.xml"
+        get "/sitemap.xml"
+      end
+
+      expect(templates.grep(/sitemap/).length).to eq(1)
+    end
+
+    it "responds with 304 without rendering the sitemap" do
+      get "/sitemap.xml"
+      etag = response.headers["ETag"]
+
+      templates = rendered_templates do
+        get "/sitemap.xml", headers: {"If-None-Match" => etag}
+      end
+
+      expect(templates.grep(/sitemap/)).to be_empty
+    end
+
+    it "invalidates the cache when a page is updated" do
+      get "/sitemap.xml"
+      etag = response.headers["ETag"]
+
+      travel 1.second do
+        page.touch
+        get "/sitemap.xml", headers: {"If-None-Match" => etag}
+      end
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    # Regression test for the revalidation trap: an ETag derived only from the
+    # page contents would never change, so a scheduled page could never enter
+    # the sitemap and clients would revalidate into a 304 forever.
+    it "invalidates the cache once max_age has elapsed" do
+      get "/sitemap.xml"
+      etag = response.headers["ETag"]
+
+      travel(max_age + 10) do
+        get "/sitemap.xml", headers: {"If-None-Match" => etag}
+      end
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "picks up a page that was scheduled to be published" do
+      scheduled = create(:alchemy_page, sitemap: true)
+      scheduled.versions.create!(public_on: 30.minutes.from_now)
+
+      get "/sitemap.xml"
+      expect(response.body).to_not include(scheduled.urlname)
+
+      travel(max_age + 10) do
+        get "/sitemap.xml"
+        expect(response.body).to include(scheduled.urlname)
+      end
+    end
+
+    # Alchemy::Site.find_for_host resolves a site from its host or its aliases,
+    # so one site can be served under several hostnames. The urls in the body
+    # are absolute, so the cache must not be shared between them.
+    it "does not serve one host's urls to another host" do
+      get "/sitemap.xml", headers: {"HOST" => "example.com"}
+      expect(response.body).to include("http://example.com/")
+
+      get "/sitemap.xml", headers: {"HOST" => "www.example.org"}
+      expect(response.body).to include("http://www.example.org/")
+      expect(response.body).to_not include("http://example.com/")
+    end
+
+    context "with an empty sitemap" do
+      before { Alchemy::Page.update_all(sitemap: false) }
+
+      it "renders a valid empty urlset" do
+        get "/sitemap.xml"
+
+        expect(response).to have_http_status(:ok)
+        xml_doc = Nokogiri::XML(response.body)
+        expect(xml_doc.namespaces["xmlns"]).to eq("http://www.sitemaps.org/schemas/sitemap/0.9")
+        expect(xml_doc.css("urlset url")).to be_empty
+      end
+    end
+  end
+
+  context "when max_age is zero" do
+    before do
+      Rails.application.config.action_controller.perform_caching = true
+      allow(Alchemy.config.sitemap).to receive(:max_age).and_return(0)
+    end
+
+    after { Rails.application.config.action_controller.perform_caching = false }
+
+    it "renders the sitemap uncached" do
+      get "/sitemap.xml"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Cache-Control"]).to_not include("public")
+      expect(Nokogiri::XML(response.body).css("urlset url loc").length).to eq(2)
+    end
+  end
+
+  context "when caching is disabled" do
+    before { Rails.application.config.action_controller.perform_caching = false }
+
+    it "does not set a public cache-control header" do
+      get "/sitemap.xml"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Cache-Control"]).to_not include("public")
+    end
+
+    it "renders the sitemap on every request" do
+      templates = rendered_templates do
+        get "/sitemap.xml"
+        get "/sitemap.xml"
+      end
+
+      expect(templates.grep(/sitemap/).length).to eq(2)
+    end
+
+    it "still renders a valid sitemap" do
+      get "/sitemap.xml"
+
+      expect(response.media_type).to eq("application/xml")
+      xml_doc = Nokogiri::XML(response.body)
+      expect(xml_doc.css("urlset url loc").length).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

The `PagesController#sitemap` action rendered the full `Page.sitemap` scope and its template on every request, with no server-side cache and only Rails' default weak ETag. On large sites every crawler hit paid the query and render cost, even when nothing had changed.

This caches the rendered XML in `Rails.cache` and answers conditional requests with `304 Not Modified` before any pages are loaded, so a revalidating crawler costs only two aggregate queries and no render. Caching reuses the existing `cache_pages` switch (so it is off wherever page caching is off, including development) and adds a `sitemap.max_age` option to tune the window, defaulting to one hour.

The cache key is the interesting part, because the sitemap has two sources of change that a naive key misses:

- **Scheduled publishing is time-dependent.** `Page.sitemap` is built on `PageVersion.published`, whose SQL is `public_on <= now AND (public_until IS NULL OR public_until > now)`. Pages enter and leave the sitemap as wall-clock time crosses those timestamps, with **no record's `updated_at` changing**. A purely content-derived key would therefore freeze: a page scheduled for midnight would never appear, and a revalidating client would receive `304` forever. The key includes a coarse `max_age` time bucket that rotates the ETag and the cache entry every `max_age` seconds, bounding how late a scheduled transition can show up.
- **URLs are absolute and hosts vary.** `show_alchemy_page_url` builds `<loc>` values from `request.base_url`, and one site can be served under several hostnames (`Site.find_for_host` matches `host` or `aliases`) and ports. The key includes `request.base_url` so those responses are never cross-served.

### Notable changes (remove if none)

New config option `Alchemy.config.sitemap.max_age` (default `3600`). Setting it to `0` disables sitemap caching. No change to the generated XML output; the uncached path is byte-for-byte what it was before, and the existing sitemap request spec passes unchanged.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change