### PR TITLE
feat(cache): control Cache-Control headers per page layout and element

### DIFF
--- a/app/controllers/alchemy/pages_controller.rb
+++ b/app/controllers/alchemy/pages_controller.rb
@@ -199,8 +199,10 @@ module Alchemy
         # reuse it after a 304, which serves stale content (e.g. flash messages) and
         # skips re-rendering elements that opted out of page caching.
         no_store
+      elsif page_cache_control.no_cache?
+        expires_now
       else
-        expires_in @page.expiration_time, {public: !@page.restricted}.merge(caching_options)
+        expires_in @page.expiration_time, {public: page_cache_control.public?}.merge(caching_options)
       end
     end
 
@@ -248,24 +250,19 @@ module Alchemy
     def render_fresh_page?
       must_not_cache? || stale?(
         etag: page_etag,
-        public: !@page.restricted,
+        public: page_cache_control.public?,
         template: "pages/show"
       )
     end
 
-    # don't cache pages if we have flash message to display or the page has caching disabled
+    # don't cache pages if app caching is off, a flash message is present, or the
+    # page's effective Cache-Control forbids storing the response.
     def must_not_cache?
-      !caching_enabled? || !@page.cache_page? || flash.present? || page_cache_disabled_by_elements?
+      !caching_enabled? || flash.present? || page_cache_control.no_store?
     end
 
-    def page_cache_disabled_by_elements?
-      return @page_cache_disabled_by_elements if defined?(@page_cache_disabled_by_elements)
-
-      opt_out_names = Alchemy::Element.definitions.filter_map { |d| d.name if d.page_cache == false }
-      @page_cache_disabled_by_elements = !!(
-        opt_out_names.any? &&
-          @page&.public_version&.elements&.published&.exists?(name: opt_out_names)
-      )
+    def page_cache_control
+      @page.cache_control
     end
 
     def caching_enabled?

--- a/app/models/alchemy/cache_control.rb
+++ b/app/models/alchemy/cache_control.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module Alchemy
+  # Normalized HTTP Cache-Control directives derived from a page layout `cache`
+  # or element `page_cache` config value. Combine two values with `#&` to get the
+  # most restrictive of the two — this is how the page layout and its elements
+  # are merged (elements can only tighten, never loosen).
+  class CacheControl
+    VISIBILITIES = [:public, :private].freeze
+
+    # @param value [nil, true, false, Integer, Hash, CacheControl]
+    # @return [CacheControl]
+    def self.parse(value)
+      case value
+      when CacheControl then value
+      when nil, true then new(default: true)
+      when false then new(no_store: true)
+      when Integer then new(max_age: value)
+      when Hash then from_hash(value)
+      else new(default: true)
+      end
+    end
+
+    def self.from_hash(hash)
+      options = hash.transform_keys(&:to_sym)
+      new(
+        no_store: !!options[:no_store],
+        no_cache: !!options[:no_cache],
+        max_age: options[:max_age],
+        visibility: (options[:visibility] || :public).to_sym
+      )
+    end
+    private_class_method :from_hash
+
+    attr_reader :max_age, :visibility
+
+    def initialize(no_store: false, no_cache: false, max_age: nil, visibility: :public, default: false)
+      @no_store = no_store
+      @no_cache = no_cache
+      @max_age = max_age
+      @visibility = visibility
+      @default = default
+    end
+
+    def no_store?
+      @no_store
+    end
+
+    def no_cache?
+      @no_cache
+    end
+
+    def default?
+      @default
+    end
+
+    # Whether the response is flagged `public` to HTTP caches. A no-cache
+    # response is never public: Rails only pairs no-cache with public, and
+    # "public" adds nothing to an always-revalidated response.
+    def public?
+      visibility == :public && !no_cache?
+    end
+
+    def private?
+      visibility == :private
+    end
+
+    # Most restrictive of self and other.
+    def &(other)
+      return self if other.nil?
+      return self.class.new(no_store: true) if no_store? || other.no_store?
+
+      vis = (private? || other.private?) ? :private : :public
+      return self.class.new(no_cache: true, visibility: vis) if no_cache? || other.no_cache?
+
+      self.class.new(visibility: vis, max_age: min_max_age(other))
+    end
+
+    def restrict_visibility
+      return self if no_store? || private?
+
+      self.class.new(no_cache: no_cache?, max_age: max_age, visibility: :private)
+    end
+
+    def ==(other)
+      other.is_a?(CacheControl) &&
+        no_store? == other.no_store? &&
+        no_cache? == other.no_cache? &&
+        max_age == other.max_age &&
+        visibility == other.visibility
+    end
+    alias_method :eql?, :==
+
+    def hash
+      [no_store?, no_cache?, max_age, visibility].hash
+    end
+
+    private
+
+    def min_max_age(other)
+      [max_age, other.max_age].compact.min
+    end
+  end
+end

