### PR TITLE
refactor(admin): pass locals to partials instead of instance variables

### DIFF
--- a/.herb.yml
+++ b/.herb.yml
@@ -6,6 +6,12 @@ linter:
   enabled: true
 
   rules:
+    # Every partial must declare its inputs with a `<%# locals: (...) %>`
+    # magic comment, so a missing local raises loudly instead of silently
+    # becoming nil via local_assigns.
+    erb-strict-locals-required:
+      enabled: true
+
     # Rules below report pre-existing offenses in the codebase. They are
     # disabled for now so this change stays scoped to a single rule:
     # erb-no-instance-variables-in-partials (enabled by default). Adopt each

--- a/.herb.yml
+++ b/.herb.yml
@@ -1,0 +1,44 @@
+# Pin the Herb version so upgrading the linter does not silently enable
+# newly-added rules. Bump this deliberately when adopting new rules.
+version: 0.10.3
+
+linter:
+  enabled: true
+
+  rules:
+    # Rules below report pre-existing offenses in the codebase. They are
+    # disabled for now so this change stays scoped to a single rule:
+    # erb-no-instance-variables-in-partials (enabled by default). Adopt each
+    # of these separately by fixing its offenses and removing the entry.
+    erb-no-unsafe-script-interpolation:
+      enabled: false
+    html-anchor-require-href:
+      enabled: false
+    html-require-script-nonce:
+      enabled: false
+    parser-no-errors:
+      enabled: false
+    erb-no-duplicate-branch-elements:
+      enabled: false
+    erb-no-output-in-attribute-position:
+      enabled: false
+    html-img-require-alt:
+      enabled: false
+    erb-no-unsafe-raw:
+      enabled: false
+    erb-no-unused-expressions:
+      enabled: false
+    erb-no-interpolated-class-names:
+      enabled: false
+    html-no-space-in-tag:
+      enabled: false
+    erb-no-unused-literals:
+      enabled: false
+    erb-no-empty-control-flow:
+      enabled: false
+    actionview-no-silent-helper:
+      enabled: false
+    html-no-unescaped-entities:
+      enabled: false
+    erb-no-commented-out-output-tags:
+      enabled: false

--- a/app/components/alchemy/ingredients/picture_editor.rb
+++ b/app/components/alchemy/ingredients/picture_editor.rb
@@ -48,7 +48,8 @@ module Alchemy
                 tag.div(class: "edit_images_bottom") do
                   render(
                     "alchemy/ingredients/shared/picture_tools",
-                    picture_editor: self
+                    picture_editor: self,
+                    page: ingredient.element.page
                   )
                 end
               )

--- a/app/controllers/alchemy/admin/attachments_controller.rb
+++ b/app/controllers/alchemy/admin/attachments_controller.rb
@@ -88,6 +88,10 @@ module Alchemy
 
       private
 
+      def archive_overlay_locals
+        super.merge(attachments: @attachments, query: @query)
+      end
+
       def default_sort_order
         "created_at desc"
       end

--- a/app/controllers/alchemy/admin/pictures_controller.rb
+++ b/app/controllers/alchemy/admin/pictures_controller.rb
@@ -192,6 +192,10 @@ module Alchemy
         session[:alchemy_pictures_size] = @size
       end
 
+      def archive_overlay_locals
+        super.merge(pictures: @pictures, size: @size, query: @query)
+      end
+
       def pictures_per_page_for_size
         case @size
         when "small" then 60

--- a/app/controllers/concerns/alchemy/admin/archive_overlay.rb
+++ b/app/controllers/concerns/alchemy/admin/archive_overlay.rb
@@ -23,8 +23,12 @@ module Alchemy
         @form_field_id = params[:form_field_id]
 
         respond_to do |format|
-          format.html { render partial: "archive_overlay" }
+          format.html { render partial: "archive_overlay", locals: archive_overlay_locals }
         end
+      end
+
+      def archive_overlay_locals
+        {form_field_id: @form_field_id}
       end
     end
   end

--- a/app/views/alchemy/_edit_mode.html.erb
+++ b/app/views/alchemy/_edit_mode.html.erb
@@ -1,2 +1,3 @@
+<%# locals: () %>
 <%= render Alchemy::Menubar.new %>
 <%= render "alchemy/preview_mode_code" %>

--- a/app/views/alchemy/_menubar.html.erb
+++ b/app/views/alchemy/_menubar.html.erb
@@ -1,2 +1,3 @@
+<%# locals: () %>
 <% Alchemy::Deprecation.warn("Rendering 'alchemy/menubar' partial is deprecated. Use `render Alchemy::Menubar.new` instead.") %>
 <%= render Alchemy::Menubar.new %>

--- a/app/views/alchemy/_preview_mode_code.html.erb
+++ b/app/views/alchemy/_preview_mode_code.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <% if Alchemy::Current.preview_page? %>
   <script type="text/javascript">
     Alchemy = { locale: "<%= session[:alchemy_locale] %>" };

--- a/app/views/alchemy/admin/_header.html.erb
+++ b/app/views/alchemy/admin/_header.html.erb
@@ -1,4 +1,4 @@
 <div id="header">
-  <%= render "alchemy/admin/pages/locked_pages", locked_pages: locked_pages %>
+  <%= render "alchemy/admin/pages/locked_pages", locked_pages: locked_pages, page: local_assigns[:page] %>
   <%= render "alchemy/admin/user_info" %>
 </div>

--- a/app/views/alchemy/admin/_header.html.erb
+++ b/app/views/alchemy/admin/_header.html.erb
@@ -1,4 +1,5 @@
+<%# locals: (locked_pages:, page: nil) %>
 <div id="header">
-  <%= render "alchemy/admin/pages/locked_pages", locked_pages: locked_pages, page: local_assigns[:page] %>
+  <%= render "alchemy/admin/pages/locked_pages", locked_pages: locked_pages, page: page %>
   <%= render "alchemy/admin/user_info" %>
 </div>

--- a/app/views/alchemy/admin/_left_menu.html.erb
+++ b/app/views/alchemy/admin/_left_menu.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <div id="left_menu">
   <%= render "alchemy/admin/main_navi" %>
 

--- a/app/views/alchemy/admin/_main_navi.html.erb
+++ b/app/views/alchemy/admin/_main_navi.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <div id="main_navi">
   <% sorted_alchemy_modules.each do |alchemy_module| %>
     <%= alchemy_main_navigation_entry(alchemy_module) %>

--- a/app/views/alchemy/admin/_top_menu.html.erb
+++ b/app/views/alchemy/admin/_top_menu.html.erb
@@ -1,5 +1,5 @@
 <div id="top_menu">
-  <%= render "alchemy/admin/header", locked_pages: locked_pages %>
+  <%= render "alchemy/admin/header", locked_pages: locked_pages, page: local_assigns[:page] %>
   <div class="toolbar">
     <%= yield(:toolbar) %>
   </div>

--- a/app/views/alchemy/admin/_top_menu.html.erb
+++ b/app/views/alchemy/admin/_top_menu.html.erb
@@ -1,5 +1,6 @@
+<%# locals: (locked_pages:, page: nil) %>
 <div id="top_menu">
-  <%= render "alchemy/admin/header", locked_pages: locked_pages, page: local_assigns[:page] %>
+  <%= render "alchemy/admin/header", locked_pages: locked_pages, page: page %>
   <div class="toolbar">
     <%= yield(:toolbar) %>
   </div>

--- a/app/views/alchemy/admin/_user_info.html.erb
+++ b/app/views/alchemy/admin/_user_info.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <div id="user_info">
   <%= render Alchemy::Admin::CurrentUserName.new(user: current_alchemy_user) %>
   <%= render Alchemy::Admin::TimezoneSelect.new %>

--- a/app/views/alchemy/admin/attachments/_archive_overlay.html.erb
+++ b/app/views/alchemy/admin/attachments/_archive_overlay.html.erb
@@ -1,6 +1,4 @@
-<% attachments = local_assigns[:attachments] %>
-<% form_field_id = local_assigns[:form_field_id] %>
-<% query = local_assigns[:query] %>
+<%# locals: (attachments:, form_field_id:, query:, size: nil) %>
 <%= turbo_frame_tag "archive_overlay" do %>
   <div class="toolbar">
     <div class="toolbar_buttons">
@@ -27,7 +25,7 @@
       <% end %>
     </div>
 
-    <%= render 'alchemy/admin/partials/overlay_search_form', query: query, form_field_id: form_field_id, size: local_assigns[:size] %>
+    <%= render 'alchemy/admin/partials/overlay_search_form', query: query, form_field_id: form_field_id, size: size %>
   </div>
 
   <div

--- a/app/views/alchemy/admin/attachments/_archive_overlay.html.erb
+++ b/app/views/alchemy/admin/attachments/_archive_overlay.html.erb
@@ -1,3 +1,6 @@
+<% attachments = local_assigns[:attachments] %>
+<% form_field_id = local_assigns[:form_field_id] %>
+<% query = local_assigns[:query] %>
 <%= turbo_frame_tag "archive_overlay" do %>
   <div class="toolbar">
     <div class="toolbar_buttons">
