### PR TITLE
[7.4] authorize nodes#index to prevent navigation tree disclosure

### DIFF
--- a/app/controllers/alchemy/api/nodes_controller.rb
+++ b/app/controllers/alchemy/api/nodes_controller.rb
@@ -6,7 +6,7 @@ module Alchemy
     before_action :authorize_access, only: [:move, :toggle_folded]
 
     def index
-      @nodes = Node.all
+      @nodes = Node.accessible_by(current_ability, :index)
       @nodes = @nodes.includes(:parent)
       @nodes = @nodes.where(language_id: params[:language_id]) if params[:language_id]
       @nodes = @nodes.ransack(params[:filter]).result.order(:lft)

--- a/app/models/alchemy/node.rb
+++ b/app/models/alchemy/node.rb
@@ -19,6 +19,27 @@ module Alchemy
       foreign_key: :related_object_id,
       inverse_of: :related_object
 
+    # All nodes of the current site whose language is published.
+    scope :from_current_public_site, -> {
+      joins(:language)
+        .where(Alchemy::Language.table_name => {site_id: Alchemy::Current.site})
+        .merge(Alchemy::Language.published)
+    }
+
+    # Nodes an anonymous visitor may see: external links or nodes attached to a
+    # published, unrestricted page, scoped to the current site.
+    scope :available_to_guests, -> {
+      from_current_public_site.where(page: nil)
+        .or(from_current_public_site.where(page: Alchemy::Page.published.not_restricted))
+    }
+
+    # Like #available_to_guests but including nodes attached to restricted pages,
+    # which logged in members are allowed to see.
+    scope :available_to_members, -> {
+      from_current_public_site.where(page: nil)
+        .or(from_current_public_site.where(page: Alchemy::Page.published))
+    }
+
     before_validation :translate_root_menu_name, if: -> { root? }
     before_validation :set_menu_type_from_root, unless: -> { root? }
 

--- a/lib/alchemy/permissions.rb
+++ b/lib/alchemy/permissions.rb
@@ -44,6 +44,11 @@ module Alchemy
         can :read, Alchemy::Page, Alchemy::Page.published.not_restricted.from_current_site do |p|
           p.public? && !p.restricted? && p.site == Alchemy::Current.site
         end
+
+        can :read, Alchemy::Node, Alchemy::Node.available_to_guests do |node|
+          node.language.public? && node.language.site_id == Alchemy::Current.site&.id &&
+            (node.page.nil? || (node.page.public? && !node.page.restricted?))
+        end
       end
     end
 
@@ -66,6 +71,11 @@ module Alchemy
 
         can :read, Alchemy::Page, Alchemy::Page.published.from_current_site do |p|
           p.public? && p.site == Alchemy::Current.site
+        end
+
+        can :read, Alchemy::Node, Alchemy::Node.available_to_members do |node|
+          node.language.public? && node.language.site_id == Alchemy::Current.site&.id &&
+            (node.page.nil? || node.page.public?)
         end
       end
     end

--- a/spec/libraries/permissions_spec.rb
+++ b/spec/libraries/permissions_spec.rb
@@ -17,6 +17,10 @@ describe Alchemy::Permissions do
   let(:published_element) { mock_model(Alchemy::Element, restricted?: false, public?: true) }
   let(:restricted_element) { mock_model(Alchemy::Element, restricted?: true, public?: true) }
   let(:language) { build(:alchemy_language) }
+  let(:public_node) { build(:alchemy_node, name: nil, page: public_page) }
+  let(:external_node) { build(:alchemy_node, :with_url) }
+  let(:restricted_node) { build(:alchemy_node, name: nil, page: restricted_page) }
+  let(:unpublished_node) { build(:alchemy_node, name: nil, page: unpublic_page) }
 
   context "A guest user" do
     let(:user) { nil }
@@ -43,6 +47,13 @@ describe Alchemy::Permissions do
       is_expected.not_to be_able_to(:show, restricted_element)
       is_expected.to be_able_to(:index, published_element)
       is_expected.not_to be_able_to(:index, restricted_element)
