### PR TITLE
ci: make the ruby 4.0 build required

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -116,7 +116,6 @@ jobs:
             ruby: "4.0"
             database: postgresql
             storage: active_storage
-            experimental: true
           - rails: "8.1"
             ruby: "3.4"
             database: postgresql
@@ -129,7 +128,6 @@ jobs:
             ruby: "3.4"
             database: sqlite
             storage: active_storage
-    continue-on-error: ${{ matrix.experimental == true }}
 
     env:
       DB: ${{ matrix.database }}


### PR DESCRIPTION
## What is this pull request for?

The Rails 8.0 / Ruby 4.0 matrix leg was marked `experimental: true`, so it ran with `continue-on-error` and a failure there passed the build silently. Ruby 4.0 has proven stable against the suite, so this promotes that leg to a required build — a Ruby 4.0 regression now blocks instead of going unnoticed.

It was the only leg using `experimental`, which left `continue-on-error: ${{ matrix.experimental == true }}` referencing an undefined key (always false), so both are removed together rather than leaving dead config. If an experimental leg is needed again later, re-adding `experimental: true` plus the `continue-on-error` line restores the mechanism.

This is independent of the Codecov upload changes — the Ruby 4.0 leg does not upload coverage (that step is gated to `ruby == '3.4'`), so nothing here affects coverage reporting.

### Notable changes (remove if none)

A Ruby 4.0 test failure will now fail CI and block merges, where previously it was tolerated.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change