### PR TITLE
fix(mysql): Do not add defaults in text columns

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -128,6 +128,10 @@ jobs:
             ruby: "3.4"
             database: sqlite
             storage: active_storage
+          - rails: "8.0"
+            ruby: "3.4"
+            database: mysql
+            storage: active_storage
 
     env:
       DB: ${{ matrix.database }}
@@ -157,6 +161,15 @@ jobs:
           MARIADB_DATABASE: alchemy_cms_dummy_test
           MARIADB_ROOT_PASSWORD: password
         options: --health-cmd="mariadb-admin ping" --health-interval=1s --health-timeout=1s --health-retries=30
+      mysql:
+        image: mysql:latest
+        ports: ["3306:3306"]
+        env:
+          MYSQL_USER: alchemy_user
+          MYSQL_PASSWORD: password
+          MYSQL_DATABASE: alchemy_cms_dummy_test
+          MYSQL_ROOT_PASSWORD: password
+        options: --health-cmd="mysqladmin ping" --health-interval=1s --health-timeout=1s --health-retries=30
     steps:
       - uses: actions/checkout@v6
       - name: Set up Ruby
@@ -178,8 +191,8 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -qq --fix-missing libpq-dev
-      - name: Install MariaDB headers
-        if: matrix.database == 'mariadb'
+      - name: Install MySQL headers
+        if: matrix.database == 'mariadb' || matrix.database == 'mysql'
         run: |
           sudo apt-get update -qq
           sudo apt-get install -qq --fix-missing libmysqlclient-dev

--- a/app/jobs/alchemy/invalidate_elements_cache_job.rb
+++ b/app/jobs/alchemy/invalidate_elements_cache_job.rb
@@ -12,7 +12,7 @@ module Alchemy
       all_element_ids = get_all_element_ids(elements, element_ids)
       Element.where(id: all_element_ids).touch_all
 
-      page_ids = elements.joins(page_version: :page).select("DISTINCT alchemy_pages.id")
+      page_ids = elements.joins(page_version: :page).distinct.pluck("alchemy_pages.id")
       Page.where(id: page_ids).touch_all
     end
 

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -153,6 +153,7 @@ module Alchemy
     # match a single quoted role with a portable LIKE. No +type: Array+, as
     # that would serialize an empty array to NULL and violate the not null
     # constraint; the writer already guarantees an array is stored.
+    attribute :permitted_roles, default: -> { ["member"] }
     serialize :permitted_roles, coder: JSON
 
     before_destroy :check_descendants_for_menu_nodes

--- a/app/models/concerns/alchemy/taggable.rb
+++ b/app/models/concerns/alchemy/taggable.rb
@@ -12,6 +12,7 @@ module Alchemy
       # has a cached_tag_list column. serialize defers until the schema loads,
       # so declaring it unconditionally never touches the DB at boot and is
       # harmless for taggables without the column.
+      base.attribute :cached_tag_list, default: -> { [] }
       base.serialize :cached_tag_list, coder: JSON
       base.before_save :remember_tag_name_change
       base.after_save :cache_tag_list

--- a/app/models/concerns/alchemy/user_methods.rb
+++ b/app/models/concerns/alchemy/user_methods.rb
@@ -3,6 +3,8 @@ module Alchemy
     extend ActiveSupport::Concern
 
     included do
+      attribute :alchemy_roles, default: "member"
+
       # Unlock all locked pages before destroy.
       before_destroy :unlock_pages!
 

