### PR TITLE
fix(taggable): guard tag_list against a nil cache column

### DIFF
--- a/app/models/concerns/alchemy/taggable.rb
+++ b/app/models/concerns/alchemy/taggable.rb
@@ -20,8 +20,11 @@ module Alchemy
     # The public list of tag names. Reads the denormalized cache column so the
     # common read paths (rendering, serializing) issue no query. Models without
     # the cache column fall back to gutentag's lazy-loading tag_names.
+    #
+    # The cache column is nil for untagged records on MySQL, which cannot
+    # default a text column, so coerce it to an empty array.
     def tag_list
-      caches_tag_list? ? cached_tag_list : tag_names
+      caches_tag_list? ? (cached_tag_list || []) : tag_names
     end
 
     # Set a list of tags

--- a/spec/models/concerns/alchemy/taggable_spec.rb
+++ b/spec/models/concerns/alchemy/taggable_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe Alchemy::Taggable do
       expect(element.reload.cached_tag_list).to match_array(%w[blue yellow])
     end
 
+    # MySQL cannot default a text column, so the cache column is nil for
+    # untagged records instead of the empty array other adapters store.
+    it "returns an empty array when the cache column is nil" do
+      element = create(:alchemy_element, name: "article")
+      allow(element).to receive(:cached_tag_list).and_return(nil)
+      expect(element.tag_list).to eq([])
+    end
+
     it "does not query the tags when saving an untagged record" do
       element = create(:alchemy_element, name: "article")
       tag_queries = 0


### PR DESCRIPTION
## What is this pull request for?

`tag_list` reads the denormalized `cached_tag_list` column, which is expected to hold an array. On PostgreSQL and SQLite that column is created with `default: "[]", null: false`, so untagged records always read back an empty array. MySQL, however, cannot set a default on a `text` column, so there the column is `nil` for untagged records and `tag_list` returned `nil` instead of an empty list — breaking every caller that expects an enumerable (rendering, serializing, the admin tag field).

Since the default cannot be guaranteed at the database level across adapters, `tag_list` now coerces a `nil` cache to an empty array, restoring consistent behavior regardless of the database.

This also fixes `Alchemy::User` from alchemy-devise, whose migration creates `cached_tag_list` as a plain nullable column, exhibiting the same `nil` result even on PostgreSQL and SQLite.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change