### PR TITLE
chore: Convert uploader button into a view component

### DIFF
--- a/app/components/alchemy/admin/uploader_button.rb
+++ b/app/components/alchemy/admin/uploader_button.rb
@@ -1,0 +1,58 @@
+module Alchemy
+  module Admin
+    class UploaderButton < ViewComponent::Base
+      delegate :alchemy, to: :helpers
+
+      attr_reader :object, :file_attribute, :accept, :dropzone, :redirect_url
+
+      def initialize(object:, file_attribute:, redirect_url:, accept: nil, dropzone: nil, label: nil)
+        @object = object
+        @file_attribute = file_attribute
+        @redirect_url = redirect_url
+        @dropzone = dropzone || "#main_content"
+        @label = label
+        @accept = accept || ((file_types.to_a == ["*"]) ? nil : file_types.map { |type| ".#{type}" }.join(", "))
+      end
+
+      def call
+        content_tag "alchemy-uploader", "redirect-url": redirect_url, dropzone: do
+          form_for [alchemy, :admin, object], html: {multipart: true, class: "upload-button"} do |f|
+            safe_join([upload_hash_field(f), file_input(f), upload_label(f)].compact)
+          end
+        end
+      end
+
+      private
+
+      def upload_hash_field(f)
+        return unless object.respond_to?(:upload_hash)
+
+        f.hidden_field(:upload_hash, name: "#{f.object_name}[upload_hash]", value: Time.current.hash)
+      end
+
+      def file_input(f)
+        f.file_field file_attribute,
+          class: "fileupload fileupload--field", multiple: true, accept: accept,
+          name: "#{f.object_name}[#{file_attribute}]", tabindex: "-1"
+      end
+
+      def upload_label(f)
+        f.label file_attribute, data: {alchemy_hotkey: "alt+n"} do
+          content_tag "sl-tooltip", content: tooltip, placement: "top-start" do
+            tag.span class: "icon_button", tabindex: "0" do
+              render Alchemy::Admin::Icon.new("upload-2")
+            end
+          end
+        end
+      end
+
+      def tooltip
+        @label.presence || Alchemy.t(:button_label, scope: [:uploader, object.class.model_name.i18n_key])
+      end
+
+      def file_types
+        Alchemy.config.uploader.allowed_filetypes[object.class.model_name.collection] || ["*"]
+      end
+    end
+  end
+end

--- a/app/views/alchemy/admin/attachments/_archive_overlay.html.erb
+++ b/app/views/alchemy/admin/attachments/_archive_overlay.html.erb
@@ -3,11 +3,10 @@
     <div class="toolbar_buttons">
       <% if can? :create, Alchemy::Attachment %>
         <div class="toolbar_button">
-          <%= render 'alchemy/admin/uploader/button',
+          <%= render Alchemy::Admin::UploaderButton.new(
             object: Alchemy::Attachment.new,
             dropzone: '#assign_file_list',
             file_attribute: 'file',
-            in_dialog: true,
             accept: Array(search_filter_params[:only]).map { |extension|
               Marcel::MimeType.for(extension:)
             }.join(",").presence,
@@ -18,7 +17,8 @@
               q: search_filter_params[:q].merge(
                 last_upload: true
               )
-            ) %>
+            )
+          ) %>
         </div>
       <% end %>
     </div>

--- a/app/views/alchemy/admin/attachments/index.html.erb
+++ b/app/views/alchemy/admin/attachments/index.html.erb
@@ -2,12 +2,13 @@
   <div class="toolbar_buttons">
     <% if can? :create, Alchemy::Attachment %>
       <div class="toolbar_button">
-        <%= render 'alchemy/admin/uploader/button',
+        <%= render Alchemy::Admin::UploaderButton.new(
           redirect_url: alchemy.admin_attachments_path(q: {
             last_upload: true
           }),
           object: Alchemy::Attachment.new,
-          file_attribute: 'file' %>
+          file_attribute: 'file'
+        ) %>
       </div>
     <% end %>
   </div>

