### PR TITLE
fix(ingredients): Escape and sanitize author supplied ingredient values

### DIFF
--- a/app/components/alchemy/ingredients/base_view.rb
+++ b/app/components/alchemy/ingredients/base_view.rb
@@ -16,7 +16,7 @@ module Alchemy
       end
 
       def call
-        value.html_safe
+        h(value)
       end
 
       def render?

--- a/app/components/alchemy/ingredients/picture_view.rb
+++ b/app/components/alchemy/ingredients/picture_view.rb
@@ -68,7 +68,7 @@ module Alchemy
       def caption
         return unless show_caption?
 
-        @_caption ||= content_tag(:figcaption, ingredient.caption.html_safe)
+        @_caption ||= content_tag(:figcaption, sanitize(ingredient.caption))
       end
 
       def src

--- a/app/components/alchemy/ingredients/text_view.rb
+++ b/app/components/alchemy/ingredients/text_view.rb
@@ -18,7 +18,7 @@ module Alchemy
 
       def call
         if disable_link?
-          dom_id.present? ? anchor : value
+          dom_id.present? ? anchor : h(value)
         else
           link_to(value, url_for(link), {
             id: dom_id.presence,
@@ -26,7 +26,7 @@ module Alchemy
             target: link_target_value(link_target),
             rel: link_rel_value(link_target)
           }.merge(html_options))
-        end.html_safe
+        end
       end
 
       private

--- a/spec/components/alchemy/ingredients/base_view_spec.rb
+++ b/spec/components/alchemy/ingredients/base_view_spec.rb
@@ -46,4 +46,14 @@ RSpec.describe Alchemy::Ingredients::BaseView do
       end
     end
   end
+
+  describe "#call", type: :component do
+    let(:ingredient) { Alchemy::Ingredients::Text.new(role: "headline", value: "<script>alert('XSS')</script>") }
+
+    it "escapes the value" do
+      render_inline described_class.new(ingredient)
+      expect(rendered_content).to include("&lt;script&gt;")
+      expect(rendered_content).to_not include("<script>")
+    end
+  end
 end

--- a/spec/components/alchemy/ingredients/picture_view_spec.rb
+++ b/spec/components/alchemy/ingredients/picture_view_spec.rb
@@ -68,6 +68,23 @@ RSpec.describe Alchemy::Ingredients::PictureView, type: :component do
       end
     end
 
+    context "having script tags" do
+      let(:ingredient) do
+        stub_model Alchemy::Ingredients::Picture,
+          role: "image",
+          picture: picture,
+          data: {
+            caption: "Cute<br />cat<script>alert('XSS')</script>"
+          }
+      end
+
+      it "sanitizes the caption, but keeps allowed tags" do
+        render_view
+        expect(rendered_content).to include("Cute<br>cat")
+        expect(rendered_content).to_not include("<script>")
+      end
+    end
+
     it "does not pass default options to picture url" do
       expect(ingredient).to receive(:picture_url).with({}) { picture_url }
       render_view

--- a/spec/components/alchemy/ingredients/select_view_spec.rb
+++ b/spec/components/alchemy/ingredients/select_view_spec.rb
@@ -70,4 +70,14 @@ RSpec.describe Alchemy::Ingredients::SelectView, type: :component do
       expect(page).to have_content("")
     end
   end
+
+  context "with a value containing html" do
+    let(:ingredient) { Alchemy::Ingredients::Select.new(value: "<script>alert('XSS')</script>") }
+
+    it "escapes the value" do
+      render_inline described_class.new(ingredient)
+      expect(rendered_content).to include("&lt;script&gt;")
+      expect(rendered_content).to_not include("<script>")
+    end
+  end
 end

--- a/spec/components/alchemy/ingredients/text_view_spec.rb
+++ b/spec/components/alchemy/ingredients/text_view_spec.rb
@@ -136,4 +136,14 @@ RSpec.describe Alchemy::Ingredients::TextView, type: :component do
       end
     end
   end
+
+  context "with a value containing html" do
+    let(:ingredient) { Alchemy::Ingredients::Text.new(value: "<script>alert('XSS')</script>") }
+
+    it "escapes the value" do
+      render_inline described_class.new(ingredient)
+      expect(rendered_content).to include("&lt;script&gt;")
+      expect(rendered_content).to_not include("<script>")
+    end
+  end
 end


### PR DESCRIPTION
## What is this pull request for?

Three ingredient view components rendered author supplied values as `html_safe`, which meant anyone with author rights could store markup that then executed in every visitor's browser on the published page. This fixes all three.

Two of them were reported: `SelectView` reaches `BaseView#call`, whose `value.html_safe` trusted the stored string outright, and the `select_values` allow list is only enforced by the admin dropdown so an author could post anything straight to the elements API. `PictureView` marked the caption `html_safe` so that the newlines a textarea caption produces would render as `br` tags, but that trusted the whole caption. The fix for `SelectView` sits in `BaseView` rather than in `SelectView` itself, so the inherited default is safe for custom ingredient views that do not override `call` either.

The third site turned up while fixing those two. `TextView` already escapes on its link and anchor paths because `link_to` and `content_tag` do it for us, but it returned the bare value as `html_safe` when neither a link nor a dom id was set, which is the ordinary case for a text ingredient. It is the same bug with a wider reach, so it is fixed here rather than left for later.

Escaping and sanitizing are deliberately not used interchangeably. Text and select values are plain strings, so they are escaped and render exactly what the author typed; running them through a sanitizer would silently delete anything tag shaped, so a value like `Widget <Special>` would lose part of itself. The caption is sanitized instead, because allowing `br` there was an intentional feature and escaping it would regress that.

Each fix is its own commit so they can be backported independently.

### Notable changes

Captions are now sanitized rather than trusted, so any tag outside Rails' safe list is dropped instead of rendered. Text ingredients without a link no longer render stored HTML, and custom ingredient views inheriting `BaseView#call` now get escaped output by default.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change