+    end
+
+    it "can only see nodes linking to public not restricted pages or external urls" do
+      is_expected.to be_able_to(:read, public_node)
+      is_expected.to be_able_to(:read, external_node)
+      is_expected.not_to be_able_to(:read, restricted_node)
+      is_expected.not_to be_able_to(:read, unpublished_node)
     end
   end
 
@@ -71,6 +82,13 @@ describe Alchemy::Permissions do
       is_expected.to be_able_to(:show, restricted_element)
       is_expected.to be_able_to(:index, published_element)
       is_expected.to be_able_to(:index, restricted_element)
+    end
+
+    it "can also see nodes linking to restricted pages" do
+      is_expected.to be_able_to(:read, public_node)
+      is_expected.to be_able_to(:read, external_node)
+      is_expected.to be_able_to(:read, restricted_node)
+      is_expected.not_to be_able_to(:read, unpublished_node)
     end
   end
 

--- a/spec/models/alchemy/node_spec.rb
+++ b/spec/models/alchemy/node_spec.rb
@@ -38,6 +38,81 @@ module Alchemy
       it { is_expected.to contain_exactly("main_menu", "footer_menu") }
     end
 
+    describe ".from_current_public_site" do
+      subject { described_class.from_current_public_site }
+
+      let(:default_language) { Alchemy::Language.default || create(:alchemy_language) }
+      let(:other_site) { create(:alchemy_site) }
+      let(:other_site_language) { create(:alchemy_language, :german, site: other_site) }
+      let(:non_public_language) { create(:alchemy_language, :klingon, public: false) }
+
+      let!(:current_site_node) { create(:alchemy_node, language: default_language) }
+      let!(:other_site_node) { create(:alchemy_node, language: other_site_language) }
+      let!(:non_public_language_node) { create(:alchemy_node, language: non_public_language) }
+
+      it "only returns nodes of the current site in a published language" do
+        is_expected.to contain_exactly(current_site_node)
+      end
+    end
+
+    describe ".available_to_guests" do
+      subject { described_class.available_to_guests }
+
+      let(:default_language) { Alchemy::Language.default || create(:alchemy_language) }
+      let(:other_site) { create(:alchemy_site) }
+      let(:other_site_language) { create(:alchemy_language, :german, site: other_site) }
+      let(:non_public_language) { create(:alchemy_language, :klingon, public: false) }
+
+      let!(:public_page_node) do
+        create(:alchemy_node, name: nil, language: default_language,
+          page: create(:alchemy_page, :public, language: default_language))
+      end
+      let!(:external_node) { create(:alchemy_node, :with_url, language: default_language) }
+      let!(:restricted_page_node) do
+        create(:alchemy_node, name: nil, language: default_language,
+          page: create(:alchemy_page, :public, :restricted, language: default_language))
+      end
+      let!(:unpublished_page_node) do
+        create(:alchemy_node, name: nil, language: default_language,
+          page: create(:alchemy_page, language: default_language))
+      end
+      let!(:other_site_node) { create(:alchemy_node, :with_url, language: other_site_language) }
+      let!(:non_public_language_node) { create(:alchemy_node, :with_url, language: non_public_language) }
+
+      it "returns external nodes and nodes with a published, unrestricted page of the current site" do
+        is_expected.to contain_exactly(public_page_node, external_node)
+      end
+    end
+
+    describe ".available_to_members" do
+      subject { described_class.available_to_members }
+
+      let(:default_language) { Alchemy::Language.default || create(:alchemy_language) }
+      let(:other_site) { create(:alchemy_site) }
+      let(:other_site_language) { create(:alchemy_language, :german, site: other_site) }
+      let(:non_public_language) { create(:alchemy_language, :klingon, public: false) }
+
+      let!(:public_page_node) do
+        create(:alchemy_node, name: nil, language: default_language,
+          page: create(:alchemy_page, :public, language: default_language))
+      end
+      let!(:external_node) { create(:alchemy_node, :with_url, language: default_language) }
+      let!(:restricted_page_node) do
+        create(:alchemy_node, name: nil, language: default_language,
+          page: create(:alchemy_page, :public, :restricted, language: default_language))
+      end
+      let!(:unpublished_page_node) do
+        create(:alchemy_node, name: nil, language: default_language,
+          page: create(:alchemy_page, language: default_language))
+      end
+      let!(:other_site_node) { create(:alchemy_node, :with_url, language: other_site_language) }
+      let!(:non_public_language_node) { create(:alchemy_node, :with_url, language: non_public_language) }
+
+      it "also returns nodes with a restricted page but still excludes unpublished, foreign site and non-public language nodes" do
+        is_expected.to contain_exactly(public_page_node, external_node, restricted_page_node)
+      end
+    end
+
     describe "#url" do
       it "is valid with leading slash" do
         expect(build(:alchemy_node, url: "/something")).to be_valid

