### PR TITLE
refactor: Extract Alchemy::SitemapController

### DIFF
--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -73,69 +73,19 @@ module Alchemy
     end
 
     # Renders a search engine compatible xml sitemap.
+    #
+    # @deprecated Point the +/sitemap.xml+ route at {Alchemy::SitemapController} instead.
+    #
     def sitemap
-      respond_to do |format|
-        format.xml do
-          if sitemap_caching_enabled?
-            render_cached_sitemap
-          else
-            render_sitemap
-          end
-        end
-      end
-    end
-
-    private
-
-    # Renders the sitemap and stores it in the cache.
-    #
-    # The etag is checked before the pages are loaded, so a revalidating client
-    # only costs us the aggregate cache key queries, not a full render.
-    #
-    def render_cached_sitemap
-      cache_key = sitemap_cache_key
-      expires_in sitemap_max_age, public: true
-
-      return unless stale?(etag: cache_key, public: true)
-
-      # The time bucket in the cache key already rotates every max_age seconds.
-      # The expiry is only here so that stale buckets do not pile up in cache
-      # stores that do not evict on their own.
-      xml = Rails.cache.fetch(cache_key, expires_in: sitemap_max_age) do
-        render_sitemap_to_string
-      end
-
-      render xml: xml
-    end
-
-    def render_sitemap
+      Alchemy::Deprecation.warn(
+        "Alchemy::PagesController#sitemap is deprecated and will be removed in Alchemy 9.0. " \
+        "Route /sitemap.xml to Alchemy::SitemapController#show instead."
+      )
       @pages = Page.sitemap
       render layout: "alchemy/sitemap"
     end
 
-    def render_sitemap_to_string
-      @pages = Page.sitemap
-      render_to_string(layout: "alchemy/sitemap", formats: [:xml])
-    end
-
-    def sitemap_cache_key
-      Page::SitemapCacheKey.new(
-        site: Current.site,
-        base_url: request.base_url,
-        max_age: sitemap_max_age
-      ).call
-    end
-
-    def sitemap_max_age
-      Alchemy.config.sitemap.max_age
-    end
-
-    # The sitemap has its own cache setting and does not follow the page cache.
-    # A max_age of zero (or less) disables it, because it would leave the time
-    # bucket undefined.
-    def sitemap_caching_enabled?
-      perform_caching && sitemap_max_age.to_i.positive?
-    end
+    private
 
     # Redirects to requested action without locale prefixed
     def enforce_no_locale

--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -130,10 +130,11 @@ module Alchemy
       Alchemy.config.sitemap.max_age
     end
 
-    # A max_age of zero (or less) disables sitemap caching, because it would
-    # leave the time bucket undefined.
+    # The sitemap has its own cache setting and does not follow the page cache.
+    # A max_age of zero (or less) disables it, because it would leave the time
+    # bucket undefined.
     def sitemap_caching_enabled?
-      caching_enabled? && sitemap_max_age.to_i.positive?
+      perform_caching && sitemap_max_age.to_i.positive?
     end
 
     # Redirects to requested action without locale prefixed

--- a/app/controllers/alchemy/sitemap_controller.rb
+++ b/app/controllers/alchemy/sitemap_controller.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Alchemy
+  # Renders a search engine compatible XML sitemap.
+  #
+  # The sitemap contains absolute urls, so it has to follow the site's primary
+  # host redirect just like a page request does.
+  #
+  class SitemapController < Alchemy::BaseController
+    include SiteRedirects
+
+    # Still the pages template, because apps override it at that path.
+    #
+    # TODO: Move to alchemy/sitemap/show in Alchemy 9.0, together with the
+    # deprecated PagesController#sitemap.
+    TEMPLATE = "alchemy/pages/sitemap"
+
+    def show
+      if sitemap_caching_enabled?
+        render_cached_sitemap
+      else
+        render_sitemap
+      end
+    end
+
+    private
+
+    # Renders the sitemap and stores it in the cache.
+    #
+    # The etag is checked before the pages are loaded, so a revalidating client
+    # only costs us the aggregate cache key queries, not a full render.
+    #
+    def render_cached_sitemap
+      cache_key = sitemap_cache_key
+      expires_in sitemap_max_age, public: true
+
+      return unless stale?(etag: cache_key, public: true)
+
+      # The time bucket in the cache key already rotates every max_age seconds.
+      # The expiry is only here so that stale buckets do not pile up in cache
+      # stores that do not evict on their own.
+      xml = Rails.cache.fetch(cache_key, expires_in: sitemap_max_age) do
+        render_sitemap_to_string
+      end
+
+      render xml: xml
+    end
+
+    def render_sitemap
+      @pages = Page.sitemap
+      render template: TEMPLATE, layout: "alchemy/sitemap"
+    end
+
+    def render_sitemap_to_string
+      @pages = Page.sitemap
+      render_to_string(template: TEMPLATE, layout: "alchemy/sitemap", formats: [:xml])
+    end
+
+    def sitemap_cache_key
+      Page::SitemapCacheKey.new(
+        site: Current.site,
+        base_url: request.base_url,
+        max_age: sitemap_max_age
+      ).call
+    end
+
+    def sitemap_max_age
+      Alchemy.config.sitemap.max_age
+    end
+
+    # The sitemap has its own cache setting and does not follow the page cache.
+    # A max_age of zero (or less) disables it, because it would leave the time
+    # bucket undefined.
+    def sitemap_caching_enabled?
+      perform_caching && sitemap_max_age.to_i.positive?
+    end
+  end
+end

