### PR TITLE
fix(Resource::Table): Build a fresh cell/action per row

### DIFF
--- a/app/components/alchemy/admin/resource/action.rb
+++ b/app/components/alchemy/admin/resource/action.rb
@@ -10,6 +10,8 @@ module Alchemy
       #   name of an action to evaluate if the user can perform these action on the given object
       # @param [String, nil] :tooltip
       #   show a tooltip around the button
+      # @param [Object, nil] :resource
+      #   the resource of the row the action belongs to
       # @param [Lambda] :block
       #   a block to include a button or a link
       #
@@ -30,15 +32,11 @@ module Alchemy
           <% end %>
         ERB
 
-        def initialize(name = nil, tooltip = nil, &block)
+        def initialize(name = nil, tooltip = nil, resource = nil, &block)
           @name = name
           @tooltip = tooltip
-          @block = block
-        end
-
-        def with_resource(resource)
           @resource = resource
-          self
+          @block = block
         end
       end
     end

--- a/app/components/alchemy/admin/resource/cell.rb
+++ b/app/components/alchemy/admin/resource/cell.rb
@@ -7,6 +7,8 @@ module Alchemy
       #
       # @param [String, nil] :css_classes
       #   css classes that are show at the table cell
+      # @param [Object, nil] :resource
+      #   the resource of the row the cell belongs to
       # @param [Lambda] :block
       #   a block to include a button or a link
       #
@@ -19,14 +21,10 @@ module Alchemy
           </td>
         ERB
 
-        def initialize(css_classes, &block)
+        def initialize(css_classes, resource = nil, &block)
           @css_classes = css_classes
-          @block = block
-        end
-
-        def with_resource(resource)
           @resource = resource
-          self
+          @block = block
         end
       end
     end

--- a/app/components/alchemy/admin/resource/table.rb
+++ b/app/components/alchemy/admin/resource/table.rb
@@ -137,13 +137,13 @@ module Alchemy
         # A fresh cell instance is built for every resource because ViewComponent
         # instances are single-use and may not be rendered more than once.
         def cell_for(cell, resource)
-          Cell.new(cell.css_classes, &cell.block).with_resource(resource)
+          Cell.new(cell.css_classes, resource, &cell.block)
         end
 
         # A fresh action instance is built for every resource because ViewComponent
         # instances are single-use and may not be rendered more than once.
         def action_for(action, resource)
-          Action.new(action.name, action.tooltip, &action.block).with_resource(resource)
+          Action.new(action.name, action.tooltip, resource, &action.block)
         end
 
         ##

--- a/app/components/alchemy/admin/resource/table.rb
+++ b/app/components/alchemy/admin/resource/table.rb
@@ -69,12 +69,12 @@ module Alchemy
                 <% collection.each do |resource| %>
                   <tr class="<%= cycle('even', 'odd') %>">
                     <% cells.each do |cell| %>
-                       <%= render cell.with_resource(resource) %>
+                       <%= render cell_for(cell, resource) %>
                     <% end %>
                     <% if actions? %>
                       <td class="tools">
                         <% actions.each do |action| %>
-                          <%= render action.with_resource(resource) %>
+                          <%= render action_for(action, resource) %>
                         <% end %>
                       </td>
                     <% end %>
@@ -133,6 +133,18 @@ module Alchemy
         end
 
         private
+
+        # A fresh cell instance is built for every resource because ViewComponent
+        # instances are single-use and may not be rendered more than once.
+        def cell_for(cell, resource)
+          Cell.new(cell.css_classes, &cell.block).with_resource(resource)
+        end
+
+        # A fresh action instance is built for every resource because ViewComponent
+        # instances are single-use and may not be rendered more than once.
+        def action_for(action, resource)
+          Action.new(action.name, action.tooltip, &action.block).with_resource(resource)
+        end
 
         ##
         # if no cells are available the resource_helper will be used, to generate the

--- a/spec/components/alchemy/admin/resource/action_spec.rb
+++ b/spec/components/alchemy/admin/resource/action_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe Alchemy::Admin::Resource::Action, type: :component do
   let(:block) { lambda { |item| "Foo" } }
   let(:custom_resource) { Struct.new(:name, :description) }
   let(:resource) { custom_resource.new("Foo", "Bar") }
-  let(:component) { described_class.new(name, tooltip, &block) }
+  let(:component) { described_class.new(name, tooltip, resource, &block) }
 
   subject(:render) do
     with_controller_class(Admin::EventsController) do
-      render_inline(component.with_resource(resource))
+      render_inline(component)
     end
   end
 

--- a/spec/components/alchemy/admin/resource/cell_spec.rb
+++ b/spec/components/alchemy/admin/resource/cell_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe Alchemy::Admin::Resource::Cell, type: :component do
   let(:block) { lambda { |item| "Foo" } }
   let(:custom_resource) { Struct.new(:name, :description) }
   let(:resource) { custom_resource.new("Foo", "Bar") }
-  let(:component) { described_class.new(css_classes, &block) }
+  let(:component) { described_class.new(css_classes, resource, &block) }
 
   subject(:render) do
     with_controller_class(Admin::EventsController) do
-      render_inline(component.with_resource(resource))
+      render_inline(component)
     end
   end
 


### PR DESCRIPTION
## What is this pull request for?

ViewComponent 4.14 raises `ViewComponent::ReusedInstanceError` when the same component instance is rendered more than once, because a reused instance can leak request-scoped state (controller, helpers, request, view flow, slot content) from an earlier render into a later one (GHSA-8qw7-6phv-7q6p).

`Alchemy::Admin::Resource::Table` registered each cell and action slot once and then re-rendered that same instance for every resource row via a `with_resource(self)`-mutation setter. Under 4.14 this now raises and breaks every resource index table. This builds a fresh `Cell` and `Action` for each resource instead.

### Notable changes (remove if none)

The `with_resource` mutation setter on `Cell` and `Action` is removed. Now that a fresh instance is built per row, the resource is passed straight into the constructor, which also removes the self-returning setter that made accidental instance reuse easy to write.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change