### PR TITLE
chore: Add annotaterb and annotate model schemas

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :development, :test do
     gem "simplecov-cobertura", "~> 3.0"
   else
     gem "launchy"
-    gem "annotate"
+    gem "annotaterb"
     gem "bumpy"
     gem "yard"
     gem "redcarpet"

--- a/app/models/alchemy/attachment.rb
+++ b/app/models/alchemy/attachment.rb
@@ -4,17 +4,23 @@
 #
 # Table name: alchemy_attachments
 #
-#  id              :integer          not null, primary key
-#  name            :string
-#  file_name       :string
-#  file_mime_type  :string
-#  file_size       :integer
-#  creator_id      :integer
-#  updater_id      :integer
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  cached_tag_list :text
-#  file_uid        :string
+#  id             :integer          not null, primary key
+#  file_mime_type :string
+#  file_name      :string
+#  file_size      :integer
+#  file_uid       :string
+#  name           :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  creator_id     :integer
+#  updater_id     :integer
+#
+# Indexes
+#
+#  index_alchemy_attachments_on_created_at  (created_at)
+#  index_alchemy_attachments_on_creator_id  (creator_id)
+#  index_alchemy_attachments_on_file_uid    (file_uid)
+#  index_alchemy_attachments_on_updater_id  (updater_id)
 #
 
 module Alchemy

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -5,20 +5,33 @@
 # Table name: alchemy_elements
 #
 #  id                :integer          not null, primary key
+#  fixed             :boolean          default(FALSE), not null
+#  folded            :boolean          default(FALSE), not null
 #  name              :string
 #  position          :integer
-#  page_version_id   :integer          not null
-#  public_on         :timestamp
-#  public_until      :timestamp
-#  fixed             :boolean          default(FALSE)
-#  folded            :boolean          default(FALSE)
-#  unique            :boolean          default(FALSE)
+#  public_on         :datetime
+#  public_until      :datetime
+#  unique            :boolean          default(FALSE), not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  creator_id        :integer
-#  updater_id        :integer
-#  cached_tag_list   :text
+#  page_version_id   :integer          not null
 #  parent_element_id :integer
+#  updater_id        :integer
+#
+# Indexes
+#
+#  idx_alchemy_elements_on_page_version_id_and_parent_element_id  (page_version_id,parent_element_id)
+#  idx_alchemy_elements_on_page_version_id_and_position           (page_version_id,position)
+#  index_alchemy_elements_on_creator_id                           (creator_id)
+#  index_alchemy_elements_on_fixed                                (fixed)
+#  index_alchemy_elements_on_page_version_id                      (page_version_id)
+#  index_alchemy_elements_on_public_on_and_public_until           (public_on,public_until)
+#  index_alchemy_elements_on_updater_id                           (updater_id)
+#
+# Foreign Keys
+#
+#  page_version_id  (page_version_id => alchemy_page_versions.id) ON DELETE => cascade
 #
 
 require_dependency "alchemy/element/definitions"

--- a/app/models/alchemy/folded_page.rb
+++ b/app/models/alchemy/folded_page.rb
@@ -5,9 +5,13 @@
 # Table name: alchemy_folded_pages
 #
 #  id      :integer          not null, primary key
+#  folded  :boolean          default(FALSE), not null
 #  page_id :integer          not null
 #  user_id :integer          not null
-#  folded  :boolean          default(FALSE)
+#
+# Indexes
+#
+#  index_alchemy_folded_pages_on_page_id_and_user_id  (page_id,user_id) UNIQUE
 #
 
 module Alchemy

