### PR TITLE
Docs(config): describe how link_target_options values are applied

### DIFF
--- a/config/alchemy/config.yml
+++ b/config/alchemy/config.yml
@@ -181,8 +181,11 @@ uploader:
 
 # === Link Target Options
 #
-# Values for the link target selectbox inside the page link overlay.
-# The value gets attached as a data-link-target attribute to the link.
+# Values for the link target selectbox inside the link dialog.
+#
+# Each value is stored with a leading underscore, so that it can be used as the
+# link's `target` attribute right away: `blank` is stored as `_blank` and
+# rendered as `target="_blank"`.
 #
 link_target_options: [blank]
 

--- a/lib/alchemy/configurations/main.rb
+++ b/lib/alchemy/configurations/main.rb
@@ -178,13 +178,23 @@ module Alchemy
 
       # === Link Target Options
       #
-      # Values for the link target selectbox inside the page link overlay.
-      # The value gets attached as a data-link-target attribute to the link.
+      # Values for the link target selectbox inside the link dialog.
+      #
+      # Each value is stored with a leading underscore, so that it can be used
+      # as the link's `target` attribute right away: `blank` is stored as
+      # `_blank` and rendered as `target="_blank"`. Views rendering a link
+      # themselves should pass the stored value through
+      # `Alchemy::Ingredients::LinkTarget#link_target_value`, which also maps
+      # the legacy `blank` (stored before the underscore was added) to
+      # `_blank`.
       #
       # == Example:
       #
       # Open all links set to overlay in a dialog window in your frontend code,
-      # based on the `data-link-target="overlay"` attribute.
+      # based on the `target="_overlay"` attribute. Such a target has no meaning
+      # to the browser, so your code needs to handle the click itself.
+      #
+      #   config.link_target_options = %w[blank overlay]
       #
       option :link_target_options, :collection, item_type: :string, default: %w[blank]
 

--- a/lib/generators/alchemy/install/templates/alchemy.rb.tt
+++ b/lib/generators/alchemy/install/templates/alchemy.rb.tt
@@ -179,8 +179,11 @@ Alchemy.configure do |config|
 
   # === Link Target Options
   #
-  # Values for the link target selectbox inside the page link overlay.
-  # The value gets attached as a data-link-target attribute to the link.
+  # Values for the link target selectbox inside the link dialog.
+  #
+  # Each value is stored with a leading underscore, so that it can be used as
+  # the link's `target` attribute right away: `blank` is stored as `_blank` and
+  # rendered as `target="_blank"`.
   #
   # config.link_target_options = <%= @default_config.link_target_options.map(&:to_s) %>
 

--- a/spec/dummy/config/initializers/alchemy.rb
+++ b/spec/dummy/config/initializers/alchemy.rb
@@ -223,13 +223,11 @@ Alchemy.configure do |config|
 
   # === Link Target Options
   #
-  # Values for the link target selectbox inside the page link overlay.
-  # The value gets attached as a data-link-target attribute to the link.
+  # Values for the link target selectbox inside the link dialog.
   #
-  # == Example:
-  #
-  # Open all links set to overlay in a dialog window in your frontend code,
-  # based on the `data-link-target="overlay"` attribute.
+  # Each value is stored with a leading underscore, so that it can be used as
+  # the link's `target` attribute right away: `blank` is stored as `_blank` and
+  # rendered as `target="_blank"`.
   #
   # config.link_target_options = ["blank"]
 


### PR DESCRIPTION
Hey Alchemy team 👋 First time contributing here — we recently migrated a site
over to Alchemy and ran into a small documentation snag on the way.

Before anything else: thank you for building and maintaining this CMS in the
open and giving it away for free. It carried a full site rebuild for us, editors
included, and the amount of care in it shows — that is easy to take for granted
from the outside. 🙏

## What is this pull request for?

A little docs fix. The `link_target_options` description still explains pre-8.0
behavior: it says the configured value "gets attached as a data-link-target
attribute to the link", and the example asks you to match those links with
`jQuery(a[data-link-target="overlay"]).dialog();`.

These days the value takes a different route:

* `Alchemy::Page.link_target_options` prepends an underscore to every configured
  value ("add an underscore to the options to provide the default syntax"), so the
  link dialog stores `_blank` — not `blank`.
* The ingredient views render that stored value as the link's `target` attribute
  (`Alchemy::Ingredients::LinkTarget`). `data-link-target` only survives as a
  marker attribute on the hidden field inside the ingredient editor, so a frontend
  selector matching on it can never match.

That is easy to act on and hard to debug: an application that renders a `Link`
ingredient in its own view component follows the documentation, compares the
stored value against the bare `"blank"`, and quietly drops the setting for every
link an editor sets — a missing `target` looks exactly like "same window". 🙈

We walked into precisely that while migrating a site from another CMS, where a
1:1 content migration writes the ingredients directly: the configured option is
`blank`, so that is what a migration seeds, while the dialog stores `_blank`. A
small trap, but a real one — and since the installer copies these comments into
every new application, one corrected sentence felt worth a PR.

So this rewrites the description in the three places it is duplicated (the
configuration class, the installer template and `config/alchemy/config.yml`, plus
the dummy app's generated initializer), documents the underscore, points at
`Alchemy::Ingredients::LinkTarget#link_target_value` for views that render a link
themselves (it also maps the legacy `blank` value), and corrects the `overlay`
example.

The same sentence lives in the guides, so there is a companion PR over there:
AlchemyCMS/alchemy-guides#282. Happy to reword any of this if you
would put it differently — and thanks in advance for taking the time to look. 🙂

### Notable changes (remove if none)

None — comments only, no behavior change.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change — documentation only
