### PR TITLE
fix(page nodes_table): Sanitize Node name

### DIFF
--- a/app/views/alchemy/admin/nodes/_page_nodes.html.erb
+++ b/app/views/alchemy/admin/nodes/_page_nodes.html.erb
@@ -7,11 +7,13 @@
       <th class="tools"></th>
     </tr>
     <% nodes = @page.nodes.select(&:persisted?) %>
-    <% seperator = '<alchemy-icon name="arrow-right-s" style="vertical-align: text-bottom"></alchemy-icon>' %>
+    <% seperator = '<alchemy-icon name="arrow-right-s" style="vertical-align: text-bottom"></alchemy-icon>'.html_safe %>
     <% if nodes.length > 0 %>
       <% nodes.each do |node| %>
         <tr class="even">
-          <td><%== node.ancestors.map(&:name).join(seperator) %><%== seperator %><strong><%== node.name %></strong></td>
+          <td>
+            <%= safe_join(node.ancestors.map(&:name), seperator) %><%= seperator %><strong><%= node.name %></strong>
+          </td>
           <td class="tools">
             <sl-tooltip content="<%= Alchemy.t("delete_node") %>">
               <%= link_to render_icon(:minus),

--- a/spec/features/admin/nodes_management_spec.rb
+++ b/spec/features/admin/nodes_management_spec.rb
@@ -70,4 +70,24 @@ RSpec.describe "Nodes management", type: :system, js: true do
       end
     end
   end
+
+  context "with a evil menu node" do
+    let!(:evil_node) do
+      create(:alchemy_node,
+        name: "<alert>Evil!</alert>",
+        parent: a_menu,
+        page: a_page)
+    end
+
+    before do
+      a_menu.update_columns(name: "<alert>Evil!</alert>")
+    end
+
+    it "does not execute injected code" do
+      open_page_properties
+      within "#page_nodes table" do
+        expect(page).to_not have_selector("alert", text: "Evil!")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What is this pull request for?

This fixes an potential XSS attack vector if a
evil Node name is used and displayed unsanitized
in this table.

Closes https://github.com/AlchemyCMS/alchemy_cms/security/advisories/GHSA-4qhx-6wrv-5hg2

Credit: https://github.com/bugmithlegend for reporting

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
