### PR TITLE
feat: Add `Alchemy::UserMethods` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,19 +162,19 @@ Alchemy.configure do |config|
 end
 ```
 
-The only thing Alchemy needs to know from your user class is the `alchemy_roles` method.
+Alchemy needs a `alchemy_roles` column in your database for the RBAC to work.
 
-This method has to return an `Array` (or `ActiveRecord::Relation`) with at least one of the following roles: `member`, `author`, `editor`, `admin`.
+Alchemy provides a migration generator that adds these tables to your users table.
 
-##### Example
+```
+$ bin/rails g alchemy:user_columns_migration --table-name=my-users-table
+```
+
+Then include this module in your model.
 
 ```ruby
-# app/models/user.rb
-
-def alchemy_roles
-  if admin?
-    %w(admin)
-  end
+class User
+  include Alchemy::UserMethods
 end
 ```
 

--- a/app/components/alchemy/admin/dashboard/widgets/online_users.html.erb
+++ b/app/components/alchemy/admin/dashboard/widgets/online_users.html.erb
@@ -13,7 +13,7 @@
       <tr>
         <td class="name"><%= user.name %></td>
         <td class="right">
-          <small><%= user.human_roles_string %></small>
+          <small><%= user.human_alchemy_roles %></small>
         </td>
       </tr>
     <% end %>

--- a/app/controllers/alchemy/admin/base_controller.rb
+++ b/app/controllers/alchemy/admin/base_controller.rb
@@ -14,8 +14,6 @@ module Alchemy
 
       before_action :load_locked_pages
 
-      helper_method :is_admin?
-
       check_authorization
 
       rescue_from Exception do |exception|
@@ -105,13 +103,6 @@ module Alchemy
         end
       end
 
-      # Returns true if the current_alchemy_user (The logged-in Alchemy User) has the admin role.
-      def is_admin?
-        return false if !current_alchemy_user
-
-        current_alchemy_user.admin?
-      end
-
       # Displays errors in a #errors div if any errors are present on the object.
       # Or redirects to the given redirect url.
       #
@@ -167,7 +158,7 @@ module Alchemy
       end
 
       def load_locked_pages
-        @locked_pages = Page.locked_by(current_alchemy_user).order(:locked_at)
+        @locked_pages ||= current_alchemy_user&.locked_pages
       end
 
       # Returns the current site for admin controllers.

--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -217,7 +217,13 @@ module Alchemy
     end
 
     def signup_required?
-      if Alchemy.config.user_class.respond_to?(:admins)
+      if Alchemy.config.user_class.respond_to?(:alchemy_admins)
+        Alchemy.config.user_class.alchemy_admins.empty?
+      elsif Alchemy.config.user_class.respond_to?(:admins)
+        Alchemy::Deprecation.warn(
+          "Using `#{Alchemy.config.user_class}.admins` is deprecated. " \
+          "Include `Alchemy::UserMethods` into your user class to provide `alchemy_admins` instead."
+        )
         Alchemy.config.user_class.admins.empty?
       end
     end

