### PR TITLE
refactor(dev): Run a single live reload watcher

### DIFF
--- a/config/initializers/rails_live_reload.rb
+++ b/config/initializers/rails_live_reload.rb
@@ -9,5 +9,17 @@ if defined?(RailsLiveReload)
     # More examples:
     config.watch %r{app/(helpers|components|decorators)/.+\.rb}, reload: :always
     config.watch %r{config/locales/.+\.yml}, reload: :always
+
+    # Listen anchors its own log/ and tmp/ defaults at each watched root, so a
+    # watcher rooted above the application still sees them. Any write in the
+    # watched tree wakes the watcher and re-checks every connected browser, so
+    # directories written while merely serving a request have to be ignored.
+    # Everything below spec/ is ignored except the dummy app's own sources, so
+    # that its logs, databases and uploads cannot wake the watcher.
+    if config.respond_to?(:ignore)
+      config.ignore %r{^spec/(?!dummy/(app|config/locales)/)}
+      config.ignore %r{^node_modules/}
+      config.ignore %r{^(db|storage|coverage)/}
+    end
   end
 end

--- a/lib/alchemy/dev_support/live_reload_watcher.rb
+++ b/lib/alchemy/dev_support/live_reload_watcher.rb
@@ -1,5 +1,38 @@
 module Alchemy
   class LiveReloadWatcher < RailsLiveReload::Watcher
+    # Directories that can hold files matching the configured watch patterns.
+    # Globbing the whole engine root would also walk node_modules, the dummy
+    # app's logs and databases and any build caches.
+    WATCHED_DIRS = %w[app vendor config/locales]
+
     def root = Alchemy::Engine.root
+
+    # The inherited implementation tracks every file below the root, although
+    # only files matching a watch pattern can ever trigger a reload. The whole
+    # tree is serialized to the browser on every change, so it is filtered down
+    # to the files that are actually able to match.
+    def build_tree
+      watched_roots.each do |dir|
+        Dir.glob(dir.join("**", "*")).each do |file|
+          next unless File.file?(file) && watched?(file)
+
+          files[file] = File.mtime(file).to_i
+        end
+      end
+    end
+
+    private
+
+    # The dummy app sits inside the engine root, so it is covered by this
+    # watcher as well.
+    def watched_roots
+      roots = [root]
+      roots << Rails.application.root if Rails.application.root.to_s.start_with?("#{root}/")
+      roots.flat_map { |dir| WATCHED_DIRS.map { |path| dir.join(path) } }
+    end
+
+    def watched?(file)
+      RailsLiveReload.patterns.keys.any? { |pattern| file.match(pattern) }
+    end
   end
 end

--- a/lib/alchemy/engine.rb
+++ b/lib/alchemy/engine.rb
@@ -160,10 +160,40 @@ module Alchemy
         end
       end
 
-      if defined?(RailsLiveReload) && Rails.env.development?
+      if Alchemy::Engine.watch_engine_files? && RailsLiveReload.enabled?
         require "alchemy/dev_support/live_reload_watcher"
 
         Alchemy::LiveReloadWatcher.init
+      end
+    end
+
+    # Alchemy is developed from a checkout when the application root lies inside
+    # the engine root. Only then is watching the engine's own files useful, and
+    # only then does our watcher cover the application as well. Installed as a
+    # gem the engine root never changes, so rails_live_reload's own watcher is
+    # the useful one and is left in place.
+    def self.watch_engine_files?
+      defined?(RailsLiveReload) && Rails.env.development? &&
+        Rails.application.root.to_s.start_with?("#{root}/")
+    end
+
+    # rails_live_reload always starts a watcher rooted at the application, which
+    # duplicates ours and fights it over the same socket. It has no hook to skip
+    # it, so it is disabled for the length of that single initializer.
+    initializer "alchemy.disable_live_reload_watcher",
+      after: "rails_live_reload.middleware",
+      before: "rails_live_reload.watcher" do
+      if Alchemy::Engine.watch_engine_files?
+        @live_reload_enabled = RailsLiveReload.enabled?
+        RailsLiveReload.config.enabled = false
+      end
+    end
+
+    initializer "alchemy.restore_live_reload",
+      after: "rails_live_reload.watcher",
+      before: "rails_live_reload.configure_metrics" do
+      if Alchemy::Engine.watch_engine_files?
+        RailsLiveReload.config.enabled = @live_reload_enabled
       end
     end
 

