### PR TITLE
perf(taggable): drop now-redundant tag eager loading

### DIFF
--- a/app/models/alchemy/eager_loading.rb
+++ b/app/models/alchemy/eager_loading.rb
@@ -18,14 +18,12 @@ module Alchemy
         raise UnsupportedPageVersion unless version.in? PAGE_VERSIONS
 
         [
-          :tags,
           {
             :language => :site,
             version => {
               elements: [
                 :page,
                 :touchable_pages,
-                :tags,
                 {
                   ingredients: :related_object
                 }

--- a/app/services/alchemy/duplicate_element.rb
+++ b/app/services/alchemy/duplicate_element.rb
@@ -4,6 +4,7 @@ module Alchemy
   class DuplicateElement
     SKIPPED_ATTRIBUTES_ON_COPY = [
       "cached_tag_list",
+      "tag_names",
       "created_at",
       "creator_id",
       "position",
@@ -27,11 +28,13 @@ module Alchemy
         .merge(differences)
         .merge(
           autogenerate_ingredients: false,
-          autogenerate_nested_elements: false,
-          tags: source_element.tags
+          autogenerate_nested_elements: false
         )
 
       new_element = Element.new(attributes)
+      # Only assign tags when the source has any, so copying untagged elements
+      # (the common case) does not trigger gutentag's tag reconciliation.
+      new_element.tag_list = source_element.tag_list if source_element.tag_list.present?
       new_element.ingredients = source_element.ingredients.map(&:dup)
       new_element.save!
 

--- a/app/services/alchemy/element_preloader.rb
+++ b/app/services/alchemy/element_preloader.rb
@@ -72,8 +72,7 @@ module Alchemy
     # Associations to preload for element rendering
     def element_includes
       [
-        {ingredients: :related_object},
-        :tags
+        {ingredients: :related_object}
       ]
     end
 

--- a/spec/models/alchemy/eager_loading_spec.rb
+++ b/spec/models/alchemy/eager_loading_spec.rb
@@ -9,14 +9,12 @@ RSpec.describe Alchemy::EagerLoading do
 
       it "returns public version includes" do
         is_expected.to match_array([
-          :tags,
           {
             language: :site,
             public_version: {
               elements: [
                 :page,
                 :touchable_pages,
-                :tags,
                 {
                   ingredients: :related_object
                 }
@@ -32,14 +30,12 @@ RSpec.describe Alchemy::EagerLoading do
 
       it "returns version includes" do
         is_expected.to match_array([
-          :tags,
           {
             language: :site,
             draft_version: {
               elements: [
                 :page,
                 :touchable_pages,
-                :tags,
                 {
                   ingredients: :related_object
                 }

--- a/spec/services/alchemy/duplicate_element_spec.rb
+++ b/spec/services/alchemy/duplicate_element_spec.rb
@@ -35,6 +35,26 @@ RSpec.describe Alchemy::DuplicateElement do
     expect(subject.cached_tag_list).to eq(element.cached_tag_list)
   end
 
+  context "when copying untagged elements" do
+    let(:page_version) { create(:alchemy_page_version) }
+    let(:element) do
+      create(:alchemy_element, :with_nestable_elements, page_version: page_version)
+    end
+
+    before do
+      2.times do
+        create(:alchemy_element, name: "slide", parent_element: element, page_version: page_version)
+      end
+    end
+
+    it "reads the source tags from the cache, not the tags association" do
+      source = Alchemy::Element.find(element.id)
+      repository = source.page_version.element_repository
+      described_class.new(source, repository: repository).call
+      expect(source.association(:tags)).not_to be_loaded
+    end
+  end
+
   context "with nested elements" do
     let(:element) do
       create(:alchemy_element, :with_ingredients, :with_nestable_elements, {

--- a/spec/services/alchemy/element_preloader_spec.rb
+++ b/spec/services/alchemy/element_preloader_spec.rb
@@ -32,10 +32,6 @@ RSpec.describe Alchemy::ElementPreloader do
       it "preloads ingredients association" do
         expect(subject.first.association(:ingredients)).to be_loaded
       end
-
-      it "preloads tags association" do
-        expect(subject.first.association(:tags)).to be_loaded
-      end
     end
 
     context "with nested elements (2 levels)" do
@@ -63,7 +59,6 @@ RSpec.describe Alchemy::ElementPreloader do
       it "preloads associations on nested elements" do
         nested = subject.first.all_nested_elements.first
         expect(nested.association(:ingredients)).to be_loaded
-        expect(nested.association(:tags)).to be_loaded
       end
     end
 
@@ -147,7 +142,7 @@ RSpec.describe Alchemy::ElementPreloader do
 
       it "loads all nested elements without N+1 queries" do
         # Queries are bounded regardless of element count (8 elements created)
-        # language (eager loaded via page), all elements, ingredients, tags
+        # language (eager loaded via page), all elements, ingredients
         expect {
           result = described_class.new(page_version: page_version).call
 
@@ -158,7 +153,7 @@ RSpec.describe Alchemy::ElementPreloader do
               nested.all_nested_elements.to_a
             end
           end
-        }.to make_database_queries(count: 4)
+        }.to make_database_queries(count: 3)
       end
     end
 


### PR DESCRIPTION
## What is this pull request for?

Now that tags are read through the denormalized `cached_tag_list` column (#4153), no render, serialize or admin path touches the `tags` association anymore. The `:tags` entries still sprinkled through our eager loading are therefore wasted work — they load an association nothing reads. This removes them from `EagerLoading.page_includes` (page- and element-level) and from `ElementPreloader`.

`DuplicateElement` was the last remaining reader of the `tags` association: it copied a source element's tags via `tags: source_element.tags`, which both required that preload and reconciled tags on every copied element. It now copies through the cached `tag_list` interface instead — matching what `CopyPage` already does — and only when the source actually has tags, so duplicating untagged elements (the common case, e.g. publishing a page) no longer reads the association.

### Notable changes (remove if none)

Behaviour is unchanged: tags are still copied on duplicate/publish (tags are global-by-name, so assigning the names yields the same `Tag` records). A regression test asserts `DuplicateElement` no longer loads the source's `tags` association, so the removed preloads can't quietly reintroduce an N+1.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change