### PR TITLE
[8.0-stable] fix(ingredients): Escape and sanitize author supplied ingredient values

### DIFF
--- a/app/components/alchemy/ingredients/base_view.rb
+++ b/app/components/alchemy/ingredients/base_view.rb
@@ -16,7 +16,7 @@ module Alchemy
       end
 
       def call
-        value.html_safe
+        h(value)
       end
 
       def render?

--- a/app/components/alchemy/ingredients/picture_view.rb
+++ b/app/components/alchemy/ingredients/picture_view.rb
@@ -68,7 +68,7 @@ module Alchemy
       def caption
         return unless show_caption?
 
-        @_caption ||= content_tag(:figcaption, ingredient.caption.html_safe)
+        @_caption ||= content_tag(:figcaption, sanitize(ingredient.caption))
       end
 
       def src

--- a/app/components/alchemy/ingredients/text_view.rb
+++ b/app/components/alchemy/ingredients/text_view.rb
@@ -18,7 +18,7 @@ module Alchemy
 
       def call
         if disable_link?
-          dom_id.present? ? anchor : value
+          dom_id.present? ? anchor : h(value)
         else
           link_to(value, url_for(link), {
             id: dom_id.presence,
@@ -26,7 +26,7 @@ module Alchemy
             target: link_target_value(link_target),
             rel: link_rel_value(link_target)
           }.merge(html_options))
-        end.html_safe
+        end
       end
 
       private

--- a/spec/components/alchemy/ingredients/base_view_spec.rb
+++ b/spec/components/alchemy/ingredients/base_view_spec.rb
@@ -46,4 +46,14 @@ RSpec.describe Alchemy::Ingredients::BaseView do
       end
     end
   end
+
+  describe "#call", type: :component do
+    let(:ingredient) { Alchemy::Ingredients::Text.new(role: "headline", value: "<script>alert('XSS')</script>") }
+
+    it "escapes the value" do
+      render_inline described_class.new(ingredient)
+      expect(rendered_content).to include("&lt;script&gt;")
+      expect(rendered_content).to_not include("<script>")
+    end
+  end
 end

--- a/spec/components/alchemy/ingredients/picture_view_spec.rb
+++ b/spec/components/alchemy/ingredients/picture_view_spec.rb
@@ -68,6 +68,23 @@ RSpec.describe Alchemy::Ingredients::PictureView, type: :component do
       end
     end
 
+    context "having script tags" do
+      let(:ingredient) do
+        stub_model Alchemy::Ingredients::Picture,
+          role: "image",
+          picture: picture,
+          data: {
+            caption: "Cute<br />cat<script>alert('XSS')</script>"
+          }
+      end
+
+      it "sanitizes the caption, but keeps allowed tags" do
+        render_view
+        expect(rendered_content).to include("Cute<br>cat")
+        expect(rendered_content).to_not include("<script>")
+      end
+    end
+
     it "does not pass default options to picture url" do
       expect(ingredient).to receive(:picture_url).with({}) { picture_url }
       render_view

--- a/spec/components/alchemy/ingredients/select_view_spec.rb
+++ b/spec/components/alchemy/ingredients/select_view_spec.rb
@@ -18,4 +18,14 @@ RSpec.describe Alchemy::Ingredients::SelectView, type: :component do
       expect(page).to have_content("")
     end
   end
+
+  context "with a value containing html" do
+    let(:ingredient) { Alchemy::Ingredients::Select.new(value: "<script>alert('XSS')</script>") }
+
+    it "escapes the value" do
+      render_inline described_class.new(ingredient)
+      expect(rendered_content).to include("&lt;script&gt;")
+      expect(rendered_content).to_not include("<script>")
+    end
+  end
 end

--- a/spec/components/alchemy/ingredients/text_view_spec.rb
+++ b/spec/components/alchemy/ingredients/text_view_spec.rb
@@ -136,4 +136,14 @@ RSpec.describe Alchemy::Ingredients::TextView, type: :component do
       end
     end
   end
+
+  context "with a value containing html" do
+    let(:ingredient) { Alchemy::Ingredients::Text.new(value: "<script>alert('XSS')</script>") }
+
+    it "escapes the value" do
+      render_inline described_class.new(ingredient)
+      expect(rendered_content).to include("&lt;script&gt;")
+      expect(rendered_content).to_not include("<script>")
+    end
+  end
 end


### PR DESCRIPTION
Manual backport of #4081 to 8.0-stable. The automated backport failed, so this was cherry picked by hand.

The three source changes apply unchanged, because `BaseView`, `TextView` and `PictureView` are identical on this branch. Only `select_view_spec.rb` conflicted: the multiple selection contexts it carries on main describe a feature 8.0 does not have, since `SelectView` here is still an empty subclass that inherits `BaseView#call` outright. Those contexts were dropped and only the escaping test was taken, which means the `BaseView` fix covers select ingredients on this branch even more directly than it does on main.

Verified on 8.0-stable rather than assumed: the ingredient component specs pass at 100 examples, 0 failures, and rendering each affected component with a script payload confirms all three now escape or sanitize it. Captions still emit `br` tags, so the textarea caption behaviour this branch relies on is preserved.

Fixes GHSA-7m8w-vg9p-qjr6 and GHSA-pm72-wq9v-wvfh on 8.0.