--- a/app/models/alchemy/element_definition.rb
+++ b/app/models/alchemy/element_definition.rb
@@ -13,7 +13,7 @@ module Alchemy
     attribute :taggable, :boolean, default: false
     attribute :compact, :boolean, default: false
     attribute :fixed, :boolean, default: false
-    attribute :page_cache, :boolean, default: true
+    attribute :page_cache, Alchemy::CacheControlType.new, default: true
     attribute :ingredients, default: []
     attribute :nestable_elements, default: []
     attribute :autogenerate, default: []

--- a/app/models/alchemy/page/page_natures.rb
+++ b/app/models/alchemy/page/page_natures.rb
@@ -31,11 +31,7 @@ module Alchemy
       def expiration_time
         return 0 unless cache_page?
 
-        if definition.cache.to_s.match?(/\d+/)
-          definition.cache.to_i
-        else
-          Alchemy.config.page_cache.max_age
-        end
+        cache_control.max_age || Alchemy.config.page_cache.max_age
       end
 
       def rootpage?
@@ -174,9 +170,46 @@ module Alchemy
       # @returns Boolean
       #
       def cache_page?
-        return false if !public? || restricted?
+        !cache_control.no_store?
+      end
 
-        definition.cache != false && definition.searchresults != true
+      # The effective Cache-Control directives for this page: the page layout's
+      # `cache` setting combined (most restrictively) with the `page_cache` of any
+      # published element on the page, then narrowed for restricted / non-public /
+      # search-results pages.
+      #
+      # @returns [Alchemy::CacheControl]
+      def cache_control
+        return @cache_control if defined?(@cache_control)
+
+        control = [definition.cache, *element_cache_controls].reduce(:&)
+
+        control = Alchemy::CacheControl.parse(false) if !public? || definition.searchresults
+
+        if restricted?
+          control = if definition.cache.default?
+            Alchemy::CacheControl.parse(false)
+          else
+            control.restrict_visibility
+          end
+        end
+
+        @cache_control = control
+      end
+
+      private
+
+      # CacheControl of every visible element on the page whose definition
+      # declares a non-default `page_cache`. Reads through the page version's
+      # element repository so it reuses already-loaded elements instead of
+      # firing its own query, and only inspects elements at all when at least
+      # one definition is non-default.
+      def element_cache_controls
+        constrained = Alchemy::Element.definitions.reject { |d| d.page_cache.default? }
+        return [] if constrained.empty?
+
+        present_names = public_version&.element_repository&.visible&.named(*constrained.map(&:name))&.map(&:name) || []
+        constrained.select { |d| present_names.include?(d.name) }.map(&:page_cache)
       end
     end
   end

--- a/app/models/alchemy/page_definition.rb
+++ b/app/models/alchemy/page_definition.rb
@@ -12,7 +12,7 @@ module Alchemy
     attribute :autogenerate, default: []
     attribute :layoutpage, :boolean, default: false
     attribute :unique, :boolean, default: false
-    attribute :cache, default: true
+    attribute :cache, Alchemy::CacheControlType.new, default: true
     attribute :insert_elements_at, :string, default: "bottom"
     attribute :fixed_attributes, default: {}
     attribute :searchable, :boolean, default: true

