### PR TITLE
fix(elements): return element repository from block helper nested_elements

### DIFF
--- a/app/helpers/alchemy/elements_block_helper.rb
+++ b/app/helpers/alchemy/elements_block_helper.rb
@@ -65,8 +65,12 @@ module Alchemy
       # instead of the +nested_elements+ association, so rendering a deeply
       # nested element tree does not issue one query per parent.
       #
+      # Returns an +Alchemy::ElementsRepository+ so callers can keep chaining
+      # scopes (e.g. +nested_elements.named(:slide)+) while still rendering it
+      # directly as a collection (+render el.nested_elements+).
+      #
       def nested_elements
-        element.page_version.element_repository.children_of(element).visible.to_a
+        element.page_version.element_repository.children_of(element).visible
       end
     end
 

--- a/app/models/alchemy/elements_repository.rb
+++ b/app/models/alchemy/elements_repository.rb
@@ -125,6 +125,17 @@ module Alchemy
       elements.each(&)
     end
 
+    # Allows the repository to be passed to the ActionView collection renderer
+    # (+render repository+), which detects a collection by +to_ary+.
+    def to_ary
+      elements
+    end
+
+    def size
+      elements.size
+    end
+    alias_method :length, :size
+
     private
 
     attr_reader :elements

--- a/spec/helpers/alchemy/elements_block_helper_spec.rb
+++ b/spec/helpers/alchemy/elements_block_helper_spec.rb
@@ -152,7 +152,12 @@ module Alchemy
           end
 
           it "returns the children in position order" do
-            expect(subject.nested_elements).to eq([first_slide, second_slide])
+            expect(subject.nested_elements.to_a).to eq([first_slide, second_slide])
+          end
+
+          it "returns an element repository that can be further scoped" do
+            expect(subject.nested_elements).to be_an(Alchemy::ElementsRepository)
+            expect(subject.nested_elements.named(:slide).to_a).to eq([first_slide, second_slide])
           end
         end
       end

--- a/spec/models/alchemy/elements_repository_spec.rb
+++ b/spec/models/alchemy/elements_repository_spec.rb
@@ -249,4 +249,26 @@ RSpec.describe Alchemy::ElementsRepository do
 
     it { is_expected.to match_array([nested_element]) }
   end
+
+  describe "#to_ary" do
+    it "returns the elements as an array" do
+      expect(repo.to_ary).to eq(elements)
+    end
+
+    it "makes the repository usable as a Rails render collection" do
+      expect(repo).to respond_to(:to_ary)
+    end
+  end
+
+  describe "#size" do
+    it "returns the number of elements" do
+      expect(repo.size).to eq(elements.size)
+    end
+  end
+
+  describe "#length" do
+    it "returns the number of elements" do
+      expect(repo.length).to eq(elements.length)
+    end
+  end
 end


### PR DESCRIPTION
## What is this pull request for?

In 8.4 the element view block helper's `nested_elements` casts its result to an `Array` with `to_a`. That drops the `Alchemy::ElementsRepository` interface, so apps that chain element scopes on it — such as `el.nested_elements.named(:slide)` — break with a `NoMethodError` after upgrading. This restores that ability.

`nested_elements` now returns the repository again. The reason it was cast in the first place was so `render el.nested_elements` kept working through Rails' collection renderer, so the repository now satisfies that contract directly: it implements `to_ary` (which ActionView uses to detect a collection) plus `size`/`length` (which the collection renderer calls on the collection object itself). Because `to_ary` exposes the already in-memory element set, nested rendering still issues no extra query per parent.

### Notable changes (remove if none)

Fixes a regression introduced in 8.4: element scopes chained on `el.nested_elements` inside element partials work again.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change