@@ -12,7 +15,7 @@
               Marcel::MimeType.for(extension:)
             }.join(",").presence,
             redirect_url: admin_attachments_path(
-              form_field_id: @form_field_id,
+              form_field_id: form_field_id,
               only: search_filter_params[:only],
               except: search_filter_params[:except],
               q: search_filter_params[:q].merge(
@@ -24,17 +27,17 @@
       <% end %>
     </div>
 
-    <%= render 'alchemy/admin/partials/overlay_search_form' %>
+    <%= render 'alchemy/admin/partials/overlay_search_form', query: query, form_field_id: form_field_id, size: local_assigns[:size] %>
   </div>
 
   <div
     id="assign_file_list"
     class="with_padding<%= search_filter_params[:tagged_with].present? ? ' filtered' : '' %>"
   >
-    <%= render 'library_sidebar' %>
+    <%= render 'library_sidebar', query: query %>
 
     <div id="overlay_file_list" class="with_tag_list">
-      <%= render 'overlay_file_list' %>
+      <%= render 'overlay_file_list', attachments: attachments, form_field_id: form_field_id %>
     </div>
   </div>
 <% end %>

--- a/app/views/alchemy/admin/attachments/_file_to_assign.html.erb
+++ b/app/views/alchemy/admin/attachments/_file_to_assign.html.erb
@@ -1,4 +1,4 @@
-<% form_field_id = local_assigns[:form_field_id] %>
+<%# locals: (file_to_assign:, form_field_id:) %>
 <li class="assign_file_file <%= cycle('even', 'odd') %>">
   <%= button_to alchemy.assign_admin_attachment_path(
       id: file_to_assign.id,

--- a/app/views/alchemy/admin/attachments/_file_to_assign.html.erb
+++ b/app/views/alchemy/admin/attachments/_file_to_assign.html.erb
@@ -1,7 +1,8 @@
+<% form_field_id = local_assigns[:form_field_id] %>
 <li class="assign_file_file <%= cycle('even', 'odd') %>">
   <%= button_to alchemy.assign_admin_attachment_path(
       id: file_to_assign.id,
-      form_field_id: @form_field_id
+      form_field_id: form_field_id
     ),
     method: :put,
     form_class: "assign_file" do %>

--- a/app/views/alchemy/admin/attachments/_files_list.html.erb
+++ b/app/views/alchemy/admin/attachments/_files_list.html.erb
@@ -1,4 +1,6 @@
-<%= render Alchemy::Admin::Resource::Table.new(@attachments, query: @query) do |table| %>
+<% attachments = local_assigns[:attachments] %>
+<% deletable_attachment_ids = local_assigns[:deletable_attachment_ids] %>
+<%= render Alchemy::Admin::Resource::Table.new(attachments, query: local_assigns[:query]) do |table| %>
   <% table.icon_column { |attachment| attachment.icon_css_class } %>
   <% table.column :name, sortable: true do |attachment| %>
     <% if can?(:show, attachment) %>
@@ -52,7 +54,7 @@
       file_attribute: 'file' %>
   <% end %>
   <% table.with_action(:destroy) do |attachment| %>
-    <% if @deletable_attachment_ids.include?(attachment.id) %>
+    <% if deletable_attachment_ids.include?(attachment.id) %>
       <sl-tooltip content="<%= Alchemy.t(:delete_file) %>">
         <%= link_to_confirm_dialog render_icon(:minus),
           Alchemy.t(:confirm_to_delete_file),

--- a/app/views/alchemy/admin/attachments/_files_list.html.erb
+++ b/app/views/alchemy/admin/attachments/_files_list.html.erb
@@ -1,6 +1,5 @@
-<% attachments = local_assigns[:attachments] %>
-<% deletable_attachment_ids = local_assigns[:deletable_attachment_ids] %>
-<%= render Alchemy::Admin::Resource::Table.new(attachments, query: local_assigns[:query]) do |table| %>
+<%# locals: (attachments:, query:, deletable_attachment_ids:) %>
+<%= render Alchemy::Admin::Resource::Table.new(attachments, query: query) do |table| %>
   <% table.icon_column { |attachment| attachment.icon_css_class } %>
   <% table.column :name, sortable: true do |attachment| %>
     <% if can?(:show, attachment) %>

--- a/app/views/alchemy/admin/attachments/_library_sidebar.html.erb
+++ b/app/views/alchemy/admin/attachments/_library_sidebar.html.erb
@@ -1,6 +1,7 @@
+<%# locals: (query:) %>
 <div id="library_sidebar">
   <%= render "sorting_select" %>
-  <%= render "filter_bar", query: local_assigns[:query] if resource_has_filters %>
+  <%= render "filter_bar", query: query if resource_has_filters %>
 
   <div class="tag-list"><%= render "tag_list" %></div>
 </div>

--- a/app/views/alchemy/admin/attachments/_library_sidebar.html.erb
+++ b/app/views/alchemy/admin/attachments/_library_sidebar.html.erb
@@ -1,6 +1,6 @@
 <div id="library_sidebar">
   <%= render "sorting_select" %>
-  <%= render "filter_bar" if resource_has_filters %>
+  <%= render "filter_bar", query: local_assigns[:query] if resource_has_filters %>
 
   <div class="tag-list"><%= render "tag_list" %></div>
 </div>

--- a/app/views/alchemy/admin/attachments/_overlay_file_list.html.erb
+++ b/app/views/alchemy/admin/attachments/_overlay_file_list.html.erb
@@ -1,4 +1,6 @@
-<% if @attachments.empty? %>
+<% attachments = local_assigns[:attachments] %>
+<% form_field_id = local_assigns[:form_field_id] %>
+<% if attachments.empty? %>
   <%= render_message do %>
     <% if search_filter_params.present? %>
       <%= Alchemy.t(:no_search_results) %>
@@ -16,7 +18,7 @@
         <%= Alchemy::Attachment.human_attribute_name('file_mime_type') %>
       </span>
     </li>
-    <%= render partial: 'file_to_assign', collection: @attachments %>
+    <%= render partial: 'file_to_assign', collection: attachments, locals: {form_field_id: form_field_id} %>
   </ul>
-  <%= render "alchemy/admin/resources/pagination", resources: @attachments, hide_per_page_select: true %>
+  <%= render "alchemy/admin/resources/pagination", resources: attachments, hide_per_page_select: true %>
 <% end %>

--- a/app/views/alchemy/admin/attachments/_overlay_file_list.html.erb
+++ b/app/views/alchemy/admin/attachments/_overlay_file_list.html.erb
@@ -1,5 +1,4 @@
-<% attachments = local_assigns[:attachments] %>
-<% form_field_id = local_assigns[:form_field_id] %>
+<%# locals: (attachments:, form_field_id:) %>
 <% if attachments.empty? %>
   <%= render_message do %>
     <% if search_filter_params.present? %>

--- a/app/views/alchemy/admin/attachments/_replace_button.html.erb
+++ b/app/views/alchemy/admin/attachments/_replace_button.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (object:, file_attribute:, redirect_url:, accept: nil) %>
 <% file_types = Alchemy.config.uploader.allowed_filetypes[object.class.model_name.collection] || ['*'] %>
 <% accept ||= file_types.to_a == ["*"] ? nil : file_types.map {|type| ".#{type}"}.join(", ") %>
 

--- a/app/views/alchemy/admin/attachments/_sorting_select.html.erb
+++ b/app/views/alchemy/admin/attachments/_sorting_select.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <div id="sorting_select">
   <div class="filter-input">
     <alchemy-auto-submit>

--- a/app/views/alchemy/admin/attachments/_tag_list.html.erb
+++ b/app/views/alchemy/admin/attachments/_tag_list.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <% if Alchemy::Attachment.tag_counts.any? %>
   <h3><%= Alchemy.t("Filter by tag") %></h3>
   <%= render Alchemy::Admin::ListFilter.new(".tag-list li", placeholder: Alchemy.t("Filter tags")) %>

--- a/app/views/alchemy/admin/attachments/index.html.erb
+++ b/app/views/alchemy/admin/attachments/index.html.erb
@@ -14,7 +14,7 @@
     <% end %>
   </div>
 
-  <%= render 'alchemy/admin/partials/search_form' %>
+  <%= render 'alchemy/admin/partials/search_form', query: @query %>
 <% end %>
 
 <% if Alchemy::Attachment.none? %>
@@ -29,7 +29,7 @@
     ) %>
   <% end %>
 <% else %>
-  <%= render "alchemy/admin/resources/table_header" %>
+  <%= render "alchemy/admin/resources/table_header", query: @query %>
 
   <% if @attachments.none? && search_filter_params.present? %>
     <%= render_message do %>
@@ -37,11 +37,11 @@
     <% end %>
   <% else %>
     <div class="resources-table-wrapper">
-      <%= render "files_list" %>
+      <%= render "files_list", attachments: @attachments, query: @query, deletable_attachment_ids: @deletable_attachment_ids %>
     </div>
   <% end %>
 
   <%= render "alchemy/admin/resources/pagination", resources: @attachments %>
 <% end %>
 
-<%= render "library_sidebar" %>
+<%= render "library_sidebar", query: @query %>

--- a/app/views/alchemy/admin/clipboard/_button.html.erb
+++ b/app/views/alchemy/admin/clipboard/_button.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (remarkable_type:, tooltip_placement: "top-start") %>
 <%= render Alchemy::Admin::ToolbarButton.new(
   url: alchemy.admin_clipboard_path(remarkable_type: remarkable_type),
   label: Alchemy.t("Show clipboard"),
@@ -8,6 +9,6 @@
     size: "400x305"
   },
   id: "clipboard_button",
-  tooltip_placement: local_assigns.fetch(:tooltip_placement, "top-start"),
+  tooltip_placement: tooltip_placement,
   if_permitted_to: [:index, :alchemy_admin_clipboard]
 ) %>

--- a/app/views/alchemy/admin/clipboard/_update_nested_element_button.turbo_stream.erb
+++ b/app/views/alchemy/admin/clipboard/_update_nested_element_button.turbo_stream.erb
@@ -1,8 +1,9 @@
 <%# Update add nested element forms for any elements that accept ONLY this as a nested element %>
-<% if @item.class == Alchemy::Element %>
+<% item = local_assigns[:item] %>
+<% if item.class == Alchemy::Element %>
   <%
-    @item.page.draft_version.elements.expanded.select do |element|
-      element.nestable_elements == [@item.name]
+    item.page.draft_version.elements.expanded.select do |element|
+      element.nestable_elements == [item.name]
     end.each do |element|
   %>
     <%= turbo_stream.replace_all ".add-nested-element[data-element-id='#{element.id}']",

--- a/app/views/alchemy/admin/clipboard/_update_nested_element_button.turbo_stream.erb
+++ b/app/views/alchemy/admin/clipboard/_update_nested_element_button.turbo_stream.erb
@@ -1,5 +1,5 @@
+<%# locals: (item:) %>
 <%# Update add nested element forms for any elements that accept ONLY this as a nested element %>
-<% item = local_assigns[:item] %>
 <% if item.class == Alchemy::Element %>
   <%
     item.page.draft_version.elements.expanded.select do |element|

--- a/app/views/alchemy/admin/clipboard/clear.turbo_stream.erb
+++ b/app/views/alchemy/admin/clipboard/clear.turbo_stream.erb
@@ -1,4 +1,4 @@
-<%= turbo_stream.replace "clipboard_button", partial: "button" %>
+<%= turbo_stream.replace "clipboard_button", partial: "button", locals: {remarkable_type: remarkable_type} %>
 <%= turbo_stream.update "clipboard_items",
   Alchemy::Admin::Message.new(Alchemy.t('No items in your clipboard')).render_in(self) %>
 <%= render "update_nested_element_button", item: @item %>

--- a/app/views/alchemy/admin/clipboard/clear.turbo_stream.erb
+++ b/app/views/alchemy/admin/clipboard/clear.turbo_stream.erb
@@ -1,4 +1,4 @@
 <%= turbo_stream.replace "clipboard_button", partial: "button" %>
 <%= turbo_stream.update "clipboard_items",
   Alchemy::Admin::Message.new(Alchemy.t('No items in your clipboard')).render_in(self) %>
-<%= render "update_nested_element_button" %>
+<%= render "update_nested_element_button", item: @item %>

--- a/app/views/alchemy/admin/clipboard/insert.turbo_stream.erb
+++ b/app/views/alchemy/admin/clipboard/insert.turbo_stream.erb
@@ -15,4 +15,4 @@
 
 <%= turbo_stream.replace "clipboard_button", partial: "button" %>
 
-<%= render "update_nested_element_button" %>
+<%= render "update_nested_element_button", item: @item %>

--- a/app/views/alchemy/admin/clipboard/insert.turbo_stream.erb
+++ b/app/views/alchemy/admin/clipboard/insert.turbo_stream.erb
@@ -13,6 +13,6 @@
   </alchemy-growl>
 <% end -%>
 
-<%= turbo_stream.replace "clipboard_button", partial: "button" %>
+<%= turbo_stream.replace "clipboard_button", partial: "button", locals: {remarkable_type: remarkable_type} %>
 
 <%= render "update_nested_element_button", item: @item %>

--- a/app/views/alchemy/admin/clipboard/remove.turbo_stream.erb
+++ b/app/views/alchemy/admin/clipboard/remove.turbo_stream.erb
@@ -2,7 +2,7 @@
   <%= render template: "alchemy/admin/clipboard/clear" %>
 <% else %>
   <%= turbo_stream.remove "clipboard_item_#{@item.id}" %>
-  <%= render "update_nested_element_button" %>
+  <%= render "update_nested_element_button", item: @item %>
   <alchemy-growl>
     <%= Alchemy.t("item removed from clipboard", name: @item.class.to_s == "Element" ? @item.display_name_with_preview_text : @item.name) %>
   </alchemy-growl>

--- a/app/views/alchemy/admin/dashboard/_dashboard.html.erb
+++ b/app/views/alchemy/admin/dashboard/_dashboard.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <%= render "top" %>
 <%= render "stats" %>
 <%= render "widgets" %>

--- a/app/views/alchemy/admin/dashboard/_footer.html.erb
+++ b/app/views/alchemy/admin/dashboard/_footer.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <footer>
   <div id="legal_info">
     <%= Alchemy.t('Alchemy is open software and itself uses open software and free resources:') %>

--- a/app/views/alchemy/admin/dashboard/_stats.html.erb
+++ b/app/views/alchemy/admin/dashboard/_stats.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <% if Alchemy.config.dashboard.stats.any? %>
   <div class="stats">
     <% Alchemy.config.dashboard.stats.each do |stat, args| %>

--- a/app/views/alchemy/admin/dashboard/_top.html.erb
+++ b/app/views/alchemy/admin/dashboard/_top.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <div class="top-row">
   <%= render Alchemy::Admin::Dashboard::Widgets::Greeting.new(user: current_alchemy_user) %>
   <%= render Alchemy::Admin::Dashboard::Widget.new(id: "NewsReader", style: "stat") %>

--- a/app/views/alchemy/admin/dashboard/_widgets.html.erb
+++ b/app/views/alchemy/admin/dashboard/_widgets.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <% if Alchemy.config.dashboard.widgets.any? %>
   <div class="widgets">
     <% Alchemy.config.dashboard.widgets.each do |widget, args| %>

--- a/app/views/alchemy/admin/elements/_add_nested_element_form.html.erb
+++ b/app/views/alchemy/admin/elements/_add_nested_element_form.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (element:) %>
 <%= content_tag :div, class: 'add-nested-element', data: { element_id: element.id } do %>
   <% if element.nestable_elements.length == 1 &&
     (nestable_element = element.nestable_elements.first) &&

--- a/app/views/alchemy/admin/elements/_fixed_element.html.erb
+++ b/app/views/alchemy/admin/elements/_fixed_element.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (element:) %>
 <sl-tab slot="nav" panel="fixed-element-<%= element.id %>">
   <%= element.display_name %>
 </sl-tab>

--- a/app/views/alchemy/admin/elements/_footer.html.erb
+++ b/app/views/alchemy/admin/elements/_footer.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (element:) %>
 <div class="element-footer">
   <% if element.has_validations? %>
     <p class="validation_notice">

--- a/app/views/alchemy/admin/elements/_form.html.erb
+++ b/app/views/alchemy/admin/elements/_form.html.erb
@@ -1,6 +1,4 @@
-<% element = local_assigns[:element] %>
-<% elements = local_assigns[:elements] %>
-<% parent_element = local_assigns[:parent_element] %>
+<%# locals: (element:, elements:, parent_element:) %>
 <%- if elements.blank? -%>
   <%= render_message do %>
     <%= Alchemy.t(:no_more_elements_to_add) %>

--- a/app/views/alchemy/admin/elements/_form.html.erb
+++ b/app/views/alchemy/admin/elements/_form.html.erb
@@ -1,22 +1,25 @@
-<%- if @elements.blank? -%>
+<% element = local_assigns[:element] %>
+<% elements = local_assigns[:elements] %>
+<% parent_element = local_assigns[:parent_element] %>
+<%- if elements.blank? -%>
   <%= render_message do %>
     <%= Alchemy.t(:no_more_elements_to_add) %>
   <% end %>
 <%- else -%>
-  <%= turbo_frame_tag @element do %>
-    <%= alchemy_form_for [:admin, @element] do |form| %>
+  <%= turbo_frame_tag element do %>
+    <%= alchemy_form_for [:admin, element] do |form| %>
       <%= form.hidden_field :page_version_id %>
       <div class="input">
         <%= form.label(:name, class: "control-label required") do %>
           <%= Alchemy.t(:element_of_type) %><abbr>*</abbr>
         <% end %>
         <%= render Alchemy::Admin::ElementSelect.new(
-          @elements,
+          elements,
           field_name: form.field_name(:name),
           autofocus: true
         ) %>
       </div>
-      <%= form.hidden_field :parent_element_id, value: @parent_element.try(:id) %>
+      <%= form.hidden_field :parent_element_id, value: parent_element.try(:id) %>
       <%= form.submit Alchemy.t(:add) %>
     <%- end -%>
   <%- end -%>

--- a/app/views/alchemy/admin/elements/_header.html.erb
+++ b/app/views/alchemy/admin/elements/_header.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (element:) %>
 <div class="element-header<%= ' has-hint' if element.has_hint? %>" id="element-header-<%= element.id %>">
   <span class="element-handle<%= ' draggable' if can?(:order, element) %>">
     <% if element.definition.blank? %>

--- a/app/views/alchemy/admin/elements/_preview_text_quote.html.erb
+++ b/app/views/alchemy/admin/elements/_preview_text_quote.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (element:) %>
 <span id="element_<%= element.id %>_preview_text_quote" class="preview_text_quote">
   <%= sanitize(element.preview_text.presence || '&nbsp;') %>
 </span>

--- a/app/views/alchemy/admin/elements/_schedule.html.erb
+++ b/app/views/alchemy/admin/elements/_schedule.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (element:) %>
 <div id="element-<%= element.id %>-schedule">
   <% if element.errors.any? %>
     <alchemy-message type="error" icon="warn">

--- a/app/views/alchemy/admin/elements/_schedule_fields.html.erb
+++ b/app/views/alchemy/admin/elements/_schedule_fields.html.erb
@@ -1,2 +1,3 @@
+<%# locals: (element:, form:) %>
 <%# Overwrite this partial if you want to add more fields to the element schedule form %>
 <%= render Alchemy::Admin::ElementScheduleTimestamps.new(element:) %>

--- a/app/views/alchemy/admin/elements/_toolbar.html.erb
+++ b/app/views/alchemy/admin/elements/_toolbar.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (element:) %>
 <% remarkable_type = "elements" %>
 <div class="element-toolbar">
   <sl-tooltip

--- a/app/views/alchemy/admin/elements/new.html.erb
+++ b/app/views/alchemy/admin/elements/new.html.erb
@@ -1,11 +1,11 @@
 <%- if clipboard_items.blank? -%>
-  <%= render 'form' %>
+  <%= render 'form', element: @element, elements: @elements, parent_element: @parent_element %>
 <%- else -%>
 <sl-tab-group id="overlay_tabs">
   <sl-tab slot="nav" panel="create_element_tab"><%= Alchemy.t('New') %></sl-tab>
   <sl-tab slot="nav" panel="paste_element_tab"><%= Alchemy.t('Paste from clipboard') %></sl-tab>
   <sl-tab-panel name="create_element_tab">
-    <%= render 'form' %>
+    <%= render 'form', element: @element, elements: @elements, parent_element: @parent_element %>
   </sl-tab-panel>
   <sl-tab-panel name="paste_element_tab">
     <%= alchemy_form_for([:admin, @element]) do |f| %>

--- a/app/views/alchemy/admin/ingredients/_audio_fields.html.erb
+++ b/app/views/alchemy/admin/ingredients/_audio_fields.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (ingredient:, f:, language:) %>
 <%= f.input :autoplay, as: :boolean %>
 <%= f.input :controls, as: :boolean %>
 <%= f.input :loop, as: :boolean %>

--- a/app/views/alchemy/admin/ingredients/_dom_id_fields.html.erb
+++ b/app/views/alchemy/admin/ingredients/_dom_id_fields.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (f:, ingredient:) %>
 <% disabled = ingredient.settings[:anchor].to_s != "true" %>
 <%= f.input :dom_id,
   disabled: disabled,

--- a/app/views/alchemy/admin/ingredients/_file_fields.html.erb
+++ b/app/views/alchemy/admin/ingredients/_file_fields.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (ingredient:, f:, language:) %>
 <%= f.input :link_text %>
 <%= f.input :title %>
 <%= f.input :css_class,

--- a/app/views/alchemy/admin/ingredients/_headline_fields.html.erb
+++ b/app/views/alchemy/admin/ingredients/_headline_fields.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (ingredient:, f:, language:) %>
 <% if ingredient.settings[:anchor] %>
   <%= render "dom_id_fields", f: f, ingredient: ingredient %>
 <% end %>

--- a/app/views/alchemy/admin/ingredients/_picture_fields.html.erb
+++ b/app/views/alchemy/admin/ingredients/_picture_fields.html.erb
@@ -1,6 +1,7 @@
+<%# locals: (ingredient:, f:, language:) %>
 <%= f.input :caption, as: ingredient.settings[:caption_as_textarea] ? 'text' : 'string' %>
 <%= f.input :title %>
-<%= f.input :alt_tag, as: :text, placeholder: ingredient.alt_text(language: local_assigns[:language]), input_html: {rows: 4} %>
+<%= f.input :alt_tag, as: :text, placeholder: ingredient.alt_text(language: language), input_html: {rows: 4} %>
 <%- if ingredient.settings[:sizes].present? && ingredient.settings[:srcset].blank? -%>
   <%= f.input :render_size,
     collection: [

--- a/app/views/alchemy/admin/ingredients/_picture_fields.html.erb
+++ b/app/views/alchemy/admin/ingredients/_picture_fields.html.erb
@@ -1,6 +1,6 @@
 <%= f.input :caption, as: ingredient.settings[:caption_as_textarea] ? 'text' : 'string' %>
 <%= f.input :title %>
-<%= f.input :alt_tag, as: :text, placeholder: ingredient.alt_text(language: @language), input_html: {rows: 4} %>
+<%= f.input :alt_tag, as: :text, placeholder: ingredient.alt_text(language: local_assigns[:language]), input_html: {rows: 4} %>
 <%- if ingredient.settings[:sizes].present? && ingredient.settings[:srcset].blank? -%>
   <%= f.input :render_size,
     collection: [

--- a/app/views/alchemy/admin/ingredients/_text_fields.html.erb
+++ b/app/views/alchemy/admin/ingredients/_text_fields.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (ingredient:, f:, language:) %>
 <% if ingredient.settings[:anchor] %>
   <%= render "dom_id_fields", f: f, ingredient: ingredient %>
 <% end %>

--- a/app/views/alchemy/admin/ingredients/_video_fields.html.erb
+++ b/app/views/alchemy/admin/ingredients/_video_fields.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (ingredient:, f:, language:) %>
 <%= f.input :width %>
 <%= f.input :height %>
 <%= f.input :autoplay, as: :boolean %>

--- a/app/views/alchemy/admin/ingredients/edit.html.erb
+++ b/app/views/alchemy/admin/ingredients/edit.html.erb
@@ -1,4 +1,4 @@
 <%= alchemy_form_for @ingredient, as: :ingredient, url: alchemy.admin_ingredient_path(@ingredient) do |f| %>
-  <%= render "alchemy/admin/ingredients/#{@ingredient.partial_name}_fields", ingredient: @ingredient, f: f %>
+  <%= render "alchemy/admin/ingredients/#{@ingredient.partial_name}_fields", ingredient: @ingredient, f: f, language: @language %>
   <%= f.submit Alchemy.t(:save) %>
 <% end %>

--- a/app/views/alchemy/admin/languages/_form.html.erb
+++ b/app/views/alchemy/admin/languages/_form.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (language:, resource: nil) %>
 <%= alchemy_form_for [alchemy, :admin, language] do |f| %>
   <%= f.input :name, autofocus: true %>
   <%= f.input :language_code, placeholder: Alchemy.t(:language_code_placeholder) %>

--- a/app/views/alchemy/admin/languages/_table.html.erb
+++ b/app/views/alchemy/admin/languages/_table.html.erb
@@ -1,4 +1,5 @@
-<%= render Alchemy::Admin::Resource::Table.new(local_assigns[:languages], query: local_assigns[:query], search_filter_params: search_filter_params) do |table| %>
+<%# locals: (languages:, query:) %>
+<%= render Alchemy::Admin::Resource::Table.new(languages, query: query, search_filter_params: search_filter_params) do |table| %>
   <% table.icon_column "translate-2", style: false %>
   <% table.column :name, sortable: true %>
   <% table.column :language_code, sortable: true %>

--- a/app/views/alchemy/admin/languages/_table.html.erb
+++ b/app/views/alchemy/admin/languages/_table.html.erb
@@ -1,4 +1,4 @@
-<%= render Alchemy::Admin::Resource::Table.new(@languages, query: @query, search_filter_params: search_filter_params) do |table| %>
+<%= render Alchemy::Admin::Resource::Table.new(local_assigns[:languages], query: local_assigns[:query], search_filter_params: search_filter_params) do |table| %>
   <% table.icon_column "translate-2", style: false %>
   <% table.column :name, sortable: true %>
   <% table.column :language_code, sortable: true %>

--- a/app/views/alchemy/admin/languages/index.html.erb
+++ b/app/views/alchemy/admin/languages/index.html.erb
@@ -14,13 +14,13 @@
       if_permitted_to: [:create, Alchemy::Language]
     ) %>
   </div>
-  <%= render 'alchemy/admin/partials/search_form' %>
+  <%= render 'alchemy/admin/partials/search_form', query: @query %>
 <% end %>
 
 <% if @languages.any? %>
-  <%= render "alchemy/admin/resources/table_header" %>
+  <%= render "alchemy/admin/resources/table_header", query: @query %>
   <div class="resources-table-wrapper">
-    <%= render "table" %>
+    <%= render "table", languages: @languages, query: @query %>
   </div>
   <%= render "alchemy/admin/resources/pagination", resources: @languages %>
 <% elsif search_filter_params.present? %>

--- a/app/views/alchemy/admin/layoutpages/_layoutpage.html.erb
+++ b/app/views/alchemy/admin/layoutpages/_layoutpage.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (layoutpage:) %>
 <li class="page_level_<%= layoutpage.level %>" id="page_<%= layoutpage.id %>">
   <div class="sitemap_page<%= layoutpage.locked? ? ' locked' : '' %>">
     <div class="sitemap_left_images">

--- a/app/views/alchemy/admin/legacy_page_urls/_label.html.erb
+++ b/app/views/alchemy/admin/legacy_page_urls/_label.html.erb
@@ -1,1 +1,2 @@
+<%# locals: (count:) %>
 (<%= count %>) <%= Alchemy::LegacyPageUrl.model_name.human(count: count) %>

--- a/app/views/alchemy/admin/legacy_page_urls/_legacy_page_url.html.erb
+++ b/app/views/alchemy/admin/legacy_page_urls/_legacy_page_url.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (legacy_page_url:) %>
 <%= turbo_frame_tag(legacy_page_url, class: ["row", cycle("even", "odd")]) do %>
   <div class="col name"><%= legacy_page_url.urlname %></div>
   <div class="col tools">

--- a/app/views/alchemy/admin/legacy_page_urls/_legacy_page_url.html.erb
+++ b/app/views/alchemy/admin/legacy_page_urls/_legacy_page_url.html.erb
@@ -3,12 +3,12 @@
   <div class="col tools">
     <sl-tooltip content="<%= Alchemy.t(:edit) %>">
       <%= link_to render_icon(:edit),
-        edit_admin_legacy_page_url_path(legacy_page_url, page_id: @page.id),
+        edit_admin_legacy_page_url_path(legacy_page_url, page_id: legacy_page_url.page_id),
         class: "icon_button", data: { turbo_frame: dom_id(legacy_page_url)} %>
     </sl-tooltip>
     <sl-tooltip content="<%= Alchemy.t(:remove) %>">
       <%= link_to render_icon(:minus),
-        admin_legacy_page_url_path(legacy_page_url, page_id: @page.id),
+        admin_legacy_page_url_path(legacy_page_url, page_id: legacy_page_url.page_id),
         class: "icon_button",
         data: { turbo_method: :delete, turbo_confirm: Alchemy.t('Are you sure?') } %>
     </sl-tooltip>

--- a/app/views/alchemy/admin/legacy_page_urls/_new.html.erb
+++ b/app/views/alchemy/admin/legacy_page_urls/_new.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (legacy_page_url:) %>
 <%= turbo_frame_tag "new_legacy_page_url" do %>
   <%= alchemy_form_for [:admin, legacy_page_url] do |f| %>
     <% if legacy_page_url.errors.any? %>

--- a/app/views/alchemy/admin/legacy_page_urls/_new.html.erb
+++ b/app/views/alchemy/admin/legacy_page_urls/_new.html.erb
@@ -5,7 +5,7 @@
         <%= legacy_page_url.errors.full_messages.join %>
       <% end %>
     <% end %>
-    <%= hidden_field_tag :page_id, @page.id %>
+    <%= hidden_field_tag :page_id, legacy_page_url.page_id %>
     <div class="inline-input">
       <div class="left-column">
         <%= f.text_field :urlname, placeholder: Alchemy::LegacyPageUrl.human_attribute_name(:urlname) %>

--- a/app/views/alchemy/admin/legacy_page_urls/_table.html.erb
+++ b/app/views/alchemy/admin/legacy_page_urls/_table.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (legacy_page_urls:) %>
 <div class="table">
   <% if legacy_page_urls.any? %>
     <header>

--- a/app/views/alchemy/admin/legacy_page_urls/_update.turbo_stream.erb
+++ b/app/views/alchemy/admin/legacy_page_urls/_update.turbo_stream.erb
@@ -1,4 +1,4 @@
-<% page = local_assigns[:page] %>
+<%# locals: (page:, message: nil) %>
 <%= turbo_stream.update "legacy_urls_label" do %>
   <%= render "label", count: page.legacy_urls.size %>
 <% end %>
@@ -9,5 +9,5 @@
   <%= render 'new', legacy_page_url: page.legacy_urls.build %>
 <% end %>
 <alchemy-growl>
-  <%= local_assigns[:message] %>
+  <%= message %>
 </alchemy-growl>

--- a/app/views/alchemy/admin/legacy_page_urls/_update.turbo_stream.erb
+++ b/app/views/alchemy/admin/legacy_page_urls/_update.turbo_stream.erb
@@ -1,12 +1,13 @@
+<% page = local_assigns[:page] %>
 <%= turbo_stream.update "legacy_urls_label" do %>
-  <%= render "label", count: @page.legacy_urls.size %>
+  <%= render "label", count: page.legacy_urls.size %>
 <% end %>
 <%= turbo_stream.update "legacy_page_urls" do %>
-  <%= render "table", legacy_page_urls: @page.legacy_urls %>
+  <%= render "table", legacy_page_urls: page.legacy_urls %>
 <% end %>
 <%= turbo_stream.update "new_legacy_page_url" do %>
-  <%= render 'new', legacy_page_url: @page.legacy_urls.build %>
+  <%= render 'new', legacy_page_url: page.legacy_urls.build %>
 <% end %>
 <alchemy-growl>
-  <%= @message %>
+  <%= local_assigns[:message] %>
 </alchemy-growl>

--- a/app/views/alchemy/admin/legacy_page_urls/create.turbo_stream.erb
+++ b/app/views/alchemy/admin/legacy_page_urls/create.turbo_stream.erb
@@ -1,5 +1,5 @@
 <% if @legacy_page_url.valid? %>
-  <%= render "update" %>
+  <%= render "update", page: @page, message: @message %>
 <% else %>
   <%= turbo_stream.replace "new_legacy_page_url" do %>
     <%= render 'new',

--- a/app/views/alchemy/admin/legacy_page_urls/destroy.turbo_stream.erb
+++ b/app/views/alchemy/admin/legacy_page_urls/destroy.turbo_stream.erb
@@ -1,1 +1,1 @@
-<%= render "update" %>
+<%= render "update", page: @page, message: @message %>

--- a/app/views/alchemy/admin/legacy_page_urls/update.turbo_stream.erb
+++ b/app/views/alchemy/admin/legacy_page_urls/update.turbo_stream.erb
@@ -1,1 +1,1 @@
-<%= render "update" %>
+<%= render "update", page: @page, message: @message %>

--- a/app/views/alchemy/admin/nodes/_form.html.erb
+++ b/app/views/alchemy/admin/nodes/_form.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (node:, button_label:) %>
 <alchemy-node-form>
 <%= alchemy_form_for([:admin, node]) do |f| %>
   <% if node.new_record? && node.root? %>

--- a/app/views/alchemy/admin/nodes/_label.html.erb
+++ b/app/views/alchemy/admin/nodes/_label.html.erb
@@ -1,1 +1,2 @@
+<%# locals: (count:) %>
 (<%= count %>) <%= Alchemy::Node.model_name.human(count: count) %>

--- a/app/views/alchemy/admin/nodes/_node.html.erb
+++ b/app/views/alchemy/admin/nodes/_node.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (node:) %>
 <%= content_tag :li, class: 'menu-item', data: { id: node.id, parent_id: node.parent_id, folded: node.folded?, type: "node" } do %>
   <%= content_tag :div, class: [
     'sitemap_node',

--- a/app/views/alchemy/admin/nodes/_page_nodes.html.erb
+++ b/app/views/alchemy/admin/nodes/_page_nodes.html.erb
@@ -1,12 +1,13 @@
+<% page = local_assigns[:page] %>
 <%= turbo_frame_tag("page_nodes") do %>
   <table class="list">
     <tr>
       <th class="name">
-        <%= Alchemy::Node.model_name.human(count: @page.nodes.size) %>
+        <%= Alchemy::Node.model_name.human(count: page.nodes.size) %>
       </th>
       <th class="tools"></th>
     </tr>
-    <% nodes = @page.nodes.select(&:persisted?) %>
+    <% nodes = page.nodes.select(&:persisted?) %>
     <% seperator = '<alchemy-icon name="arrow-right-s" style="vertical-align: text-bottom"></alchemy-icon>'.html_safe %>
     <% if nodes.length > 0 %>
       <% nodes.each do |node| %>
@@ -35,12 +36,12 @@
   <fieldset>
     <legend><%= Alchemy.t('Create node on parent:') %></legend>
 
-    <%= alchemy_form_for([:admin, @page.nodes.build], id: "new_node_form") do |f| %>
-      <%= f.hidden_field :page_id, value: @page.id %>
-      <%= f.hidden_field :language_id, value: @page.language_id %>
+    <%= alchemy_form_for([:admin, page.nodes.build], id: "new_node_form") do |f| %>
+      <%= f.hidden_field :page_id, value: page.id %>
+      <%= f.hidden_field :language_id, value: page.language_id %>
       <div class="inline-input">
         <div class="left-column">
-          <%= render Alchemy::Admin::NodeSelect.new(nil, url: alchemy.api_nodes_path(language_id: @page.language_id, include: :ancestors)) do %>
+          <%= render Alchemy::Admin::NodeSelect.new(nil, url: alchemy.api_nodes_path(language_id: page.language_id, include: :ancestors)) do %>
             <%= f.text_field :parent_id, class: 'alchemy_selectbox full_width' %>
           <% end %>
         </div>

--- a/app/views/alchemy/admin/nodes/_page_nodes.html.erb
+++ b/app/views/alchemy/admin/nodes/_page_nodes.html.erb
@@ -1,4 +1,4 @@
-<% page = local_assigns[:page] %>
+<%# locals: (page:) %>
 <%= turbo_frame_tag("page_nodes") do %>
   <table class="list">
     <tr>

--- a/app/views/alchemy/admin/nodes/_update.turbo_stream.erb
+++ b/app/views/alchemy/admin/nodes/_update.turbo_stream.erb
@@ -1,9 +1,10 @@
+<% page = local_assigns[:page] %>
 <% key = flash.keys.first %>
 <alchemy-growl message="<%= flash[key] %>" type="<%= key %>"></alchemy-growl>
 
 <%= turbo_stream.replace "page_nodes" do %>
-  <%= render "page_nodes" %>
+  <%= render "page_nodes", page: page %>
 <% end %>
 <%= turbo_stream.update_all '[panel="nodes"]' do %>
-  <%= render('alchemy/admin/nodes/label', count: @page.nodes.select(&:persisted?).length) %>
+  <%= render('alchemy/admin/nodes/label', count: page.nodes.select(&:persisted?).length) %>
 <% end %>

--- a/app/views/alchemy/admin/nodes/_update.turbo_stream.erb
+++ b/app/views/alchemy/admin/nodes/_update.turbo_stream.erb
@@ -1,4 +1,4 @@
-<% page = local_assigns[:page] %>
+<%# locals: (page:) %>
 <% key = flash.keys.first %>
 <alchemy-growl message="<%= flash[key] %>" type="<%= key %>"></alchemy-growl>
 

--- a/app/views/alchemy/admin/nodes/create.turbo_stream.erb
+++ b/app/views/alchemy/admin/nodes/create.turbo_stream.erb
@@ -1,1 +1,1 @@
-<%= render "update" %>
+<%= render "update", page: @page %>

--- a/app/views/alchemy/admin/nodes/destroy.turbo_stream.erb
+++ b/app/views/alchemy/admin/nodes/destroy.turbo_stream.erb
@@ -1,1 +1,1 @@
-<%= render "update" %>
+<%= render "update", page: @page %>

--- a/app/views/alchemy/admin/pages/_create_language_form.html.erb
+++ b/app/views/alchemy/admin/pages/_create_language_form.html.erb
@@ -1,12 +1,15 @@
+<% languages_with_page_tree = local_assigns[:languages_with_page_tree] %>
+<% language = local_assigns[:language] %>
+<% page_layouts = local_assigns[:page_layouts] %>
 <%= render "alchemy/admin/resources/empty_state" do %>
-  <%- if @languages_with_page_tree.size >= 1 -%>
+  <%- if languages_with_page_tree.size >= 1 -%>
     <%= form_tag(alchemy.copy_language_tree_admin_pages_path) do %>
       <h3><%= Alchemy.t(:copy_language_tree_heading) %></h3>
       <p><%= Alchemy.t(:want_to_make_copy_of_existing_language) %></p>
       <div class="input select">
         <%= label_tag('languages[old_lang_id]', Alchemy.t('Language tree'), class: 'control-label') %>
-        <%= select_tag("languages[old_lang_id]", options_for_select(@languages_with_page_tree.map{ |l| [l.name, l.id] }), is: "alchemy-select") %>
-        <%= hidden_field_tag("languages[new_lang_id]", @language.id) %>
+        <%= select_tag("languages[old_lang_id]", options_for_select(languages_with_page_tree.map{ |l| [l.name, l.id] }), is: "alchemy-select") %>
+        <%= hidden_field_tag("languages[new_lang_id]", language.id) %>
       </div>
       <div class="submit">
         <%= button_tag Alchemy.t(:copy) %>
@@ -15,20 +18,20 @@
   <%- end -%>
 
   <%= alchemy_form_for([:admin, Alchemy::Page.new], id: 'create_language_tree') do |form| %>
-    <% if @languages_with_page_tree.size >= 1 %>
+    <% if languages_with_page_tree.size >= 1 %>
       <h3><%= Alchemy.t(:create_language_tree_heading) %></h3>
       <p><%= Alchemy.t(:want_to_create_new_language) %></p>
     <% end %>
-    <%= form.input :name, input_html: {value: @language.frontpage_name} %>
+    <%= form.input :name, input_html: {value: language.frontpage_name} %>
     <%= form.input :page_layout,
-      collection: @page_layouts,
-      selected: @language.page_layout,
+      collection: page_layouts,
+      selected: language.page_layout,
       label: Alchemy.t(:page_type),
       include_blank: Alchemy.t('Please choose'),
       required: true,
       input_html: {is: 'alchemy-select'} %>
-    <%= form.hidden_field :language_id, value: @language.id %>
-    <%= form.hidden_field :language_code, value: @language.code %>
+    <%= form.hidden_field :language_id, value: language.id %>
+    <%= form.hidden_field :language_code, value: language.code %>
     <%= form.hidden_field :language_root, value: true %>
     <%= form.hidden_field :public, value: Alchemy::Language.all.size == 1 %>
     <%= form.submit Alchemy.t(:create), autofocus: true %>

--- a/app/views/alchemy/admin/pages/_create_language_form.html.erb
+++ b/app/views/alchemy/admin/pages/_create_language_form.html.erb
@@ -1,6 +1,4 @@
-<% languages_with_page_tree = local_assigns[:languages_with_page_tree] %>
-<% language = local_assigns[:language] %>
-<% page_layouts = local_assigns[:page_layouts] %>
+<%# locals: (languages_with_page_tree:, language:, page_layouts:) %>
 <%= render "alchemy/admin/resources/empty_state" do %>
   <%- if languages_with_page_tree.size >= 1 -%>
     <%= form_tag(alchemy.copy_language_tree_admin_pages_path) do %>

--- a/app/views/alchemy/admin/pages/_current_page.html.erb
+++ b/app/views/alchemy/admin/pages/_current_page.html.erb
@@ -1,6 +1,7 @@
+<%# locals: (current_page:, published: false) %>
 <div class="page_status_and_name" id="locked_page_<%= current_page.id %>">
   <%= render 'alchemy/admin/pages/page_infos', page: current_page %>
   <%= render 'alchemy/admin/pages/page_status',
-    published: local_assigns.fetch(:published, false),
+    published:,
     page: current_page %>
 </div>

--- a/app/views/alchemy/admin/pages/_form.html.erb
+++ b/app/views/alchemy/admin/pages/_form.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (page:) %>
 <%= turbo_frame_tag page do %>
   <%= alchemy_form_for [:admin, page], class: 'edit_page' do |f| %>
     <% unless page.language_root? || page.layoutpage %>

--- a/app/views/alchemy/admin/pages/_legacy_urls.html.erb
+++ b/app/views/alchemy/admin/pages/_legacy_urls.html.erb
@@ -1,4 +1,4 @@
-<% page = local_assigns[:page] %>
+<%# locals: (page:) %>
 <%= render_message do %>
   <p><%== Alchemy.t(:legacy_url_info_text) %></p>
 <% end %>

--- a/app/views/alchemy/admin/pages/_legacy_urls.html.erb
+++ b/app/views/alchemy/admin/pages/_legacy_urls.html.erb
@@ -1,12 +1,13 @@
+<% page = local_assigns[:page] %>
 <%= render_message do %>
   <p><%== Alchemy.t(:legacy_url_info_text) %></p>
 <% end %>
 
 <%= turbo_frame_tag("legacy_page_urls") do %>
-  <%= render "alchemy/admin/legacy_page_urls/table", legacy_page_urls: @page.legacy_urls %>
+  <%= render "alchemy/admin/legacy_page_urls/table", legacy_page_urls: page.legacy_urls %>
 <% end %>
 
 <fieldset>
   <legend><%= Alchemy.t('Add page link') %></legend>
-  <%= render 'alchemy/admin/legacy_page_urls/new', legacy_page_url: @page.legacy_urls.build %>
+  <%= render 'alchemy/admin/legacy_page_urls/new', legacy_page_url: page.legacy_urls.build %>
 </fieldset>

--- a/app/views/alchemy/admin/pages/_locked_page.html.erb
+++ b/app/views/alchemy/admin/pages/_locked_page.html.erb
@@ -1,5 +1,6 @@
-<% if action_name == "edit" && local_assigns[:page] == locked_page %>
-  <%= render 'alchemy/admin/pages/current_page', current_page: local_assigns[:page] %>
+<%# locals: (locked_page:, page:) %>
+<% if action_name == "edit" && page == locked_page %>
+  <%= render 'alchemy/admin/pages/current_page', current_page: page %>
 <% else %>
   <div class="locked_page wide" id="locked_page_<%= locked_page.id %>">
     <%= link_to alchemy.edit_admin_page_path(locked_page) do %>

--- a/app/views/alchemy/admin/pages/_locked_page.html.erb
+++ b/app/views/alchemy/admin/pages/_locked_page.html.erb
@@ -1,5 +1,5 @@
-<% if action_name == "edit" && @page == locked_page %>
-  <%= render 'alchemy/admin/pages/current_page', current_page: @page %>
+<% if action_name == "edit" && local_assigns[:page] == locked_page %>
+  <%= render 'alchemy/admin/pages/current_page', current_page: local_assigns[:page] %>
 <% else %>
   <div class="locked_page wide" id="locked_page_<%= locked_page.id %>">
     <%= link_to alchemy.edit_admin_page_path(locked_page) do %>

--- a/app/views/alchemy/admin/pages/_locked_pages.html.erb
+++ b/app/views/alchemy/admin/pages/_locked_pages.html.erb
@@ -1,5 +1,5 @@
 <% if locked_pages.present? %>
   <div id="locked_pages">
-    <%= render partial: 'alchemy/admin/pages/locked_page', collection: locked_pages %>
+    <%= render partial: 'alchemy/admin/pages/locked_page', collection: locked_pages, locals: { page: local_assigns[:page] } %>
   </div>
 <% end %>

--- a/app/views/alchemy/admin/pages/_locked_pages.html.erb
+++ b/app/views/alchemy/admin/pages/_locked_pages.html.erb
@@ -1,5 +1,6 @@
+<%# locals: (locked_pages:, page:) %>
 <% if locked_pages.present? %>
   <div id="locked_pages">
-    <%= render partial: 'alchemy/admin/pages/locked_page', collection: locked_pages, locals: { page: local_assigns[:page] } %>
+    <%= render partial: 'alchemy/admin/pages/locked_page', collection: locked_pages, locals: { page: } %>
   </div>
 <% end %>

--- a/app/views/alchemy/admin/pages/_new_page_form.html.erb
+++ b/app/views/alchemy/admin/pages/_new_page_form.html.erb
@@ -1,20 +1,23 @@
-<%= alchemy_form_for([:admin, @page]) do |f| %>
-  <% if @page.parent_id || @page.layoutpage %>
+<% page = local_assigns[:page] %>
+<% current_language = local_assigns[:current_language] %>
+<% page_layouts = local_assigns[:page_layouts] %>
+<%= alchemy_form_for([:admin, page]) do |f| %>
+  <% if page.parent_id || page.layoutpage %>
     <%= f.hidden_field(:parent_id) %>
   <% else %>
-    <% @page.parent = @current_language.root_page %>
-    <%= render Alchemy::Admin::PageSelect.new(@page.parent) do %>
+    <% page.parent = current_language.root_page %>
+    <%= render Alchemy::Admin::PageSelect.new(page.parent) do %>
       <%= f.input :parent_id, as: :string %>
     <% end %>
   <% end %>
   <%= f.hidden_field(:language_id) %>
   <%= f.hidden_field(:layoutpage) %>
   <%= f.input :page_layout,
-    collection: @page_layouts,
+    collection: page_layouts,
     label: Alchemy.t(:page_type),
-    include_blank: @page_layouts.length == 1 ? nil : Alchemy.t('Please choose'),
+    include_blank: page_layouts.length == 1 ? nil : Alchemy.t('Please choose'),
     required: true,
-    selected: @page_layouts.length == 1 ? @page_layouts.first : @page.page_layout,
+    selected: page_layouts.length == 1 ? page_layouts.first : page.page_layout,
     input_html: {is: 'alchemy-select'} %>
   <%= f.input :name %>
   <%= f.submit Alchemy.t(:create) %>

--- a/app/views/alchemy/admin/pages/_new_page_form.html.erb
+++ b/app/views/alchemy/admin/pages/_new_page_form.html.erb
@@ -1,6 +1,4 @@
-<% page = local_assigns[:page] %>
-<% current_language = local_assigns[:current_language] %>
-<% page_layouts = local_assigns[:page_layouts] %>
+<%# locals: (page:, current_language:, page_layouts:) %>
 <%= alchemy_form_for([:admin, page]) do |f| %>
   <% if page.parent_id || page.layoutpage %>
     <%= f.hidden_field(:parent_id) %>

--- a/app/views/alchemy/admin/pages/_page_infos.html.erb
+++ b/app/views/alchemy/admin/pages/_page_infos.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (page:) %>
 <% if page.definition.blank? %>
   <%= page_layout_missing_warning %>
 <% end %>

--- a/app/views/alchemy/admin/pages/_page_status.html.erb
+++ b/app/views/alchemy/admin/pages/_page_status.html.erb
@@ -1,5 +1,6 @@
+<%# locals: (page:, published: false) %>
 <span class="page_status">
-  <% if local_assigns[:published] || page.public? %>
+  <% if published || page.public? %>
     <%= render_icon(:cloud, size: "1x") %>
   <% else %>
     <%= render_icon("cloud-off", size: "1x", class: "disabled") %>

--- a/app/views/alchemy/admin/pages/_publication_fields.html.erb
+++ b/app/views/alchemy/admin/pages/_publication_fields.html.erb
@@ -1,2 +1,3 @@
+<%# locals: (page:) %>
 <%# Overwrite this partial if you want to add more fields to the page schedule form %>
 <%= render Alchemy::Admin::PagePublicationFields.new(page:) %>

--- a/app/views/alchemy/admin/pages/_table.html.erb
+++ b/app/views/alchemy/admin/pages/_table.html.erb
@@ -1,4 +1,4 @@
-<%= render Alchemy::Admin::Resource::Table.new(@pages, query: @query, search_filter_params: search_filter_params) do |table| %>
+<%= render Alchemy::Admin::Resource::Table.new(local_assigns[:pages], query: local_assigns[:query], search_filter_params: search_filter_params) do |table| %>
   <% table.column :icon, header: "" do |page| %>
     <% if can?(:edit_content, page) %>
       <% if page.locked? %>

--- a/app/views/alchemy/admin/pages/_table.html.erb
+++ b/app/views/alchemy/admin/pages/_table.html.erb
@@ -1,4 +1,5 @@
-<%= render Alchemy::Admin::Resource::Table.new(local_assigns[:pages], query: local_assigns[:query], search_filter_params: search_filter_params) do |table| %>
+<%# locals: (pages:, query:) %>
+<%= render Alchemy::Admin::Resource::Table.new(pages, query:, search_filter_params: search_filter_params) do |table| %>
   <% table.column :icon, header: "" do |page| %>
     <% if can?(:edit_content, page) %>
       <% if page.locked? %>

--- a/app/views/alchemy/admin/pages/_toolbar.html.erb
+++ b/app/views/alchemy/admin/pages/_toolbar.html.erb
@@ -1,9 +1,11 @@
+<% current_language = local_assigns[:current_language] %>
+<% view = local_assigns[:view] %>
 <div class="toolbar_buttons">
   <%= render "alchemy/admin/partials/site_select" %>
   <%= render "alchemy/admin/partials/language_tree_select" %>
   <%= render Alchemy::Admin::ToolbarButton.new(
     icon: "add",
-    url: alchemy.new_admin_page_path(language: @current_language),
+    url: alchemy.new_admin_page_path(language: current_language),
     hotkey: 'alt+n',
     primary: true,
     tooltip_placement: "top-start",
@@ -35,7 +37,7 @@
       <%= link_to(
         render_icon(:"menu-2"),
         alchemy.admin_pages_path(view: "tree"),
-        class: ["icon_button", @view != "list" && "active"].compact
+        class: ["icon_button", view != "list" && "active"].compact
       ) %>
     </sl-tooltip>
   </div>
@@ -44,12 +46,13 @@
       <%= link_to(
         render_icon("sort-desc", style: false),
         alchemy.admin_pages_path(view: "list"),
-        class: ["icon_button", @view == "list" && "active"].compact
+        class: ["icon_button", view == "list" && "active"].compact
       ) %>
     </sl-tooltip>
   </div>
 </div>
 <% search_filter_params[:view] = "list" %>
 <%= render "alchemy/admin/partials/search_form",
+  query: local_assigns[:query],
   url: alchemy.admin_pages_path(search_filter_params.except(:q, :page)),
   additional_params: [:view] %>

--- a/app/views/alchemy/admin/pages/_toolbar.html.erb
+++ b/app/views/alchemy/admin/pages/_toolbar.html.erb
@@ -1,5 +1,4 @@
-<% current_language = local_assigns[:current_language] %>
-<% view = local_assigns[:view] %>
+<%# locals: (current_language:, view:, query:) %>
 <div class="toolbar_buttons">
   <%= render "alchemy/admin/partials/site_select" %>
   <%= render "alchemy/admin/partials/language_tree_select" %>
@@ -53,6 +52,6 @@
 </div>
 <% search_filter_params[:view] = "list" %>
 <%= render "alchemy/admin/partials/search_form",
-  query: local_assigns[:query],
+  query:,
   url: alchemy.admin_pages_path(search_filter_params.except(:q, :page)),
   additional_params: [:view] %>

--- a/app/views/alchemy/admin/pages/configure.html.erb
+++ b/app/views/alchemy/admin/pages/configure.html.erb
@@ -15,6 +15,6 @@
     <%= render 'alchemy/admin/nodes/page_nodes', page: @page %>
   </sl-tab-panel>
   <sl-tab-panel name="legacy_urls">
-    <%= render 'legacy_urls' %>
+    <%= render 'legacy_urls', page: @page %>
   </sl-tab-panel>
 </sl-tab-group>

--- a/app/views/alchemy/admin/pages/index.html.erb
+++ b/app/views/alchemy/admin/pages/index.html.erb
@@ -1,26 +1,26 @@
 <% content_for :toolbar do %>
-  <%= render "alchemy/admin/pages/toolbar" %>
+  <%= render "alchemy/admin/pages/toolbar", current_language: @current_language, view: @view, query: @query %>
 <% end %>
 
 <% if @view == "list" %>
-  <%= render "alchemy/admin/resources/table_header", resources_instance_variable: @pages %>
+  <%= render "alchemy/admin/resources/table_header", resources_instance_variable: @pages, query: @query %>
 
   <% if @pages.any? %>
     <div class="resources-table-wrapper">
-      <%= render "table" %>
+      <%= render "table", pages: @pages, query: @query %>
     </div>
   <% elsif search_filter_params.present? %>
     <%= render_message do %>
       <%= Alchemy.t("No pages found") %>
     <% end %>
   <% elsif can?(:create, Alchemy::Page) %>
-    <%= render partial: "create_language_form" %>
+    <%= render partial: "create_language_form", locals: {languages_with_page_tree: @languages_with_page_tree, language: @language, page_layouts: @page_layouts} %>
   <% end %>
 
   <%= render "alchemy/admin/resources/pagination", resources: @pages %>
 
   <div id="library_sidebar">
-    <%= render "filter_bar" if resource_has_filters %>
+    <%= render "filter_bar", query: @query if resource_has_filters %>
     <%= render "tag_list" if resource_has_tags %>
   </div>
 <% else %>
@@ -30,7 +30,7 @@
       <alchemy-spinner></alchemy-spinner>
     <% end %>
   <% elsif can?(:create, Alchemy::Page) %>
-    <%= render partial: "create_language_form" %>
+    <%= render partial: "create_language_form", locals: {languages_with_page_tree: @languages_with_page_tree, language: @language, page_layouts: @page_layouts} %>
   <% else %>
     <%= render_message :warn do %>
       <h2>No language root page found.</h2>

--- a/app/views/alchemy/admin/pages/new.html.erb
+++ b/app/views/alchemy/admin/pages/new.html.erb
@@ -1,11 +1,11 @@
 <%- if clipboard_items.blank? -%>
-  <%= render 'new_page_form' %>
+  <%= render 'new_page_form', page: @page, current_language: @current_language, page_layouts: @page_layouts %>
 <%- else -%>
 <sl-tab-group id="overlay_tabs">
   <sl-tab slot="nav" panel="create_page_tab"><%= Alchemy.t('New page') %></sl-tab>
   <sl-tab slot="nav" panel="paste_page_tab"><%= Alchemy.t('Paste from clipboard') %></sl-tab>
   <sl-tab-panel name="create_page_tab">
-    <%= render 'new_page_form' %>
+    <%= render 'new_page_form', page: @page, current_language: @current_language, page_layouts: @page_layouts %>
   </sl-tab-panel>
   <sl-tab-panel name="paste_page_tab">
     <%= render 'alchemy/admin/partials/paste_from_clipboard_form', item: @page %>

--- a/app/views/alchemy/admin/pages/update.turbo_stream.erb
+++ b/app/views/alchemy/admin/pages/update.turbo_stream.erb
@@ -11,7 +11,7 @@
   <turbo-stream action="reload_preview"></turbo-stream>
 <% else %>
   <%= turbo_stream.replace "locked_page_#{@page.id}" do %>
-    <%= render("alchemy/admin/pages/locked_page", locked_page: @page) %>
+    <%= render("alchemy/admin/pages/locked_page", locked_page: @page, page: @page) %>
   <% end %>
 
   <% if @view == "list" %>

--- a/app/views/alchemy/admin/partials/_autocomplete_tag_list.html.erb
+++ b/app/views/alchemy/admin/partials/_autocomplete_tag_list.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (f:) %>
 <%= render Alchemy::Admin::TagsAutocomplete.new do %>
   <%= f.text_field :tag_list, value: f.object.tag_list.join(",") %>
 <% end %>

--- a/app/views/alchemy/admin/partials/_flash_notices.html.erb
+++ b/app/views/alchemy/admin/partials/_flash_notices.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <div id="flash_notices" data-auto-dismiss-delay="5000">
 <% flash.keys.each do |flash_type| %>
   <% if flash[flash_type.to_sym].present? %>

--- a/app/views/alchemy/admin/partials/_language_tree_select.html.erb
+++ b/app/views/alchemy/admin/partials/_language_tree_select.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <% languages = Alchemy::Language.on_current_site %>
 <% if can?(:switch_language, Alchemy::Page) && languages.many? %>
 <div class="toolbar_button">

--- a/app/views/alchemy/admin/partials/_main_navigation_entry.html.erb
+++ b/app/views/alchemy/admin/partials/_main_navigation_entry.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (alchemy_module:, navigation:) %>
 <% if can? *navigate_module(navigation) %>
   <%= content_tag :"alchemy-main-navi-entry", class: main_navigation_css_classes(navigation), data: navigation["data"] do %>
     <%= link_to url_for_module(alchemy_module) do %>

--- a/app/views/alchemy/admin/partials/_overlay_search_form.html.erb
+++ b/app/views/alchemy/admin/partials/_overlay_search_form.html.erb
@@ -1,13 +1,16 @@
+<% query = local_assigns[:query] %>
+<% form_field_id = local_assigns[:form_field_id] %>
+<% size = local_assigns[:size] %>
 <%- clear_url ||= url_for({ action: 'index' }.merge(
   q: search_filter_params[:q]&.except(resource_handler.search_field_name),
   only: search_filter_params[:only],
   except: search_filter_params[:except],
-  form_field_id: @form_field_id,
-  size: @size
+  form_field_id: form_field_id,
+  size: size
 )) -%>
 
-<%= search_form_for @query, url: url_for(action: 'index', size: @size), html: {class: 'search_form', id: "resource_search"} do |f| %>
-  <%= hidden_field_tag :form_field_id, @form_field_id %>
+<%= search_form_for query, url: url_for(action: 'index', size: size), html: {class: 'search_form', id: "resource_search"} do |f| %>
+  <%= hidden_field_tag :form_field_id, form_field_id %>
   <% Array(params[:only]).each do |only| %>
     <%= hidden_field_tag("only[]", only, form: "resource_search", id: nil) %>
   <% end %>

--- a/app/views/alchemy/admin/partials/_overlay_search_form.html.erb
+++ b/app/views/alchemy/admin/partials/_overlay_search_form.html.erb
@@ -1,6 +1,4 @@
-<% query = local_assigns[:query] %>
-<% form_field_id = local_assigns[:form_field_id] %>
-<% size = local_assigns[:size] %>
+<%# locals: (query:, form_field_id:, size:, clear_url: nil) %>
 <%- clear_url ||= url_for({ action: 'index' }.merge(
   q: search_filter_params[:q]&.except(resource_handler.search_field_name),
   only: search_filter_params[:only],

--- a/app/views/alchemy/admin/partials/_paste_from_clipboard_form.html.erb
+++ b/app/views/alchemy/admin/partials/_paste_from_clipboard_form.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (item:) %>
 <%= alchemy_form_for [:admin, item] do |f| %>
   <%= f.hidden_field(:parent_id) %>
   <%= f.hidden_field(:language_id) %>

--- a/app/views/alchemy/admin/partials/_routes.html.erb
+++ b/app/views/alchemy/admin/partials/_routes.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <script>
   Alchemy.routes = {
 

--- a/app/views/alchemy/admin/partials/_search_form.html.erb
+++ b/app/views/alchemy/admin/partials/_search_form.html.erb
@@ -1,8 +1,9 @@
+<%# locals: (query:, url: nil, additional_params: []) %>
 <%- url ||= resource_url_proxy.url_for({ action: 'index' }.merge(
   q: search_filter_params[:q]&.except(resource_handler.search_field_name))
 ) -%>
 
-<%= search_form_for local_assigns[:query], url: resource_url_proxy.url_for(action: "index"), id: "resource_search", class: 'search_form' do |f| %>
+<%= search_form_for query, url: resource_url_proxy.url_for(action: "index"), id: "resource_search", class: 'search_form' do |f| %>
   <div class="search_field">
     <button type="submit">
       <%= render_icon('search') %>
@@ -21,7 +22,7 @@
       <%= hidden_field_tag :tagged_with, search_filter_params.fetch(:tagged_with), id: nil %>
     <% end %>
 
-    <% local_assigns.fetch(:additional_params, []).each do |additional_param| %>
+    <% additional_params.each do |additional_param| %>
       <%= hidden_field_tag additional_param, search_filter_params[additional_param], id: nil %>
     <% end %>
   </div>

--- a/app/views/alchemy/admin/partials/_search_form.html.erb
+++ b/app/views/alchemy/admin/partials/_search_form.html.erb
@@ -2,7 +2,7 @@
   q: search_filter_params[:q]&.except(resource_handler.search_field_name))
 ) -%>
 
-<%= search_form_for @query, url: resource_url_proxy.url_for(action: "index"), id: "resource_search", class: 'search_form' do |f| %>
+<%= search_form_for local_assigns[:query], url: resource_url_proxy.url_for(action: "index"), id: "resource_search", class: 'search_form' do |f| %>
   <div class="search_field">
     <button type="submit">
       <%= render_icon('search') %>

--- a/app/views/alchemy/admin/partials/_site_select.html.erb
+++ b/app/views/alchemy/admin/partials/_site_select.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <%- if multi_site? -%>
 <div class="toolbar_button">
   <sl-tooltip content="<%= Alchemy.t("Current site") %>">

--- a/app/views/alchemy/admin/partials/_sub_navigation.html.erb
+++ b/app/views/alchemy/admin/partials/_sub_navigation.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (entries:) %>
 <% if entries.present? %>
   <div class="sub_navigation">
     <% entries.each do |entry| %>

--- a/app/views/alchemy/admin/picture_descriptions/_form.html.erb
+++ b/app/views/alchemy/admin/picture_descriptions/_form.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (description_field_name_prefix:, picture_description:) %>
 <% if picture_description.persisted? %>
   <%= hidden_field description_field_name_prefix, :id, value: picture_description.id %>
 <% else %>

--- a/app/views/alchemy/admin/pictures/_archive.html.erb
+++ b/app/views/alchemy/admin/pictures/_archive.html.erb
@@ -1,6 +1,4 @@
-<% size = local_assigns[:size] %>
-<% pictures = local_assigns[:pictures] %>
-<% deletable_picture_ids = local_assigns[:deletable_picture_ids] %>
+<%# locals: (size:, pictures:, deletable_picture_ids:) %>
 <% forwarded_params = search_filter_params.merge(
   page: params[:page],
   size: size.presence

--- a/app/views/alchemy/admin/pictures/_archive.html.erb
+++ b/app/views/alchemy/admin/pictures/_archive.html.erb
@@ -1,6 +1,9 @@
+<% size = local_assigns[:size] %>
+<% pictures = local_assigns[:pictures] %>
+<% deletable_picture_ids = local_assigns[:deletable_picture_ids] %>
 <% forwarded_params = search_filter_params.merge(
   page: params[:page],
-  size: @size.presence
+  size: size.presence
 ).to_h %>
 
 <%= form_tag delete_multiple_admin_pictures_path(forwarded_params), method: :delete do %>
@@ -23,7 +26,7 @@
       class: 'secondary button with_icon'
     ) %>
   </div>
-  <div id="pictures" class="picture-size--<%= @size %>">
-    <%= render partial: "picture", collection: @pictures, locals: {picture_offset: picture_offset} %>
+  <div id="pictures" class="picture-size--<%= size %>">
+    <%= render partial: "picture", collection: pictures, locals: {picture_offset: picture_offset, size: size, deletable_picture_ids: deletable_picture_ids} %>
   </div>
 <% end %>

--- a/app/views/alchemy/admin/pictures/_archive_overlay.html.erb
+++ b/app/views/alchemy/admin/pictures/_archive_overlay.html.erb
@@ -1,7 +1,4 @@
-<% pictures = local_assigns[:pictures] %>
-<% size = local_assigns[:size] %>
-<% form_field_id = local_assigns[:form_field_id] %>
-<% query = local_assigns[:query] %>
+<%# locals: (pictures:, size:, form_field_id:, query:) %>
 <%= turbo_frame_tag "archive_overlay" do %>
   <div class="toolbar">
     <%= render 'filter_and_size_bar', form_field_id: form_field_id %>

--- a/app/views/alchemy/admin/pictures/_archive_overlay.html.erb
+++ b/app/views/alchemy/admin/pictures/_archive_overlay.html.erb
@@ -1,11 +1,15 @@
+<% pictures = local_assigns[:pictures] %>
+<% size = local_assigns[:size] %>
+<% form_field_id = local_assigns[:form_field_id] %>
+<% query = local_assigns[:query] %>
 <%= turbo_frame_tag "archive_overlay" do %>
   <div class="toolbar">
-    <%= render 'filter_and_size_bar' %>
-    <%= render 'alchemy/admin/partials/overlay_search_form' %>
+    <%= render 'filter_and_size_bar', form_field_id: form_field_id %>
+    <%= render 'alchemy/admin/partials/overlay_search_form', query: query, form_field_id: form_field_id, size: size %>
   </div>
   <div id="assign_image_list" class="with_padding<%= search_filter_params[:tagged_with].present? ? ' filtered' : '' %>">
-    <%= render "library_sidebar" %>
-    <% if @pictures.empty? %>
+    <%= render "library_sidebar", query: query %>
+    <% if pictures.empty? %>
       <%= render_message do %>
         <% if search_filter_params.empty? %>
           <%= Alchemy.t(:no_images_in_archive) %>
@@ -14,12 +18,12 @@
         <% end %>
       <% end %>
     <% else %>
-      <div id="overlay_picture_list" class="picture-size--<%= @size %>">
+      <div id="overlay_picture_list" class="picture-size--<%= size %>">
         <%= render partial: 'picture_to_assign',
-          collection: @pictures,
-          locals: {size: @size} %>
+          collection: pictures,
+          locals: {size: size, form_field_id: form_field_id} %>
 
-        <%= render "alchemy/admin/resources/pagination", resources: @pictures, hide_per_page_select: true %>
+        <%= render "alchemy/admin/resources/pagination", resources: pictures, hide_per_page_select: true %>
       </div>
     <% end %>
   </div>

--- a/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
+++ b/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
@@ -1,4 +1,4 @@
-<% form_field_id = local_assigns[:form_field_id] %>
+<%# locals: (form_field_id:) %>
 <div class="toolbar_buttons">
   <% if can? :create, Alchemy::Picture %>
     <div class="toolbar_button">

--- a/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
+++ b/app/views/alchemy/admin/pictures/_filter_and_size_bar.html.erb
@@ -1,3 +1,4 @@
+<% form_field_id = local_assigns[:form_field_id] %>
 <div class="toolbar_buttons">
   <% if can? :create, Alchemy::Picture %>
     <div class="toolbar_button">
@@ -10,7 +11,7 @@
         redirect_url: alchemy.admin_pictures_path(
           size: search_filter_params[:size],
           q: { last_upload: true },
-          form_field_id: @form_field_id
+          form_field_id: form_field_id
         )
       ) %>
     </div>
@@ -23,7 +24,7 @@
         alchemy.admin_pictures_path(
           search_filter_params.merge(
             size: "small",
-            form_field_id: @form_field_id
+            form_field_id: form_field_id
           ).to_h
         ),
         class: "icon_button"
@@ -35,7 +36,7 @@
         alchemy.admin_pictures_path(
           search_filter_params.merge(
             size: "medium",
-            form_field_id: @form_field_id
+            form_field_id: form_field_id
           ).to_h
         ),
         class: "icon_button"
@@ -47,7 +48,7 @@
         alchemy.admin_pictures_path(
           search_filter_params.merge(
             size: "large",
-            form_field_id: @form_field_id
+            form_field_id: form_field_id
           ).to_h
         ),
         class: "icon_button"

--- a/app/views/alchemy/admin/pictures/_form.html.erb
+++ b/app/views/alchemy/admin/pictures/_form.html.erb
@@ -1,15 +1,17 @@
-<%= turbo_frame_tag(@picture) do %>
-  <%= alchemy_form_for @picture,
+<% picture = local_assigns[:picture] %>
+<% size = local_assigns[:size] %>
+<%= turbo_frame_tag(picture) do %>
+  <%= alchemy_form_for picture,
     url: alchemy.admin_picture_path(
-      @picture,
+      picture,
       search_filter_params.merge(
-        size: @size,
+        size: size,
         picture_index: picture_index
       ).to_h
     ),
     class: "picture-form" do |f| %>
     <%= f.input :name %>
-    <%= render "alchemy/admin/pictures/picture_description_field", f: f %>
+    <%= render "alchemy/admin/pictures/picture_description_field", f: f, picture: picture, picture_description: local_assigns[:picture_description] %>
     <%= render Alchemy::Admin::TagsAutocomplete.new(additional_class: "input tags") do %>
       <%= f.label :tag_list %>
       <%= f.text_field :tag_list, value: f.object.tag_list.join(",") %>

--- a/app/views/alchemy/admin/pictures/_form.html.erb
+++ b/app/views/alchemy/admin/pictures/_form.html.erb
@@ -1,5 +1,4 @@
-<% picture = local_assigns[:picture] %>
-<% size = local_assigns[:size] %>
+<%# locals: (picture:, size:, picture_index:, picture_description:) %>
 <%= turbo_frame_tag(picture) do %>
   <%= alchemy_form_for picture,
     url: alchemy.admin_picture_path(
@@ -11,7 +10,7 @@
     ),
     class: "picture-form" do |f| %>
     <%= f.input :name %>
-    <%= render "alchemy/admin/pictures/picture_description_field", f: f, picture: picture, picture_description: local_assigns[:picture_description] %>
+    <%= render "alchemy/admin/pictures/picture_description_field", f: f, picture: picture, picture_description: picture_description %>
     <%= render Alchemy::Admin::TagsAutocomplete.new(additional_class: "input tags") do %>
       <%= f.label :tag_list %>
       <%= f.text_field :tag_list, value: f.object.tag_list.join(",") %>

--- a/app/views/alchemy/admin/pictures/_infos.html.erb
+++ b/app/views/alchemy/admin/pictures/_infos.html.erb
@@ -1,4 +1,4 @@
-<% picture = local_assigns[:picture] %>
+<%# locals: (picture:, assignments:) %>
 <div class="resource_info file-infos">
   <div class="value">
     <label><%= Alchemy::Picture.human_attribute_name(:image_file_name) %></label>
@@ -25,5 +25,5 @@
 <hr>
 
 <%= render "alchemy/admin/resources/resource_usage_info",
-  assignments: local_assigns[:assignments],
+  assignments: assignments,
   resource_name: :picture %>

--- a/app/views/alchemy/admin/pictures/_infos.html.erb
+++ b/app/views/alchemy/admin/pictures/_infos.html.erb
@@ -1,28 +1,29 @@
+<% picture = local_assigns[:picture] %>
 <div class="resource_info file-infos">
   <div class="value">
     <label><%= Alchemy::Picture.human_attribute_name(:image_file_name) %></label>
-    <p><%= @picture.image_file_name %></p>
+    <p><%= picture.image_file_name %></p>
   </div>
   <div class="value">
     <label><%= Alchemy::Picture.human_attribute_name(:image_file_dimensions) %></label>
-    <p><%= @picture.image_file_dimensions %>px</p>
+    <p><%= picture.image_file_dimensions %>px</p>
   </div>
   <div class="value">
     <label><%= Alchemy::Picture.human_attribute_name(:image_file_size) %></label>
-    <p><%= number_to_human_size @picture.image_file_size %></p>
+    <p><%= number_to_human_size picture.image_file_size %></p>
   </div>
   <div class="value">
     <label><%= Alchemy::Picture.human_attribute_name(:image_file_format) %></label>
-    <p><%= Alchemy.t(@picture.image_file_format, scope: [:filters, :picture, :by_file_format, :values]) %></p>
+    <p><%= Alchemy.t(picture.image_file_format, scope: [:filters, :picture, :by_file_format, :values]) %></p>
   </div>
   <div class="value">
     <label><%= Alchemy::Picture.human_attribute_name(:created_at) %></label>
-    <p><%= l(@picture.created_at, format: :"alchemy.default") %></p>
+    <p><%= l(picture.created_at, format: :"alchemy.default") %></p>
   </div>
 </div>
 
 <hr>
 
 <%= render "alchemy/admin/resources/resource_usage_info",
-  assignments: @assignments,
+  assignments: local_assigns[:assignments],
   resource_name: :picture %>

--- a/app/views/alchemy/admin/pictures/_library_sidebar.html.erb
+++ b/app/views/alchemy/admin/pictures/_library_sidebar.html.erb
@@ -1,6 +1,6 @@
 <div id="library_sidebar">
   <%= render "sorting_select" %>
-  <%= render "filter_bar" if resource_has_filters %>
+  <%= render "filter_bar", query: local_assigns[:query] if resource_has_filters %>
   <div class="tag-list">
     <%= render "tag_list" %>
   </div>

--- a/app/views/alchemy/admin/pictures/_library_sidebar.html.erb
+++ b/app/views/alchemy/admin/pictures/_library_sidebar.html.erb
@@ -1,6 +1,7 @@
+<%# locals: (query:) %>
 <div id="library_sidebar">
   <%= render "sorting_select" %>
-  <%= render "filter_bar", query: local_assigns[:query] if resource_has_filters %>
+  <%= render "filter_bar", query: query if resource_has_filters %>
   <div class="tag-list">
     <%= render "tag_list" %>
   </div>

--- a/app/views/alchemy/admin/pictures/_picture.html.erb
+++ b/app/views/alchemy/admin/pictures/_picture.html.erb
@@ -1,8 +1,10 @@
-<div class="picture_thumbnail <%= @size %>" id="picture_<%= picture.id %>">
+<% size = local_assigns[:size] %>
+<% deletable_picture_ids = local_assigns[:deletable_picture_ids] %>
+<div class="picture_thumbnail <%= size %>" id="picture_<%= picture.id %>">
   <span class="picture_tool select">
     <%= check_box_tag "picture_ids[]", picture.id %>
   </span>
-  <% if @deletable_picture_ids.include?(picture.id) && can?(:destroy, picture) %>
+  <% if deletable_picture_ids.include?(picture.id) && can?(:destroy, picture) %>
   <div class="picture_tool delete">
     <sl-tooltip content="<%= Alchemy.t('Delete image') %>">
       <%= link_to_confirm_dialog(
@@ -12,7 +14,7 @@
           picture,
           search_filter_params.merge(
             page: params[:page],
-            size: @size.presence
+            size: size.presence
           ).to_h
         )
       ) -%>
@@ -25,13 +27,13 @@
       picture,
       search_filter_params.merge(
         picture_index: picture_index.to_i + 1,
-        size: @size.presence
+        size: size.presence
       ).to_h
     ) do %>
-      <%= render Alchemy::Admin::PictureThumbnail.new(picture, size: @size) %>
+      <%= render Alchemy::Admin::PictureThumbnail.new(picture, size: size) %>
     <% end %>
   <% else %>
-    <%= render Alchemy::Admin::PictureThumbnail.new(picture, size: @size) %>
+    <%= render Alchemy::Admin::PictureThumbnail.new(picture, size: size) %>
   <% end %>
   <span class="picture_name" title="<%= picture.name %>">
     <%= picture.name %>

--- a/app/views/alchemy/admin/pictures/_picture.html.erb
+++ b/app/views/alchemy/admin/pictures/_picture.html.erb
@@ -1,5 +1,4 @@
-<% size = local_assigns[:size] %>
-<% deletable_picture_ids = local_assigns[:deletable_picture_ids] %>
+<%# locals: (picture:, size:, deletable_picture_ids:, picture_offset: nil, picture_index: nil, picture_iteration: nil) %>
 <div class="picture_thumbnail <%= size %>" id="picture_<%= picture.id %>">
   <span class="picture_tool select">
     <%= check_box_tag "picture_ids[]", picture.id %>

--- a/app/views/alchemy/admin/pictures/_picture_description_field.html.erb
+++ b/app/views/alchemy/admin/pictures/_picture_description_field.html.erb
@@ -1,9 +1,9 @@
-<% picture_description = local_assigns[:picture_description] %>
+<%# locals: (f:, picture:, picture_description:) %>
 <div class="input">
   <%= render Alchemy::Admin::PictureDescriptionSelect.new(
     url: alchemy.edit_admin_picture_description_url(
       id: picture_description.id || "__ID__",
-      picture_id: local_assigns[:picture]
+      picture_id: picture
     ),
     selected: picture_description.language_id,
     name_prefix: description_field_name_prefix

--- a/app/views/alchemy/admin/pictures/_picture_description_field.html.erb
+++ b/app/views/alchemy/admin/pictures/_picture_description_field.html.erb
@@ -1,16 +1,17 @@
+<% picture_description = local_assigns[:picture_description] %>
 <div class="input">
   <%= render Alchemy::Admin::PictureDescriptionSelect.new(
     url: alchemy.edit_admin_picture_description_url(
-      id: @picture_description.id || "__ID__",
-      picture_id: @picture
+      id: picture_description.id || "__ID__",
+      picture_id: local_assigns[:picture]
     ),
-    selected: @picture_description.language_id,
+    selected: picture_description.language_id,
     name_prefix: description_field_name_prefix
   ) %>
 
   <turbo-frame id="picture_descriptions">
     <%= render "alchemy/admin/picture_descriptions/form",
       description_field_name_prefix: description_field_name_prefix,
-      picture_description: @picture_description %>
+      picture_description: picture_description %>
   </turbo-frame>
 </div>

--- a/app/views/alchemy/admin/pictures/_picture_to_assign.html.erb
+++ b/app/views/alchemy/admin/pictures/_picture_to_assign.html.erb
@@ -1,4 +1,4 @@
-<% form_field_id = local_assigns[:form_field_id] %>
+<%# locals: (picture_to_assign:, size:, form_field_id:) %>
 <div class="picture_thumbnail" name="<%= picture_to_assign.name %>" id="assignable_<%= picture_to_assign.id %>">
   <% if picture_to_assign.image_file %>
     <sl-tooltip content="<%= Alchemy.t(:assign_image) %>">

--- a/app/views/alchemy/admin/pictures/_picture_to_assign.html.erb
+++ b/app/views/alchemy/admin/pictures/_picture_to_assign.html.erb
@@ -1,10 +1,11 @@
+<% form_field_id = local_assigns[:form_field_id] %>
 <div class="picture_thumbnail" name="<%= picture_to_assign.name %>" id="assignable_<%= picture_to_assign.id %>">
   <% if picture_to_assign.image_file %>
     <sl-tooltip content="<%= Alchemy.t(:assign_image) %>">
       <%= button_to(
         alchemy.assign_admin_picture_path(
           id: picture_to_assign.id,
-          form_field_id: @form_field_id
+          form_field_id: form_field_id
         ),
         method: :put,
         form_class: "assign_picture"

--- a/app/views/alchemy/admin/pictures/_sorting_select.html.erb
+++ b/app/views/alchemy/admin/pictures/_sorting_select.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <div id="sorting_select">
   <div class="filter-input">
     <alchemy-auto-submit>

--- a/app/views/alchemy/admin/pictures/_tag_list.html.erb
+++ b/app/views/alchemy/admin/pictures/_tag_list.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <% if Alchemy::Picture.tag_counts.any? %>
   <label><%= Alchemy.t("Filter by tag") %></label>
   <%= render Alchemy::Admin::ListFilter.new(".tag-list li", placeholder: Alchemy.t("Filter tags")) %>

--- a/app/views/alchemy/admin/pictures/index.html.erb
+++ b/app/views/alchemy/admin/pictures/index.html.erb
@@ -59,6 +59,7 @@
   </div>
 
   <%= render 'alchemy/admin/partials/search_form',
+    query: @query,
     additional_params: [:size] %>
 <% end %>
 
@@ -81,7 +82,7 @@
         <%= @pictures.total_count %>
         <%= Alchemy::Picture.model_name.human(count: @pictures.total_count) %>
       </h2>
-      <%= render "alchemy/admin/resources/applied_filters" %>
+      <%= render "alchemy/admin/resources/applied_filters", query: @query %>
     </div>
 
     <% if @pictures.none? && @recent_pictures.blank? && search_filter_params.present? %>
@@ -89,14 +90,14 @@
         <%= Alchemy.t(:no_search_results) %>
       <% end %>
     <% else %>
-      <%= render "archive" %>
+      <%= render "archive", size: @size, pictures: @pictures, deletable_picture_ids: @deletable_picture_ids %>
     <% end %>
 
     <%= render "alchemy/admin/resources/pagination", resources: @pictures %>
   <% end %>
 </div>
 
-<%= render "library_sidebar" %>
+<%= render "library_sidebar", query: @query %>
 
 <% content_for :javascripts do %>
   <script type="module">

--- a/app/views/alchemy/admin/pictures/show.html.erb
+++ b/app/views/alchemy/admin/pictures/show.html.erb
@@ -35,9 +35,9 @@
   </div>
 
   <div class="picture-details-overlay">
-    <%= render 'form', picture_index: @previous || @next || 0 %>
+    <%= render 'form', picture_index: @previous || @next || 0, picture: @picture, size: @size, picture_description: @picture_description %>
     <hr>
-    <%= render 'infos' %>
+    <%= render 'infos', picture: @picture, assignments: @assignments %>
   </div>
 
   <div class="picture-overlay-handle">

--- a/app/views/alchemy/admin/pictures/update.turbo_stream.erb
+++ b/app/views/alchemy/admin/pictures/update.turbo_stream.erb
@@ -2,5 +2,5 @@
   <%= @message[:body] %>
 </alchemy-growl>
 <%= turbo_stream.replace("picture_#{@picture.id}") do %>
-  <%= render "picture", picture: @picture, picture_index: params[:picture_index] %>
+  <%= render "picture", picture: @picture, picture_index: params[:picture_index], size: @size, deletable_picture_ids: @deletable_picture_ids %>
 <% end %>

--- a/app/views/alchemy/admin/resources/_applied_filters.html.erb
+++ b/app/views/alchemy/admin/resources/_applied_filters.html.erb
@@ -1,8 +1,9 @@
+<%# locals: (query:) %>
 <% if applied_filters.present? %>
   <div class="applied-filters">
     <b><%= Alchemy.t("filtered_by") %></b>
     <% applied_filters.each do |filter| %>
-      <%= render filter.applied_filter_component(search_filter_params:, resource_url_proxy:, query: local_assigns[:query]) %>
+      <%= render filter.applied_filter_component(search_filter_params:, resource_url_proxy:, query:) %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/alchemy/admin/resources/_applied_filters.html.erb
+++ b/app/views/alchemy/admin/resources/_applied_filters.html.erb
@@ -2,7 +2,7 @@
   <div class="applied-filters">
     <b><%= Alchemy.t("filtered_by") %></b>
     <% applied_filters.each do |filter| %>
-      <%= render filter.applied_filter_component(search_filter_params:, resource_url_proxy:, query: @query) %>
+      <%= render filter.applied_filter_component(search_filter_params:, resource_url_proxy:, query: local_assigns[:query]) %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/alchemy/admin/resources/_empty_state.html.erb
+++ b/app/views/alchemy/admin/resources/_empty_state.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <% content_for(:alchemy_body_class) { "centered" } %>
 
 <div class="empty-state panel">

--- a/app/views/alchemy/admin/resources/_filter_bar.html.erb
+++ b/app/views/alchemy/admin/resources/_filter_bar.html.erb
@@ -1,7 +1,7 @@
 <div id="filter_bar">
   <alchemy-auto-submit>
     <% alchemy_filters.each do |filter| %>
-      <%= render filter.input_component(search_filter_params, @query) %>
+      <%= render filter.input_component(search_filter_params, local_assigns[:query]) %>
     <% end %>
   </alchemy-auto-submit>
 </div>

--- a/app/views/alchemy/admin/resources/_filter_bar.html.erb
+++ b/app/views/alchemy/admin/resources/_filter_bar.html.erb
@@ -1,7 +1,8 @@
+<%# locals: (query:) %>
 <div id="filter_bar">
   <alchemy-auto-submit>
     <% alchemy_filters.each do |filter| %>
-      <%= render filter.input_component(search_filter_params, local_assigns[:query]) %>
+      <%= render filter.input_component(search_filter_params, query) %>
     <% end %>
   </alchemy-auto-submit>
 </div>

--- a/app/views/alchemy/admin/resources/_form.html.erb
+++ b/app/views/alchemy/admin/resources/_form.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (resource:, **rest) %>
 <%= alchemy_form_for resource, url: resource_path(resource, search_filter_params) do |f| %>
   <% resource_handler.editable_attributes.each do |attribute| %>
     <% if relation = attribute[:relation] %>

--- a/app/views/alchemy/admin/resources/_pagination.html.erb
+++ b/app/views/alchemy/admin/resources/_pagination.html.erb
@@ -1,6 +1,7 @@
+<%# locals: (resources:, hide_per_page_select: false) %>
 <div class="pagination-wrapper">
   <%= paginate resources, theme: "alchemy" %>
-  <% unless local_assigns[:hide_per_page_select] %>
+  <% unless hide_per_page_select %>
     <%= render "alchemy/admin/resources/per_page_select" %>
   <% end %>
 </div>

--- a/app/views/alchemy/admin/resources/_per_page_select.html.erb
+++ b/app/views/alchemy/admin/resources/_per_page_select.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <%= form_tag url_for, method: :get, class: 'per-page-select-form' do |f| %>
   <% search_filter_params.reject { |k, _| k == 'page' || k == 'per_page' }.each do |key, value| %>
     <% if value.respond_to?(:keys) %>

--- a/app/views/alchemy/admin/resources/_resource_table.html.erb
+++ b/app/views/alchemy/admin/resources/_resource_table.html.erb
@@ -1,1 +1,1 @@
-<%= render Alchemy::Admin::Resource::Table.new(resources_instance_variable, query: @query, search_filter_params: search_filter_params, icon: local_assigns[:icon]) %>
+<%= render Alchemy::Admin::Resource::Table.new(resources_instance_variable, query: local_assigns[:query], search_filter_params: search_filter_params, icon: local_assigns[:icon]) %>

--- a/app/views/alchemy/admin/resources/_resource_table.html.erb
+++ b/app/views/alchemy/admin/resources/_resource_table.html.erb
@@ -1,1 +1,2 @@
-<%= render Alchemy::Admin::Resource::Table.new(resources_instance_variable, query: local_assigns[:query], search_filter_params: search_filter_params, icon: local_assigns[:icon]) %>
+<%# locals: (query:, icon: nil, url: nil) %>
+<%= render Alchemy::Admin::Resource::Table.new(resources_instance_variable, query:, search_filter_params: search_filter_params, icon:) %>

--- a/app/views/alchemy/admin/resources/_resource_usage_info.html.erb
+++ b/app/views/alchemy/admin/resources/_resource_usage_info.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (assignments:, resource_name:) %>
 <div class="resource-usage-info">
   <% if assignments.any? %>
     <h2 class="resource-info-headline">

--- a/app/views/alchemy/admin/resources/_table_header.html.erb
+++ b/app/views/alchemy/admin/resources/_table_header.html.erb
@@ -1,7 +1,8 @@
+<%# locals: (query:, **rest) %>
 <div class="resources-header">
   <h2>
     <%= resources_instance_variable.total_count %>
     <%= resource_model.model_name.human(count: resources_instance_variable.total_count) %>
   </h2>
-  <%= render "alchemy/admin/resources/applied_filters", query: local_assigns[:query] %>
+  <%= render "alchemy/admin/resources/applied_filters", query: %>
 </div>

--- a/app/views/alchemy/admin/resources/_table_header.html.erb
+++ b/app/views/alchemy/admin/resources/_table_header.html.erb
@@ -3,5 +3,5 @@
     <%= resources_instance_variable.total_count %>
     <%= resource_model.model_name.human(count: resources_instance_variable.total_count) %>
   </h2>
-  <%= render "alchemy/admin/resources/applied_filters" %>
+  <%= render "alchemy/admin/resources/applied_filters", query: local_assigns[:query] %>
 </div>

--- a/app/views/alchemy/admin/resources/_tag_list.html.erb
+++ b/app/views/alchemy/admin/resources/_tag_list.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <div class="tag-list<%= ' with_filter_bar' if resource_has_filters %><%= ' filtered' if search_filter_params[:tagged_with].present? %>">
   <h3><%= Alchemy.t("Filter by tag") %></h3>
   <%= render Alchemy::Admin::ListFilter.new(".tag-list li", placeholder: Alchemy.t("Filter tags")) %>

--- a/app/views/alchemy/admin/resources/index.html.erb
+++ b/app/views/alchemy/admin/resources/index.html.erb
@@ -22,7 +22,7 @@
       if_permitted_to: [:index, resource_model]
     ) %>
   </div>
-  <%= render 'alchemy/admin/partials/search_form' %>
+  <%= render 'alchemy/admin/partials/search_form', query: @query %>
 <% end %>
 
 <% if resource_model.any? %>
@@ -53,7 +53,7 @@
 
 <% if resource_has_tags || resource_has_filters %>
   <div id="library_sidebar">
-    <%= render "filter_bar" if resource_has_filters %>
+    <%= render "filter_bar", query: @query if resource_has_filters %>
     <%= render "tag_list" if resource_has_tags %>
   </div>
 <% end %>

--- a/app/views/alchemy/admin/sites/_form.html.erb
+++ b/app/views/alchemy/admin/sites/_form.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (site:, resource: nil) %>
 <%= alchemy_form_for site, url: resource_path(site, search_filter_params) do |f| %>
   <%= f.input :host, hint: resource_handler.help_text_for(name: :host)&.html_safe %>
   <%= f.input :name %>

--- a/app/views/alchemy/admin/sites/index.html.erb
+++ b/app/views/alchemy/admin/sites/index.html.erb
@@ -14,7 +14,7 @@
       if_permitted_to: [:create, Alchemy::Site]
     ) %>
   </div>
-  <%= render 'alchemy/admin/partials/search_form' %>
+  <%= render 'alchemy/admin/partials/search_form', query: @query %>
 <% end %>
 
 <% if Alchemy::Site.any? %>

--- a/app/views/alchemy/admin/tags/_radio_tag.html.erb
+++ b/app/views/alchemy/admin/tags/_radio_tag.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (radio_tag:, name:) %>
 <li name="<%= radio_tag.name.downcase %>">
   <%= radio_button_tag name + "[merge_to]", radio_tag.id, false, :id => radio_tag.name + "_tag_list" %>
   <label for="<%= radio_tag.name + "_tag_list" %>">

--- a/app/views/alchemy/admin/tags/index.html.erb
+++ b/app/views/alchemy/admin/tags/index.html.erb
@@ -14,11 +14,11 @@
       if_permitted_to: [:create, Alchemy::Tag]
     ) %>
   </div>
-  <%= render 'alchemy/admin/partials/search_form' %>
+  <%= render 'alchemy/admin/partials/search_form', query: @query %>
 <% end %>
 
 <% if Alchemy::Tag.any? %>
-  <%= render 'alchemy/admin/resources/table_header' %>
+  <%= render 'alchemy/admin/resources/table_header', query: @query %>
 
   <% if @tags.any? %>
     <div class="resources-table-wrapper">

--- a/app/views/alchemy/admin/tinymce/_setup.html.erb
+++ b/app/views/alchemy/admin/tinymce/_setup.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <% tinymce_base_path = "#{Rails.application.config.assets.prefix}/tinymce" %>
 
 <link rel="preload" href="<%= asset_path("#{tinymce_base_path}/skins/ui/alchemy/skin.min.css") %>" as="style">

--- a/app/views/alchemy/admin/uploader/_button.html.erb
+++ b/app/views/alchemy/admin/uploader/_button.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (object:, file_attribute:, redirect_url:, accept: nil, dropzone: nil, layout: nil, label: nil) %>
 <% Alchemy::Deprecation.warn(
   "Rendering the `alchemy/admin/uploader/button` partial is deprecated! `render Alchemy::Admin::UploaderButton.new` instead."
 ) %>
@@ -5,7 +6,7 @@
   object:,
   file_attribute:,
   redirect_url:,
-  accept: local_assigns[:accept],
-  dropzone: local_assigns[:dropzone],
-  layout: local_assigns[:layout],
-  label: local_assigns[:label]) %>
+  accept:,
+  dropzone:,
+  layout:,
+  label:) %>

