### PR TITLE
fix(permissions): hide unreadable pages from menu and breadcrumb

### DIFF
--- a/app/helpers/alchemy/pages_helper.rb
+++ b/app/helpers/alchemy/pages_helper.rb
@@ -126,6 +126,11 @@ module Alchemy
         pages = pages.where.not(id: without.try(:collect, &:id) || without.id)
       end
 
+      # Drop ancestors the current user is not allowed to read, so a restricted
+      # page never leaks its name and url through the breadcrumb. permitted_roles
+      # is a column, so readable_by? adds no query per page.
+      pages = pages.select { |page| page.readable_by?(current_alchemy_user) }
+
       render "alchemy/breadcrumb/wrapper", pages: pages, options: options
     end
 

--- a/app/models/alchemy/node.rb
+++ b/app/models/alchemy/node.rb
@@ -67,6 +67,18 @@ module Alchemy
       read_attribute(:name).presence || page&.name
     end
 
+    # Direct children whose attached page the given user is allowed to read.
+    #
+    # Nodes without a page (external links) are always included. Menu partials
+    # render through this so a restricted page never appears in navigation for
+    # a user who cannot open it. +permitted_roles+ is a column, so +readable_by?+
+    # adds no query per node beyond the eager loaded page.
+    def readable_children(user)
+      children.includes(:page, :children).select do |node|
+        node.page.nil? || node.page.readable_by?(user)
+      end
+    end
+
     class << self
       # Returns all root nodes for current language
       def language_root_nodes

--- a/lib/alchemy/upgrader/eight_four.rb
+++ b/lib/alchemy/upgrader/eight_four.rb
@@ -11,6 +11,24 @@ module Alchemy
 
         run %(bundle add dragonfly --version "~> 1.4")
       end
+
+      # Menus now hide nodes whose page a user may not read. The generated menu
+      # partials live in the host app, so Alchemy cannot update them here.
+      def mention_menu_partials_readable_children
+        todo(<<~TODO.strip, "Update your menu partials for restricted pages")
+          Alchemy now hides menu nodes whose page a user is not allowed to read
+          (restricted pages and pages limited to certain roles).
+
+          The generated menu partials in `app/views/alchemy/menus/*/` were changed
+          to render `node.readable_children(current_alchemy_user)` instead of
+          `node.children`, and to include the current user in their `cache` key so
+          a filtered menu is not served to a different user.
+
+          Please apply the same change to your menu partials (or regenerate them
+          with `bin/rails g alchemy:menus`), otherwise restricted pages keep
+          leaking their name and url through your navigation.
+        TODO
+      end
     end
   end
 end

--- a/lib/generators/alchemy/menus/templates/node.html.erb
+++ b/lib/generators/alchemy/menus/templates/node.html.erb
@@ -1,5 +1,6 @@
-<%% cache [node, @page, Alchemy::Current.preview_page?] do %>
-  <%%= content_tag :li, class: ['nav-item', node.children.any? ? 'dropdown' : nil].compact do %>
+<%% cache [node, @page, Alchemy::Current.preview_page?, current_alchemy_user&.alchemy_roles] do %>
+  <%% children = node.readable_children(current_alchemy_user) %>
+  <%%= content_tag :li, class: ['nav-item', children.any? ? 'dropdown' : nil].compact do %>
     <%%= link_to_if node.url,
       node.name,
       Alchemy::Current.preview_page? ? 'javascript: void(0)' : node.url,
@@ -7,9 +8,9 @@
       title: node.title,
       target: node.external? ? '_blank' : nil,
       rel: node.nofollow? ? 'nofollow' : nil %>
-    <%% if node.children.any? %>
+    <%% if children.any? %>
       <ul class="dropdown-menu">
-        <%%= render node.children.includes(:page, :children), as: 'node' %>
+        <%%= render children, as: 'node' %>
       </ul>
     <%% end %>
   <%% end %>

--- a/lib/generators/alchemy/menus/templates/node.html.haml
+++ b/lib/generators/alchemy/menus/templates/node.html.haml
@@ -1,6 +1,7 @@
-- cache [node, @page, Alchemy::Current.preview_page?] do
+- cache [node, @page, Alchemy::Current.preview_page?, current_alchemy_user&.alchemy_roles] do
+  - children = node.readable_children(current_alchemy_user)
   = content_tag :li,
-    class: ['nav-item', node.children.any? ? 'dropdown' : nil].compact do
+    class: ['nav-item', children.any? ? 'dropdown' : nil].compact do
     = link_to_if node.url,
       node.name,
       Alchemy::Current.preview_page? ? 'javascript: void(0)' : node.url,
