### PR TITLE
fix(active_storage): pre-generate archive thumbnails on upload

### DIFF
--- a/app/models/alchemy/storage_adapter/active_storage.rb
+++ b/app/models/alchemy/storage_adapter/active_storage.rb
@@ -5,7 +5,6 @@ module Alchemy
         def self.included(base)
           base.has_one_attached :image_file do |attachable|
             Alchemy.storage_adapter.preprocessor_class.new(attachable).call
-            Alchemy.storage_adapter.preprocessor_class.generate_thumbs!(attachable)
           end
 
           base.after_create_commit if: :svg? do

--- a/app/models/alchemy/storage_adapter/active_storage.rb
+++ b/app/models/alchemy/storage_adapter/active_storage.rb
@@ -11,6 +11,10 @@ module Alchemy
             SanitizeSvgJob.perform_later(self, file_accessor: :image_file)
           end
 
+          base.after_create_commit if: :has_convertible_format? do
+            Alchemy.storage_adapter.preprocessor_class.generate_thumbs!(self)
+          end
+
           # The image file's dirty state is cleared by the time
           # +after_update_commit+ runs, so capture it here to know whether the
           # blob was actually replaced (rather than only its metadata updated).

--- a/app/models/alchemy/storage_adapter/active_storage/preprocessor.rb
+++ b/app/models/alchemy/storage_adapter/active_storage/preprocessor.rb
@@ -23,9 +23,13 @@ module Alchemy
       attr_reader :attachable
 
       class << self
-        def generate_thumbs!(attachable)
-          Alchemy::Picture::THUMBNAIL_SIZES.values.each do |size|
-            process_thumb(attachable, size: size, flatten: true)
+        def generate_thumbs!(picture)
+          format = picture.image_file_extension || "jpg"
+          Alchemy::Picture::THUMBNAIL_SIZES.each_value do |size|
+            transformations = Alchemy::DragonflyToImageProcessing.call(
+              flatten: true, format: format, size: size
+            )
+            ::ActiveStorage::TransformJob.perform_later(picture.image_file.blob, transformations)
           end
         end
 

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -35,10 +35,13 @@ module Dummy
     # Rails 8.1 eagerly requires the configured variant processor's transformer
     # at boot. The dragonfly adapter doesn't use ActiveStorage variants, so
     # disable it there to avoid needing an image backend; active_storage uses vips.
-    if ENV["ALCHEMY_STORAGE_ADAPTER"] == "active_storage"
-      config.active_storage.variant_processor = :vips
+    # Mirror the engine's adapter resolution, which defaults to active_storage
+    # when the env var is unset (see Alchemy::Engine), so the default setup gets
+    # a working variant processor rather than a disabled one.
+    config.active_storage.variant_processor = if ENV.fetch("ALCHEMY_STORAGE_ADAPTER", "active_storage") == "active_storage"
+      :vips
     else
-      config.active_storage.variant_processor = :disabled
+      :disabled
     end
 
     # This app lives inside the engine root, so rails_live_reload's own watcher

--- a/spec/models/alchemy/picture_spec.rb
+++ b/spec/models/alchemy/picture_spec.rb
@@ -590,6 +590,24 @@ module Alchemy
           }.not_to have_enqueued_job(StorageAdapter::ActiveStorage::SanitizeSvgJob)
         end
       end
+
+      context "with a convertible image file" do
+        it "enqueues an ActiveStorage::TransformJob for each thumbnail size" do
+          expect {
+            create(:alchemy_picture, image_file: image_file)
+          }.to have_enqueued_job(ActiveStorage::TransformJob).exactly(3).times
+        end
+      end
+
+      context "with a non-convertible file" do
+        let(:svg_file) { fixture_file_upload("icon.svg", "image/svg+xml") }
+
+        it "does not enqueue an ActiveStorage::TransformJob" do
+          expect {
+            create(:alchemy_picture, image_file: svg_file)
+          }.not_to have_enqueued_job(ActiveStorage::TransformJob)
+        end
+      end
     end
 
     describe "after update", if: Alchemy.storage_adapter.active_storage? do