--- a/app/types/alchemy/cache_control_type.rb
+++ b/app/types/alchemy/cache_control_type.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Alchemy
+  # Casts a page layout `cache` / element `page_cache` config value into an
+  # {Alchemy::CacheControl} and validates the hash grammar at definition-load
+  # time (see {#assert_valid_value}, called eagerly on attribute assignment).
+  class CacheControlType < ActiveModel::Type::Value
+    ALLOWED_KEYS = [:visibility, :max_age, :no_cache, :no_store].freeze
+
+    def cast(value)
+      Alchemy::CacheControl.parse(value)
+    end
+
+    def assert_valid_value(value)
+      case value
+      when nil, true, false, Alchemy::CacheControl
+        nil
+      when Integer
+        assert_valid_max_age!(value)
+      when Hash
+        assert_valid_hash!(value)
+      else
+        raise ArgumentError,
+          "#{value.inspect} is not a valid cache setting. " \
+          "Must be true, false, an Integer, or a Hash."
+      end
+    end
+
+    private
+
+    def assert_valid_hash!(hash)
+      options = hash.transform_keys(&:to_sym)
+
+      unknown = options.keys - ALLOWED_KEYS
+      if unknown.any?
+        raise ArgumentError,
+          "unknown cache option(s) #{unknown.map(&:inspect).join(", ")}. " \
+          "Allowed: #{ALLOWED_KEYS.map(&:inspect).join(", ")}."
+      end
+
+      assert_valid_visibility!(options[:visibility]) if options.key?(:visibility)
+      assert_valid_max_age!(options[:max_age]) if options.key?(:max_age)
+      assert_boolean!(:no_cache, options[:no_cache]) if options.key?(:no_cache)
+      assert_boolean!(:no_store, options[:no_store]) if options.key?(:no_store)
+      assert_no_conflicts!(options)
+    end
+
+    def assert_valid_visibility!(value)
+      unless CacheControl::VISIBILITIES.include?(value.to_s.to_sym)
+        raise ArgumentError,
+          "cache visibility #{value.inspect} is invalid. Must be :public or :private."
+      end
+    end
+
+    def assert_valid_max_age!(value)
+      unless value.is_a?(Integer) && value >= 0
+        raise ArgumentError,
+          "cache max_age #{value.inspect} is invalid. Must be a non-negative Integer."
+      end
+    end
+
+    def assert_boolean!(key, value)
+      unless [true, false].include?(value)
+        raise ArgumentError, "cache #{key} #{value.inspect} is invalid. Must be true or false."
+      end
+    end
+
+    def assert_no_conflicts!(options)
+      if options[:no_store]
+        conflicting = [:max_age, :visibility, :no_cache].select { |k| truthy?(options, k) }
+        if conflicting.any?
+          raise ArgumentError,
+            "cache no_store cannot be combined with #{conflicting.map(&:inspect).join(", ")}."
+        end
+      elsif options[:no_cache] && options.key?(:max_age)
+        raise ArgumentError, "cache no_cache cannot be combined with max_age."
+      end
+    end
+
+    def truthy?(options, key)
+      options.key?(key) && options[key]
+    end
+  end
+end