--- a/app/models/alchemy/ingredient.rb
+++ b/app/models/alchemy/ingredient.rb
@@ -1,5 +1,31 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: alchemy_ingredients
+#
+#  id                  :integer          not null, primary key
+#  data                :json
+#  related_object_type :string
+#  role                :string           not null
+#  type                :string           not null
+#  value               :text
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  element_id          :integer          not null
+#  related_object_id   :integer
+#
+# Indexes
+#
+#  idx_alchemy_ingredient_relation                   (related_object_id,related_object_type)
+#  index_alchemy_ingredients_on_element_id           (element_id)
+#  index_alchemy_ingredients_on_element_id_and_role  (element_id,role) UNIQUE
+#  index_alchemy_ingredients_on_type                 (type)
+#
+# Foreign Keys
+#
+#  element_id  (element_id => alchemy_elements.id) ON DELETE => cascade
+#
 module Alchemy
   class Ingredient < BaseRecord
     class DefinitionError < StandardError; end

--- a/app/models/alchemy/language.rb
+++ b/app/models/alchemy/language.rb
@@ -5,19 +5,31 @@
 # Table name: alchemy_languages
 #
 #  id             :integer          not null, primary key
-#  name           :string
-#  language_code  :string
+#  country_code   :string           default(""), not null
+#  default        :boolean          default(FALSE), not null
 #  frontpage_name :string
+#  language_code  :string
+#  locale         :string
+#  name           :string
 #  page_layout    :string           default("intro")
-#  public         :boolean          default(FALSE)
+#  public         :boolean          default(FALSE), not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  creator_id     :integer
-#  updater_id     :integer
-#  default        :boolean          default(FALSE)
-#  country_code   :string           default(""), not null
 #  site_id        :integer          not null
-#  locale         :string
+#  updater_id     :integer
+#
+# Indexes
+#
+#  index_alchemy_languages_on_creator_id                      (creator_id)
+#  index_alchemy_languages_on_language_code                   (language_code)
+#  index_alchemy_languages_on_language_code_and_country_code  (language_code,country_code)
+#  index_alchemy_languages_on_site_id                         (site_id)
+#  index_alchemy_languages_on_updater_id                      (updater_id)
+#
+# Foreign Keys
+#
+#  site_id  (site_id => alchemy_sites.id)
 #
 
 require_dependency "alchemy/site"

--- a/app/models/alchemy/legacy_page_url.rb
+++ b/app/models/alchemy/legacy_page_url.rb
@@ -6,9 +6,14 @@
 #
 #  id         :integer          not null, primary key
 #  urlname    :string           not null
-#  page_id    :integer          not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  page_id    :integer          not null
+#
+# Indexes
+#
+#  index_alchemy_legacy_page_urls_on_page_id  (page_id)
+#  index_alchemy_legacy_page_urls_on_urlname  (urlname)
 #
 
 class Alchemy::LegacyPageUrl < ActiveRecord::Base

--- a/app/models/alchemy/node.rb
+++ b/app/models/alchemy/node.rb
@@ -1,5 +1,43 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: alchemy_nodes
+#
+#  id          :integer          not null, primary key
+#  depth       :integer          default(0), not null
+#  external    :boolean          default(FALSE), not null
+#  folded      :boolean          default(FALSE), not null
+#  lft         :integer          not null
+#  menu_type   :string           not null
+#  name        :string
+#  nofollow    :boolean          default(FALSE), not null
+#  rgt         :integer          not null
+#  title       :string
+#  url         :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  creator_id  :integer
+#  language_id :integer          not null
+#  page_id     :integer
+#  parent_id   :integer
+#  updater_id  :integer
+#
+# Indexes
+#
+#  index_alchemy_nodes_on_creator_id   (creator_id)
+#  index_alchemy_nodes_on_language_id  (language_id)
+#  index_alchemy_nodes_on_lft          (lft)
+#  index_alchemy_nodes_on_page_id      (page_id)
+#  index_alchemy_nodes_on_parent_id    (parent_id)
+#  index_alchemy_nodes_on_rgt          (rgt)
+#  index_alchemy_nodes_on_updater_id   (updater_id)
+#
+# Foreign Keys
+#
+#  language_id  (language_id => alchemy_languages.id)
+#  page_id      (page_id => alchemy_pages.id) ON DELETE => restrict
+#
 module Alchemy
   class Node < BaseRecord
     include Alchemy::RelatableResource

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -4,36 +4,45 @@
 #
 # Table name: alchemy_pages
 #