--- a/spec/requests/alchemy/api/nodes_controller_spec.rb
+++ b/spec/requests/alchemy/api/nodes_controller_spec.rb
@@ -80,6 +80,61 @@ module Alchemy
           end
         end
       end
+
+      context "with restricted, unpublished and foreign nodes present" do
+        let(:result) { JSON.parse(response.body) }
+
+        let(:default_language) { Alchemy::Language.default || create(:alchemy_language) }
+        let(:public_page) { create(:alchemy_page, :public, language: default_language) }
+        let(:restricted_page) { create(:alchemy_page, :public, :restricted, language: default_language) }
+        let(:unpublished_page) { create(:alchemy_page, language: default_language) }
+
+        let(:other_site) { create(:alchemy_site) }
+        let(:other_site_language) { create(:alchemy_language, :german, site: other_site) }
+        let(:hidden_language) { create(:alchemy_language, :klingon, public: false) }
+
+        let!(:public_node) { create(:alchemy_node, page: public_page, name: nil, language: default_language) }
+        let!(:external_node) { create(:alchemy_node, :with_url, language: default_language) }
+        let!(:restricted_node) { create(:alchemy_node, page: restricted_page, name: nil, language: default_language) }
+        let!(:unpublished_node) { create(:alchemy_node, page: unpublished_page, name: nil, language: default_language) }
+        let!(:other_site_node) { create(:alchemy_node, :with_url, language: other_site_language) }
+        let!(:hidden_language_node) { create(:alchemy_node, :with_url, language: hidden_language) }
+
+        context "as guest user" do
+          it "only returns current site nodes linking to public unrestricted pages or external urls" do
+            get alchemy.api_nodes_path(params: {format: :json})
+
+            expect(result["data"].map { |n| n["id"] }).to match_array([
+              public_node.id,
+              external_node.id
+            ])
+          end
+        end
+
+        context "as member user" do
+          before { authorize_user(build(:alchemy_dummy_user)) }
+
+          it "also returns nodes linking to restricted pages" do
+            get alchemy.api_nodes_path(params: {format: :json})
+
+            expect(result["data"].map { |n| n["id"] }).to match_array([
+              public_node.id,
+              external_node.id,
+              restricted_node.id
+            ])
+          end
+        end
+
+        context "as author user" do
+          before { authorize_user(build(:alchemy_dummy_user, :as_author)) }
+
+          it "returns all nodes" do
+            get alchemy.api_nodes_path(params: {format: :json})
+
+            expect(result["data"].map { |n| n["id"] }).to match_array(Alchemy::Node.pluck(:id))
+          end
+        end
+      end
     end
 
     describe "#move" do


### PR DESCRIPTION
## What is this pull request for?

Api::NodesController#index returned Node.all with no authorization or site/language scoping, making it the only API index action without an accessible_by guard. Because a node derives its name and url from an attached page, an anonymous GET /api/nodes disclosed the names and URL paths of restricted and unpublished pages, internal URLs stored in menus, and the complete navigation tree of every other site and language on the install.

Scope the action through the ability like its sibling API actions and add guest and member read rules for Alchemy::Node that mirror the existing Page rules, so anonymous callers only see nodes of the current site in a published language that link to nothing or to a published page. Authors keep manage access, so the admin menu tree is unaffected.

(cherry picked from commit 0d7caed902e8827c77406e186defa97a5cac63d3)

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
