### PR TITLE
Select filter: multiple/include_blank as Boolean or Proc

### DIFF
--- a/app/controllers/alchemy/admin/attachments_controller.rb
+++ b/app/controllers/alchemy/admin/attachments_controller.rb
@@ -6,16 +6,19 @@ module Alchemy
       include UploaderResponses
       include ArchiveOverlay
 
-      add_alchemy_filter :by_file_type, type: :select, options: ->(_query, params) do
-        case params&.to_h
-        in {except:}
-          Attachment.file_types - Attachment.file_types(from_extensions: except)
-        in {only:}
-          Attachment.file_types(from_extensions: only)
-        else
-          Attachment.file_types
+      add_alchemy_filter :by_file_type, type: :select,
+        multiple: ->(params) { params[:only].presence&.many? || params[:except].present? },
+        include_blank: ->(params) { params[:only].blank? && params[:except].blank? },
+        options: ->(_query, params) do
+          case params&.to_h
+          in {except:}
+            Attachment.file_types - Attachment.file_types(from_extensions: except)
+          in {only:}
+            Attachment.file_types(from_extensions: only)
+          else
+            Attachment.file_types
+          end
         end
-      end
 
       add_alchemy_filter :recent, type: :checkbox
       add_alchemy_filter :last_upload, type: :checkbox

--- a/app/controllers/alchemy/admin/pictures_controller.rb
+++ b/app/controllers/alchemy/admin/pictures_controller.rb
@@ -27,9 +27,12 @@ module Alchemy
       # that would otherwise fire for every picture the view renders.
       before_action :load_deletable_picture_ids, only: [:index, :update]
 
-      add_alchemy_filter :by_file_format, type: :select, options: ->(query) do
-        Alchemy::Picture.file_formats(query.result)
-      end
+      add_alchemy_filter :by_file_format, type: :select,
+        multiple: ->(params) { params[:only].presence&.many? || params[:except].present? },
+        include_blank: ->(params) { params[:only].blank? && params[:except].blank? },
+        options: ->(query) do
+          Alchemy::Picture.file_formats(query.result)
+        end
       add_alchemy_filter :recent, type: :checkbox
       add_alchemy_filter :last_upload, type: :checkbox
       add_alchemy_filter :without_tag, type: :checkbox

--- a/app/controllers/concerns/alchemy/admin/resource_filter.rb
+++ b/app/controllers/concerns/alchemy/admin/resource_filter.rb
@@ -76,7 +76,7 @@ module Alchemy
       def permitted_ransack_search_fields
         [
           resource_handler.search_field_name
-        ] + alchemy_filters.map(&:name)
+        ] + alchemy_filters.flat_map(&:permitted_search_params)
       end
 
       def resource_has_filters

--- a/app/controllers/concerns/alchemy/admin/resource_filter.rb
+++ b/app/controllers/concerns/alchemy/admin/resource_filter.rb
@@ -21,6 +21,8 @@ module Alchemy
         #   add_alchemy_filter :by_location, type: :select, options: ->(query) { Location.pluck(:name, :id) }
         #   add_alchemy_filter :future, type: :checkbox
         #   add_alchemy_filter :by_timeframe, type: :select, options: ["today", "tomorrow"]
