### PR TITLE
ci(codecov): flag coverage legs and wait for all uploads

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -213,6 +213,9 @@ jobs:
           slug: AlchemyCMS/alchemy_cms
           disable_search: true
           files: ./coverage/coverage.xml
+          # Flag each database leg so Codecov can carry a leg's coverage forward
+          # when its upload flakes, instead of counting it as uncovered.
+          flags: ${{ matrix.database }}
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,34 @@
-# Coverage produced by the browser-driven system specs is slightly
-# nondeterministic, so the overall project percentage can wobble by a few
-# hundredths of a percent between runs. Allow a small drop on the project
-# status so that jitter does not fail unrelated pull requests, while leaving
-# the patch status strict so genuinely uncovered new code still fails.
+# Coverage is uploaded from three CI legs (one per database, all on the same
+# Ruby/Rails), which Codecov merges into one report. Two problems followed from
+# that and this config fixes both:
+#
+# 1. When a leg's upload flakes, its lines were counted as uncovered and the
+#    project percentage dropped by whole percents, failing unrelated pull
+#    requests. Each leg is now flagged by database (see build_test.yml) and
+#    carried forward, so a missing upload reuses that leg's previous coverage
+#    instead of counting as zero.
+#
+# 2. Codecov posted its status after the first upload arrived, so a pull request
+#    looked failed mid-run until the remaining legs uploaded. `after_n_builds`
+#    makes it wait for all three uploads before reporting.
+#
+# The browser-driven system specs are slightly nondeterministic, so a small
+# project threshold still absorbs the remaining sub-percent jitter while the
+# patch status stays strict.
+codecov:
+  notify:
+    after_n_builds: 3
+    wait_for_ci: true
+
 coverage:
   status:
     project:
       default:
         threshold: 0.5%
+
+comment:
+  after_n_builds: 3
+
+flag_management:
+  default_rules:
+    carryforward: true


### PR DESCRIPTION
## What is this pull request for?

Coverage is uploaded from three CI legs — one per database (`postgresql`, `mariadb`, `sqlite`), all on the same Ruby/Rails — and Codecov merges them into a single report. That setup produced two recurring, spurious failures unrelated to the code under review:

1. **A flaked upload silently dropped the project percentage.** The Codecov action does not fail the job when an upload fails, so a leg could finish green without its report reaching Codecov. Its lines were then counted as uncovered and the merged project coverage fell by whole percents (e.g. a missing `mariadb`+dragonfly upload made all dragonfly/storage code look untested), tripping `codecov/project` on pull requests that changed none of it.

2. **Codecov reported before all uploads arrived.** The status was computed on the first upload, so a pull request showed a failing Codecov check mid-run and only turned green once the other legs finished — noisy and easy to mistake for a real failure.

This flags each leg by its database so Codecov can **carry a leg's coverage forward** when its upload is missing (reusing that leg's previous coverage instead of zero), and sets **`after_n_builds: 3`** so the status and PR comment wait for all three uploads before reporting.

Carryforward is the load-bearing part: it keeps the merged total correct even when an upload never arrives. `after_n_builds` removes the mid-run false-failure. The existing `0.5%` project threshold stays to absorb the small jitter from the browser-driven system specs, and patch coverage remains strict.

`codecov.yml` was validated with Codecov's `POST /validate` endpoint.

### Notable changes (remove if none)

None (CI configuration only; no application code changes).

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change