### PR TITLE
fix(active_storage): harden SVG attachment/picture handling against stored XSS

### DIFF
--- a/app/models/alchemy/storage_adapter/active_storage.rb
+++ b/app/models/alchemy/storage_adapter/active_storage.rb
@@ -11,6 +11,17 @@ module Alchemy
           base.after_create_commit if: :svg? do
             SanitizeSvgJob.perform_later(self, file_accessor: :image_file)
           end
+
+          # The image file's dirty state is cleared by the time
+          # +after_update_commit+ runs, so capture it here to know whether the
+          # blob was actually replaced (rather than only its metadata updated).
+          base.before_update do
+            @image_file_replaced = image_file.changed?
+          end
+
+          base.after_update_commit if: -> { @image_file_replaced && svg? } do
+            SanitizeSvgJob.perform_later(self, file_accessor: :image_file)
+          end
         end
       end
 
@@ -18,6 +29,17 @@ module Alchemy
         def self.included(base)
           base.has_one_attached :file
           base.after_create_commit if: :svg? do
+            SanitizeSvgJob.perform_later(self, file_accessor: :file)
+          end
+
+          # The file's dirty state is cleared by the time
+          # +after_update_commit+ runs, so capture it here to know whether the
+          # blob was actually replaced (rather than only its metadata updated).
+          base.before_update do
+            @file_replaced = file.changed?
+          end
+
+          base.after_update_commit if: -> { @file_replaced && svg? } do
             SanitizeSvgJob.perform_later(self, file_accessor: :file)
           end
         end

--- a/lib/alchemy/engine.rb
+++ b/lib/alchemy/engine.rb
@@ -172,13 +172,12 @@ module Alchemy
       end
 
       if app.config.active_storage
-        # Rails sends svg images as attachment instead of inline.
-        # We want to display svgs and not download them.
-        unless app.config.active_storage.content_types_allowed_inline.include? svg
-          app.config.active_storage.content_types_allowed_inline += [svg]
-        end
-        # Rails renders SVG as binary for security reasons.
-        # We sanitize SVGs on upload and therefore can serve them as image.
+        # Serve SVGs with their real image/svg+xml content type so they render
+        # in <img> tags. We deliberately do NOT add svg to
+        # +content_types_allowed_inline+: an SVG opened as a top-level document
+        # executes its embedded scripts, so it must be served with an
+        # attachment (download) disposition rather than inline. <img> ignores
+        # Content-Disposition, so image display is unaffected.
         if app.config.active_storage.content_types_to_serve_as_binary.include? svg
           app.config.active_storage.content_types_to_serve_as_binary.delete(svg)
         end

--- a/spec/controllers/alchemy/attachments_controller_spec.rb
+++ b/spec/controllers/alchemy/attachments_controller_spec.rb
@@ -29,6 +29,19 @@ module Alchemy
         expect(response.headers["Content-Disposition"]).to match(/inline/)
       end
 
+      context "with an SVG attachment", if: Alchemy.storage_adapter.active_storage? do
+        let(:attachment) do
+          create(:alchemy_attachment, file: fixture_file_upload("icon.svg", "image/svg+xml"))
+        end
+
+        it "serves it with its image content type but forces a download" do
+          get :show, params: {id: attachment.id}
+          expect(response.status).to eq(200)
+          expect(response.headers["Content-Type"]).to match(%r{image/svg\+xml})
+          expect(response.headers["Content-Disposition"]).to match(/attachment/)
+        end
+      end
+
       context "adds Content-Length to header" do
         it "when downloading attachment" do
           get :download, params: {id: attachment.id}

--- a/spec/models/alchemy/attachment_spec.rb
+++ b/spec/models/alchemy/attachment_spec.rb
@@ -173,6 +173,46 @@ module Alchemy
       end
     end
 
