### PR TITLE
fix: create only one draft version per seeded page

### DIFF
--- a/lib/alchemy/seeder.rb
+++ b/lib/alchemy/seeder.rb
@@ -111,7 +111,6 @@ module Alchemy
       def create_page(draft, attributes = {})
         children = draft.delete("children") || []
         page = Alchemy::Page.new(draft.merge(attributes))
-        page.versions.build
         page.save!
         log "Created page: #{page.name}"
         children.each do |child|

--- a/spec/features/page_seeder_spec.rb
+++ b/spec/features/page_seeder_spec.rb
@@ -40,6 +40,13 @@ RSpec.describe "Page seeding", type: :system do
         expect(home_page.draft_version).to be_present
       end
 
+      it "creates only one draft version per page" do
+        seed
+        Alchemy::Page.find_each do |page|
+          expect(page.versions.draft.count).to eq(1)
+        end
+      end
+
       context "when more then one content root page is present" do
         let(:seeds_file) do
           "spec/fixtures/pages_with_two_roots.yml"


### PR DESCRIPTION
## What is this pull request for?

The page seeder created two draft versions for every seeded page instead of one. `Alchemy::Page` already builds a draft version on initialization through the `ensure_draft_version` `after_initialize` callback, but `Alchemy::Seeder#create_page` also called `page.versions.build` explicitly. Each seeded page therefore ended up with a redundant duplicate draft version (a demo app with 8 pages produced 23 page versions instead of the expected 15).

Removing the explicit build leaves the model's callback as the single source of the draft version, so exactly one draft version is created per page. Published pages still additionally get their public version via the `public_on=` setter.

### Notable changes (remove if none)

None.

### Screenshots

Remove if no visual changes have been made.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change