### PR TITLE
chore: Fix dummy app ability

### DIFF
--- a/spec/controllers/alchemy/admin/resources_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/resources_controller_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe Alchemy::Admin::ResourcesController do
     expect(controller.respond_to?(:resource_window_size)).to be_truthy
   end
 
+  before do
+    authorize_user(:as_admin)
+  end
+
   describe "#index" do
     let(:params) { {} }
     let!(:peter) { create(:event, name: "Peter") }
     let!(:lustig) { create(:event, name: "Lustig") }
-
-    before do
-      authorize_user(:as_admin)
-    end
 
     it "returns all records" do
       get :index, params: params

--- a/spec/controllers/alchemy/admin/translations_spec.rb
+++ b/spec/controllers/alchemy/admin/translations_spec.rb
@@ -6,7 +6,7 @@ describe Alchemy::Admin::DashboardController do
   routes { Alchemy::Engine.routes }
 
   context "in admin backend" do
-    let(:dummy_user) { mock_model(Alchemy.config.user_class, alchemy_roles: %w[admin], language: "de") }
+    let(:dummy_user) { mock_model(Alchemy.config.user_class, alchemy_roles: %w[admin], language: "de", admin?: true) }
 
     before { authorize_user(dummy_user) }
 
@@ -49,7 +49,7 @@ describe Alchemy::Admin::DashboardController do
       end
 
       context "if user has no preferred locale" do
-        let(:dummy_user) { mock_model(Alchemy.config.user_class, alchemy_roles: %w[admin], language: nil) }
+        let(:dummy_user) { mock_model(Alchemy.config.user_class, alchemy_roles: %w[admin], language: nil, admin?: true) }
 
         context "if locale is available" do
           before do
@@ -66,7 +66,7 @@ describe Alchemy::Admin::DashboardController do
 
           context "if user language is an instance of a model" do
             let(:language) { create(:alchemy_language) }
-            let(:dummy_user) { mock_model(Alchemy.config.user_class, alchemy_roles: %w[admin], language: language) }
+            let(:dummy_user) { mock_model(Alchemy.config.user_class, alchemy_roles: %w[admin], language: language, admin?: true) }
 
             context "if language doesn't return a valid locale symbol" do
               it "should use the browsers language setting" do

--- a/spec/dummy/app/models/ability.rb
+++ b/spec/dummy/app/models/ability.rb
@@ -3,14 +3,16 @@
 class Ability
   include CanCan::Ability
 
-  def initialize(*)
-    can :manage, Event
-    can :index, :admin_events
-    can :manage, Location
-    can :index, :admin_locations
-    can :manage, Series
-    can :index, :admin_series
-    can :manage, Booking
-    can :index, :admin_bookings
+  def initialize(user)
+    if user&.admin?
+      can :manage, Event
+      can :index, :admin_events
+      can :manage, Location
+      can :index, :admin_locations
+      can :manage, Series
+      can :index, :admin_series
+      can :manage, Booking
+      can :index, :admin_bookings
+    end
   end
 end

--- a/spec/requests/alchemy/admin/resources_requests_spec.rb
+++ b/spec/requests/alchemy/admin/resources_requests_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe "Resource requests" do
     }
   end
 
-  describe "create from a dialog" do
-    before { authorize_user(:as_admin) }
+  before { authorize_user(:as_admin) }
 
+  describe "create from a dialog" do
     context "with invalid params" do
       it "re-renders the form wrapped in the dialog frame with a 422" do
         post "/admin/events", params: {event: {name: ""}}, headers: dialog_headers
@@ -40,8 +40,6 @@ RSpec.describe "Resource requests" do
   end
 
   describe "create outside a dialog" do
-    before { authorize_user(:as_admin) }
-
     it "re-renders the form unwrapped with a 422" do
       post "/admin/events", params: {event: {name: ""}}
 


### PR DESCRIPTION
## What is this pull request for?

Now that we use alchemy-devise in the dummy app,
we need a real ability that only allows admins to access the custom modules.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have updated tests to cover this change
