### PR TITLE
Add current user to Alchemy::Current

### DIFF
--- a/app/models/alchemy/current.rb
+++ b/app/models/alchemy/current.rb
@@ -1,6 +1,6 @@
 module Alchemy
   class Current < ActiveSupport::CurrentAttributes
-    attribute :preview_page, :preview_time, :page, :language, :site
+    attribute :preview_page, :preview_time, :page, :language, :site, :user
 
     def language
       super || Language.default

--- a/lib/alchemy/controller_actions.rb
+++ b/lib/alchemy/controller_actions.rb
@@ -7,6 +7,7 @@ module Alchemy
     included do
       before_action :set_current_alchemy_site
       before_action :set_alchemy_language
+      before_action :set_current_alchemy_user
 
       helper "alchemy/pages"
 
@@ -57,6 +58,18 @@ module Alchemy
     #
     def set_current_alchemy_site
       Current.site = current_alchemy_site
+    end
+
+    # Stores the current user in +Current.user+ so models and services can
+    # access the acting user without threading it through every call.
+    #
+    # Apps without a configured +current_user_method+ leave it +nil+ instead
+    # of raising, so the public frontend keeps working without authentication.
+    #
+    def set_current_alchemy_user
+      Current.user = current_alchemy_user
+    rescue NoCurrentUserFoundError
+      Current.user = nil
     end
 
     # Sets the current language for Alchemy.

--- a/spec/libraries/controller_actions_spec.rb
+++ b/spec/libraries/controller_actions_spec.rb
@@ -40,6 +40,32 @@ describe "Alchemy::ControllerActions", type: "controller" do
     end
   end
 
+  describe "#set_current_alchemy_user" do
+    after { Alchemy::Current.user = nil }
+
+    context "when a current user is present" do
+      let(:user) { double("User") }
+
+      before { allow(controller).to receive(:current_user).and_return(user) }
+
+      it "stores it in Current.user" do
+        controller.send :set_current_alchemy_user
+        expect(Alchemy::Current.user).to eq(user)
+      end
+    end
+
+    context "when no current_user_method is implemented" do
+      before do
+        stub_alchemy_config(current_user_method: :not_implemented_method)
+      end
+
+      it "leaves Current.user nil" do
+        controller.send :set_current_alchemy_user
+        expect(Alchemy::Current.user).to be_nil
+      end
+    end
+  end
+
   describe "#set_alchemy_language" do
     let!(:default_language) { create(:alchemy_language, code: :en) }
     let(:klingon) { create(:alchemy_language, :klingon) }

--- a/spec/models/alchemy/current_spec.rb
+++ b/spec/models/alchemy/current_spec.rb
@@ -159,4 +159,15 @@ RSpec.describe Alchemy::Current do
       end
     end
   end
+
+  describe ".user" do
+    let(:user) { double("User") }
+
+    before { described_class.user = user }
+    after { described_class.user = nil }
+
+    it "returns the current user" do
+      expect(described_class.user).to eq(user)
+    end
+  end
 end


### PR DESCRIPTION
## What is this pull request for?

`Alchemy::Current` already carries the request-scoped site, language and
preview time. This adds the acting **user** to it, populated from
`current_alchemy_user` via a `before_action` in `Alchemy::ControllerActions`
(so it is set on both the frontend and the admin).

The motivation is to let models and services reach the current user without
threading it through every call — the same ambient pattern already used for
site/language/preview time. Apps that have no configured `current_user_method`
leave `Current.user` as `nil` instead of raising, so a public frontend without
authentication keeps working unchanged.

This is a small, self-contained foundation for upcoming user-aware visibility
features (element visibility conditions), shipped on its own so it can land and
be reviewed independently.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change