+        #   add_alchemy_filter :by_tag, type: :select, options: ->(query) { Tag.pluck(:name) }, multiple: true, include_blank: false
+        #   add_alchemy_filter :by_tag, type: :select, options: ->(query) { Tag.pluck(:name) }, multiple: ->(params) { params[:only].present? }
         def add_alchemy_filter(name, type:, **args)
           alchemy_filters << "Alchemy::Admin::Filters::#{type.to_s.camelize}".constantize.new(
             name:,

--- a/app/models/alchemy/admin/filters/base.rb
+++ b/app/models/alchemy/admin/filters/base.rb
@@ -11,6 +11,13 @@ module Alchemy
           @resource_name = resource_name
         end
 
+        # The strong parameters entries needed to permit this filter's value(s)
+        # under `q`. Override in subclasses whose input can submit a shape
+        # other than a single scalar value (e.g. an array from `<select multiple>`).
+        def permitted_search_params
+          [name]
+        end
+
         def applied_filter_component(search_filter_params:, resource_url_proxy:, query:)
           Alchemy::Admin::Resource::AppliedFilter.new(
             link: dismiss_filter_url(search_filter_params, resource_url_proxy),

--- a/app/models/alchemy/admin/filters/select.rb
+++ b/app/models/alchemy/admin/filters/select.rb
@@ -10,9 +10,13 @@ module Alchemy
         # @param name [String] The name of the filter.
         # @param resource_name [String] The name of the resource.
         # @param options [Proc, Array] A proc that returns the options for the select, or an array of options.
-        def initialize(name:, resource_name:, options:)
+        # @param multiple [Boolean, Proc] Whether multiple values can be selected, or a proc called with the search filter params that returns a Boolean.
+        # @param include_blank [Boolean, String, Proc] Whether (or with what label) to include a blank option, or a proc called with the search filter params that returns a Boolean/String.
+        def initialize(name:, resource_name:, options:, multiple: false, include_blank: true)
           super(name:, resource_name:)
           @options = options_to_proc(options)
+          @multiple = bool_or_proc(multiple)
+          @include_blank = bool_or_proc(include_blank)
         end
 
         # Returns a select filter component.
@@ -34,15 +38,18 @@ module Alchemy
         private
 
         def multiple?(params)
-          params[:only].presence&.many? || params[:except].present?
+          @multiple.call(params)
         end
 
         def include_blank(params)
-          if params[:only].present? || params[:except].present?
-            false
-          else
-            Alchemy.t(:all, scope: [:filters, resource_name, name])
-          end
+          value = @include_blank.call(params)
+          return value unless value == true
+
+          Alchemy.t(:all, scope: [:filters, resource_name, name])
+        end
+
+        def bool_or_proc(value)
+          value.is_a?(Proc) ? value : ->(_params) { value }
         end
 
         def options_to_proc(options)

--- a/app/models/alchemy/admin/filters/select.rb
+++ b/app/models/alchemy/admin/filters/select.rb
@@ -35,6 +35,12 @@ module Alchemy
           )
         end
 
+        # `multiple` can be enabled dynamically via a Proc, so both the
+        # scalar and array shape of the submitted value need to be permitted.
+        def permitted_search_params
+          [name, {name => []}]
+        end
+
         private
 
         def multiple?(params)

--- a/spec/models/alchemy/admin/filters/checkbox_spec.rb
+++ b/spec/models/alchemy/admin/filters/checkbox_spec.rb
@@ -39,4 +39,10 @@ RSpec.describe Alchemy::Admin::Filters::Checkbox do
       expect(component.checked).to be true
     end
   end
+
+  describe "#permitted_search_params" do
+    it "permits the field name as a scalar value" do
+      expect(checkbox.permitted_search_params).to eq(["published"])
+    end
+  end
 end

--- a/spec/models/alchemy/admin/filters/select_spec.rb
+++ b/spec/models/alchemy/admin/filters/select_spec.rb
@@ -149,4 +149,10 @@ RSpec.describe Alchemy::Admin::Filters::Select do
       end
     end
   end
+
+  describe "#permitted_search_params" do
+    it "permits both the scalar and array shape of the field, since multiple may be enabled dynamically" do
+      expect(checkbox.permitted_search_params).to eq(["by_page_layout", {"by_page_layout" => []}])
+    end
+  end
 end

--- a/spec/models/alchemy/admin/filters/select_spec.rb
+++ b/spec/models/alchemy/admin/filters/select_spec.rb
@@ -100,22 +100,51 @@ RSpec.describe Alchemy::Admin::Filters::Select do
       end
     end
 
-    context "when params[:only] is multiple values" do
-      let(:params) { {q: {by_page_layout: "standard"}, only: ["standard", "news"]} }
+    context "when multiple/include_blank are not given" do
+      it "defaults to multiple: false and a translated blank option" do
+        expect(component.multiple).to be false
+        expect(component.include_blank).to eq("All page types")
+      end
+    end
 
-      it "returns a select filter input component with multiple selection enabled and no blank option" do
-        expect(component).to be_a(Alchemy::Admin::Resource::SelectFilter)
+    context "when multiple is given as a boolean" do
+      let(:checkbox) { described_class.new(name:, resource_name:, options:, multiple: true) }
+
+      it "returns a select filter input component with multiple selection enabled" do
         expect(component.multiple).to be true
+      end
+    end
+
+    context "when multiple is given as a proc" do
+      let(:params) { {q: {by_page_layout: "standard"}, only: ["standard", "news"]} }
+      let(:checkbox) { described_class.new(name:, resource_name:, options:, multiple: ->(params) { params[:only].present? }) }
+
+      it "calls the proc with the search filter params" do
+        expect(component.multiple).to be true
+      end
+    end
+
+    context "when include_blank is given as a boolean" do
+      let(:checkbox) { described_class.new(name:, resource_name:, options:, include_blank: false) }
+
+      it "returns a select filter input component without a blank option" do
         expect(component.include_blank).to be false
       end
     end
 
-    context "when params[:only] is a single value" do
-      let(:params) { {q: {by_page_layout: "standard"}, only: ["standard"]} }
+    context "when include_blank is given as a string" do
+      let(:checkbox) { described_class.new(name:, resource_name:, options:, include_blank: "Choose one") }
 
-      it "returns a select filter input component with multiple selection disabled and no blank option" do
-        expect(component).to be_a(Alchemy::Admin::Resource::SelectFilter)
-        expect(component.multiple).to be false
+      it "returns a select filter input component with the given blank option label" do
+        expect(component.include_blank).to eq("Choose one")
+      end
+    end
+
+    context "when include_blank is given as a proc" do
+      let(:params) { {q: {by_page_layout: "standard"}, only: ["standard"]} }
+      let(:checkbox) { described_class.new(name:, resource_name:, options:, include_blank: ->(params) { params[:only].blank? }) }
+
+      it "calls the proc with the search filter params" do
         expect(component.include_blank).to be false
       end
     end


### PR DESCRIPTION
## What is this pull request for?

Refactors the select resource filter's `multiple` and `include_blank` options to accept a Boolean (or String, for `include_blank`) or a Proc called with the search filter params, instead of being implicitly inferred from `params[:only]`/`params[:except]`. This lets controller authors configure these per-filter directly:

```ruby
add_alchemy_filter :by_tag, type: :select, options: ->(query) { Tag.pluck(:name) },
  multiple: true, include_blank: false
add_alchemy_filter :by_tag, type: :select, options: ->(query) { Tag.pluck(:name) },
  multiple: ->(params) { params[:only].present? }
```

### Notable changes (remove if none)

- **Breaking:** `multiple`/`include_blank` no longer auto-infer from `params[:only]`/`params[:except]`. Filters relying on that behavior must now pass `multiple:`/`include_blank:` explicitly. New defaults are `multiple: false`, `include_blank: true` (translated "all" text). The `by_file_format` (pictures) and `by_file_type` (attachments) filters, which power the archive-overlay file pickers, were updated with equivalent procs to preserve their existing behavior.
- Enabling `multiple` lets the browser submit a filter's value as an array instead of a scalar. Strong parameters treats `field` and `field: []` as distinct permitted shapes, so array submissions were previously stripped silently. Each filter class now declares its own `permitted_search_params` (scalar-only by default in `Base`; `Select` safelists both shapes) so `resource_filter.rb` no longer has to assume every filter is scalar-only.

### Screenshots

Remove if no visual changes have been made.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