-#  id               :integer          not null, primary key
-#  name             :string
-#  urlname          :string
-#  title            :string           (deprecated - use draft_version.title)
-#  language_code    :string
-#  language_root    :boolean
-#  page_layout      :string
-#  meta_keywords    :text             (deprecated - use draft_version.meta_keywords)
-#  meta_description :text             (deprecated - use draft_version.meta_description)
-#  lft              :integer
-#  rgt              :integer
-#  parent_id        :integer
-#  depth            :integer
-#  locked_by        :integer
-#  restricted       :boolean          default(FALSE)
-#  permitted_roles  :text             default("[\"member\"]"), not null
-#  robot_index      :boolean          default(TRUE)
-#  robot_follow     :boolean          default(TRUE)
-#  sitemap          :boolean          default(TRUE)
-#  layoutpage       :boolean          default(FALSE)
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  creator_id       :integer
-#  updater_id       :integer
-#  language_id      :integer
-#  cached_tag_list  :text
-#  published_at     :datetime
-#  public_on        :datetime
-#  public_until     :datetime
-#  locked_at        :datetime
+#  id              :integer          not null, primary key
+#  depth           :integer
+#  language_code   :string
+#  language_root   :boolean          default(FALSE), not null
+#  layoutpage      :boolean          default(FALSE), not null
+#  lft             :integer
+#  locked_at       :datetime
+#  locked_by       :integer
+#  name            :string
+#  page_layout     :string
+#  permitted_roles :text             default("[\"member\"]"), not null
+#  published_at    :datetime
+#  restricted      :boolean          default(FALSE), not null
+#  rgt             :integer
+#  robot_follow    :boolean          default(TRUE), not null
+#  robot_index     :boolean          default(TRUE), not null
+#  searchable      :boolean          default(TRUE), not null
+#  sitemap         :boolean          default(TRUE), not null
+#  urlname         :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  creator_id      :integer
+#  language_id     :integer          not null
+#  parent_id       :integer
+#  updater_id      :integer
+#
+# Indexes
+#
+#  index_alchemy_pages_on_creator_id               (creator_id)
+#  index_alchemy_pages_on_language_id              (language_id)
+#  index_alchemy_pages_on_locked_at_and_locked_by  (locked_at,locked_by)
+#  index_alchemy_pages_on_rgt                      (rgt)
+#  index_alchemy_pages_on_updater_id               (updater_id)
+#  index_pages_on_parent_id_and_lft                (parent_id,lft)
+#  index_pages_on_urlname                          (urlname)
+#
+# Foreign Keys
+#
+#  language_id  (language_id => alchemy_languages.id)
 #
 
 require_dependency "alchemy/page/fixed_attributes"

--- a/app/models/alchemy/page_mutex.rb
+++ b/app/models/alchemy/page_mutex.rb
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: alchemy_page_mutexes
+#
+#  id         :integer          not null, primary key
+#  created_at :datetime
+#  page_id    :integer          not null
+#
+# Indexes
+#
+#  index_alchemy_page_mutexes_on_page_id  (page_id) UNIQUE
+#
+# Foreign Keys
+#
+#  page_id  (page_id => alchemy_pages.id)
+#
 module Alchemy
   class PageMutex < BaseRecord
     class LockFailed < StandardError; end

--- a/app/models/alchemy/page_version.rb
+++ b/app/models/alchemy/page_version.rb
@@ -1,5 +1,28 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: alchemy_page_versions
+#
+#  id               :integer          not null, primary key
+#  meta_description :text
+#  meta_keywords    :text
+#  public_on        :datetime
+#  public_until     :datetime
+#  title            :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  page_id          :integer          not null
+#
+# Indexes
+#
+#  index_alchemy_page_versions_on_page_id                     (page_id)
+#  index_alchemy_page_versions_on_public_on_and_public_until  (public_on,public_until)
+#
+# Foreign Keys
+#
+#  page_id  (page_id => alchemy_pages.id) ON DELETE => cascade
+#
 module Alchemy
   class PageVersion < BaseRecord
     include Alchemy::Publishable

