### PR TITLE
feat(attachments): Support more audio and video media types

### DIFF
--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -79,9 +79,13 @@ en:
       application/x-rar: RAR Archive
       application/x-shockwave-flash: Flash Movie
       application/zip: ZIP Archive
+      audio/aac: AAC Audio
+      audio/flac: FLAC Audio
       audio/mp4: MPEG-4 Audio
       audio/mpeg: MP3 Audio
+      audio/ogg: Ogg Audio
       audio/wav: WAV Audio
+      audio/webm: WebM Audio
       audio/x-wav: WAV Audio
       image/avif: AVIF Image
       image/gif: GIF Image
@@ -95,6 +99,7 @@ en:
       text/x-vcard: vCard
       video/mp4: MPEG-4 Video
       video/mpeg: MPEG Video
+      video/ogg: Ogg Video
       video/quicktime: Quicktime Video
       video/webm: WebM Video
       video/x-flv: Flash Video

--- a/lib/alchemy/filetypes.rb
+++ b/lib/alchemy/filetypes.rb
@@ -5,9 +5,13 @@ module Alchemy
     ARCHIVE_FILE_TYPES = ["application/zip", "application/x-rar"]
 
     AUDIO_FILE_TYPES = [
+      "audio/aac",
+      "audio/flac",
       "audio/mpeg",
       "audio/mp4",
+      "audio/ogg",
       "audio/wav",
+      "audio/webm",
       "audio/x-wav"
     ]
 
@@ -29,6 +33,7 @@ module Alchemy
       "video/x-flv",
       "video/mp4",
       "video/mpeg",
+      "video/ogg",
       "video/quicktime",
       "video/webm",
       "video/x-msvideo",


### PR DESCRIPTION
## What is this pull request for?

Alchemy only recognized a small set of audio and video mime types, so common web media formats were shown with the generic file icon and no human readable type name in the attachment archive. This adds the requested `audio/webm` and `audio/ogg` types, together with the equally common `audio/flac`, `audio/aac` and `video/ogg` formats.

Each new type is added to the matching `AUDIO_FILE_TYPES` / `VIDEO_FILE_TYPES` constant, so it automatically resolves to the existing audio (`file-music`) and video (`file-video`) icon groups via `Alchemy::Attachment#icon_css_class`, and each gets a human readable name under the `mime_types` locale scope.

Only English translations are provided; the other locales fall back to English for the new keys.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change