--- a/spec/models/alchemy/cache_control_spec.rb
+++ b/spec/models/alchemy/cache_control_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Alchemy
+  RSpec.describe CacheControl do
+    describe ".parse" do
+      it "treats nil and true as the unconstrained default" do
+        [nil, true].each do |value|
+          control = described_class.parse(value)
+          expect(control.default?).to be(true)
+          expect(control.no_store?).to be(false)
+          expect(control.no_cache?).to be(false)
+          expect(control.max_age).to be_nil
+          expect(control.public?).to be(true)
+        end
+      end
+
+      it "treats false as no_store" do
+        control = described_class.parse(false)
+        expect(control.no_store?).to be(true)
+        expect(control.default?).to be(false)
+      end
+
+      it "treats an Integer as a public max_age" do
+        control = described_class.parse(3600)
+        expect(control.max_age).to eq(3600)
+        expect(control.public?).to be(true)
+        expect(control.default?).to be(false)
+      end
+
+      it "parses a hash with symbol keys" do
+        control = described_class.parse(visibility: :private, max_age: 60)
+        expect(control.private?).to be(true)
+        expect(control.max_age).to eq(60)
+      end
+
+      it "parses a hash with string keys and string visibility" do
+        control = described_class.parse("visibility" => "private", "max_age" => 60)
+        expect(control.private?).to be(true)
+        expect(control.max_age).to eq(60)
+      end
+
+      it "parses no_cache and no_store hashes" do
+        expect(described_class.parse(no_cache: true).no_cache?).to be(true)
+        expect(described_class.parse(no_store: true).no_store?).to be(true)
+      end
+
+      it "is never public when no_cache (public adds nothing to no-cache)" do
+        expect(described_class.parse(no_cache: true).public?).to be(false)
+      end
+
+      it "is idempotent for a CacheControl" do
+        control = described_class.parse(60)
+        expect(described_class.parse(control)).to equal(control)
+      end
+
+      it "falls back to the default for unsupported values" do
+        expect(described_class.parse("nonsense").default?).to be(true)
+      end
+    end
+
+    describe "#&" do
+      it "no_store wins over everything" do
+        a = described_class.parse(3600)
+        b = described_class.parse(no_store: true)
+        expect((a & b).no_store?).to be(true)
+        expect((b & a).no_store?).to be(true)
+      end
+
+      it "no_cache wins over a plain max_age" do
+        a = described_class.parse(3600)
+        b = described_class.parse(no_cache: true)
+        expect((a & b).no_cache?).to be(true)
+      end
+
+      it "private wins over public" do
+        a = described_class.parse(visibility: :public, max_age: 60)
+        b = described_class.parse(visibility: :private, max_age: 60)
+        expect((a & b).private?).to be(true)
+      end
+
+      it "takes the smaller max_age, treating nil as unbounded" do
+        expect((described_class.parse(60) & described_class.parse(3600)).max_age).to eq(60)
+        expect((described_class.parse(true) & described_class.parse(3600)).max_age).to eq(3600)
+        expect((described_class.parse(true) & described_class.parse(true)).max_age).to be_nil
+      end
+    end
+
+    describe "#restrict_visibility" do
+      it "downgrades public to private" do
+        expect(described_class.parse(60).restrict_visibility.private?).to be(true)
+      end
+
+      it "leaves no_store untouched" do
+        control = described_class.parse(no_store: true).restrict_visibility
+        expect(control.no_store?).to be(true)
+      end
+
+      it "keeps no_cache but makes it private" do
+        control = described_class.parse(no_cache: true).restrict_visibility
+        expect(control.no_cache?).to be(true)
+        expect(control.private?).to be(true)
+      end
+    end
+
+    describe "#==" do
+      it "compares by directives, ignoring default?" do
+        expect(described_class.parse(true)).to eq(described_class.new(visibility: :public))
+        expect(described_class.parse(60)).not_to eq(described_class.parse(30))
+      end
+    end
+
+    describe "#hash" do
+      it "is equal for equal directives, so instances dedupe as hash keys" do
+        expect(described_class.parse(60).hash).to eq(described_class.parse(60).hash)
+        expect([described_class.parse(60), described_class.parse(60)].uniq.size).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/models/alchemy/element_definition_spec.rb
+++ b/spec/models/alchemy/element_definition_spec.rb
@@ -37,12 +37,23 @@ module Alchemy
     end
 
     describe "#page_cache" do
-      it "defaults to true" do
-        expect(described_class.new.page_cache).to be(true)
+      it "defaults to an unconstrained CacheControl" do
+        expect(described_class.new.page_cache).to be_a(Alchemy::CacheControl)
+        expect(described_class.new.page_cache.default?).to be(true)
       end
 