--- a/spec/libraries/alchemy/dev_support/live_reload_watcher_spec.rb
+++ b/spec/libraries/alchemy/dev_support/live_reload_watcher_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "tmpdir"
+require "alchemy/dev_support/live_reload_watcher"
+
+RSpec.describe Alchemy::LiveReloadWatcher do
+  # Both the subclass and the initializers ordered around the gem's own reach
+  # into rails_live_reload internals that it does not document. An upgrade that
+  # moves them has to fail here, rather than in a browser that quietly stops
+  # reloading.
+  describe "the rails_live_reload API this builds on" do
+    it "provides the initializers the engine orders against" do
+      expect(RailsLiveReload::Railtie.initializers.map(&:name)).to include(
+        "rails_live_reload.middleware",
+        "rails_live_reload.watcher",
+        "rails_live_reload.configure_metrics"
+      )
+    end
+
+    it "allows toggling the gem's own watcher off and on" do
+      expect(RailsLiveReload).to respond_to(:enabled?)
+      expect(RailsLiveReload.config).to respond_to(:enabled=)
+    end
+
+    it "exposes the watch patterns as regexps" do
+      expect(RailsLiveReload.patterns.keys).to all(be_a(Regexp))
+    end
+
+    it "defines the methods the subclass overrides and relies on" do
+      expect(RailsLiveReload::Watcher.instance_methods).to include(:build_tree, :files)
+    end
+  end
+
+  describe "the configured patterns" do
+    it "ignores the directories written while serving a request" do
+      expect(RailsLiveReload.ignore_patterns).to include(
+        %r{^node_modules/},
+        %r{^(db|storage|coverage)/}
+      )
+    end
+
+    it "ignores everything below spec except the dummy app's own sources" do
+      pattern = RailsLiveReload.ignore_patterns.detect { |p| p.source.include?("spec") }
+
+      expect("spec/dummy/log/development.log").to match(pattern)
+      expect("spec/models/alchemy/page_spec.rb").to match(pattern)
+      expect("spec/dummy/app/views/layouts/application.html.erb").to_not match(pattern)
+    end
+  end
+
+  describe "#build_tree" do
+    # The inherited constructor opens a socket and starts a listener thread.
+    # Only the tree building is under test, so it is skipped.
+    subject(:watcher) do
+      described_class.allocate.tap { |w| w.instance_variable_set(:@files, {}) }
+    end
+
+    let(:root) { Pathname.new(Dir.mktmpdir).realpath }
+
+    let(:fixtures) do
+      %w[
+        app/views/alchemy/pages/show.html.erb
+        app/assets/builds/alchemy/admin.css
+        app/javascript/alchemy_admin/components/node_select.js
+        app/components/alchemy/foo_component.rb
+        app/models/alchemy/page.rb
+        config/locales/alchemy.en.yml
+        vendor/javascript/sortable.min.js
+        node_modules/sortablejs/dist/sortable.js
+      ]
+    end
+
+    before do
+      fixtures.each do |path|
+        file = root.join(path)
+        FileUtils.mkdir_p(file.dirname)
+        FileUtils.touch(file)
+      end
+      allow(watcher).to receive(:root).and_return(root)
+    end
+
+    after { FileUtils.remove_entry(root) }
+
+    def tracked
+      watcher.build_tree
+      watcher.files.keys.map { |file| Pathname.new(file).relative_path_from(root).to_s }
+    end
+
+    it "tracks only the files a watch pattern can match" do
+      expect(tracked).to match_array(%w[
+        app/views/alchemy/pages/show.html.erb
+        app/assets/builds/alchemy/admin.css
+        app/javascript/alchemy_admin/components/node_select.js
+        app/components/alchemy/foo_component.rb
+        config/locales/alchemy.en.yml
+      ])
+    end
+
+    it "does not track node_modules" do
+      expect(tracked).to_not include(a_string_matching("node_modules"))
+    end
+
+    it "does not track files no pattern can match" do
+      expect(tracked).to_not include("app/models/alchemy/page.rb")
+    end
+
+    # The asset pattern expects a directory between `javascript/` and the file,
+    # but the vendored bundles sit directly in `vendor/javascript`, so none of
+    # them are watched. Rebuilding them does not reload the browser. This is
+    # inherited from the gem's default configuration rather than intended, and
+    # the assertion is here to record it until the pattern is widened.
+    it "does not track the vendored bundles" do
+      expect(tracked).to_not include("vendor/javascript/sortable.min.js")
+    end
+
+    it "records the mtime of every tracked file" do
+      watcher.build_tree
+
+      expect(watcher.files.values).to all(be_an(Integer))
+    end
+
+    context "when the application lives inside the engine root" do
+      let(:app_root) { root.join("spec/dummy") }
+
+      before do
+        file = app_root.join("app/views/layouts/application.html.erb")
+        FileUtils.mkdir_p(file.dirname)
+        FileUtils.touch(file)
+        allow(Rails.application).to receive(:root).and_return(app_root)
+      end
+
+      it "covers the application as well" do
+        expect(tracked).to include("spec/dummy/app/views/layouts/application.html.erb")
+      end
+    end
+
+    context "when the application lives outside the engine root" do
+      before do
+        allow(Rails.application).to receive(:root).and_return(Pathname.new("/somewhere/else"))
+      end
+
+      it "only tracks the engine" do
+        expect { tracked }.to_not raise_error
+        expect(tracked).to_not include(a_string_matching("somewhere/else"))
+      end
+    end
+  end
+end

--- a/spec/libraries/alchemy/engine_spec.rb
+++ b/spec/libraries/alchemy/engine_spec.rb
@@ -34,6 +34,107 @@ RSpec.describe Alchemy::Engine do
     end
   end
 
