### PR TITLE
chore(dev): make Docker dev rebuilds easier and uid-safe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,13 @@ bin/start
 
 This starts a Rails server and pnpm watch task in the dummy application for running a full dev environment.
 
+After changing dependencies (`Gemfile` or `package.json`), rebuild the image and
+refresh the baked `node_modules` in one step:
+
+```bash
+bin/start --refresh
+```
+
 ### Starting the Rails console
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -363,6 +363,13 @@ server, Sass watcher, and JS bundle watcher):
 $ bin/start
 ```
 
+After changing dependencies (`Gemfile` or `package.json`), rebuild the image and
+refresh the baked `node_modules` in one step:
+
+```bash
+$ bin/start --refresh
+```
+
 Or, to run the dummy app locally without Docker:
 
 ```bash

--- a/bin/setup
+++ b/bin/setup
@@ -12,6 +12,11 @@ def system!(*args)
 end
 
 FileUtils.chdir GEM_ROOT do
+  # Docker Compose reads .env for the uid/gid baked into the image's container
+  # user, which must match the host to write into the bind mounted workspace on
+  # Linux. Written per machine and gitignored so any compose invocation matches.
+  File.write(".env", "USER_ID=#{Process.uid}\nGROUP_ID=#{Process.gid}\n")
+
   system! "gem install bundler --conservative"
   system("bundle check") || system!("bundle install")
   system("pnpm -v &> /dev/null") || system!("corepack enable")

--- a/bin/start
+++ b/bin/start
@@ -13,4 +13,17 @@ USER_ID="${USER_ID:-$(id -u)}"
 GROUP_ID="${GROUP_ID:-$(id -g)}"
 export USER_ID GROUP_ID
 
-exec docker compose up --build "$@"
+# node_modules is baked into the image but shadowed by an anonymous volume, so a
+# rebuilt image is not picked up until that volume is recreated. `--refresh`
+# renews it after changing dependencies; a plain start skips the reseed cost.
+renew=""
+args=""
+for arg in "$@"; do
+  if [ "$arg" = "--refresh" ]; then
+    renew="--renew-anon-volumes"
+  else
+    args="$args $arg"
+  fi
+done
+
+exec docker compose up --build $renew $args

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,8 @@ x-app: &app
 # volume. node_modules sits under the bind mount, so an anonymous volume
 # (`- /workspace/node_modules`) shadows the host directory and surfaces the
 # image's copy instead of the host's (which has platform-specific binaries).
-# After changing dependencies, rebuild the image; refresh node_modules with
-# `docker compose up --build --renew-anon-volumes`.
+# After changing dependencies, rebuild the image and refresh node_modules with
+# `bin/start --refresh`.
 #
 # USER_ID/GROUP_ID select the uid/gid of the image's `alchemy` user, which has to
 # own the `.:/workspace` bind mount to be able to write into it. `bin/start` sets


### PR DESCRIPTION
## What is this pull request for?

The dockerized dev stack bakes `node_modules` into the image and shadows it with an anonymous volume. Because of that, a rebuilt image is not actually picked up until the anonymous volume is recreated — which forced contributors to remember the awkward `docker compose up --build --renew-anon-volumes`. This adds a `bin/start --refresh` flag that renews the volume for you, while a plain `bin/start` stays fast and skips the reseed cost.

It also closes a related footgun in the same workflow: the image bakes its container user at the host's uid/gid, but only `bin/start` exported those values. Building through a raw `docker compose up --build` defaulted the user to uid 1000, making the bind-mounted workspace read-only on Linux and failing on the very first `rm Gemfile.lock` in the `setup` service. `bin/setup` now writes a gitignored `.env` with the host uid/gid, so every Compose invocation — not just `bin/start` — bakes a user that can write the workspace.

`AGENTS.md` and `README.md` gain a short note pointing at `bin/start --refresh`, and the `docker-compose.yml` comment that used to spell out the long command now points at it too.

### Notable changes (remove if none)

None breaking. `.env` is already gitignored and generated per machine, so it stays out of version control.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change — not applicable; this only touches the Docker dev tooling (shell scripts, Compose config, docs), which has no automated test surface