@@ -8,6 +9,6 @@
       title: node.title,
       target: node.external? ? '_blank' : nil,
       rel: node.nofollow? ? 'nofollow' : nil
-      - if node.children.any?
+      - if children.any?
         %ul.dropdown-menu
-          = render node.children.includes(:page, :children), as: 'node'
+          = render children, as: 'node'

--- a/lib/generators/alchemy/menus/templates/node.html.slim
+++ b/lib/generators/alchemy/menus/templates/node.html.slim
@@ -1,6 +1,7 @@
-- cache [node, @page, Alchemy::Current.preview_page?] do
+- cache [node, @page, Alchemy::Current.preview_page?, current_alchemy_user&.alchemy_roles] do
+  - children = node.readable_children(current_alchemy_user)
   = content_tag :li,
-    class: ['nav-item', node.children.any? ? 'dropdown' : nil].compact do
+    class: ['nav-item', children.any? ? 'dropdown' : nil].compact do
     = link_to_if node.url,
       node.name,
       Alchemy::Current.preview_page? ? 'javascript: void(0)' : node.url,
@@ -8,6 +9,6 @@
       title: node.title,
       target: node.external? ? '_blank' : nil,
       rel: node.nofollow? ? 'nofollow' : nil
-      - if node.children.any?
+      - if children.any?
         ul.dropdown-menu
-          = render node.children.includes(:page, :children), as: 'node'
+          = render children, as: 'node'

--- a/lib/generators/alchemy/menus/templates/wrapper.html.erb
+++ b/lib/generators/alchemy/menus/templates/wrapper.html.erb
@@ -1,7 +1,7 @@
-<%% cache [menu, @page, Alchemy::Current.preview_page?] do %>
+<%% cache [menu, @page, Alchemy::Current.preview_page?, current_alchemy_user&.alchemy_roles] do %>
   <ul class="nav">
     <%%= render partial: menu.to_partial_path,
-      collection: menu.children.includes(:page, :children),
+      collection: menu.readable_children(current_alchemy_user),
       locals: { options: options },
       as: 'node' %>
   </ul>

--- a/lib/generators/alchemy/menus/templates/wrapper.html.haml
+++ b/lib/generators/alchemy/menus/templates/wrapper.html.haml
@@ -1,6 +1,6 @@
-- cache [menu, @page, Alchemy::Current.preview_page?] do
+- cache [menu, @page, Alchemy::Current.preview_page?, current_alchemy_user&.alchemy_roles] do
   %ul.nav
     = render partial: menu.to_partial_path,
-      collection: menu.children.includes(:page, :children),
+      collection: menu.readable_children(current_alchemy_user),
       locals: { options: options },
       as: 'node'

--- a/lib/generators/alchemy/menus/templates/wrapper.html.slim
+++ b/lib/generators/alchemy/menus/templates/wrapper.html.slim
@@ -1,6 +1,6 @@
-- cache [menu, @page, Alchemy::Current.preview_page?] do
+- cache [menu, @page, Alchemy::Current.preview_page?, current_alchemy_user&.alchemy_roles] do
   ul.nav
     = render partial: menu.to_partial_path,
-      collection: menu.children.includes(:page, :children),
+      collection: menu.readable_children(current_alchemy_user),
       locals: { options: options },
       as: 'node'

--- a/lib/tasks/alchemy/upgrade.rake
+++ b/lib/tasks/alchemy/upgrade.rake
@@ -59,12 +59,18 @@ namespace :alchemy do
 
     namespace "8.4" do
       task "run" => [
-        "alchemy:upgrade:8.4:add_dragonfly_gem"
+        "alchemy:upgrade:8.4:add_dragonfly_gem",
+        "alchemy:upgrade:8.4:mention_menu_partials_readable_children"
       ]
 
       desc "Add dragonfly gem to the Gemfile if the app uses the dragonfly storage adapter"
       task add_dragonfly_gem: [:environment] do
         Alchemy::Upgrader["8.4"].add_dragonfly_gem
+      end
+
+      desc "Mention that menu partials must be updated to hide restricted pages"
+      task mention_menu_partials_readable_children: [:environment] do
+        Alchemy::Upgrader["8.4"].mention_menu_partials_readable_children
       end
     end
   end

--- a/spec/dummy/app/views/alchemy/menus/footer_navigation/_node.html.erb
+++ b/spec/dummy/app/views/alchemy/menus/footer_navigation/_node.html.erb
@@ -1,4 +1,5 @@
-<%= content_tag :li, class: ['nav-item', node.children.any? ? 'dropdown' : nil].compact do %>
+<% children = node.readable_children(current_alchemy_user) %>
+<%= content_tag :li, class: ['nav-item', children.any? ? 'dropdown' : nil].compact do %>
   <%= link_to_if node.url,
     node.name,
     Alchemy::Current.preview_page? ? 'javascript: void(0)' : node.url,