--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -5,19 +5,26 @@
 # Table name: alchemy_pictures
 #
 #  id                :integer          not null, primary key
-#  name              :string
-#  image_file_name   :string
-#  image_file_width  :integer
+#  image_file_format :string
 #  image_file_height :integer
+#  image_file_name   :string
+#  image_file_size   :integer
+#  image_file_uid    :string
+#  image_file_width  :integer
+#  name              :string
+#  upload_hash       :string
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  creator_id        :integer
 #  updater_id        :integer
-#  upload_hash       :string
-#  cached_tag_list   :text
-#  image_file_uid    :string
-#  image_file_size   :integer
-#  image_file_format :string
+#
+# Indexes
+#
+#  index_alchemy_pictures_on_created_at       (created_at)
+#  index_alchemy_pictures_on_creator_id       (creator_id)
+#  index_alchemy_pictures_on_image_file_name  (image_file_name)
+#  index_alchemy_pictures_on_name             (name)
+#  index_alchemy_pictures_on_updater_id       (updater_id)
 #
 
 module Alchemy

--- a/app/models/alchemy/picture_description.rb
+++ b/app/models/alchemy/picture_description.rb
@@ -1,3 +1,25 @@
+# == Schema Information
+#
+# Table name: alchemy_picture_descriptions
+#
+#  id          :integer          not null, primary key
+#  text        :text
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  language_id :integer          not null
+#  picture_id  :integer          not null
+#
+# Indexes
+#
+#  alchemy_picture_descriptions_on_picture_id_and_language_id  (picture_id,language_id) UNIQUE
+#  index_alchemy_picture_descriptions_on_language_id           (language_id)
+#  index_alchemy_picture_descriptions_on_picture_id            (picture_id)
+#
+# Foreign Keys
+#
+#  language_id  (language_id => alchemy_languages.id)
+#  picture_id   (picture_id => alchemy_pictures.id)
+#
 module Alchemy
   class PictureDescription < ActiveRecord::Base
     belongs_to :picture, class_name: "Alchemy::Picture"

--- a/app/models/alchemy/picture_thumb.rb
+++ b/app/models/alchemy/picture_thumb.rb
@@ -1,5 +1,23 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: alchemy_picture_thumbs
+#
+#  id         :integer          not null, primary key
+#  signature  :string           not null
+#  uid        :text             not null
+#  picture_id :integer          not null
+#
+# Indexes
+#
+#  index_alchemy_picture_thumbs_on_picture_id  (picture_id)
+#  index_alchemy_picture_thumbs_on_signature   (signature) UNIQUE
+#
+# Foreign Keys
+#
+#  picture_id  (picture_id => alchemy_pictures.id)
+#
 module Alchemy
   # The persisted version of a rendered picture variant
   #

--- a/app/models/alchemy/site.rb
+++ b/app/models/alchemy/site.rb
@@ -5,13 +5,18 @@
 # Table name: alchemy_sites
 #
 #  id                       :integer          not null, primary key
+#  aliases                  :text
 #  host                     :string
 #  name                     :string
+#  public                   :boolean          default(FALSE), not null
+#  redirect_to_primary_host :boolean          default(FALSE), not null
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
-#  public                   :boolean          default(FALSE)
-#  aliases                  :text
-#  redirect_to_primary_host :boolean
+#
+# Indexes
+#
+#  alchemy_sites_public_hosts_idx  (host,public)
+#  index_alchemy_sites_on_host     (host)
 #
 
 module Alchemy

--- a/app/models/alchemy/tag.rb
+++ b/app/models/alchemy/tag.rb
@@ -5,8 +5,15 @@
 # Table name: gutentag_tags
 #
 #  id             :integer          not null, primary key
-#  name           :string
-#  taggings_count :integer          default(0)
+#  name           :string           not null
+#  taggings_count :integer          default(0), not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
+# Indexes
+#
+#  index_gutentag_tags_on_name            (name) UNIQUE
+#  index_gutentag_tags_on_taggings_count  (taggings_count)
 #
 
 # Just holds some useful tag methods.