-      it "can be disabled" do
-        expect(described_class.new(page_cache: false).page_cache).to be(false)
+      it "casts false to a no_store CacheControl" do
+        expect(described_class.new(page_cache: false).page_cache.no_store?).to be(true)
+      end
+
+      it "casts a hash into a CacheControl" do
+        control = described_class.new(page_cache: {visibility: "private", max_age: 60}).page_cache
+        expect(control.private?).to be(true)
+        expect(control.max_age).to eq(60)
+      end
+
+      it "raises for an invalid hash" do
+        expect { described_class.new(page_cache: {bogus: true}) }.to raise_error(ArgumentError)
       end
     end
 

--- a/spec/models/alchemy/page_spec.rb
+++ b/spec/models/alchemy/page_spec.rb
@@ -2263,6 +2263,75 @@ module Alchemy
       end
     end
 
+    describe "#cache_control" do
+      subject { page.cache_control }
+
+      let(:page) { build(:alchemy_page, :public, page_layout: "standard") }
+
+      it "returns the layout's CacheControl for a public page" do
+        expect(subject).to be_a(Alchemy::CacheControl)
+        expect(subject.max_age).to eq(60)
+        expect(subject.public?).to be(true)
+      end
+
+      context "when the layout disables caching" do
+        let(:page) { build(:alchemy_page, :public, page_layout: "contact") }
+
+        it "is no_store" do
+          expect(subject.no_store?).to be(true)
+        end
+      end
+
+      context "when the layout is a search results page" do
+        let(:page) { build(:alchemy_page, :public, page_layout: "search") }
+
+        it "is no_store" do
+          expect(subject.no_store?).to be(true)
+        end
+      end
+
+      context "when the page is restricted" do
+        before { allow(page).to receive(:restricted?) { true } }
+
+        context "and the layout uses the default cache setting" do
+          let(:page) { build(:alchemy_page, :public, page_layout: "everything") }
+
+          it "is no_store (restricted default is never cached)" do
+            expect(subject.no_store?).to be(true)
+          end
+        end
+
+        context "and the layout explicitly configures caching" do
+          let(:page) { build(:alchemy_page, :public, page_layout: "standard") }
+
+          it "downgrades public to private" do
+            expect(subject.private?).to be(true)
+            expect(subject.max_age).to eq(60)
+          end
+        end
+      end
+
+      context "with a published element that tightens caching" do
+        around do |example|
+          Alchemy::ElementDefinition.add({"name" => "private_element", "page_cache" => {"visibility" => "private"}})
+          Alchemy::PageDefinition.add({"name" => "with_private_element", "cache" => 3600, "elements" => ["private_element"]})
+          example.run
+        ensure
+          Alchemy::ElementDefinition.reset!
+          Alchemy::PageDefinition.reset!
+        end
+
+        let(:page) { create(:alchemy_page, :public, page_layout: "with_private_element") }
+
+        it "combines to the most restrictive (private, layout max_age)" do
+          create(:alchemy_element, name: "private_element", page_version: page.public_version)
+
+          expect(page.cache_control.private?).to be(true)
+          expect(page.cache_control.max_age).to eq(3600)
+        end
+      end
+    end
+
     describe "#cache_page?" do
       let(:page) { build(:alchemy_page, :public, page_layout: "news") }
 

--- a/spec/requests/alchemy/page_request_caching_spec.rb
+++ b/spec/requests/alchemy/page_request_caching_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Page request caching" do
 
       context "when page must not be cached" do
         before do
-          allow_any_instance_of(Alchemy::Page).to receive(:cache_page?) { false }
+          allow_any_instance_of(Alchemy::Page).to receive(:cache_control) { Alchemy::CacheControl.parse(false) }
         end
 
         it "sets no-store cache-control header" do
@@ -164,6 +164,67 @@ RSpec.describe "Page request caching" do
         end
       end
 