--- a/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
+++ b/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
@@ -1,16 +1,16 @@
 <div class="toolbar_buttons">
   <% if can? :create, Alchemy::Picture %>
     <div class="toolbar_button">
-      <%= render 'alchemy/admin/uploader/button',
+      <%= render Alchemy::Admin::UploaderButton.new(
         object: Alchemy::Picture.new,
         dropzone: '#assign_image_list',
         file_attribute: 'image_file',
-        in_dialog: true,
         redirect_url: alchemy.admin_pictures_path(
           size: search_filter_params[:size],
           q: { last_upload: true },
           form_field_id: @form_field_id
-        ) %>
+        )
+      ) %>
     </div>
     <div class="toolbar_spacer"></div>
   <% end %>

--- a/app/views/alchemy/admin/pictures/index.html.erb
+++ b/app/views/alchemy/admin/pictures/index.html.erb
@@ -2,13 +2,14 @@
   <div class="toolbar_buttons">
     <% if can? :create, Alchemy::Picture %>
       <div class="toolbar_button">
-        <%= render 'alchemy/admin/uploader/button',
+        <%= render Alchemy::Admin::UploaderButton.new(
           object: Alchemy::Picture.new,
           file_attribute: 'image_file',
           redirect_url: alchemy.admin_pictures_path(
             size: @size,
             q: { last_upload: true }
-          ) %>
+          )
+        ) %>
       </div>
       <div class="toolbar_spacer"></div>
     <% end %>