--- a/app/views/alchemy/admin/uploader/_setup.html.erb
+++ b/app/views/alchemy/admin/uploader/_setup.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <script>
   Alchemy.uploader_defaults = <%== Alchemy.config.uploader.to_json %>
 </script>

--- a/app/views/alchemy/breadcrumb/_page.html.erb
+++ b/app/views/alchemy/breadcrumb/_page.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (page:, pages:, options: {}, **rest) %>
 <% css_classes = [options[:page] == page ? "active" : nil] %>
 <% if page == pages.first %>
   <% css_classes << "first" %>

--- a/app/views/alchemy/breadcrumb/_separator.html.erb
+++ b/app/views/alchemy/breadcrumb/_separator.html.erb
@@ -1,1 +1,2 @@
+<%# locals: (options: {}, **rest) %>
 <span class="separator"><%= sanitize options[:separator] %></span>

--- a/app/views/alchemy/breadcrumb/_wrapper.html.erb
+++ b/app/views/alchemy/breadcrumb/_wrapper.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (pages:, options: {}, **rest) %>
 <% if pages.any? %>
   <div class="breadcrumb">
     <%= render({

--- a/app/views/alchemy/elements/_view_not_found.html.erb
+++ b/app/views/alchemy/elements/_view_not_found.html.erb
@@ -1,1 +1,2 @@
+<%# locals: (name:) %>
 <!-- Missing view for <%= name %> element -->

--- a/app/views/alchemy/ingredients/shared/_anchor.html.erb
+++ b/app/views/alchemy/ingredients/shared/_anchor.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (ingredient:) %>
 <span class="edit-ingredient-anchor-link">
   <% disabled = cannot?(:edit, ingredient) %>
   <%= content_tag "sl-tooltip", content: Alchemy.t(:edit_anchor), disabled: disabled do %>

--- a/app/views/alchemy/ingredients/shared/_link_tools.html.erb
+++ b/app/views/alchemy/ingredients/shared/_link_tools.html.erb
@@ -1,5 +1,6 @@
+<%# locals: (ingredient:, wrapper_class: nil) %>
 <% disabled = cannot?(:edit, ingredient) %>
-<%= content_tag "alchemy-link-buttons", class: local_assigns[:wrapper_class], data: {ingredient_id: ingredient.id} do %>
+<%= content_tag "alchemy-link-buttons", class: wrapper_class, data: {ingredient_id: ingredient.id} do %>
   <%= content_tag "sl-tooltip",
     content: Alchemy.t(:place_link),
     disabled: disabled do %>

--- a/app/views/alchemy/ingredients/shared/_picture_css_class.html.erb
+++ b/app/views/alchemy/ingredients/shared/_picture_css_class.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (css_class:) %>
 <div class="picture_ingredient_css_class">
   <%= render_icon "pencil-ruler-2", style: "line", size: "1x" %>
   <%= Alchemy.t(css_class,

--- a/app/views/alchemy/ingredients/shared/_picture_tools.html.erb
+++ b/app/views/alchemy/ingredients/shared/_picture_tools.html.erb
@@ -41,7 +41,7 @@
 
 <%= content_tag "sl-tooltip", content: Alchemy.t(:edit_image_properties), placement: "top-end", disabled: disabled do %>
   <%= link_to_dialog render_icon(:edit),
-    disabled ? nil : alchemy.edit_admin_ingredient_path(id: picture_editor.id, language_id: @page.language_id),
+    disabled ? nil : alchemy.edit_admin_ingredient_path(id: picture_editor.id, language_id: local_assigns[:page]&.language_id),
     {
       title: Alchemy.t(:edit_image_properties),
       size: "380x255"

--- a/app/views/alchemy/ingredients/shared/_picture_tools.html.erb
+++ b/app/views/alchemy/ingredients/shared/_picture_tools.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (picture_editor:, page: nil) %>
 <% linkable = picture_editor.settings[:linkable] != false %>
 <% croppable = picture_editor.allow_image_cropping? %>
 <% crop_configured = !!picture_editor.settings[:crop] %>
@@ -41,7 +42,7 @@
 
 <%= content_tag "sl-tooltip", content: Alchemy.t(:edit_image_properties), placement: "top-end", disabled: disabled do %>
   <%= link_to_dialog render_icon(:edit),
-    disabled ? nil : alchemy.edit_admin_ingredient_path(id: picture_editor.id, language_id: local_assigns[:page]&.language_id),
+    disabled ? nil : alchemy.edit_admin_ingredient_path(id: picture_editor.id, language_id: page&.language_id),
     {
       title: Alchemy.t(:edit_image_properties),
       size: "380x255"

--- a/app/views/alchemy/language_links/_language.html.erb
+++ b/app/views/alchemy/language_links/_language.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (language:, languages:, options: {}, **rest) %>
 <%= link_to(
   content_tag(:span, language.label(options[:linkname])).html_safe,
   show_alchemy_page_path(

--- a/app/views/alchemy/language_links/_spacer.html.erb
+++ b/app/views/alchemy/language_links/_spacer.html.erb
@@ -1,1 +1,2 @@
+<%# locals: (options: {}, **rest) %>
 <%= options[:spacer].html_safe %>

--- a/app/views/alchemy/pages/_meta_data.html.erb
+++ b/app/views/alchemy/pages/_meta_data.html.erb
@@ -1,8 +1,9 @@
-<% if @page %>
+<% page = local_assigns.fetch(:page, Alchemy::Current.page) %>
+<% if page %>
   <meta charset="utf-8">
   <title><%= page_title prefix: local_assigns.fetch(:title_prefix, nil), suffix: local_assigns.fetch(:title_suffix, nil), separator: local_assigns.fetch(:title_separator, nil) %></title>
-  <%= tag(:meta, name: 'created', content: @page.updated_at) %>
+  <%= tag(:meta, name: 'created', content: page.updated_at) %>
   <%= tag(:meta, name: 'robots', content: meta_robots) %>
-  <%= tag(:meta, name: 'description', content: meta_description, lang: @page.language_code) if meta_description.present? %>
-  <%= tag(:meta, name: 'keywords', content: meta_keywords, lang: @page.language_code) if meta_keywords.present? %>
+  <%= tag(:meta, name: 'description', content: meta_description, lang: page.language_code) if meta_description.present? %>
+  <%= tag(:meta, name: 'keywords', content: meta_keywords, lang: page.language_code) if meta_keywords.present? %>
 <% end %>

--- a/app/views/alchemy/pages/_meta_data.html.erb
+++ b/app/views/alchemy/pages/_meta_data.html.erb
@@ -1,7 +1,7 @@
-<% page = local_assigns.fetch(:page, Alchemy::Current.page) %>
+<%# locals: (page: Alchemy::Current.page, title_prefix: nil, title_suffix: nil, title_separator: nil) %>
 <% if page %>
   <meta charset="utf-8">
-  <title><%= page_title prefix: local_assigns.fetch(:title_prefix, nil), suffix: local_assigns.fetch(:title_suffix, nil), separator: local_assigns.fetch(:title_separator, nil) %></title>
+  <title><%= page_title prefix: title_prefix, suffix: title_suffix, separator: title_separator %></title>
   <%= tag(:meta, name: 'created', content: page.updated_at) %>
   <%= tag(:meta, name: 'robots', content: meta_robots) %>
   <%= tag(:meta, name: 'description', content: meta_description, lang: page.language_code) if meta_description.present? %>

--- a/app/views/kaminari/alchemy/_first_page.html.erb
+++ b/app/views/kaminari/alchemy/_first_page.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (url:, current_page:, **rest) %>
 <%# Link to the "First" page
   - available local variables
     url:           url to the first page

--- a/app/views/kaminari/alchemy/_gap.html.erb
+++ b/app/views/kaminari/alchemy/_gap.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (**rest) %>
 <%# Non-link tag that stands for skipped pages...
   - available local variables
     current_page:  a page object for the currently displayed page

--- a/app/views/kaminari/alchemy/_last_page.html.erb
+++ b/app/views/kaminari/alchemy/_last_page.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (url:, current_page:, **rest) %>
 <%# Link to the "Last" page
   - available local variables
     url:           url to the last page

--- a/app/views/kaminari/alchemy/_next_page.html.erb
+++ b/app/views/kaminari/alchemy/_next_page.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (url:, current_page:, **rest) %>
 <%# Link to the "Next" page
   - available local variables
     url:           url to the next page

--- a/app/views/kaminari/alchemy/_page.html.erb
+++ b/app/views/kaminari/alchemy/_page.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (page:, url:, **rest) %>
 <%# Link showing page number
   - available local variables
     page:          a page object for "this" page

--- a/app/views/kaminari/alchemy/_paginator.html.erb
+++ b/app/views/kaminari/alchemy/_paginator.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (paginator:, **rest) %>
 <%# The container tag
   - available local variables
     current_page:  a page object for the currently displayed page

--- a/app/views/kaminari/alchemy/_prev_page.html.erb
+++ b/app/views/kaminari/alchemy/_prev_page.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (url:, current_page:, **rest) %>
 <%# Link to the "Previous" page
   - available local variables
     url:           url to the previous page

--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -50,7 +50,7 @@
       <%= yield %>
     </div>
     <% if current_alchemy_user %>
-      <%= render "alchemy/admin/top_menu", locked_pages: @locked_pages %>
+      <%= render "alchemy/admin/top_menu", locked_pages: @locked_pages, page: @page %>
     <% end %>
     <%= render 'alchemy/admin/uploader/setup' %>
     <%= yield(:javascripts) %>

--- a/lib/generators/alchemy/install/files/_article.html.erb
+++ b/lib/generators/alchemy/install/files/_article.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (article:, element: nil, counter: 1, options: {}, **rest) %>
 <%- cache(article) do -%>
   <%= element_view_for(article, tag: "article", class: "w-full max-w-xl mx-auto bg-slate-100 shadow my-8 px-8 py-4 rounded") do |el| -%>
     <%= el.render :headline, {}, class: "text-2xl font-bold my-4" %>

--- a/lib/generators/alchemy/install/files/_standard.html.erb
+++ b/lib/generators/alchemy/install/files/_standard.html.erb
@@ -1,1 +1,2 @@
+<%# locals: (standard:, element: nil, counter: 1, options: {}, **rest) %>
 <%= render_elements %>

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "tom-select": "^2.6.2"
   },
   "devDependencies": {
-    "@herb-tools/linter": "^0.8.10",
+    "@herb-tools/linter": "^0.10.3",
     "@rollup/plugin-commonjs": "^29.0.3",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-terser": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         version: 2.6.2
     devDependencies:
       '@herb-tools/linter':
-        specifier: ^0.8.10
-        version: 0.8.10(tailwindcss@4.3.0)
+        specifier: ^0.10.3
+        version: 0.10.3(tailwindcss@4.3.0)
       '@rollup/plugin-commonjs':
         specifier: ^29.0.3
         version: 29.0.3(rollup@4.62.5)
@@ -204,32 +204,32 @@ packages:
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
-  '@herb-tools/config@0.8.10':
-    resolution: {integrity: sha512-feFfAcr/n400vBxtjlLExkcDGjQwUY/SJI+/iwDv9qyLjU6JuwAfsMyG6Td5Kx23U5IFWVC+YbTF9bnd8ZtFdQ==}
+  '@herb-tools/config@0.10.3':
+    resolution: {integrity: sha512-cSaOwuWnij1wiB4Xh9Zfx/s+lhis7cN/+PXssanT/mXQLSRU2QeYasivyCQ1tRnpIVdGGOC/rqHVJQeNmj4pqg==}
 
-  '@herb-tools/core@0.8.10':
-    resolution: {integrity: sha512-KFZX6SUcB9ZSJB8XITEOogq4/hH+QabQp4c0PJqG6c9Iv+EEfEUgVQflFOmJ59NKHrT7Og78lmgJhyeBC20wxQ==}
+  '@herb-tools/core@0.10.3':
+    resolution: {integrity: sha512-rtDoh6C/EMYLEtFwYpuY+IlnV7PLsF5hQszq7uMDE/bwEpLVBlPFd2Wlk9E0RB31PVQKV1MwgGqstte87XqF9g==}
 
-  '@herb-tools/highlighter@0.8.10':
-    resolution: {integrity: sha512-jeFLJ9ZIrcja9Ac61QWQfa/6ENHAE5Tju8/ScmjYWZGoF5awaEJM6hmdVVboGQzBcSd0Qjp8Kxq1Odsp+344pg==}
+  '@herb-tools/highlighter@0.10.3':
+    resolution: {integrity: sha512-vyBPl/oWalPcXrhni6RrQzeizzC0i7An3yMAg/Xx+4HDhgU/zOlRqSUYLU7SpzjfK4OU5QhRDdc3OBI8dT5qmg==}
     hasBin: true
 
-  '@herb-tools/linter@0.8.10':
-    resolution: {integrity: sha512-li/JFDoHMpSkYbUMKmFDst+Glf931fobrILvGrnaIp4r7pGBDJQONcImGBdnumKPqMk2p1UkHWONRcEHx33jSw==}
+  '@herb-tools/linter@0.10.3':
+    resolution: {integrity: sha512-uNwJZkzswJ/IcpsjbuEzOXQQcfc40KGy8Ao1L69na2J6H7b4LFig2OIZ22vJasGdv4jODWJWnMDozRvWuv1vFA==}
     hasBin: true
 
-  '@herb-tools/node-wasm@0.8.10':
-    resolution: {integrity: sha512-lxOL0olfFydmYG76v/br/MHsCbJE/r6vm86oqarOnsZLT+th6MCiKK6E9tE6RlYk/4OeOANePm4NLTqpqF2/5g==}
+  '@herb-tools/node-wasm@0.10.3':
+    resolution: {integrity: sha512-KUwHUMB6kluyvRiW0A9wbTiuO/qlvXLlSAnewmH2za7yePvYRSiThfAZEmXPqEmpmMRcIksFxaNaxUc6nBqyuA==}
 
-  '@herb-tools/printer@0.8.10':
-    resolution: {integrity: sha512-/fKbm7e4bhIyxsYkEaNTJajcvhzlfzKrZ/DftcBmeOZeblz0lTkL3Vx9nvRNQuLT1LyPBfmEzMp1qPKvWUyaCw==}
+  '@herb-tools/printer@0.10.3':
+    resolution: {integrity: sha512-OuuIisERq3TLnms/Wm5N6w/ITYqlBPPLsc1FNHdN3qedPOA/ey1dF2rKewUzQAsAZheRCs5nem7tDYRhPb2D/Q==}
     hasBin: true
 
-  '@herb-tools/rewriter@0.8.10':
-    resolution: {integrity: sha512-Fak3lheNaiYXBfhi9U7aQjgBnziJ4EOtQr4j8BbkV5luH25Wc3LET3/aKn8w910ZQdfNmQ+rmBvVpJWq5XP+7g==}
+  '@herb-tools/rewriter@0.10.3':
+    resolution: {integrity: sha512-UsqWOJVcmB7lptLtjUeFpVvOn44LFae+I44p5ixQ9nDLNnZiN/2+R52tJmVLOWijQORvtMInCWOHrSvXF6Bf/g==}
 
-  '@herb-tools/tailwind-class-sorter@0.8.10':
-    resolution: {integrity: sha512-bwvvQDiwfRP0BsziM+AFCnRkFZx7aSSCoo5qO2ox5R3nJKGUEQrG+JJF4fwrtT1phyjqBytDPtctpXps77J2HA==}
+  '@herb-tools/tailwind-class-sorter@0.10.3':
+    resolution: {integrity: sha512-KAowwSS6NmcRTQrQ591DR6dGI675KB0o/yxZt113BNDWiBB+bl4xdnd3hT19JV6Jsh3sS/0e90hYGUj/6PBW0g==}
     engines: {node: '>=14.21.3'}
     peerDependencies:
       tailwindcss: ^3.0 || ^4.0
@@ -740,6 +740,9 @@ packages:
     resolution: {integrity: sha512-/gDJaRs4gl0NPIwqCz+6PkpmhhjRAD2j6P4rSNHBzUkO3naEx2mIU0pRle1vUNRQ7mE/+8OOeXLTv/J56FKiQg==}
     cpu: [x64]
     os: [win32]
+
+  '@ruby/prism@1.9.0':
+    resolution: {integrity: sha512-/j+JfP1eA0nCjx6c/8L6K/ENErmsqc6RMAba8rKYNz4RadrT7AW20u4WrjpWYWzdlk6k1YWHxoW9OS68w02+Vw==}
 
   '@shoelace-style/animations@1.2.0':
     resolution: {integrity: sha512-avvo1xxkLbv2dgtabdewBbqcJfV0e0zCwFqkPMnHFGbJbBHorRFfMAHh1NG9ymmXn0jW95ibUVH03E1NYXD6Gw==}
@@ -1720,10 +1723,6 @@ packages:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
-    engines: {node: '>=12.0.0'}
-
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -2047,51 +2046,56 @@ snapshots:
 
   '@floating-ui/utils@0.2.12': {}
 
-  '@herb-tools/config@0.8.10':
+  '@herb-tools/config@0.10.3':
     dependencies:
-      '@herb-tools/core': 0.8.10
+      '@herb-tools/core': 0.10.3
       picomatch: 4.0.5
       tinyglobby: 0.2.17
       yaml: 2.9.0
 
-  '@herb-tools/core@0.8.10': {}
-
-  '@herb-tools/highlighter@0.8.10':
+  '@herb-tools/core@0.10.3':
     dependencies:
-      '@herb-tools/core': 0.8.10
-      '@herb-tools/node-wasm': 0.8.10
+      '@ruby/prism': 1.9.0
 
-  '@herb-tools/linter@0.8.10(tailwindcss@4.3.0)':
+  '@herb-tools/highlighter@0.10.3':
     dependencies:
-      '@herb-tools/config': 0.8.10
-      '@herb-tools/core': 0.8.10
-      '@herb-tools/highlighter': 0.8.10
-      '@herb-tools/node-wasm': 0.8.10
-      '@herb-tools/printer': 0.8.10
-      '@herb-tools/rewriter': 0.8.10(tailwindcss@4.3.0)
-      picomatch: 4.0.4
-      tinyglobby: 0.2.16
-    transitivePeerDependencies:
-      - tailwindcss
+      '@herb-tools/core': 0.10.3
+      '@herb-tools/node-wasm': 0.10.3
 
-  '@herb-tools/node-wasm@0.8.10':
+  '@herb-tools/linter@0.10.3(tailwindcss@4.3.0)':
     dependencies:
-      '@herb-tools/core': 0.8.10
-
-  '@herb-tools/printer@0.8.10':
-    dependencies:
-      '@herb-tools/core': 0.8.10
-      tinyglobby: 0.2.17
-
-  '@herb-tools/rewriter@0.8.10(tailwindcss@4.3.0)':
-    dependencies:
-      '@herb-tools/core': 0.8.10
-      '@herb-tools/tailwind-class-sorter': 0.8.10(tailwindcss@4.3.0)
+      '@herb-tools/config': 0.10.3
+      '@herb-tools/core': 0.10.3
+      '@herb-tools/highlighter': 0.10.3
+      '@herb-tools/node-wasm': 0.10.3
+      '@herb-tools/printer': 0.10.3
+      '@herb-tools/rewriter': 0.10.3(tailwindcss@4.3.0)
+      '@ruby/prism': 1.9.0
+      picomatch: 4.0.5
       tinyglobby: 0.2.17
     transitivePeerDependencies:
       - tailwindcss
 
-  '@herb-tools/tailwind-class-sorter@0.8.10(tailwindcss@4.3.0)':
+  '@herb-tools/node-wasm@0.10.3':
+    dependencies:
+      '@herb-tools/core': 0.10.3
+      '@ruby/prism': 1.9.0
+
+  '@herb-tools/printer@0.10.3':
+    dependencies:
+      '@herb-tools/core': 0.10.3
+      tinyglobby: 0.2.17
+
+  '@herb-tools/rewriter@0.10.3(tailwindcss@4.3.0)':
+    dependencies:
+      '@herb-tools/core': 0.10.3
+      '@herb-tools/tailwind-class-sorter': 0.10.3(tailwindcss@4.3.0)
+      '@ruby/prism': 1.9.0
+      tinyglobby: 0.2.17
+    transitivePeerDependencies:
+      - tailwindcss
+
+  '@herb-tools/tailwind-class-sorter@0.10.3(tailwindcss@4.3.0)':
     dependencies:
       clear-module: 4.1.3
       escalade: 3.2.0
@@ -2431,6 +2435,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.62.5':
     optional: true
+
+  '@ruby/prism@1.9.0': {}
 
   '@shoelace-style/animations@1.2.0': {}
 
@@ -3408,11 +3414,6 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinyexec@1.3.0: {}
-
-  tinyglobby@0.2.16:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.5)
-      picomatch: 4.0.5
 
   tinyglobby@0.2.17:
     dependencies:

--- a/spec/dummy/app/views/alchemy/elements/_all_you_can_eat.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_all_you_can_eat.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (all_you_can_eat:, element: nil, counter: 1, options: {}, **rest) %>
 <%- cache(all_you_can_eat) do -%>
   <%= element_view_for(all_you_can_eat) do |el| -%>
     <div class="headline">

--- a/spec/dummy/app/views/alchemy/elements/_article.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_article.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (article:, element: nil, counter: 1, options: {}, **rest) %>
 <%- cache(article) do -%>
   <%= element_view_for(article) do |el| -%>
     <% if el.has?(:intro) %>

--- a/spec/dummy/app/views/alchemy/elements/_bild.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_bild.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (bild:, element: nil, counter: 1, options: {}, **rest) %>
 <%- cache(bild) do -%>
   <%= element_view_for(bild) do |el| -%>
     <%= el.render :image %>

--- a/spec/dummy/app/views/alchemy/elements/_contactform.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_contactform.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (contactform:, element: nil, counter: 1, options: {}, **rest) %>
 <%- cache(contactform) do -%>
   <%= element_view_for(contactform) do |el| -%>
     <form action="/messages" method="POST">

--- a/spec/dummy/app/views/alchemy/elements/_download.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_download.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (download:, element: nil, counter: 1, options: {}, **rest) %>
 <%- cache(download) do -%>
   <%= element_view_for(download) do |el| -%>
     <%= el.render :file %>

--- a/spec/dummy/app/views/alchemy/elements/_erb_element.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_erb_element.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (erb_element:, element: nil, counter: 1, options: {}, **rest) %>
 <%- cache(erb_element) do -%>
   <%= element_view_for(erb_element) do |el| -%>
     <%= el.render :text %>

--- a/spec/dummy/app/views/alchemy/elements/_gallery.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_gallery.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (gallery:, element: nil, counter: 1, options: {}, **rest) %>
 <%- cache(gallery) do -%>
   <%= element_view_for(gallery) do |el| -%>
     <div class="gallery_images">

--- a/spec/dummy/app/views/alchemy/elements/_gallery_picture.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_gallery_picture.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (gallery_picture:, element: nil, counter: 1, options: {}, **rest) %>
 <%- cache(gallery_picture) do -%>
   <%= element_view_for(gallery_picture) do |el| -%>
     <%= el.render :picture %>

--- a/spec/dummy/app/views/alchemy/elements/_header.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_header.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (header:, element: nil, counter: 1, options: {}, **rest) %>
 <%- cache(header) do -%>
   <%= element_view_for(header) do |el| -%>
     <%= el.render :image %>

--- a/spec/dummy/app/views/alchemy/elements/_headline.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_headline.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (headline:, element: nil, counter: 1, options: {}, **rest) %>
 <%= element_view_for(headline, tag: 'h1') do |el| %>
   <%= local_assigns[:counter] -%>. <%= el.render(:headline) %>
   <small><%= local_assigns[:some] -%></small>

--- a/spec/dummy/app/views/alchemy/elements/_left_column.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_left_column.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (left_column:, element: nil, counter: 1, options: {}, **rest) %>
 <%- cache(left_column) do -%>
   <%= element_view_for(left_column) do |el| -%>
     <%= render el.nested_elements %>

--- a/spec/dummy/app/views/alchemy/elements/_menu.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_menu.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (menu:, element: nil, counter: 1, options: {}, **rest) %>
 <%- cache(menu) do -%>
   <%= element_view_for(menu) do |el| -%>
     <%= el.render :menu %>

--- a/spec/dummy/app/views/alchemy/elements/_news.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_news.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (news:, element: nil, counter: 1, options: {}, **rest) %>
 <%= element_view_for(news) do |el| %>
   <div class="date">
     <%= el.render :date, date_format: "%d.%m.%Y" %>

--- a/spec/dummy/app/views/alchemy/elements/_other_headline.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_other_headline.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (other_headline:, element: nil, counter: 1, options: {}, **rest) %>
 <%= element_view_for(other_headline, tag: 'h3') do |el| %>
   <%= local_assigns[:counter] -%>. <%= el.render(:headline) %>
   <small><%= local_assigns[:some] -%></small>

--- a/spec/dummy/app/views/alchemy/elements/_right_column.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_right_column.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (right_column:, element: nil, counter: 1, options: {}, **rest) %>
 <%- cache(right_column) do -%>
   <%= element_view_for(right_column) do |el| -%>
     <%= el.render :title %>

--- a/spec/dummy/app/views/alchemy/elements/_search.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_search.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (search:, element: nil, counter: 1, options: {}, **rest) %>
 <%- cache(search) do -%>
   <%= element_view_for(search) do |el| -%>
   <%- end -%>

--- a/spec/dummy/app/views/alchemy/elements/_slide.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_slide.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (slide:, element: nil, counter: 1, options: {}, **rest) %>
 <%- cache(slide) do -%>
   <%= element_view_for(slide) do |el| -%>
     <%= el.render :picture %>

--- a/spec/dummy/app/views/alchemy/elements/_slider.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_slider.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (slider:, element: nil, counter: 1, options: {}, **rest) %>
 <%- cache(slider) do -%>
   <%= element_view_for(slider) do |el| -%>
     <%= render el.nested_elements %>

--- a/spec/dummy/app/views/alchemy/elements/_text.html.erb
+++ b/spec/dummy/app/views/alchemy/elements/_text.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (text:, element: nil, counter: 1, options: {}, **rest) %>
 <%- cache(text) do -%>
   <%= element_view_for(text) do |el| -%>
     <%= el.render :text %>

--- a/spec/dummy/app/views/alchemy/menus/footer_navigation/_node.html.erb
+++ b/spec/dummy/app/views/alchemy/menus/footer_navigation/_node.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (node:, options: {}, **rest) %>
 <%= content_tag :li, class: ['nav-item', node.children.any? ? 'dropdown' : nil].compact do %>
   <%= link_to_if node.url,
     node.name,

--- a/spec/dummy/app/views/alchemy/menus/footer_navigation/_wrapper.html.erb
+++ b/spec/dummy/app/views/alchemy/menus/footer_navigation/_wrapper.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (menu:, options: {}, **rest) %>
 <ul class="nav">
   <%= render partial: menu.to_partial_path,
     collection: menu.children.includes(:page, :children),

--- a/spec/dummy/app/views/alchemy/menus/main_menu/_node.html.erb
+++ b/spec/dummy/app/views/alchemy/menus/main_menu/_node.html.erb
@@ -1,4 +1,4 @@
-<% cache [node, @page, Alchemy::Current.preview_page?] do %>
+<% cache [node, Alchemy::Current.page, Alchemy::Current.preview_page?] do %>
   <%= content_tag :li, class: ['nav-item', node.children.any? ? 'dropdown' : nil].compact do %>
     <%= link_to_if node.url,
       node.name,

--- a/spec/dummy/app/views/alchemy/menus/main_menu/_node.html.erb
+++ b/spec/dummy/app/views/alchemy/menus/main_menu/_node.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (node:, options: {}, **rest) %>
 <% cache [node, Alchemy::Current.page, Alchemy::Current.preview_page?] do %>
   <%= content_tag :li, class: ['nav-item', node.children.any? ? 'dropdown' : nil].compact do %>
     <%= link_to_if node.url,

--- a/spec/dummy/app/views/alchemy/menus/main_menu/_wrapper.html.erb
+++ b/spec/dummy/app/views/alchemy/menus/main_menu/_wrapper.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (menu:, options: {}, **rest) %>
 <% cache [menu, Alchemy::Current.page, Alchemy::Current.preview_page?] do %>
   <ul class="nav">
     <%= render partial: menu.to_partial_path,

--- a/spec/dummy/app/views/alchemy/menus/main_menu/_wrapper.html.erb
+++ b/spec/dummy/app/views/alchemy/menus/main_menu/_wrapper.html.erb
@@ -1,4 +1,4 @@
-<% cache [menu, @page, Alchemy::Current.preview_page?] do %>
+<% cache [menu, Alchemy::Current.page, Alchemy::Current.preview_page?] do %>
   <ul class="nav">
     <%= render partial: menu.to_partial_path,
       collection: menu.children.includes(:page, :children),

--- a/spec/dummy/app/views/alchemy/page_layouts/_everything.html.erb
+++ b/spec/dummy/app/views/alchemy/page_layouts/_everything.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (**rest) %>
 <div id="content">
   <%= render_elements %>
 </div>

--- a/spec/dummy/app/views/alchemy/page_layouts/_standard.html.erb
+++ b/spec/dummy/app/views/alchemy/page_layouts/_standard.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (**rest) %>
 <div id="header">
   <div id="header_image">
     <%= render_elements(:only => 'header') %>

--- a/spec/views/alchemy/admin/partials/_main_navigation_entry.html.erb_spec.rb
+++ b/spec/views/alchemy/admin/partials/_main_navigation_entry.html.erb_spec.rb
@@ -21,14 +21,17 @@ describe "alchemy/admin/partials/_main_navigation_entry.html.erb" do
   let(:navigation) { alchemy_module[:navigation] }
 
   before do
-    allow(view).to receive(:navigation).and_return(navigation)
-    allow(view).to receive(:alchemy_module).and_return(alchemy_module)
     allow(view).to receive(:can?).and_return(true)
     view.extend Alchemy::Admin::NavigationHelper
   end
 
+  subject(:render_partial) do
+    render partial: "alchemy/admin/partials/main_navigation_entry",
+      locals: {alchemy_module: alchemy_module, navigation: navigation}
+  end
+
   it "renders navigation with data attribute" do
-    render
+    render_partial
 
     expect(rendered).to have_selector('alchemy-main-navi-entry[data-turbo="false"]')
   end
@@ -49,7 +52,7 @@ describe "alchemy/admin/partials/_main_navigation_entry.html.erb" do
     end
 
     it "renders navigation without data attribute" do
-      render
+      render_partial
 
       expect(rendered).not_to have_selector('alchemy-main-navi-entry[data-turbo="false"]')
     end

--- a/spec/views/pages/meta_data_spec.rb
+++ b/spec/views/pages/meta_data_spec.rb
@@ -20,7 +20,10 @@ module Alchemy
     end
 
     context "when current page is set" do
-      before { view.instance_variable_set(:@page, page) }
+      before do
+        view.instance_variable_set(:@page, page)
+        allow(Alchemy::Current).to receive(:page).and_return(page)
+      end
 
       describe "meta keywords" do
         context "are set" do


### PR DESCRIPTION
## What is this pull request for?

Herb's `erb-no-instance-variables-in-partials` rule flags partials that read controller instance variables. That hidden coupling makes a partial fragile and hard to reuse, because its inputs are not part of its interface. This converts every offending admin partial — plus the frontend `pages/_meta_data` and the dummy app menu partials — to receive explicit locals threaded from their render call sites.

Where a value is already reachable from an object the partial is handed, it is read from there rather than threaded (e.g. `legacy_page_url.page_id`). The frontend meta data partial takes a `page` local that defaults to `Alchemy::Current.page`, so host-app layouts that render it keep working unchanged. The shared archive overlay gains an overridable `archive_overlay_locals` hook so the pictures and attachments controllers each supply their own locals.

Building on that, the final commit makes the partial contracts explicit and enforced: every partial declares its inputs with a Rails strict-locals `<%# locals: (...) %>` comment, and Herb's `erb-strict-locals-required` rule is enabled. This closes the remaining gap — a required local that a call site (including a host-app override) forgets to pass now raises instead of silently becoming `nil` via `local_assigns`. Framework- and Kaminari-rendered partials use a keyword splat to absorb their dynamic locals; element views keep `element`/`counter`/`options` optional because nested elements render through Rails collection rendering.

The change is behavior-preserving and is covered by the existing view, request, component, and feature specs; the `pages/_meta_data` and `_main_navigation_entry` specs are updated to the partials' explicit local interfaces.

### Notable changes

`@herb-tools/linter` is upgraded to 0.10.3 (which ships both rules) and a `.herb.yml` pins the version so future upgrades do not silently enable new rules. The config enforces these two rules while disabling the rules that report unrelated pre-existing offenses, keeping the change scoped; those can be adopted separately. Contributors need to run `pnpm install` to pick up the new linter version.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [] I have added tests to cover this change