+      context "with hash-based cache directives" do
+        around do |example|
+          Alchemy::PageDefinition.add({"name" => "private_cache_layout", "cache" => {"visibility" => "private", "max_age" => 120}})
+          Alchemy::PageDefinition.add({"name" => "no_cache_layout", "cache" => {"no_cache" => true}})
+          example.run
+        ensure
+          Alchemy::PageDefinition.reset!
+        end
+
+        it "sets a private max-age header" do
+          private_page = create(:alchemy_page, :public, page_layout: "private_cache_layout")
+
+          get "/#{private_page.urlname}"
+
+          expect(response.headers["Cache-Control"]).to eq("max-age=120, private, must-revalidate")
+        end
+
+        it "sets a no-cache header and still allows revalidation" do
+          no_cache_page = create(:alchemy_page, :public, page_layout: "no_cache_layout")
+
+          expect_any_instance_of(Alchemy::PagesController).to receive(:stale?).and_call_original
+
+          get "/#{no_cache_page.urlname}"
+
+          expect(response.headers["Cache-Control"]).to eq("no-cache")
+        end
+      end
+
+      # Elements can only tighten a page's caching, never loosen it: a more
+      # permissive element directive must not override the page layout.
+      context "when a published element is less restrictive than the page" do
+        around do |example|
+          Alchemy::ElementDefinition.add({"name" => "cacheable_element", "page_cache" => 3600})
+          Alchemy::ElementDefinition.add({"name" => "public_element", "page_cache" => {"visibility" => "public"}})
+          Alchemy::PageDefinition.add({"name" => "disabled_layout", "cache" => false, "elements" => ["cacheable_element"]})
+          Alchemy::PageDefinition.add({"name" => "private_layout", "cache" => {"visibility" => "private", "max_age" => 120}, "elements" => ["public_element"]})
+          example.run
+        ensure
+          Alchemy::ElementDefinition.reset!
+          Alchemy::PageDefinition.reset!
+        end
+
+        it "keeps the page's no-store when the element enables caching" do
+          disabled_page = create(:alchemy_page, :public, page_layout: "disabled_layout")
+          create(:alchemy_element, name: "cacheable_element", page_version: disabled_page.public_version)
+
+          get "/#{disabled_page.urlname}"
+
+          expect(response.headers["Cache-Control"]).to eq("no-store")
+        end
+
+        it "keeps the page private when the element is public" do
+          private_page = create(:alchemy_page, :public, page_layout: "private_layout")
+          create(:alchemy_element, name: "public_element", page_version: private_page.public_version)
+
+          get "/#{private_page.urlname}"
+
+          expect(response.headers["Cache-Control"]).to eq("max-age=120, private, must-revalidate")
+        end
+      end
+
       it "does not set last-modified header" do
         get "/#{page.urlname}"
         expect(response.headers).to_not have_key("Last-Modified")
@@ -172,7 +233,7 @@ RSpec.describe "Page request caching" do
 
     context "but page should not be cached" do
       before do
-        allow_any_instance_of(Alchemy::Page).to receive(:cache_page?) { false }
+        allow_any_instance_of(Alchemy::Page).to receive(:cache_control) { Alchemy::CacheControl.parse(false) }
       end
 
       it "sets no-store header" do