+    describe "after update", if: Alchemy.storage_adapter.active_storage? do
+      let(:svg_file) { fixture_file_upload("icon.svg", "image/svg+xml") }
+
+      context "when the file is replaced with an SVG" do
+        let(:attachment) { create(:alchemy_attachment) }
+
+        before { attachment }
+
+        it "enqueues SanitizeSvgJob" do
+          expect {
+            attachment.update(file: svg_file)
+          }.to have_enqueued_job(StorageAdapter::ActiveStorage::SanitizeSvgJob)
+        end
+      end
+
+      context "when an existing SVG file is replaced with another SVG" do
+        let(:attachment) { create(:alchemy_attachment, file: svg_file) }
+
+        before { attachment }
+
+        it "enqueues SanitizeSvgJob" do
+          expect {
+            attachment.update(file: fixture_file_upload("icon.svg", "image/svg+xml"))
+          }.to have_enqueued_job(StorageAdapter::ActiveStorage::SanitizeSvgJob)
+        end
+      end
+
+      context "when a non-file attribute is updated on an SVG attachment" do
+        let(:attachment) { create(:alchemy_attachment, file: svg_file) }
+
+        before { attachment }
+
+        it "does not enqueue SanitizeSvgJob" do
+          expect {
+            attachment.update(name: "new name")
+          }.not_to have_enqueued_job(StorageAdapter::ActiveStorage::SanitizeSvgJob)
+        end
+      end
+    end
+
     describe ".file_types" do
       before do
         allow(Alchemy.storage_adapter).to receive(:file_formats)

--- a/spec/models/alchemy/picture_spec.rb
+++ b/spec/models/alchemy/picture_spec.rb
@@ -591,5 +591,45 @@ module Alchemy
         end
       end
     end
+
+    describe "after update", if: Alchemy.storage_adapter.active_storage? do
+      let(:svg_file) { fixture_file_upload("icon.svg", "image/svg+xml") }
+
+      context "when the image file is replaced with an SVG" do
+        let(:picture) { create(:alchemy_picture) }
+
+        before { picture }
+
+        it "enqueues SanitizeSvgJob" do
+          expect {
+            picture.update(image_file: svg_file)
+          }.to have_enqueued_job(StorageAdapter::ActiveStorage::SanitizeSvgJob)
+        end
+      end
+
+      context "when an existing SVG file is replaced with another SVG" do
+        let(:picture) { create(:alchemy_picture, image_file: svg_file) }
+
+        before { picture }
+
+        it "enqueues SanitizeSvgJob" do
+          expect {
+            picture.update(image_file: fixture_file_upload("icon.svg", "image/svg+xml"))
+          }.to have_enqueued_job(StorageAdapter::ActiveStorage::SanitizeSvgJob)
+        end
+      end
+
+      context "when a non-file attribute is updated on an SVG picture" do
+        let(:picture) { create(:alchemy_picture, image_file: svg_file) }
+
+        before { picture }
+
+        it "does not enqueue SanitizeSvgJob" do
+          expect {
+            picture.update(name: "new name")
+          }.not_to have_enqueued_job(StorageAdapter::ActiveStorage::SanitizeSvgJob)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## What is this pull request for?

Fixes a stored XSS via SVG attachments/pictures. Two independent gaps let
attacker-controlled SVG reach a victim's browser and execute in the app origin:

1. **Sanitization only ran on create.** `SanitizeSvgJob` was wired to
   `after_create_commit` only, so replacing an existing attachment's or
   picture's file through the admin `update` action never re-sanitized the
   blob. An `editor` could swap in an SVG with `<script>`/`onload` payloads
   past the scrubber.

2. **SVG was served inline.** Alchemy added `image/svg+xml` to
   `content_types_allowed_inline`, so the public attachment `show` route and
   picture blob URLs served SVG with an inline disposition. An SVG opened as a
   top-level document (e.g. following a link, or the copyable URL shown in the
   attachment dialog) executes its embedded scripts — a sink independent of
   sanitization, and one that also covers consumers that never go through the
   sanitizer.

This PR closes both, as layered defense:

- **Sanitize on replacement** — re-run the scrubber whenever the underlying
  blob is actually replaced, not just on create. The dirty state is captured
  in a `before_update` callback because it is already cleared by the time
  `after_update_commit` runs, so metadata-only updates (e.g. a rename) do not
  needlessly re-enqueue.

- **Serve SVG as a download** — stop adding `svg` to
  `content_types_allowed_inline` while still removing it from
  `content_types_to_serve_as_binary`. SVGs keep their real `image/svg+xml`
  content type, so they still render in `<img>` tags (which ignore
  `Content-Disposition`), but direct navigation now downloads them instead of
  rendering them as a script-executing document. This covers attachments and
  pictures with one change and is timing-independent.

### Notable changes (remove if none)

SVG **attachments** opened directly via the `show` route now download instead
of rendering in a browser tab. SVGs embedded as images (picture views, admin
thumbnails, the attachment preview — all `<img>`) are unaffected.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change