--- a/app/models/concerns/alchemy/user_methods.rb
+++ b/app/models/concerns/alchemy/user_methods.rb
@@ -1,0 +1,81 @@
+module Alchemy
+  module UserMethods
+    extend ActiveSupport::Concern
+
+    included do
+      # Unlock all locked pages before destroy.
+      before_destroy :unlock_pages!
+
+      scope :alchemy_admins, -> { with_alchemy_role(:admin) }
+
+      scope :with_alchemy_role, ->(role) {
+        role = role.to_s.downcase
+        unless Alchemy.config.user_roles.include?(role)
+          Alchemy::Logger.warn("Unknown Alchemy role: #{role.inspect}")
+        end
+
+        col = arel_table[:alchemy_roles]
+        where(
+          col.eq(role)
+            .or(col.matches("#{role} %"))
+            .or(col.matches("% #{role} %"))
+            .or(col.matches("% #{role}"))
+        )
+      }
+
+      validates :alchemy_roles,
+        presence: true,
+        inclusion: {
+          in: Alchemy.config.user_roles,
+          message: "is not included in #{Alchemy.config.user_roles.join(", ")}"
+        }
+
+      # Returns all pages locked by user.
+      #
+      # A page gets locked when the user starts to edit the page.
+      #
+      has_many :locked_pages,
+        -> { order(:locked_at) },
+        foreign_key: :locked_by,
+        class_name: "Alchemy::Page",
+        inverse_of: :locker
+    end
+
+    class_methods do
+      def human_alchemy_rolename(role)
+        Alchemy.t("user_roles.#{role}")
+      end
+    end
+
+    def alchemy_admin?
+      has_alchemy_role?("admin")
+    end
+
+    def alchemy_roles
+      read_attribute(:alchemy_roles).split(" ")
+    end
+
+    def alchemy_roles=(roles)
+      roles = Array(roles).map { _1.to_s.strip }
+      roles.reject!(&:blank?)
+      roles.uniq!
+      super(roles.join(" "))
+    end
+
+    # Returns true if the user has the given role.
+    def has_alchemy_role?(role)
+      alchemy_roles.include?(role.to_s)
+    end
+
+    def human_alchemy_roles
+      alchemy_roles.map do |role|
+        self.class.human_alchemy_rolename(role)
+      end.to_sentence
+    end
+
+    # Calls unlock on all locked pages
+    def unlock_pages!
+      locked_pages.each(&:unlock!)
+    end
+  end
+end

--- a/app/models/concerns/alchemy/user_methods.rb
+++ b/app/models/concerns/alchemy/user_methods.rb
@@ -52,7 +52,22 @@ module Alchemy
     end
 
     def alchemy_roles
-      read_attribute(:alchemy_roles).split(" ")
+      if self.class.columns_hash["alchemy_roles"]
+        read_attribute(:alchemy_roles).to_s.split(" ")
+      else
+        Alchemy::Logger.warn <<-WARN.strip_heredoc
+          The `alchemy_roles` column is missing in the #{self.class.table_name} table!
+
+          Please run
+
+            rails generate alchemy:user_columns_migration
+
+          to add it.
+
+          Falling back to default role: `member`.
+        WARN
+        ["member"]
+      end
     end
 
     def alchemy_roles=(roles)

--- a/lib/generators/alchemy/module/templates/ability.rb.tt
+++ b/lib/generators/alchemy/module/templates/ability.rb.tt
@@ -2,7 +2,7 @@ class <%= @controller_class %>Ability
   include CanCan::Ability
 
   def initialize(user)
-    if user.present? && user.is_admin?
+    if user&.is_alchemy_admin?
       can :manage, <%= @class_name %>
       can :manage, :admin_<%= @controller_name %>
     end

--- a/lib/generators/alchemy/user_columns_migration/templates/migration.rb.tt
+++ b/lib/generators/alchemy/user_columns_migration/templates/migration.rb.tt
@@ -1,0 +1,17 @@
+class AddAlchemyFieldsTo<%= table_name.camelcase %>Table < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction! if connection.adapter_name.match?(/postgres/i)
+
+  def change
+    add_column <%= table_name.inspect %>, :alchemy_roles, :text, if_not_exists: true, default: "member", comment: "Space separated list of Alchemy roles this user has"
+    add_column <%= table_name.inspect %>, :updater_id, :integer, if_not_exists: true, comment: "ID of the user that last updated this record"
+    add_column <%= table_name.inspect %>, :creator_id, :integer, if_not_exists: true, comment: "ID of the user that created this record"
+    add_index <%= table_name.inspect %>, :updater_id, if_not_exists: true, algorithm: algorithm
+    add_index <%= table_name.inspect %>, :creator_id, if_not_exists: true, algorithm: algorithm
+  end
+
+  private
+
+  def algorithm
+    connection.adapter_name.match?(/postgres/i) ? :concurrently : nil
+  end
+end

