### PR TITLE
[8.3] fix(Menubar): Normalize line-height

### DIFF
--- a/app/views/alchemy/_menubar.html.erb
+++ b/app/views/alchemy/_menubar.html.erb
@@ -17,7 +17,7 @@
           box-shadow: 0 0 0 1px #fff;
           box-sizing: border-box;
           border-bottom-right-radius: var(--border-radius);
-          padding: 12px 16px 12px;
+          padding: 12px 16px 12px 12px;
           gap: 12px;
           justify-content: space-between;
           align-items: center;
@@ -26,6 +26,7 @@
           font-family: "Open Sans", "Lucida Grande", "Lucida Sans Unicode",
             "Lucida Sans", Verdana, Tahoma, sans-serif;
           font-size: 13px;
+          line-height: normal;
         }
 
         .menubar * {
@@ -107,7 +108,7 @@
           <% end %>
         <% end %>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30">
-          <path fill="#fff" d="M15.7 7.9L9.9 2.2 2.1 4.3 0 12.1l5.7 5.8 7.8-2.1 2.2-7.9zm-5.3 10.3l-1.2 4.4 3.2 3.2 4.4-1.2 1.2-4.4-3.2-3.2-4.4 1.2zM23.5 7.3L17.2 9l-1.7 6.2 4.5 4.6 6.2-1.7 1.7-6.2-4.4-4.6z"/>
+          <path fill="#fff" d="M15.7 7.9L9.9 2.2 2.1 4.3 0 12.1l5.7 5.8 7.8-2.1 2.2-7.9zm-5.3 10.3l-1.2 4.4 3.2 3.2 4.4-1.2 1.2-4.4-3.2-3.2-4.4 1.2zM23.5 7.3L17.2 9l-1.7 6.2 4.5 4.6 6.2-1.7 1.7-6.2-4.4-4.6z" />
         </svg>
       </div>
     </template>


### PR DESCRIPTION
## What is this pull request for?

Backport of #4154 for 8.3-stable

On pages with a global line-height we do not want it to leak into the menubar.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