+  describe ".watch_engine_files?" do
+    subject { described_class.watch_engine_files? }
+
+    context "in development, with the application inside the engine root" do
+      before do
+        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
+        allow(Rails.application).to receive(:root).and_return(described_class.root.join("spec/dummy"))
+      end
+
+      it { is_expected.to be(true) }
+    end
+
+    context "in development, with the application outside the engine root" do
+      before do
+        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
+        allow(Rails.application).to receive(:root).and_return(Pathname.new("/somewhere/else"))
+      end
+
+      it { is_expected.to be(false) }
+    end
+
+    context "outside of development" do
+      before do
+        allow(Rails.application).to receive(:root).and_return(described_class.root.join("spec/dummy"))
+      end
+
+      it { is_expected.to be(false) }
+    end
+
+    context "without rails_live_reload" do
+      before do
+        hide_const("RailsLiveReload")
+        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
+        allow(Rails.application).to receive(:root).and_return(described_class.root.join("spec/dummy"))
+      end
+
+      it { is_expected.to be_falsey }
+    end
+  end
+
+  # Two watchers over the same tree fight over one socket, and the gem offers no
+  # hook to skip its own. It is disabled for the length of that one initializer
+  # instead, so both halves have to stay paired.
+  describe "toggling the gem's own watcher" do
+    # The pair hands the previous setting over in an instance variable, so both
+    # halves have to run against the engine instance they are bound to at boot.
+    # The unbound class level collection carries a nil context.
+    def initializer(name)
+      described_class.instance.initializers.detect { _1.name == name }
+    end
+
+    around do |example|
+      was_enabled = RailsLiveReload.config.enabled
+      example.run
+      RailsLiveReload.config.enabled = was_enabled
+    end
+
+    context "when Alchemy is developed from a checkout" do
+      before do
+        allow(described_class).to receive(:watch_engine_files?).and_return(true)
+        RailsLiveReload.config.enabled = true
+      end
+
+      it "disables the gem's watcher before the gem starts it" do
+        initializer("alchemy.disable_live_reload_watcher").run(Rails.application)
+
+        expect(RailsLiveReload.config.enabled).to be(false)
+      end
+
+      it "restores the previous setting once the gem is past it" do
+        initializer("alchemy.disable_live_reload_watcher").run(Rails.application)
+        initializer("alchemy.restore_live_reload").run(Rails.application)
+
+        expect(RailsLiveReload.config.enabled).to be(true)
+      end
+    end
+
+    context "when Alchemy is installed as a gem" do
+      before do
+        allow(described_class).to receive(:watch_engine_files?).and_return(false)
+        RailsLiveReload.config.enabled = true
+      end
+
+      it "leaves the gem's watcher alone" do
+        initializer("alchemy.disable_live_reload_watcher").run(Rails.application)
+
+        expect(RailsLiveReload.config.enabled).to be(true)
+      end
+    end
+
+    it "disables the watcher after the gem's middleware and before its watcher" do
+      expect(initializer("alchemy.disable_live_reload_watcher").after).to eq("rails_live_reload.middleware")
+      expect(initializer("alchemy.disable_live_reload_watcher").before).to eq("rails_live_reload.watcher")
+    end
+
+    it "restores the setting after the gem's watcher and before its metrics" do
+      expect(initializer("alchemy.restore_live_reload").after).to eq("rails_live_reload.watcher")
+      expect(initializer("alchemy.restore_live_reload").before).to eq("rails_live_reload.configure_metrics")
+    end
+  end
+
   describe "alchemy.importmap" do
     let(:additional_importmap) do
       Alchemy::Configurations::Importmap.new(


### PR DESCRIPTION
## What is this pull request for?

`rails_live_reload` starts a watcher rooted at the application and we add a second one rooted at the engine. In an Alchemy checkout the engine root contains the dummy app, so both watch the same tree and compete for the same Unix socket, which logs an `Errno::ENOENT` on every boot and leaves it to a race which one reaches the server. The gem has no hook to skip its own watcher, so it is disabled for the length of that one initializer, leaving a single watcher that covers the engine and the dummy app.

That watcher also tracked everything below the engine root, `node_modules` included: 1449 files, of which only 447 can ever match a watch pattern. The whole map is serialized to every connected browser on each change, so it now only holds files a pattern can actually match. Directories written while merely serving a request are ignored, so they cannot wake the watcher.

Keeping a single watcher costs a subclass of `RailsLiveReload::Watcher` and a pair of initializers ordered around the gem's own, all of which reach into internals the gem neither documents nor promises. Nothing about that coupling fails loudly on its own: if an upgrade renames an initializer or moves a method, live reload simply stops working and the next person spends an afternoon finding out why. The specs assert that surface directly, so the upgrade breaks the suite instead.

### Notable changes

The specs record one pre-existing gap rather than quietly fixing it, since it is outside the scope of this change. The asset watch pattern expects a directory between `javascript/` and the filename, while the vendored bundles sit directly in `vendor/javascript`, so none of them are watched and rebuilding them never reloads the browser. Widening the pattern is a separate call.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change