--- a/spec/dummy/.annotaterb.yml
+++ b/spec/dummy/.annotaterb.yml
@@ -1,0 +1,71 @@
+---
+:position: before
+:position_in_additional_file_patterns: before
+:position_in_class: before
+:position_in_factory: before
+:position_in_fixture: before
+:position_in_routes: before
+:position_in_serializer: before
+:position_in_test: before
+:classified_sort: true
+:exclude_controllers: true
+:exclude_factories: false
+:exclude_fixtures: false
+:exclude_helpers: true
+:exclude_scaffolds: true
+:exclude_serializers: false
+:exclude_sti_subclasses: true
+:exclude_tests: false
+:force: false
+:format_markdown: false
+:format_rdoc: false
+:format_yard: false
+:frozen: false
+:grouped_polymorphic: false
+:ignore_database_name: false
+:ignore_model_sub_dir: false
+:ignore_unknown_models: false
+:include_version: false
+:show_check_constraints: false
+:show_unique_constraints: false
+:show_exclusion_constraints: false
+:show_enums: false
+:show_complete_foreign_keys: false
+:show_foreign_keys: true
+:show_indexes: true
+:show_indexes_comments: false
+:show_indexes_include: false
+:simple_indexes: false
+:sort: false
+:timestamp: false
+:trace: false
+:with_comment: true
+:with_column_comments: true
+:with_table_comments: true
+:position_of_column_comment: :with_name
+:active_admin: false
+:command:
+:debug: false
+:hide_default_column_types: ''
+:hide_limit_column_types: ''
+:timestamp_columns:
+- created_at
+- updated_at
+:ignore_columns:
+:ignore_routes:
+:ignore_multi_database_name: false
+:models: true
+:routes: false
+:skip_on_db_migrate: false
+:auto_annotate_routes_after_migrate: false
+:target_action: :do_annotations
+:wrapper:
+:wrapper_close:
+:wrapper_open:
+:classes_default_to_s: []
+:additional_file_patterns: []
+:model_dir:
+- "../../app/models"
+:require: []
+:root_dir:
+- ''

--- a/spec/dummy/lib/tasks/annotate_rb.rake
+++ b/spec/dummy/lib/tasks/annotate_rb.rake
@@ -1,0 +1,10 @@
+# This rake task was added by annotate_rb gem.
+
+# Can set `ANNOTATERB_SKIP_ON_DB_TASKS` to be anything to skip this
+if Rails.env.development? && ENV["ANNOTATERB_SKIP_ON_DB_TASKS"].nil?
+  require "annotate_rb"
+
+  # Can modify the config path here if needed - by default, it's .annotaterb.yml in the root of the project
+  # AnnotateRb::ConfigFinder.config_path = ""
+  AnnotateRb::Core.load_rake_tasks
+end


### PR DESCRIPTION
## What is this pull request for?

Model files gained schema summary comments long ago via the `annotate`
gem, but the gem was only declared in the Gemfile (pinned to an ancient
2.6.5) and never actually wired up, so the annotations had drifted out
of date — showing columns that had since moved to `page_versions` and
missing indexes and foreign keys entirely.

This switches to `annotaterb`, the maintained successor to the now
dormant `annotate` gem, and configures it to work with our engine
layout. Because Alchemy is an engine, the config (`.annotaterb.yml`) and
the `db:migrate` hook live in the dummy app where migrations actually
run, with `model_dir` pointed back at the engine's `app/models`. The
hook is guarded to the development environment so CI never requires the
gem or mutates files. STI ingredient subclasses are excluded so the
shared `alchemy_ingredients` block is not duplicated across every
subclass. All existing model annotations are refreshed to match the
current schema.

From now on, adding a migration and running it in the dummy app updates
the affected model's annotation automatically.

### Notable changes (remove if none)

Replaces the `annotate` development dependency with `annotaterb`.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change