--- a/app/controllers/alchemy/sitemap_controller.rb
+++ b/app/controllers/alchemy/sitemap_controller.rb
@@ -17,47 +17,27 @@ module Alchemy
 
     def show
       if sitemap_caching_enabled?
-        render_cached_sitemap
-      else
-        render_sitemap
+        expires_in sitemap_max_age, public: true
+
+        # The etag is checked before the pages are loaded, so a revalidating
+        # client only costs us the cache key queries, not a full render.
+        return unless stale?(etag: sitemap_cache_key, public: true)
+
+        @sitemap_cache_key = sitemap_cache_key
+        @sitemap_max_age = sitemap_max_age
       end
+
+      # Left unloaded on purpose. The template wraps the urls in a fragment
+      # cache, so a cache hit never runs this query.
+      @pages = Page.sitemap
+
+      render template: TEMPLATE, layout: "alchemy/sitemap"
     end
 
     private
 
-    # Renders the sitemap and stores it in the cache.
-    #
-    # The etag is checked before the pages are loaded, so a revalidating client
-    # only costs us the aggregate cache key queries, not a full render.
-    #
-    def render_cached_sitemap
-      cache_key = sitemap_cache_key
-      expires_in sitemap_max_age, public: true
-
-      return unless stale?(etag: cache_key, public: true)
-
-      # The time bucket in the cache key already rotates every max_age seconds.
-      # The expiry is only here so that stale buckets do not pile up in cache
-      # stores that do not evict on their own.
-      xml = Rails.cache.fetch(cache_key, expires_in: sitemap_max_age) do
-        render_sitemap_to_string
-      end
-
-      render xml: xml
-    end
-
-    def render_sitemap
-      @pages = Page.sitemap
-      render template: TEMPLATE, layout: "alchemy/sitemap"
-    end
-
-    def render_sitemap_to_string
-      @pages = Page.sitemap
-      render_to_string(template: TEMPLATE, layout: "alchemy/sitemap", formats: [:xml])
-    end
-
     def sitemap_cache_key