--- a/lib/generators/alchemy/user_columns_migration/user_columns_migration_generator.rb
+++ b/lib/generators/alchemy/user_columns_migration/user_columns_migration_generator.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails/generators/active_record/migration"
+
+module Alchemy
+  module Generators
+    class UserColumnsMigrationGenerator < Rails::Generators::Base
+      include ActiveRecord::Generators::Migration
+
+      desc "Generate migration for columns needed by Alchemy user class"
+
+      class_option :table_name,
+        type: :string,
+        desc: "User class table name",
+        default: Alchemy.config.user_class.table_name
+
+      source_root File.expand_path("templates", File.dirname(__FILE__))
+
+      def generate
+        migration_template "migration.rb.tt", "db/migrate/add_alchemy_fields_to_#{table_name}_table.rb"
+      end
+
+      private
+
+      def table_name
+        options[:table_name] || Alchemy.config.user_class.table_name
+      end
+    end
+  end
+end

--- a/spec/components/alchemy/admin/dashboard/widgets/online_users_spec.rb
+++ b/spec/components/alchemy/admin/dashboard/widgets/online_users_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Alchemy::Admin::Dashboard::Widgets::OnlineUsers, type: :component
       let(:users) { [another_user] }
 
       let(:another_user) do
-        mock_model("DummyUser", name: "Another User", human_roles_string: "Administrator")
+        mock_model("DummyUser", name: "Another User", human_alchemy_roles: "Administrator")
       end
 
       it "renders online_users" do

--- a/spec/controllers/alchemy/admin/translations_spec.rb
+++ b/spec/controllers/alchemy/admin/translations_spec.rb
@@ -6,7 +6,13 @@ describe Alchemy::Admin::DashboardController do
   routes { Alchemy::Engine.routes }
 
   context "in admin backend" do
-    let(:dummy_user) { mock_model(Alchemy.config.user_class, alchemy_roles: %w[admin], language: "de", admin?: true) }
+    let(:dummy_user) do
+      mock_model(Alchemy.config.user_class,
+        alchemy_roles: %w[admin],
+        language: "de",
+        alchemy_admin?: true,
+        locked_pages: [])
+    end
 
     before { authorize_user(dummy_user) }
 
@@ -49,7 +55,13 @@ describe Alchemy::Admin::DashboardController do
       end
 
       context "if user has no preferred locale" do
-        let(:dummy_user) { mock_model(Alchemy.config.user_class, alchemy_roles: %w[admin], language: nil, admin?: true) }
+        let(:dummy_user) do
+          mock_model(Alchemy.config.user_class,
+            alchemy_roles: %w[admin],
+            language: nil,
+            alchemy_admin?: true,
+            locked_pages: [])
+        end
 
         context "if locale is available" do
           before do
@@ -66,7 +78,14 @@ describe Alchemy::Admin::DashboardController do
 
           context "if user language is an instance of a model" do
             let(:language) { create(:alchemy_language) }
-            let(:dummy_user) { mock_model(Alchemy.config.user_class, alchemy_roles: %w[admin], language: language, admin?: true) }
+
+            let(:dummy_user) do
+              mock_model(Alchemy.config.user_class,
+                alchemy_roles: %w[admin],
+                language: language,
+                alchemy_admin?: true,
+                locked_pages: [])
+            end
 
             context "if language doesn't return a valid locale symbol" do
               it "should use the browsers language setting" do

--- a/spec/controllers/alchemy/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/pages_controller_spec.rb
@@ -22,14 +22,49 @@ module Alchemy
         autogenerate_elements: true
     end
 
-    before do
-      allow(controller).to receive(:signup_required?).and_return(false)
-    end
-
     describe "#index" do
       context "without a site or language present" do
