### PR TITLE
perf(elements): reuse preloaded element set for nested rendering

### DIFF
--- a/app/helpers/alchemy/elements_block_helper.rb
+++ b/app/helpers/alchemy/elements_block_helper.rb
@@ -58,6 +58,16 @@ module Alchemy
         element.ingredient_by_role(role)
       end
       alias_method :ingredient, :ingredient_by_role
+
+      # The element's visible nested children.
+      #
+      # Reads them from the page version's shared in-memory element repository
+      # instead of the +nested_elements+ association, so rendering a deeply
+      # nested element tree does not issue one query per parent.
+      #
+      def nested_elements
+        element.page_version.element_repository.children_of(element).visible.to_a
+      end
     end
 
     # Block-level helper for element views. Constructs a DOM element wrapping

--- a/app/models/alchemy/page_version.rb
+++ b/app/models/alchemy/page_version.rb
@@ -30,7 +30,7 @@ module Alchemy
     before_destroy :delete_elements
 
     def element_repository
-      ElementsRepository.new(elements)
+      @element_repository ||= ElementsRepository.new(elements)
     end
 
     private

--- a/lib/alchemy/upgrader/eight_four.rb
+++ b/lib/alchemy/upgrader/eight_four.rb
@@ -11,6 +11,61 @@ module Alchemy
 
         run %(bundle add dragonfly --version "~> 1.4")
       end