-      Page::SitemapCacheKey.new(
+      @_sitemap_cache_key ||= Page::SitemapCacheKey.new(
         site: Current.site,
         base_url: request.base_url,
         max_age: sitemap_max_age

--- a/app/views/alchemy/pages/sitemap.xml.erb
+++ b/app/views/alchemy/pages/sitemap.xml.erb
@@ -1,6 +1,8 @@
+<%- cache_if @sitemap_cache_key, @sitemap_cache_key, expires_in: @sitemap_max_age do -%>
 <%- @pages.each do |page| -%>
 <url>
   <loc><%= show_alchemy_page_url(page) %></loc>
   <lastmod><%= page.updated_at.utc.iso8601 %></lastmod>
 </url>
+<%- end -%>
 <%- end -%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ require "alchemy/routing_constraints"
 Alchemy::Engine.routes.draw do
   root to: "pages#index"
 
-  get "/sitemap.xml", to: "pages#sitemap", format: "xml"
+  get "/sitemap.xml", to: "sitemap#show", format: "xml"
 
   scope Alchemy.admin_path, constraints: Alchemy.admin_constraints do
     get "/", to: redirect("#{Alchemy.admin_path}/dashboard"), as: :admin

--- a/spec/controllers/alchemy/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/pages_controller_spec.rb
@@ -373,5 +373,36 @@ module Alchemy
         end
       end
     end
+
+    # TODO: Remove in Alchemy 9.0 together with Alchemy::PagesController#sitemap
+    describe "#sitemap" do
+      render_views
+
+      # Alchemy routes /sitemap.xml to Alchemy::SitemapController now, so this
+      # stands in for an app that kept pointing its own route at this action.
+      routes do
+        ActionDispatch::Routing::RouteSet.new.tap do |set|
+          set.draw do
+            get "/sitemap.xml", to: "alchemy/pages#sitemap", format: "xml"
+          end
+        end
+      end
+
+      let!(:sitemap_page) { create(:alchemy_page, :public, sitemap: true) }
+
+      it "is deprecated" do
+        expect(Alchemy::Deprecation).to receive(:warn)
+        get :sitemap, format: :xml
+      end
+
+      it "still renders the sitemap" do
+        allow(Alchemy::Deprecation).to receive(:warn)
+        get :sitemap, format: :xml
+
+        xml_doc = Nokogiri::XML(response.body)
+        expect(xml_doc.namespaces["xmlns"]).to eq("http://www.sitemaps.org/schemas/sitemap/0.9")
+        expect(xml_doc.css("urlset url loc").length).to eq(2)
+      end
+    end
   end
 end

--- a/spec/controllers/alchemy/sitemap_controller_spec.rb
+++ b/spec/controllers/alchemy/sitemap_controller_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Alchemy
+  describe SitemapController do
+    routes { Alchemy::Engine.routes }
+
+    let!(:page) { create(:alchemy_page, :public, sitemap: true) }
+
+    describe "#show" do
+      # The template stays at its old path for the deprecation window, so that
+      # apps overriding it keep getting their own version rendered.
+      it "renders the pages sitemap template" do
+        expect(get(:show, format: :xml)).to render_template("alchemy/pages/sitemap")
+      end
+    end
+  end
+end

--- a/spec/requests/alchemy/sitemap_caching_spec.rb
+++ b/spec/requests/alchemy/sitemap_caching_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe "XML sitemap caching" do
   end
 
   context "when caching is enabled" do
-    before { Rails.application.config.action_controller.perform_caching = true }
-    after { Rails.application.config.action_controller.perform_caching = false }
+    before { ActionController::Base.perform_caching = true }
+    after { ActionController::Base.perform_caching = false }
 
     it "sets a public cache-control header with the configured max-age" do
       get "/sitemap.xml"
@@ -132,6 +132,20 @@ RSpec.describe "XML sitemap caching" do
       expect(response.body).to_not include("http://example.com/")
     end
 
+    # The sitemap is not a page, and sitemap.max_age is its own switch.
+    context "with page caching turned off" do
+      before { stub_alchemy_config(cache_pages: false) }
+
+      it "still caches the sitemap" do
+        templates = rendered_templates do
+          get "/sitemap.xml"
+          get "/sitemap.xml"
+        end
+
+        expect(templates.grep(/sitemap/).length).to eq(1)
+      end
+    end
+
     context "with an empty sitemap" do
       before { Alchemy::Page.update_all(sitemap: false) }
 
@@ -148,11 +162,11 @@ RSpec.describe "XML sitemap caching" do
 
   context "when max_age is zero" do
     before do
-      Rails.application.config.action_controller.perform_caching = true
+      ActionController::Base.perform_caching = true
       allow(Alchemy.config.sitemap).to receive(:max_age).and_return(0)
     end
 
-    after { Rails.application.config.action_controller.perform_caching = false }
+    after { ActionController::Base.perform_caching = false }
 
     it "renders the sitemap uncached" do
       get "/sitemap.xml"
@@ -164,7 +178,7 @@ RSpec.describe "XML sitemap caching" do
   end
 
   context "when caching is disabled" do
-    before { Rails.application.config.action_controller.perform_caching = false }
+    before { ActionController::Base.perform_caching = false }
 
     it "does not set a public cache-control header" do
       get "/sitemap.xml"

--- a/spec/requests/alchemy/sitemap_caching_spec.rb
+++ b/spec/requests/alchemy/sitemap_caching_spec.rb
@@ -7,11 +7,14 @@ RSpec.describe "XML sitemap caching" do
 
   let(:max_age) { Alchemy.config.sitemap.max_age }
 
-  # The test environment uses a :null_store, which would make every
-  # Rails.cache.fetch a miss and render the cache assertions meaningless.
-  let(:cache_store) { ActiveSupport::Cache::MemoryStore.new }
-
-  before { allow(Rails).to receive(:cache).and_return(cache_store) }
+  # The test environment configures a :null_store, which would make every
+  # fragment lookup a miss and render the cache assertions meaningless.
+  around do |example|
+    original_store = ActionController::Base.cache_store
+    ActionController::Base.cache_store = ActiveSupport::Cache::MemoryStore.new
+    example.run
+    ActionController::Base.cache_store = original_store
+  end
 
   # Counts template renders so we can tell a cache hit from a re-render.
   def rendered_templates
@@ -21,6 +24,18 @@ RSpec.describe "XML sitemap caching" do
       yield
     end
     templates
+  end
+
+  # The urls are wrapped in a fragment cache, so the template itself still
+  # renders on a hit. Fragment writes only happen on a miss, which is what
+  # tells a reused fragment from a rebuilt one.
+  def fragment_writes
+    writes = 0
+    subscriber = ->(*) { writes += 1 }
+    ActiveSupport::Notifications.subscribed(subscriber, "write_fragment.action_controller") do
+      yield
+    end
+    writes
   end
 
   context "when caching is enabled" do
@@ -61,13 +76,13 @@ RSpec.describe "XML sitemap caching" do
       expect(response.body).to be_empty
     end
 
-    it "renders the sitemap only once for repeated requests" do
-      templates = rendered_templates do
+    it "builds the sitemap only once for repeated requests" do
+      writes = fragment_writes do
         get "/sitemap.xml"
         get "/sitemap.xml"
       end
 
-      expect(templates.grep(/sitemap/).length).to eq(1)
+      expect(writes).to eq(1)
     end
 
     it "responds with 304 without rendering the sitemap" do
@@ -137,12 +152,12 @@ RSpec.describe "XML sitemap caching" do
       before { stub_alchemy_config(cache_pages: false) }
 
       it "still caches the sitemap" do
-        templates = rendered_templates do
+        writes = fragment_writes do
           get "/sitemap.xml"
           get "/sitemap.xml"
         end
 
-        expect(templates.grep(/sitemap/).length).to eq(1)
+        expect(writes).to eq(1)
       end
     end
 

--- a/spec/requests/alchemy/sitemap_spec.rb
+++ b/spec/requests/alchemy/sitemap_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Requests for PagesController#sitemap" do
+RSpec.describe "Requests for SitemapController#show" do
   let!(:page) { create(:alchemy_page, :public, sitemap: true) }
 
   it "renders valid xml sitemap" do


### PR DESCRIPTION
## What is this pull request for?

The XML sitemap was served from `Alchemy::PagesController#sitemap`. Once the sitemap gained its own caching layer in #4054, that action dragged six private helpers into a controller whose job is rendering pages, and the two resources share nothing but the class they happened to live in. The sitemap is its own resource with its own caching policy, so it gets its own controller and its own route.

Before the move, the first commit unties sitemap caching from `cache_pages`. Gating one on the other meant an app that renders pages dynamically also rebuilt its sitemap on every crawler hit, even though `sitemap.max_age` is already documented as the way to turn the sitemap cache off. It follows Rails' `perform_caching` now. That caching layer has not shipped yet, so nobody is relying on the old gate.

`Alchemy::SitemapController` includes `SiteRedirects`, because that concern is declared without an `only:` scope and therefore already applied to the sitemap. The sitemap emits absolute urls, which makes following the site's primary host redirect part of its behaviour rather than an accident. It deliberately does *not* include `LegacyPageRedirects`, which is scoped to the `show` action and so never ran for `pages#sitemap` — naming the new action `show` would have switched it on silently.

The template deliberately stays at `alchemy/pages/sitemap` and is rendered explicitly. Apps override it at that path, and moving it would have broken those overrides without a word. It moves once the deprecated action is gone.

The last commit replaces the hand rolled cache. Storing the rendered sitemap in `Rails.cache` needed a `render_to_string` and a cache fetch in the controller purely because the template did not cache itself. A fragment cache around the urls says the same thing with Rails' own tools, keeps the page scope an unloaded relation so a hit still skips the query, and leaves the controller with nothing but the etag and the expiry headers.

### Notable changes

`/sitemap.xml` now routes to `sitemap#show`. The path is unchanged and the route was never named, so no url helper changes.

`Alchemy::PagesController#sitemap` is deprecated and will be removed in Alchemy 9.0. It still renders the sitemap, so apps that route `/sitemap.xml` themselves, or that subclass `PagesController`, keep working for one major version. Nothing has to move in an upgrading app.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change