--- a/spec/types/alchemy/cache_control_type_spec.rb
+++ b/spec/types/alchemy/cache_control_type_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Alchemy
+  RSpec.describe CacheControlType do
+    subject(:type) { described_class.new }
+
+    describe "#cast" do
+      it "casts scalars into a CacheControl" do
+        expect(type.cast(true)).to be_a(Alchemy::CacheControl)
+        expect(type.cast(false).no_store?).to be(true)
+        expect(type.cast(3600).max_age).to eq(3600)
+      end
+
+      it "casts a hash into a CacheControl" do
+        control = type.cast("visibility" => "private", "max_age" => 60)
+        expect(control.private?).to be(true)
+        expect(control.max_age).to eq(60)
+      end
+
+      it "returns a CacheControl unchanged" do
+        control = Alchemy::CacheControl.parse(60)
+        expect(type.cast(control)).to equal(control)
+      end
+    end
+
+    describe "#assert_valid_value" do
+      it "accepts scalars and nil" do
+        [nil, true, false, 600].each do |value|
+          expect { type.assert_valid_value(value) }.not_to raise_error
+        end
+      end
+
+      it "accepts a valid hash (symbol or string keys)" do
+        expect { type.assert_valid_value(visibility: :private, max_age: 60) }.not_to raise_error
+        expect { type.assert_valid_value("no_cache" => true, "visibility" => "public") }.not_to raise_error
+        expect { type.assert_valid_value(no_store: true) }.not_to raise_error
+      end
+
+      it "raises for an unknown key" do
+        expect { type.assert_valid_value(bogus: true) }.to raise_error(
+          ArgumentError, /unknown cache option.*bogus/i
+        )
+      end
+
+      it "raises for an invalid visibility" do
+        expect { type.assert_valid_value(visibility: "secret") }.to raise_error(
+          ArgumentError, /visibility.*public.*private/i
+        )
+      end
+
+      it "raises for a non-integer max_age" do
+        expect { type.assert_valid_value(max_age: "soon") }.to raise_error(
+          ArgumentError, /max_age.*integer/i
+        )
+      end
+
+      it "raises for a negative max_age" do
+        expect { type.assert_valid_value(max_age: -5) }.to raise_error(
+          ArgumentError, /max_age/i
+        )
+      end
+
+      it "raises for contradictory no_store + max_age" do
+        expect { type.assert_valid_value(no_store: true, max_age: 60) }.to raise_error(
+          ArgumentError, /no_store/i
+        )
+      end
+
+      it "raises for contradictory no_cache + max_age" do
+        expect { type.assert_valid_value(no_cache: true, max_age: 60) }.to raise_error(
+          ArgumentError, /no_cache/i
+        )
+      end
+
+      it "raises for a non-boolean no_cache/no_store" do
+        expect { type.assert_valid_value(no_cache: "yes") }.to raise_error(
+          ArgumentError, /no_cache.*true or false/i
+        )
+        expect { type.assert_valid_value(no_store: "nope") }.to raise_error(
+          ArgumentError, /no_store.*true or false/i
+        )
+      end
+
+      it "raises for an unsupported type" do
+        expect { type.assert_valid_value([1, 2]) }.to raise_error(
+          ArgumentError, /not a valid cache setting/i
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

This lets a page layout (`cache:`) and an element definition (`page_cache:`)
declare the full set of relevant HTTP `Cache-Control` directives, not just an
on/off switch and a max-age. Both keys gain a shared hash grammar —
`visibility: public|private`, `max_age:`, `no_cache: true`, `no_store: true` —
while every existing scalar form (`true`, `false`, an Integer) keeps its current
meaning. This builds directly on the element-level page-cache opt-out from #3980,
generalizing that boolean into the same expressive grammar.

A new `Alchemy::CacheControl` value object normalizes a config value and combines
two of them most-restrictively, so a page's effective directive is its layout's
`cache` folded with the `page_cache` of every published element on the page.
Because the combination only ever tightens, an element can make a page less
cacheable but never more — a safe default that keeps a single opted-out element
from being overridden by a permissive layout. A new `Alchemy::CacheControlType`
(ActiveModel type, alongside `WildcardUrlType`) validates the hash grammar
eagerly at definition-load time, so a malformed `cache:`/`page_cache:` raises a
clear `ArgumentError` instead of silently misbehaving.

### Notable changes (remove if none)

- `ElementDefinition#page_cache` and `PageDefinition#cache` now return an
  `Alchemy::CacheControl` value object rather than the raw config value. The
  `page_cache: false` element opt-out from #3980 still results in `no-store`.
- Restricted pages remain out of any shared cache: a `public` directive is
  downgraded to `private`, and a restricted page on a plain-default layout stays
  uncacheable. Newly, a restricted page can be privately cached when its layout
  explicitly opts in (e.g. `cache: { visibility: private, max_age: … }`).
- `no_cache`/`no_store` intentionally mirror the HTTP directive names and Rails'
  own `cache_control` keys (rather than positive booleans), so the config maps
  1:1 onto the response.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change