--- a/spec/models/alchemy/storage_adapter/active_storage/preprocessor_spec.rb
+++ b/spec/models/alchemy/storage_adapter/active_storage/preprocessor_spec.rb
@@ -30,18 +30,30 @@ RSpec.describe Alchemy::StorageAdapter::ActiveStorage::Preprocessor, if: Alchemy
   end
 
   describe ".generate_thumbs!" do
-    let(:sizes) { {small: "100x100", large: "800x800"} }
+    let(:blob) { instance_double(ActiveStorage::Blob) }
+    let(:image_file) { double("image_file", blob: blob) }
+    let(:picture) { double("picture", image_file: image_file, image_file_extension: "png") }
 
     before do
-      stub_const("Alchemy::Picture::THUMBNAIL_SIZES", sizes)
-      allow(described_class).to receive(:process_thumb)
+      stub_const("Alchemy::Picture::THUMBNAIL_SIZES", {
+        small: "80x60",
+        medium: "160x120",
+        large: "240x180"
+      })
+      allow(ActiveStorage::TransformJob).to receive(:perform_later)
     end
 
-    it "calls process_thumb for each thumbnail size" do
-      described_class.generate_thumbs!(attachable)
-      sizes.values.each do |size|
-        expect(described_class).to have_received(:process_thumb).with(attachable, size: size, flatten: true)
-      end
+    it "enqueues a TransformJob for each thumbnail size" do
+      described_class.generate_thumbs!(picture)
+      expect(ActiveStorage::TransformJob).to have_received(:perform_later).exactly(3).times
+    end
+
+    it "enqueues the medium thumbnail with the same transformations the archive requests" do
+      described_class.generate_thumbs!(picture)
+      expect(ActiveStorage::TransformJob).to have_received(:perform_later).with(
+        blob,
+        {resize_to_limit: [160, 120, {sharpen: false}], format: "png", saver: {quality: 85}}
+      )
     end
   end
 


### PR DESCRIPTION
## What is this pull request for?

With the ActiveStorage adapter, the three admin archive thumbnail sizes were never actually pre-generated on upload, so the picture library fell back to on-demand generation and could show images at their native size.

The preprocessor declared all three `THUMBNAIL_SIZES` as a single named `:thumb` variant inside the `has_one_attached` block. Because that block is evaluated once at class-load and every size reused the same name, only the last size survived, and the resulting named variant never matched the anonymous, per-size variant the archive requests at display time (ActiveStorage keys variants by their exact transformation hash). The pre-processing was therefore effectively a no-op.

This enqueues one `ActiveStorage::TransformJob` per size from an `after_create_commit` callback (mirroring the Dragonfly adapter, guarded by `has_convertible_format?`), using the same transformation hash `Picture#thumbnail_url` builds. The pre-generated variant is now byte-identical to the one served, so the archive shows correctly sized, already-processed thumbnails.

While verifying this against the running dummy app, it also surfaced that the default setup disabled image processing entirely: the engine resolves the adapter as `ENV.fetch("ALCHEMY_STORAGE_ADAPTER", Alchemy.config.storage_adapter)` (default `active_storage`), but the dummy app only enabled the vips variant processor on a strict `ENV["ALCHEMY_STORAGE_ADAPTER"] == "active_storage"` match. With the env var unset, the default active_storage adapter ran with `variant_processor = :disabled` and served originals unresized. The dummy config now mirrors the engine's default-aware resolution.

### Notable changes (remove if none)

- The ActiveStorage `Preprocessor.generate_thumbs!` signature now takes an `Alchemy::Picture` (previously the attachment reflection). The `preprocess_image_resize` path is unchanged.
- `spec/dummy` dev/test config only: enables the vips variant processor for the default active_storage adapter.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change