--- a/app/views/alchemy/admin/resources/index.html.erb
+++ b/app/views/alchemy/admin/resources/index.html.erb
@@ -1,16 +1,13 @@
-<% label_title = Alchemy.t("Create #{resource_name}", default: Alchemy.t('Create')) %>
-
 <% content_for(:toolbar) do %>
   <div class="toolbar_buttons">
     <%= render Alchemy::Admin::ToolbarButton.new(
       icon: "add",
-      label: label_title,
+      label: Alchemy.t("Add #{resource_name}"),
       url: new_resource_path,
-      title: label_title,
       hotkey: 'alt+n',
       tooltip_placement: "top-start",
       dialog_options: {
-        title: label_title,
+        title: Alchemy.t("Create #{resource_name}", default: Alchemy.t('Create')),
         size: resource_window_size
       },
       if_permitted_to: [:create, resource_model]

--- a/app/views/alchemy/admin/uploader/_button.html.erb
+++ b/app/views/alchemy/admin/uploader/_button.html.erb
@@ -1,17 +1,10 @@
-<% file_types = Alchemy.config.uploader.allowed_filetypes[object.class.model_name.collection] || ['*'] %>
-<% accept ||= file_types.to_a == ["*"] ? nil : file_types.map {|type| ".#{type}"}.join(", ") %>
-
-<alchemy-uploader redirect-url="<%= redirect_url %>" dropzone="<%= local_assigns[:dropzone] || "#main_content" %>">
-  <%= form_for [:admin, object], html: { multipart: true, class: 'upload-button' } do |f| %>
-    <%= f.file_field file_attribute,
-      class: 'fileupload fileupload--field', multiple: true, accept: accept,
-      name: "#{f.object_name}[#{file_attribute}]", tabindex: '-1' %>
-    <%= hidden_field_tag("#{f.object_name}[upload_hash]", Time.current.hash) if object.respond_to?(:upload_hash) %>
-    <%= f.label file_attribute, data: { alchemy_hotkey: 'alt+n' } do %>
-      <%= content_tag "sl-tooltip", content: local_assigns[:label] ||
-                Alchemy.t(:button_label, scope: [:uploader, object.class.model_name.i18n_key]), placement: "top-start" do %>
-        <span class="icon_button" tabindex="0"><%= render_icon "upload-2" %></span>
-      <% end %>
-    <% end %>
-  <% end %>
-</alchemy-uploader>
+<% Alchemy::Deprecation.warn(
+  "Rendering the `alchemy/admin/uploader/button` partial is deprecated! `render Alchemy::Admin::UploaderButton.new` instead."
+) %>
+<%= render Alchemy::Admin::UploaderButton.new(
+  object:,
+  file_attribute:,
+  redirect_url:,
+  accept: local_assigns[:accept],
+  dropzone: local_assigns[:dropzone],
+  label: local_assigns[:label]) %>

--- a/spec/components/alchemy/admin/uploader_button_spec.rb
+++ b/spec/components/alchemy/admin/uploader_button_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::Admin::UploaderButton, type: :component do
+  let(:object) { Alchemy::Picture.new }
+  let(:file_attribute) { :image_file }
+  let(:redirect_url) { "/admin/pictures" }
+
+  subject(:render) do
+    render_inline(described_class.new(object:, file_attribute:, redirect_url:))
+  end
+
+  it "renders a alchemy-uploader component" do
+    render
+    expect(page).to have_selector("alchemy-uploader[redirect-url='/admin/pictures']")
+  end
+
+  context "when wildcard is configured (all file types allowed)" do
+    before do
+      allow(Alchemy.config.uploader.allowed_filetypes).to receive(:alchemy_pictures) do
+        ["*"]
+      end
+    end
+
+    it "does not render the accept attribute" do
+      render
+      expect(page).to have_selector('input[type="file"].fileupload')
+      expect(page).not_to have_selector('input[type="file"][accept]')
+    end
+  end
+
+  context "when specific file types are configured" do
+    before do
+      allow(Alchemy.config.uploader.allowed_filetypes).to receive(:alchemy_pictures) do
+        ["jpg", "png", "gif"]
+      end
+    end
+
+    it "renders the accept attribute with the correct file extensions" do
+      render
+      expect(page).to have_selector('input[type="file"].fileupload')
+      expect(page).to have_selector('input[type="file"][accept=".jpg, .png, .gif"]')
+    end
+  end
+
+  context "with Attachment object and wildcard" do
+    let(:object) { Alchemy::Attachment.new }
+    let(:file_attribute) { :file }
+
+    before do
+      allow(Alchemy.config.uploader.allowed_filetypes).to receive(:alchemy_attachments) do
+        ["*"]
+      end
+    end
+
+    it "does not render the accept attribute" do
+      render
+      expect(page).to have_selector('input[type="file"].fileupload')
+      expect(page).not_to have_selector('input[type="file"][accept]')
+    end
+  end
+
+  context "with Attachment object and specific file types" do
+    let(:object) { Alchemy::Attachment.new }
+    let(:file_attribute) { :file }
+
+    before do
+      allow(Alchemy.config.uploader.allowed_filetypes).to receive(:alchemy_attachments) do
+        ["pdf", "doc", "docx"]
+      end
+    end
+
+    it "renders the accept attribute with the correct file extensions" do
+      render
+      expect(page).to have_selector('input[type="file"].fileupload')
+      expect(page).to have_selector('input[type="file"][accept=".pdf, .doc, .docx"]')
+    end
+  end
+
+  describe "upload_hash field" do
+    context "when the object responds to upload_hash" do
+      it "renders a hidden upload_hash field" do
+        render
+        expect(page).to have_selector('input[type="hidden"][name="picture[upload_hash]"]', visible: :hidden)
+      end
+    end
+
+    context "when the object does not respond to upload_hash" do
+      let(:object) { Alchemy::Attachment.new }
+      let(:file_attribute) { :file }
+
+      it "does not render a upload_hash field" do
+        render
+        expect(page).not_to have_selector('input[name*="upload_hash"]', visible: :all)
+      end
+    end
+  end
+end

--- a/spec/views/alchemy/admin/uploader/_button.html.erb_spec.rb
+++ b/spec/views/alchemy/admin/uploader/_button.html.erb_spec.rb
@@ -2,90 +2,36 @@
 
 require "rails_helper"
 
-describe "alchemy/admin/uploader/_button.html.erb" do
+RSpec.describe "alchemy/admin/uploader/_button.html.erb" do
   let(:object) { Alchemy::Picture.new }
   let(:file_attribute) { :image_file }
   let(:redirect_url) { "/admin/pictures" }
+  let(:component) { instance_double(Alchemy::Admin::UploaderButton, render_in: "") }
+
+  subject(:render_partial) do
+    render partial: "alchemy/admin/uploader/button",
+      locals: {object:, file_attribute:, redirect_url:}
+  end
 
   before do
-    allow(view).to receive(:admin_pictures_path).and_return("/admin/pictures")
-    allow(view).to receive(:admin_attachments_path).and_return("/admin/attachments")
-    view.extend Alchemy::BaseHelper
+    allow(Alchemy::Deprecation).to receive(:warn)
+    allow(Alchemy::Admin::UploaderButton).to receive(:new).and_return(component)
   end
 
-  it "renders a alchemy-uploader component" do
-    render partial: "alchemy/admin/uploader/button",
-      locals: {object: object, file_attribute: file_attribute, redirect_url: redirect_url}
-    expect(rendered).to have_selector("alchemy-uploader[redirect-url='/admin/pictures']")
+  it "renders the UploaderButton component with the forwarded arguments" do
+    expect(Alchemy::Admin::UploaderButton).to receive(:new).with(
+      object:,
+      file_attribute:,
+      redirect_url:,
+      accept: nil,
+      dropzone: nil,
+      label: nil
+    ).and_return(component)
+    render_partial
   end
 
-  context "when wildcard is configured (all file types allowed)" do
-    before do
-      allow(Alchemy.config.uploader.allowed_filetypes).to receive(:alchemy_pictures) do
-        ["*"]
-      end
-    end
-
-    it "does not render the accept attribute" do
-      render partial: "alchemy/admin/uploader/button",
-        locals: {object: object, file_attribute: file_attribute, redirect_url: redirect_url}
-
-      expect(rendered).to have_selector('input[type="file"].fileupload')
-      expect(rendered).not_to have_selector('input[type="file"][accept]')
-    end
-  end
-
-  context "when specific file types are configured" do
-    before do
-      allow(Alchemy.config.uploader.allowed_filetypes).to receive(:alchemy_pictures) do
-        ["jpg", "png", "gif"]
-      end
-    end
-
-    it "renders the accept attribute with the correct file extensions" do
-      render partial: "alchemy/admin/uploader/button",
-        locals: {object: object, file_attribute: file_attribute, redirect_url: redirect_url}
-
-      expect(rendered).to have_selector('input[type="file"].fileupload')
-      expect(rendered).to have_selector('input[type="file"][accept=".jpg, .png, .gif"]')
-    end
-  end
-
-  context "with Attachment object and wildcard" do
-    let(:object) { Alchemy::Attachment.new }
-    let(:file_attribute) { :file }
-
-    before do
-      allow(Alchemy.config.uploader.allowed_filetypes).to receive(:alchemy_attachments) do
-        ["*"]
-      end
-    end
-
-    it "does not render the accept attribute" do
-      render partial: "alchemy/admin/uploader/button",
-        locals: {object: object, file_attribute: file_attribute, redirect_url: redirect_url}
-
-      expect(rendered).to have_selector('input[type="file"].fileupload')
-      expect(rendered).not_to have_selector('input[type="file"][accept]')
-    end
-  end
-
-  context "with Attachment object and specific file types" do
-    let(:object) { Alchemy::Attachment.new }
-    let(:file_attribute) { :file }
-
-    before do
-      allow(Alchemy.config.uploader.allowed_filetypes).to receive(:alchemy_attachments) do
-        ["pdf", "doc", "docx"]
-      end
-    end
-
-    it "renders the accept attribute with the correct file extensions" do
-      render partial: "alchemy/admin/uploader/button",
-        locals: {object: object, file_attribute: file_attribute, redirect_url: redirect_url}
-
-      expect(rendered).to have_selector('input[type="file"].fileupload')
-      expect(rendered).to have_selector('input[type="file"][accept=".pdf, .doc, .docx"]')
-    end
+  it "warns about the deprecation" do
+    expect(Alchemy::Deprecation).to receive(:warn)
+    render_partial
   end
 end


### PR DESCRIPTION
## What is this pull request for?

Rendering the `alchemy/admin/uploader/button` partial still works but is deprecated now.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