@@ -6,9 +7,9 @@
     title: node.title,
     target: node.external? ? '_blank' : nil,
     rel: node.nofollow? ? 'nofollow' : nil %>
-  <% if node.children.any? %>
+  <% if children.any? %>
     <ul class="dropdown-menu">
-      <%= render node.children.includes(:page, :children), as: 'node' %>
+      <%= render children, as: 'node' %>
     </ul>
   <% end %>
 <% end %>

--- a/spec/dummy/app/views/alchemy/menus/footer_navigation/_wrapper.html.erb
+++ b/spec/dummy/app/views/alchemy/menus/footer_navigation/_wrapper.html.erb
@@ -1,6 +1,6 @@
 <ul class="nav">
   <%= render partial: menu.to_partial_path,
-    collection: menu.children.includes(:page, :children),
+    collection: menu.readable_children(current_alchemy_user),
     locals: { options: options },
     as: 'node' %>
 </ul>

--- a/spec/dummy/app/views/alchemy/menus/main_menu/_node.html.erb
+++ b/spec/dummy/app/views/alchemy/menus/main_menu/_node.html.erb
@@ -1,5 +1,6 @@
-<% cache [node, @page, Alchemy::Current.preview_page?] do %>
-  <%= content_tag :li, class: ['nav-item', node.children.any? ? 'dropdown' : nil].compact do %>
+<% cache [node, @page, Alchemy::Current.preview_page?, current_alchemy_user&.alchemy_roles] do %>
+  <% children = node.readable_children(current_alchemy_user) %>
+  <%= content_tag :li, class: ['nav-item', children.any? ? 'dropdown' : nil].compact do %>
     <%= link_to_if node.url,
       node.name,
       Alchemy::Current.preview_page? ? 'javascript: void(0)' : node.url,
@@ -7,9 +8,9 @@
       title: node.title,
       target: node.external? ? '_blank' : nil,
       rel: node.nofollow? ? 'nofollow' : nil %>
-    <% if node.children.any? %>
+    <% if children.any? %>
       <ul class="dropdown-menu">
-        <%= render node.children.includes(:page, :children), as: 'node' %>
+        <%= render children, as: 'node' %>
       </ul>
     <% end %>
   <% end %>

--- a/spec/dummy/app/views/alchemy/menus/main_menu/_wrapper.html.erb
+++ b/spec/dummy/app/views/alchemy/menus/main_menu/_wrapper.html.erb
@@ -1,7 +1,7 @@
-<% cache [menu, @page, Alchemy::Current.preview_page?] do %>
+<% cache [menu, @page, Alchemy::Current.preview_page?, current_alchemy_user&.alchemy_roles] do %>
   <ul class="nav">
     <%= render partial: menu.to_partial_path,
-      collection: menu.children.includes(:page, :children),
+      collection: menu.readable_children(current_alchemy_user),
       locals: { options: options },
       as: "node" %>
   </ul>

--- a/spec/helpers/alchemy/pages_helper_spec.rb
+++ b/spec/helpers/alchemy/pages_helper_spec.rb
@@ -65,6 +65,11 @@ module Alchemy
       subject { helper.render_menu(menu_type) }
 
       let(:menu_type) { "main_menu" }
+      let(:user) { nil }
+
+      before do
+        allow(helper).to receive(:current_alchemy_user).and_return(user)
+      end
 
       context "if menu exists" do
         let(:menu) { create(:alchemy_node, menu_type: menu_type) }
@@ -120,6 +125,28 @@ module Alchemy
           is_expected.not_to have_selector('ul.nav > li.nav-item > a.nav-link[href="/klingon"]')
         end
       end
+
+      context "with a node linking to a restricted page" do
+        let(:menu) { create(:alchemy_node, menu_type: menu_type) }
+        let!(:restricted_page) { create(:alchemy_page, :public, :restricted, name: "Secret") }
+        let!(:node) { create(:alchemy_node, parent: menu, page: restricted_page, name: nil) }
+
+        context "as a guest" do
+          let(:user) { nil }
+
+          it "does not render the restricted page's node" do
+            is_expected.to_not have_selector("a.nav-link", text: "Secret")
+          end
+        end
+
+        context "as a member permitted to read it" do
+          let(:user) { build(:alchemy_dummy_user) }
+
+          it "renders the restricted page's node" do
+            is_expected.to have_selector("a.nav-link", text: "Secret")
+          end
+        end
+      end
     end
 
     describe "#render_breadcrumb" do
@@ -129,6 +156,7 @@ module Alchemy
 
       before do
         allow(helper).to receive(:multi_language?).and_return(false)