-        it "returns a no_index page" do
-          expect(get(:index)).to render_template("alchemy/no_index")
+        context "with no admin users present" do
+          context "user class respond to alchemy_admins" do
+            before do
+              allow(Alchemy.config.user_class).to receive(:alchemy_admins).and_return(double(empty?: true))
+            end
+
+            it "returns a welcome page" do
+              expect(get(:index)).to render_template("alchemy/welcome")
+            end
+          end
+
+          context "user class does not respond to alchemy_admins" do
+            context "user class respond to admins" do
+              before do
+                allow(Alchemy.config.user_class).to receive(:respond_to?).with(:alchemy_admins).and_return(false)
+                allow(Alchemy.config.user_class).to receive(:respond_to?).with(:admins).and_return(true)
+                allow(Alchemy.config.user_class).to receive(:admins).and_return(double(empty?: true))
+                allow(Alchemy::Deprecation).to receive(:warn)
+              end
+
+              it "returns a welcome page" do
+                expect(get(:index)).to render_template("alchemy/welcome")
+              end
+
+              it "warns that the admins method is deprecated" do
+                expect(Alchemy::Deprecation).to receive(:warn).with(/admins` is deprecated/)
+                get(:index)
+              end
+            end
+
+            context "user class does not respond to admins" do
+              before do
+                allow(Alchemy.config.user_class).to receive(:respond_to?).with(:alchemy_admins).and_return(false)
+                allow(Alchemy.config.user_class).to receive(:respond_to?).with(:admins).and_return(false)
+              end
+
+              it "returns no_index page" do
+                expect(get(:index)).to render_template("alchemy/no_index")
+              end
+            end
+          end
         end
       end
 
@@ -169,7 +204,7 @@ module Alchemy
         let(:product) { create(:alchemy_page, :public, name: "Screwdriver", urlname: "screwdriver", parent: products, language: default_language, autogenerate_elements: true) }
 
         before do
-          allow(Alchemy.config.user_class).to receive(:admins).and_return(double(count: 1))
+          allow(Alchemy.config.user_class).to receive(:alchemy_admins).and_return(double(count: 1))
           product.elements.find_by(name: "article").ingredients.texts.first.update_column(:value, "screwdriver")
         end
 

--- a/spec/dummy/app/models/ability.rb
+++ b/spec/dummy/app/models/ability.rb
@@ -4,7 +4,7 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
-    if user&.admin?
+    if user&.alchemy_admin?
       can :manage, Event
       can :index, :admin_events
       can :manage, Location

--- a/spec/dummy/app/models/dummy_user.rb
+++ b/spec/dummy/app/models/dummy_user.rb
@@ -1,35 +1,21 @@
 # frozen_string_literal: true
 
 class DummyUser < ActiveRecord::Base
+  include Alchemy::UserMethods
+
   has_many :folded_pages, class_name: "Alchemy::FoldedPage"
-  attr_writer :alchemy_roles, :name
+  attr_writer :name
 
   def self.logged_in
     []
-  end
-
-  def self.admins
-    [first].compact
-  end
-
-  def alchemy_roles
-    @alchemy_roles || %w[admin]
   end
 
   def name
     @name || email
   end
 
-  def admin?
-    alchemy_roles.include?("admin")
-  end
-
   def alchemy_display_name
     name
-  end
-
-  def human_roles_string
-    alchemy_roles.map(&:humanize)
   end
 
   def sign_in_count = 0

--- a/spec/dummy/db/migrate/20260813142318_add_alchemy_fields_to_dummy_users_table.rb
+++ b/spec/dummy/db/migrate/20260813142318_add_alchemy_fields_to_dummy_users_table.rb
@@ -1,0 +1,17 @@
+class AddAlchemyFieldsToDummyUsersTable < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction! if connection.adapter_name.match?(/postgres/i)
+
+  def change
+    add_column "dummy_users", :alchemy_roles, :text, if_not_exists: true, default: "member"
+    add_column "dummy_users", :updater_id, :integer, if_not_exists: true
+    add_column "dummy_users", :creator_id, :integer, if_not_exists: true
+    add_index "dummy_users", :updater_id, if_not_exists: true, algorithm: algorithm
+    add_index "dummy_users", :creator_id, if_not_exists: true, algorithm: algorithm
+  end
+
+  private
+
+  def algorithm
+    connection.adapter_name.match?(/postgres/i) ? :concurrently : nil
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -318,9 +318,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_153412) do
   end
 
   create_table "dummy_users", force: :cascade do |t|
+    t.text "alchemy_roles", default: "member"
+    t.integer "creator_id"
     t.string "email"
     t.string "password"
+    t.integer "updater_id"
+    t.index ["creator_id"], name: "index_dummy_users_on_creator_id"
     t.index ["email"], name: "index_dummy_users_on_email"
+    t.index ["updater_id"], name: "index_dummy_users_on_updater_id"
   end
 
   create_table "events", force: :cascade do |t|

--- a/spec/features/page_feature_spec.rb
+++ b/spec/features/page_feature_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe "Show page feature:", type: :system do
   describe "Handling of non-existing pages" do
     before do
       # We need a admin user or the signup page will show up
-      allow(Alchemy.config.user_class).to receive(:admins).and_return([1, 2])
+      allow(Alchemy.config.user_class).to receive(:alchemy_admins).and_return([1, 2])
     end
 
     it "should render public/404.html" do

--- a/spec/features/page_redirects_spec.rb
+++ b/spec/features/page_redirects_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe "Requesting a page" do
 
     context "wrong language requested" do
       before do
-        allow(Alchemy.config.user_class).to receive(:admins).and_return([1, 2])
+        allow(Alchemy.config.user_class).to receive(:alchemy_admins).and_return([1, 2])
       end
 
       it "should render 404 if urlname and lang parameter do not belong to same page" do

--- a/spec/models/alchemy/user_methods_spec.rb
+++ b/spec/models/alchemy/user_methods_spec.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::UserMethods do
+  let(:user) { build_stubbed(:alchemy_dummy_user) }
+
+  it "should have at least member role" do
+    expect(user.alchemy_roles).not_to be_blank
+    expect(user.alchemy_roles).to include("member")
+  end
+
+  describe "validations" do
+    it "should validate alchemy_roles" do
+      user.alchemy_roles = nil
+      expect(user).not_to be_valid
+      expect(user.errors[:alchemy_roles]).to include("can't be blank")
+    end
+
+    it "should validate alchemy_roles inclusion" do
+      user.alchemy_roles = ["invalid_role"]
+      expect(user).not_to be_valid
+      expect(user.errors[:alchemy_roles]).to include("is not included in #{Alchemy.config.user_roles.join(", ")}")
+    end
+  end
+
+  describe "scopes" do
+    let!(:user) { create(:alchemy_dummy_user, :as_admin) }
+
+    describe ".alchemy_admins" do
+      let!(:member) { create(:alchemy_dummy_user, alchemy_roles: "member") }
+
+      it "should only return users with admin role" do
+        expect(Alchemy.config.user_class.alchemy_admins).to include(user)
+        expect(Alchemy.config.user_class.alchemy_admins).not_to include(member)
+      end
+    end
+
+    describe ".with_alchemy_role" do
+      [:editor, "Author", :Admin].each do |role|
+        context "with role #{role}" do
+          it "should return users with #{role.to_s.downcase} role" do
+            user = create(:alchemy_dummy_user, alchemy_roles: role.to_s.downcase)
+            expect(Alchemy.config.user_class.with_alchemy_role(role)).to include(user)
+          end
+        end
+      end
+
+      context "with users having multiple roles" do
+        it "should return users with given role at the end" do
+          user = create(:alchemy_dummy_user, alchemy_roles: "admin member")
+          expect(Alchemy.config.user_class.with_alchemy_role("member")).to include(user)
+        end
+
+        it "should return users with given role at the start" do
+          user = create(:alchemy_dummy_user, alchemy_roles: "member admin")
+          expect(Alchemy.config.user_class.with_alchemy_role("member")).to include(user)
+        end
+
+        it "should return users with given role in the middle" do
+          user = create(:alchemy_dummy_user, alchemy_roles: "editor member admin")
+          expect(Alchemy.config.user_class.with_alchemy_role("member")).to include(user)
+        end
+      end
+
+      context "with unknown role" do
+        it "logs a warning but still runs the query" do
+          expect(Alchemy::Logger).to receive(:warn).with("Unknown Alchemy role: \"unknown role\"")
+          expect(Alchemy.config.user_class.with_alchemy_role("Unknown role")).to be_empty
+        end
+      end
+    end
+  end
+
+  describe ".human_alchemy_rolename" do
+    it "return a translated role name" do
+      expect(Alchemy.config.user_class.human_alchemy_rolename("member")).to eq("Member")
+    end
+  end
+
+  describe "#human_alchemy_roles" do
+    it "should return a humanized roles string." do
+      user.alchemy_roles = ["member", "admin"]
+      expect(user.human_alchemy_roles).to eq("Member and Administrator")
+    end
+  end
+
+  describe "#has_alchemy_role?" do
+    context "with given role" do
+      it "should return true." do
+        expect(user.has_alchemy_role?("member")).to be_truthy
+      end
+    end
+
+    context "with role given as symbol" do
+      it "should return true." do
+        expect(user.has_alchemy_role?(:member)).to be_truthy
+      end
+    end
+
+    context "without given role" do
+      it "should return true." do
+        expect(user.has_alchemy_role?("admin")).to be_falsey
+      end
+    end
+  end
+
+  describe "#alchemy_roles" do
+    it "should return an array of user roles" do
+      expect(user.alchemy_roles).to eq(["member"])
+    end
+  end
+
+  describe "#alchemy_roles=" do
+    it "should accept a single user role" do
+      user.alchemy_roles = "admin"
+      expect(user.alchemy_roles).to eq(["admin"])
+    end
+
+    it "should accept an array of user roles" do
+      user.alchemy_roles = ["admin"]
+      expect(user.alchemy_roles).to eq(["admin"])
+    end
+
+    it "should accept a string of space separated user roles" do
+      user.alchemy_roles = "admin member"
+      expect(user.alchemy_roles).to eq(["admin", "member"])
+    end
+
+    it "should store the user roles as space seperated string" do
+      user.alchemy_roles = ["admin", "member"]
+      expect(user.read_attribute(:alchemy_roles)).to eq("admin member")
+    end
+
+    it "should strip user roles" do
+      user.alchemy_roles = ["admin ", " member"]
+      expect(user.read_attribute(:alchemy_roles)).to eq("admin member")
+    end
+  end
+
+  describe "#locked_pages" do
+    let(:user) { create(:alchemy_dummy_user) }
+    let(:page) { create(:alchemy_page) }
+
+    it "should return all pages that are locked by user" do
+      user.save!
+      page.lock_to!(user)
+      expect(user.locked_pages).to include(page)
+    end
+  end
+
+  describe "#unlock_pages" do
+    let(:user) { create(:alchemy_dummy_user) }
+    let(:page) { create(:alchemy_page) }
+
+    before do
+      page.lock_to!(user)
+    end
+
+    it "should unlock all users lockes pages" do
+      user.unlock_pages!
+      expect(user.locked_pages.reload).to be_empty
+    end
+  end
+
+  describe "#alchemy_admin?" do
+    it "should return true if the user has admin role" do
+      user.alchemy_roles = "admin"
+      expect(user.alchemy_admin?).to be_truthy
+    end
+  end
+end

--- a/spec/models/alchemy/user_methods_spec.rb
+++ b/spec/models/alchemy/user_methods_spec.rb
@@ -109,6 +109,22 @@ RSpec.describe Alchemy::UserMethods do
     it "should return an array of user roles" do
       expect(user.alchemy_roles).to eq(["member"])
     end
+
+    context "when the alchemy_roles column is missing" do
+      before do
+        allow(user.class).to receive(:columns_hash).and_return({})
+      end
+
+      it "logs a warning" do
+        expect(Alchemy::Logger).to receive(:warn).with(/alchemy_roles.*column is missing/m)
+        user.alchemy_roles
+      end
+
+      it "falls back to the default member role" do
+        allow(Alchemy::Logger).to receive(:warn)
+        expect(user.alchemy_roles).to eq(["member"])
+      end
+    end
   end
 
   describe "#alchemy_roles=" do


### PR DESCRIPTION
## What is this pull request for?

This module adds all necessary accessors, scopes and mehtods that alchemy needs from a custom user model.

Simply include it in your model. Also a generator is provided that creates a migration for necessary columns.

### Notable changes

1. All user methods and scopes are prefixed with `alchemy_` now. 
  So `User#admin?` becomes `User#alchemy_admin?`, etc.

3. Roles are now validated against configured `Alchemy.config.user_roles`.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