+
+      # Element partials that render nested elements through the
+      # +nested_elements+ association issue one database query per parent
+      # element. Rendering through the block helper's +nested_elements+
+      # instead reuses the page version's preloaded element set.
+      def upgrade_nested_elements_rendering
+        rewritten = []
+        manual = []
+        Dir.glob(Rails.root.join("app/views/alchemy/elements/*")).each do |file|
+          next unless File.file?(file)
+
+          content = File.read(file)
+          block_variable = content[/element_view_for\b.*?do\s*\|\s*(\w+)\s*\|/m, 1]
+
+          if block_variable
+            pattern = /render\s+(?!#{block_variable}\b)\w+\.nested_elements(?:\.published)?/
+            if content.match?(pattern)
+              gsub_file(file, pattern, "render #{block_variable}.nested_elements")
+              rewritten << file
+            end
+          elsif content.match?(/render\s+\w+\.nested_elements/)
+            manual << file
+          end
+        end
+
+        list = ->(files) { files.map { |file| "  - #{Pathname.new(file).relative_path_from(Rails.root)}" }.join("\n") }
+
+        if rewritten.any?
+          todo(<<~TODO.strip, "Nested elements are now rendered through the block helper")
+            We rewrote the following element partials to render nested elements
+            through the `element_view_for` block helper instead of the
+            `nested_elements` association, which issues one query per element:
+
+            #{list.call(rewritten)}
+
+            Please review these changes and commit them. Also check your views
+            for other uses of `element.nested_elements` that were not rewritten
+            automatically (for example assigned to a variable first).
+          TODO
+        end
+
+        if manual.any?
+          todo(<<~TODO.strip, "Nested elements rendered outside a block helper")
+            The following element partials render nested elements through the
+            `nested_elements` association but not inside an `element_view_for`
+            block, so we could not rewrite them automatically:
+
+            #{list.call(manual)}
+
+            Please render them through the block helper (`render el.nested_elements`)
+            so nested rendering reuses the preloaded element set instead of
+            querying per parent.
+          TODO
+        end
+      end
     end
   end
 end

--- a/lib/generators/alchemy/elements/templates/view.html.erb
+++ b/lib/generators/alchemy/elements/templates/view.html.erb
@@ -10,7 +10,7 @@
     <%- end -%>
   <%- end -%>
   <%- if @element['nestable_elements'].present? -%>
-    <%%= render <%= @element_name %>.nested_elements.published %>
+    <%%= render el.nested_elements %>
   <%- end -%>
   <%% end -%>
 <%% end -%>

--- a/lib/generators/alchemy/elements/templates/view.html.haml
+++ b/lib/generators/alchemy/elements/templates/view.html.haml
@@ -10,5 +10,5 @@
     <%- end -%>
   <%- end -%>
   <%- if @element['nestable_elements'].present? -%>
-    = render <%= @element_name -%>.nested_elements.published
+    = render el.nested_elements
   <%- end -%>

--- a/lib/generators/alchemy/elements/templates/view.html.slim
+++ b/lib/generators/alchemy/elements/templates/view.html.slim
@@ -10,5 +10,5 @@
     <%- end -%>
   <%- end -%>
   <%- if @element['nestable_elements'].present? -%>
-    = render <%= @element_name -%>.nested_elements.published
+    = render el.nested_elements
   <%- end -%>

--- a/lib/tasks/alchemy/upgrade.rake
+++ b/lib/tasks/alchemy/upgrade.rake
@@ -59,12 +59,18 @@ namespace :alchemy do
 
     namespace "8.4" do
       task "run" => [
-        "alchemy:upgrade:8.4:add_dragonfly_gem"
+        "alchemy:upgrade:8.4:add_dragonfly_gem",
+        "alchemy:upgrade:8.4:upgrade_nested_elements_rendering"
       ]
 
       desc "Add dragonfly gem to the Gemfile if the app uses the dragonfly storage adapter"
       task add_dragonfly_gem: [:environment] do
         Alchemy::Upgrader["8.4"].add_dragonfly_gem
+      end
+
+      desc "Rewrite element partials to render nested elements through the block helper"
+      task upgrade_nested_elements_rendering: [:environment] do
+        Alchemy::Upgrader["8.4"].upgrade_nested_elements_rendering
       end
     end
   end

--- a/spec/controllers/alchemy/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/pages_controller_spec.rb
@@ -190,6 +190,54 @@ module Alchemy
         end
       end
 
+      describe "nested element rendering" do
+        render_views
+
+        let(:nested_page) do
+          create(:alchemy_page, :public, name: "Nested", urlname: "nested",
+            page_layout: "standard", parent: default_language_root, language: default_language)
+        end
+
+        # Builds a chain of `gallery` containers `depth` levels deep, each
+        # holding a `text` leaf, on the page's public version.
+        def build_nested_chain(page, depth)
+          page.public_version.elements.destroy_all
+          parent = nil
+          depth.times do
+            container = create(:alchemy_element, name: "gallery",
+              page_version: page.public_version, parent_element: parent)
+            create(:alchemy_element, :with_ingredients, name: "text",
+              page_version: page.public_version, parent_element: container)
+            parent = container
+          end
+          page.reload
+        end
+
+        before do
+          allow(Alchemy.config.user_class).to receive(:admins).and_return(double(count: 1))
+        end
+
+        it "reuses the preloaded element set instead of querying per nesting level" do
+          build_nested_chain(nested_page, 6)
+          element_selects = 0
+          sub = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
+            payload = args.last
+            next if payload[:cached]
+            element_selects += 1 if /SELECT.*FROM ["`]?alchemy_elements["`]?/i.match?(payload[:sql])
+          end
+          get :show, params: {urlname: "nested"}
+          ActiveSupport::Notifications.unsubscribe(sub)
+          expect(element_selects).to eq(1)
+        end
+
+        it "renders the deeply nested leaf content" do
+          build_nested_chain(nested_page, 4)
+          get :show, params: {urlname: "nested"}
+          expect(Capybara.string(response.body))
+            .to have_css("div.gallery_images div.gallery_images div.gallery_images div.gallery_images")
+        end
+      end
+
       context "when a non-existent page is requested" do
         it "should rescue a RoutingError with rendering a 404 page." do
           expect {

--- a/spec/dummy/app/views/alchemy/elements/_gallery.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_gallery.html.erb
@@ -1,7 +1,7 @@
 <%- cache(gallery) do -%>
   <%= element_view_for(gallery) do |el| -%>
     <div class="gallery_images">
-      <%= render gallery.nested_elements %>
+      <%= render el.nested_elements %>
     </div>
   <%- end -%>
 <%- end -%>

--- a/spec/dummy/app/views/alchemy/elements/_left_column.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_left_column.html.erb
@@ -1,5 +1,5 @@
 <%- cache(left_column) do -%>
   <%= element_view_for(left_column) do |el| -%>
-    <%= render left_column.nested_elements %>
+    <%= render el.nested_elements %>
   <%- end -%>
 <%- end -%>

--- a/spec/dummy/app/views/alchemy/elements/_right_column.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_right_column.html.erb
@@ -1,6 +1,6 @@
 <%- cache(right_column) do -%>
   <%= element_view_for(right_column) do |el| -%>
     <%= el.render :title %>
-    <%= render right_column.nested_elements %>
+    <%= render el.nested_elements %>
   <%- end -%>
 <%- end -%>

--- a/spec/dummy/app/views/alchemy/elements/_slider.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_slider.html.erb
@@ -1,5 +1,5 @@
 <%- cache(slider) do -%>
   <%= element_view_for(slider) do |el| -%>
-    <%= render slider.nested_elements %>
+    <%= render el.nested_elements %>
   <%- end -%>
 <%- end -%>

--- a/spec/helpers/alchemy/elements_block_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_block_helper_spec.rb
@@ -128,6 +128,34 @@ module Alchemy
           expect(subject.ingredient(:headline)).to eq(ingredient)
         end
       end
+
+      describe "#nested_elements" do
+        context "with visible and hidden nested children" do
+          let(:page_version) { create(:alchemy_page_version) }
+          let(:element) do
+            create(:alchemy_element, name: "slider", page_version: page_version,
+              autogenerate_nested_elements: false)
+          end
+          let!(:first_slide) do
+            create(:alchemy_element, name: "slide", parent_element: element, page_version: page_version)
+          end
+          let!(:second_slide) do
+            create(:alchemy_element, name: "slide", parent_element: element, page_version: page_version)
+          end
+          let!(:hidden_slide) do
+            create(:alchemy_element, name: "slide", parent_element: element,
+              page_version: page_version, public_on: 1.day.from_now)
+          end
+
+          it "returns only the element's visible nested children" do
+            expect(subject.nested_elements).to match_array([first_slide, second_slide])
+          end
+
+          it "returns the children in position order" do
+            expect(subject.nested_elements).to eq([first_slide, second_slide])
+          end
+        end
+      end
     end
   end
 end

--- a/spec/lib/alchemy/upgrader/eight_four_spec.rb
+++ b/spec/lib/alchemy/upgrader/eight_four_spec.rb
@@ -41,4 +41,88 @@ RSpec.describe Alchemy::Upgrader::EightFour do
       end
     end
   end
+
+  describe "#upgrade_nested_elements_rendering" do
+    subject { upgrader.upgrade_nested_elements_rendering }
+
+    let(:partial_path) { Rails.root.join("app/views/alchemy/elements/_gallery.html.erb").to_s }
+
+    before do
+      allow(Dir).to receive(:glob).and_return([partial_path])
+      allow(File).to receive(:file?).and_return(true)
+      allow(File).to receive(:read).and_return(partial_content)
+      allow(upgrader).to receive(:gsub_file)
+    end
+
+    context "when an element partial renders via the nested_elements association" do
+      let(:partial_content) do
+        <<~ERB
+          <%= element_view_for(gallery) do |el| %>
+            <%= render gallery.nested_elements.published %>
+          <% end %>
+        ERB
+      end
+
+      it "rewrites the partial to render through the block helper" do
+        expect(upgrader).to receive(:gsub_file)
+          .with(partial_path, instance_of(Regexp), "render el.nested_elements")
+        subject
+      end
+
+      it "adds a todo about the change" do
+        expect(upgrader).to receive(:todo).with(kind_of(String), kind_of(String))
+        subject
+      end
+    end
+
+    context "when the block variable was renamed by the developer" do
+      let(:partial_content) do
+        <<~ERB
+          <%= element_view_for(gallery) do |item| %>
+            <%= render gallery.nested_elements %>
+          <% end %>
+        ERB
+      end
+
+      it "rewrites using the actual block variable name" do
+        expect(upgrader).to receive(:gsub_file)
+          .with(partial_path, instance_of(Regexp), "render item.nested_elements")
+        subject
+      end
+    end
+
+    context "when a partial renders nested elements outside an element_view_for block" do
+      let(:partial_content) { "<%= render gallery.nested_elements %>" }
+
+      it "does not rewrite it automatically" do
+        expect(upgrader).not_to receive(:gsub_file)
+        subject
+      end
+
+      it "adds a todo asking to update it manually" do
+        expect(upgrader).to receive(:todo).with(kind_of(String), kind_of(String))
+        subject
+      end
+    end
+
+    context "when element partials already render through the block helper" do
+      let(:partial_content) do
+        <<~ERB
+          <%= element_view_for(gallery) do |el| %>
+            <%= render el.nested_elements %>
+          <% end %>
+        ERB
+      end
+
+      it "does not rewrite anything" do
+        expect(upgrader).not_to receive(:gsub_file)
+        subject
+      end
+
+      it "does not add a todo" do
+        expect(upgrader).not_to receive(:todo)
+        subject
+      end
+    end
+  end
 end

--- a/spec/models/alchemy/page_version_spec.rb
+++ b/spec/models/alchemy/page_version_spec.rb
@@ -73,5 +73,9 @@ describe Alchemy::PageVersion do
       expect(Alchemy::ElementsRepository).to receive(:new).with(page_version.elements).and_call_original
       expect(subject).to be_a(Alchemy::ElementsRepository)
     end
+
+    it "memoizes the repository so nested rendering reuses one in-memory load" do
+      expect(page_version.element_repository).to be(page_version.element_repository)
+    end
   end
 end


### PR DESCRIPTION
## What is this pull request for?

Rendering nested elements walked the `nested_elements` association on every container, issuing one database query per parent even though the whole page version's elements were already materialized into the element repository. On deeply nested, fragment-cached pages this produced an elements N+1 on each cache miss, and it also defeated ingredient eager loading: the re-queried children were fresh records without the preloaded ingredients/tags, so `EagerLoading.page_includes` had no effect on the frontend.

This makes the page version memoize its element repository and adds a `nested_elements` method to the `element_view_for` block helper that reads a container's visible children from that shared in-memory set. Element partials now render nested children with `render el.nested_elements` instead of the association, so a page's elements load once regardless of nesting depth. The Russian-doll fragment cache is unaffected: a warm page still renders from cache, while a cold or partially stale page no longer pays the per-container query cost. As a side effect, the existing `EagerLoading.page_includes` becomes effective for nested frontend rendering again, since children are now served from the preloaded collection.

### Notable changes (remove if none)

The generator templates for element views now emit `render el.nested_elements`. Existing apps keep working unchanged (partials still using the association just retain the previous per-element query behaviour). A `8.4` upgrade task rewrites element partials to the block-helper form using each partial's own block variable, and flags any partial that renders nested elements outside an `element_view_for` block for manual review.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change