--- a/db/migrate/20260727120000_add_permitted_roles_to_alchemy_pages.rb
+++ b/db/migrate/20260727120000_add_permitted_roles_to_alchemy_pages.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 class AddPermittedRolesToAlchemyPages < ActiveRecord::Migration[7.2]
-  def change
-    add_column :alchemy_pages, :permitted_roles, :text, default: '["member"]', null: false, if_not_exists: true
+  def up
+    add_column :alchemy_pages, :permitted_roles, :text, if_not_exists: true
+    execute(%(UPDATE #{quote_table_name("alchemy_pages")} SET permitted_roles = '["member"]' WHERE permitted_roles IS NULL))
+    change_column_null :alchemy_pages, :permitted_roles, false
+  end
+
+  def down
+    remove_column :alchemy_pages, :permitted_roles, if_exists: true
   end
 end

--- a/db/migrate/20260820120000_add_cached_tag_list_to_taggables.rb
+++ b/db/migrate/20260820120000_add_cached_tag_list_to_taggables.rb
@@ -10,12 +10,17 @@ class AddCachedTagListToTaggables < ActiveRecord::Migration[7.2]
 
   def up
     TAGGABLE_MODELS.each do |model_name|
-      add_column model_name.constantize.table_name, :cached_tag_list, :text,
-        default: "[]", null: false, if_not_exists: true
+      add_column model_name.constantize.table_name, :cached_tag_list, :text, if_not_exists: true
     end
 
     say_with_time "Backfilling cached_tag_list from existing taggings" do
       backfill
+    end
+
+    TAGGABLE_MODELS.each do |model_name|
+      table = model_name.constantize.table_name
+      execute("UPDATE #{quote_table_name(table)} SET cached_tag_list = '[]' WHERE cached_tag_list IS NULL")
+      change_column_null table, :cached_tag_list, false
     end
   end
 

--- a/lib/alchemy/tasks/tidy.rb
+++ b/lib/alchemy/tasks/tidy.rb
@@ -64,8 +64,8 @@ module Alchemy
       def remove_duplicate_legacy_urls
         puts "\n## Removing duplicate legacy URLs"
         keep_ids = Alchemy::LegacyPageUrl
-          .select("MAX(id)")
           .group(:page_id, :urlname)
+          .pluck(Arel.sql("MAX(id)"))
         count = Alchemy::LegacyPageUrl
           .where.not(id: keep_ids)
           .delete_all

--- a/lib/generators/alchemy/user_columns_migration/templates/migration.rb.tt
+++ b/lib/generators/alchemy/user_columns_migration/templates/migration.rb.tt
@@ -2,7 +2,9 @@ class AddAlchemyFieldsTo<%= table_name.camelcase %>Table < ActiveRecord::Migrati
   disable_ddl_transaction! if connection.adapter_name.match?(/postgres/i)
 
   def change
-    add_column <%= table_name.inspect %>, :alchemy_roles, :text, if_not_exists: true, default: "member", comment: "Space separated list of Alchemy roles this user has"
+    add_column <%= table_name.inspect %>, :alchemy_roles, :text,
+      comment: "Space separated list of Alchemy roles this user has",
+      if_not_exists: true
     add_column <%= table_name.inspect %>, :updater_id, :integer, if_not_exists: true, comment: "ID of the user that last updated this record"
     add_column <%= table_name.inspect %>, :creator_id, :integer, if_not_exists: true, comment: "ID of the user that created this record"
     add_index <%= table_name.inspect %>, :updater_id, if_not_exists: true, algorithm: algorithm

--- a/spec/dummy/db/migrate/20260729082848_add_permitted_roles_to_alchemy_pages.alchemy.rb
+++ b/spec/dummy/db/migrate/20260729082848_add_permitted_roles_to_alchemy_pages.alchemy.rb
@@ -2,7 +2,13 @@
 
 # This migration comes from alchemy (originally 20260727120000)
 class AddPermittedRolesToAlchemyPages < ActiveRecord::Migration[7.2]
-  def change
-    add_column :alchemy_pages, :permitted_roles, :text, default: '["member"]', null: false, if_not_exists: true
+  def up
+    add_column :alchemy_pages, :permitted_roles, :text, if_not_exists: true
+    execute(%(UPDATE #{quote_table_name("alchemy_pages")} SET permitted_roles = '["member"]' WHERE permitted_roles IS NULL))
+    change_column_null :alchemy_pages, :permitted_roles, false
+  end
+
+  def down
+    remove_column :alchemy_pages, :permitted_roles, if_exists: true
   end
 end

--- a/spec/dummy/db/migrate/20260813142318_add_alchemy_fields_to_dummy_users_table.rb
+++ b/spec/dummy/db/migrate/20260813142318_add_alchemy_fields_to_dummy_users_table.rb
@@ -2,7 +2,9 @@ class AddAlchemyFieldsToDummyUsersTable < ActiveRecord::Migration[7.2]
   disable_ddl_transaction! if connection.adapter_name.match?(/postgres/i)
 
   def change
-    add_column "dummy_users", :alchemy_roles, :text, if_not_exists: true, default: "member"
+    add_column "dummy_users", :alchemy_roles, :text,
+      comment: "Space separated list of Alchemy roles this user has",
+      if_not_exists: true
     add_column "dummy_users", :updater_id, :integer, if_not_exists: true
     add_column "dummy_users", :creator_id, :integer, if_not_exists: true
     add_index "dummy_users", :updater_id, if_not_exists: true, algorithm: algorithm

--- a/spec/dummy/db/migrate/20260820153412_add_cached_tag_list_to_taggables.alchemy.rb
+++ b/spec/dummy/db/migrate/20260820153412_add_cached_tag_list_to_taggables.alchemy.rb
@@ -11,12 +11,17 @@ class AddCachedTagListToTaggables < ActiveRecord::Migration[7.2]
 
   def up
     TAGGABLE_MODELS.each do |model_name|
-      add_column model_name.constantize.table_name, :cached_tag_list, :text,
-        default: "[]", null: false, if_not_exists: true
+      add_column model_name.constantize.table_name, :cached_tag_list, :text, if_not_exists: true
     end
 
     say_with_time "Backfilling cached_tag_list from existing taggings" do
       backfill
+    end
+
+    TAGGABLE_MODELS.each do |model_name|
+      table = model_name.constantize.table_name
+      execute("UPDATE #{quote_table_name(table)} SET cached_tag_list = '[]' WHERE cached_tag_list IS NULL")
+      change_column_null table, :cached_tag_list, false
     end
   end
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -40,7 +40,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_153412) do
   end
 
   create_table "alchemy_attachments", force: :cascade do |t|
-    t.text "cached_tag_list", default: "[]", null: false
+    t.text "cached_tag_list", null: false
     t.datetime "created_at", null: false
     t.integer "creator_id"
     t.string "file_mime_type"
@@ -57,7 +57,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_153412) do
   end
 
   create_table "alchemy_elements", force: :cascade do |t|
-    t.text "cached_tag_list", default: "[]", null: false
+    t.text "cached_tag_list", null: false
     t.datetime "created_at", null: false
     t.integer "creator_id"
     t.boolean "fixed", default: false, null: false
@@ -188,7 +188,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_153412) do
   end
 
   create_table "alchemy_pages", force: :cascade do |t|
-    t.text "cached_tag_list", default: "[]", null: false
+    t.text "cached_tag_list", null: false
     t.datetime "created_at", null: false
     t.integer "creator_id"
     t.integer "depth"
@@ -204,7 +204,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_153412) do
     t.string "name"
     t.string "page_layout"
     t.integer "parent_id"
-    t.text "permitted_roles", default: "[\"member\"]", null: false
+    t.text "permitted_roles", null: false
     t.datetime "published_at", precision: nil
     t.boolean "restricted", default: false, null: false
     t.integer "rgt"
@@ -245,7 +245,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_153412) do
   end
 
   create_table "alchemy_pictures", force: :cascade do |t|
-    t.text "cached_tag_list", default: "[]", null: false
+    t.text "cached_tag_list", null: false
     t.datetime "created_at", null: false
     t.integer "creator_id"
     t.string "image_file_format"
@@ -318,7 +318,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_153412) do
   end
 
   create_table "dummy_users", force: :cascade do |t|
-    t.text "alchemy_roles", default: "member"
+    t.text "alchemy_roles"
     t.integer "creator_id"
     t.string "email"
     t.string "password"


### PR DESCRIPTION
## What is this pull request for?

MySQL [does not support adding defaults to text columns](https://github.com/AlchemyCMS/alchemy-devise/actions/runs/33151703830/job/98784955693). Not having them is not harm, just less user friendly.

### Notable changes

- Adding MySQL back to the matrix

### Screenshots

Remove if no visual changes have been made.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message

