### PR TITLE
fix(admin): Open the image overlay when a picture is activated with the keyboard

### DIFF
--- a/app/views/alchemy/admin/pictures/index.html.erb
+++ b/app/views/alchemy/admin/pictures/index.html.erb
@@ -77,7 +77,8 @@
     import { on } from "alchemy_admin/utils/events";
 
     pictureSelector();
-    on("click", "#picture_archive", ".thumbnail_background", (event) => {
+    // A keyboard activated click targets the link, not the thumbnail inside it.
+    on("click", "#picture_archive", ".picture_thumbnail > a", (event) => {
       const url = event.target.closest("a")?.href;
       const overlay = new ImageOverlay(url, {
         size: `${window.clientWidth}x${window.clientHeight}`,

--- a/spec/features/admin/picture_library_integration_spec.rb
+++ b/spec/features/admin/picture_library_integration_spec.rb
@@ -267,4 +267,31 @@ RSpec.describe "Picture Library", type: :system do
       end
     end
   end
+
+  describe "Opening a picture in the image overlay" do
+    let!(:picture) { create(:alchemy_picture, name: "Picture 1") }
+
+    scenario "opens the overlay when clicking the thumbnail", :js do
+      visit alchemy.admin_pictures_path
+
+      find("#picture_#{picture.id} alchemy-picture-thumbnail").click
+
+      expect(page).to have_css(".alchemy-image-overlay-container")
+    end
+
+    scenario "opens the overlay when the focused link is activated with enter", :js do
+      visit alchemy.admin_pictures_path
+
+      page.execute_script(<<~JS)
+        document
+          .querySelector("#picture_#{picture.id} alchemy-picture-thumbnail")
+          .closest("a")
+          .focus()
+      JS
+      page.driver.browser.action.send_keys(:enter).perform
+
+      expect(page).to have_css(".alchemy-image-overlay-container")
+      expect(page).to have_current_path(alchemy.admin_pictures_path)
+    end
+  end
 end


### PR DESCRIPTION
## What is this pull request for?

Tabbing to a picture in the archive and hitting enter did not open it in the
image overlay. The browser followed the link and showed the picture inline
instead.

The overlay is opened from a click handler delegated to `.thumbnail_background`
— the thumbnail element *inside* the picture link. A mouse click targets that
thumbnail, so the delegation matches and the handler calls `preventDefault()`.
But activating a link with the keyboard fires the click on the `<a>` itself,
which is the thumbnail's *parent*, so the delegation never matched, the default
was never prevented and the browser navigated.

Delegating on the link (`.picture_thumbnail > a`) fixes it: a mouse click still
matches by bubbling up from the thumbnail, and a keyboard activated click
matches the link directly. The delete link is nested deeper
(`.picture_tool.delete > sl-tooltip > a`), so it is not a direct child of the
picture and stays unaffected.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