+        allow(helper).to receive(:current_alchemy_user).and_return(user)
         allow(helper).to receive(:current_ability).and_return(Alchemy::Permissions.new(user))
       end
 
@@ -138,6 +166,30 @@ module Alchemy
 
       it "should render a breadcrumb to current page" do
         is_expected.to have_selector(".active.last[contains('#{page.name}')]")
+      end
+
+      context "with a restricted ancestor page" do
+        before do
+          page # create the (unrestricted) page and parent first
+          parent.update_columns(restricted: true, name: "A restricted ancestor")
+        end
+
+        context "as a guest" do
+          let(:user) { nil }
+
+          it "does not leak the restricted ancestor" do
+            is_expected.to have_selector("*[contains(\"#{page.name}\")]")
+            is_expected.to_not have_selector("*[contains(\"#{parent.name}\")]")
+          end
+        end
+
+        context "as a member permitted to read it" do
+          let(:user) { build(:alchemy_dummy_user) }
+
+          it "includes the restricted ancestor" do
+            is_expected.to have_selector("*[contains(\"#{parent.name}\")]")
+          end
+        end
       end
 
       context "with options[:separator] given" do

--- a/spec/lib/alchemy/upgrader/eight_four_spec.rb
+++ b/spec/lib/alchemy/upgrader/eight_four_spec.rb
@@ -41,4 +41,14 @@ RSpec.describe Alchemy::Upgrader::EightFour do
       end
     end
   end
+
+  describe "#mention_menu_partials_readable_children" do
+    it "adds a todo asking to update the menu partials" do
+      expect(upgrader).to receive(:todo).with(
+        /readable_children/,
+        "Update your menu partials for restricted pages"
+      )
+      upgrader.mention_menu_partials_readable_children
+    end
+  end
 end

--- a/spec/models/alchemy/node_spec.rb
+++ b/spec/models/alchemy/node_spec.rb
@@ -201,6 +201,33 @@ module Alchemy
       end
     end
 
+    describe "#readable_children" do
+      subject { menu.readable_children(user) }
+
+      let(:user) { nil }
+      let(:menu) { create(:alchemy_node) }
+      let!(:public_child) { create(:alchemy_node, parent: menu, page: create(:alchemy_page, :public)) }
+      let!(:external_child) { create(:alchemy_node, :with_url, parent: menu) }
+      let!(:restricted_child) do
+        create(:alchemy_node, parent: menu, page: create(:alchemy_page, :public, :restricted))
+      end
+
+      context "for a guest" do
+        it "returns children with a readable or no page and excludes restricted ones" do
+          expect(subject).to include(public_child, external_child)
+          expect(subject).to_not include(restricted_child)
+        end
+      end
+
+      context "for a member permitted to read the restricted page" do
+        let(:user) { build(:alchemy_dummy_user) }
+
+        it "also includes the restricted child" do
+          expect(subject).to include(public_child, external_child, restricted_child)
+        end
+      end
+    end
+
     describe "#name" do
       subject { node.name }
 


### PR DESCRIPTION
## What is this pull request for?

Follow-up to the security review of #4112. Page read access is enforced in the authorization layer, but two frontend helpers rendered navigation **without** consulting it, so a restricted page (now including one limited to certain roles) still leaked its **name and url**:

- `render_breadcrumb` listed every published ancestor of the current page.
- `render_menu` rendered every child node, and the menu fragment cache key did not include the user.

Both now filter by the current user's read permission via `Page#readable_by?`, which keeps the check a column read (no extra query) and automatically honors `permitted_roles`.

### Notable changes

- **`render_breadcrumb`** drops ancestors the current user cannot read.
- **`Alchemy::Node#readable_children(user)`** returns only children whose page is readable (external nodes without a page are always kept). The **generated menu partials** (`wrapper`/`node`, erb/haml/slim) render through it **and add the current user to their `cache` key**, so a filtered menu is never served to a different user.
- Because menu partials are generated into the **host app**, the engine cannot rewrite existing apps' copies. An **8.4 upgrade `todo`** (`bin/rails alchemy:upgrade`) tells maintainers to apply the same change (or regenerate with `bin/rails g alchemy:menus`). The dummy app's partials are updated so the behavior is covered by specs.

Specs cover: breadcrumb hides a restricted ancestor from a guest but shows it to a permitted member; a menu node to a restricted page is hidden from a guest and shown to a permitted member; `Node#readable_children` filtering; and the upgrade todo.

> [!NOTE]
> **Stacked on #4112** — this depends on `Page#readable_by?` from the permitted-roles branch, so its base is `permitted-roles-for-restricted-pages`. Merge after #4112; GitHub will retarget the base to `main` once #4112 lands.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change