### PR TITLE
feat(admin): show image file type in picture info dialog

### DIFF
--- a/app/views/alchemy/admin/pictures/_infos.html.erb
+++ b/app/views/alchemy/admin/pictures/_infos.html.erb
@@ -12,6 +12,10 @@
     <p><%= number_to_human_size @picture.image_file_size %></p>
   </div>
   <div class="value">
+    <label><%= Alchemy::Picture.human_attribute_name(:image_file_format) %></label>
+    <p><%= Alchemy.t(@picture.image_file_format, scope: [:filters, :picture, :by_file_format, :values]) %></p>
+  </div>
+  <div class="value">
     <label><%= Alchemy::Picture.human_attribute_name(:created_at) %></label>
     <p><%= l(@picture.created_at, format: :"alchemy.default") %></p>
   </div>

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -986,6 +986,7 @@ en:
         image_file_height: "Height"
         image_file_width: "Width"
         image_file_dimensions: "Dimensions"
+        image_file_format: "File type"
         image_file_size: "Filesize"
         name: "Name"
         tag_list: Tags

--- a/spec/views/admin/pictures/show_spec.rb
+++ b/spec/views/admin/pictures/show_spec.rb
@@ -45,6 +45,14 @@ describe "alchemy/admin/pictures/show.html.erb" do
     expect(rendered).to have_selector('img[src*="gif"]')
   end
 
+  it "displays the translated image file type" do
+    assign(:assignments, [])
+
+    render
+
+    expect(rendered).to have_content("GIF Image")
+  end
+
   it "separates the tags with a comma" do
     allow(picture).to receive(:tag_list).and_return(["one", "two", "three"])
     assign(:assignments, [])


### PR DESCRIPTION
## What is this pull request for?

The picture info overlay (shown when viewing a single image in the admin picture library) already lists the filename, dimensions, and file size, but never the file type. This adds a "File type" row right next to the file size so authors can tell an image's format at a glance.

The value reuses the exact translated mime type labels already used by the image file type filter select (`filters.picture.by_file_format.values`), so both the Active Storage adapter's content types (`image/png`) and the Dragonfly adapter's extension values (`png`) resolve to the same human-readable label ("PNG Image").

### Screenshots

Remove if no visual changes have been made.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change