### PR TITLE
fix(richtext): Apply the sanitizer setting to rendered output

### DIFF
--- a/app/components/alchemy/ingredients/richtext_view.rb
+++ b/app/components/alchemy/ingredients/richtext_view.rb
@@ -3,6 +3,8 @@ module Alchemy
     class RichtextView < BaseView
       attr_reader :plain_text
 
+      delegate :sanitizer_settings, to: :ingredient
+
       # @param ingredient [Alchemy::Ingredient]
       # @param plain_text [Boolean] (false) Whether to show as plain text or with markup
       def initialize(ingredient, plain_text: nil, html_options: {})
@@ -13,6 +15,8 @@ module Alchemy
       def call
         if plain_text
           ingredient.stripped_body
+        elsif sanitizer_settings.present?
+          sanitize(value.to_s, **sanitizer_settings)
         else
           value.to_s.html_safe
         end.html_safe

--- a/app/models/alchemy/ingredients/richtext.rb
+++ b/app/models/alchemy/ingredients/richtext.rb
@@ -36,6 +36,10 @@ module Alchemy
         settings[:tinymce] || {}
       end
 
+      def sanitizer_settings
+        settings[:sanitizer] || {}
+      end
+
       private
 
       def strip_content
@@ -47,10 +51,6 @@ module Alchemy
           value,
           sanitizer_settings
         )
-      end
-
-      def sanitizer_settings
-        settings[:sanitizer] || {}
       end
     end
   end

--- a/spec/components/alchemy/ingredients/richtext_view_spec.rb
+++ b/spec/components/alchemy/ingredients/richtext_view_spec.rb
@@ -45,4 +45,28 @@ RSpec.describe Alchemy::Ingredients::RichtextView, type: :component do
       end
     end
   end
+
+  context "without ingredient.settings[:sanitizer]" do
+    it "renders the value unsanitized" do
+      is_expected.to have_selector("h1")
+    end
+  end
+
+  context "with ingredient.settings[:sanitizer]" do
+    before do
+      allow(ingredient).to receive(:settings).and_return({sanitizer: {tags: ["p"]}})
+    end
+
+    it "renders only the allowed tags" do
+      is_expected.to have_content("Lorem ipsum dolor sit amet consectetur adipiscing elit.")
+      is_expected.to_not have_selector("h1")
+      is_expected.to have_selector("p")
+    end
+
+    it "applies the current settings, even if the ingredient was not saved since" do
+      allow(ingredient).to receive(:settings).and_return({sanitizer: {tags: ["h1"]}})
+      is_expected.to have_selector("h1")
+      is_expected.to_not have_selector("p")
+    end
+  end
 end


### PR DESCRIPTION
## What is this pull request for?

Setting `sanitizer:` on a Richtext ingredient in `elements.yml` currently only shapes the stored `sanitized_body` field, and the default HTML renderer does not render that field. It is only used in the json-api gem currently. So a developer who configures an allow list gets no sanitization on the published page via the default HTML output.

`RichtextView` now sanitizes when a sanitizer is configured and keeps rendering the raw value when it is not, so anyone who never set the option is completely unaffected. That distinction matters more than it sounds: Rails' default safe list removes iframes, tables and figures outright, so sanitizing by default would quietly gut existing content on upgrade. Only sites that explicitly opted in see any change.

Sanitizing while rendering rather than reading the stored snapshot is deliberate. `sanitized_body` is only written in a `before_save`, so it goes stale the moment `elements.yml` changes, which would reproduce the very confusion this fixes, and it is `nil` for records untouched since the field was introduced in 2021, which would render those pages blank. Sanitizing at render costs roughly 1ms per richtext blob, paid only by opted-in sites and absorbed by fragment caching.

The stored field and its callback are left exactly as they are. It has been public API since #2055 and sites may render it in their own views, so removing it would break them for no gain.

### Notable changes

Sites that configured `sanitizer:` will see their rendered richtext change, in the direction they originally intended. Their content was never actually being sanitized before, and now it is. Sites without the setting render byte for byte what they rendered previously.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change