### PR TITLE
feat: Add admin component registry

### DIFF
--- a/app/components/alchemy/admin/element_status_indicators.html.erb
+++ b/app/components/alchemy/admin/element_status_indicators.html.erb
@@ -1,0 +1,16 @@
+<span class="element-status-icons">
+  <% unless element.public? || element.scheduled? %>
+    <alchemy-icon name="cloud-off" size="1x"></alchemy-icon>
+    <span class="element-hidden-label">
+      <%= Alchemy.t(:element_hidden) %>
+    </span>
+  <% end %>
+  <sl-tooltip
+    class="element-scheduled-icon"
+    content="<%= scheduled_tooltip %>"
+    <%= "hidden" unless element.scheduled? %>
+  >
+    <alchemy-icon name="calendar-schedule" size="1x"></alchemy-icon>
+    <%= scheduled_label %>
+  </sl-tooltip>
+</span>

--- a/app/components/alchemy/admin/element_status_indicators.rb
+++ b/app/components/alchemy/admin/element_status_indicators.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Alchemy
+  module Admin
+    # Renders the visibility state badges (hidden / scheduled) shown for an
+    # element in the element header.
+    class ElementStatusIndicators < ViewComponent::Base
+      def initialize(element:)
+        @element = element
+      end
+
+      private
+
+      attr_reader :element
+
+      def scheduled_tooltip
+        Alchemy.t(
+          element.public_on&.future? ? :public_on : :public_until,
+          scope: :element_scheduled,
+          public_on: element.public_on && ::I18n.l(element.public_on, format: :"alchemy.default"),
+          public_until: element.public_until && ::I18n.l(element.public_until, format: :"alchemy.default")
+        )
+      end
+
+      def scheduled_label
+        date = element.public_on&.future? ? element.public_on : element.public_until
+        date && ::I18n.l(date, format: :"alchemy.short_datetime")
+      end
+    end
+  end
+end

--- a/app/components/alchemy/admin/page_node.html.erb
+++ b/app/components/alchemy/admin/page_node.html.erb
@@ -65,7 +65,7 @@
       </div>
 
       <div class="page_infos">
-        <%= render Alchemy::Admin::PageStatusIndicators.new(page: @page) %>
+        <%= render Alchemy.config.admin_components.page_status_indicators.new(page: @page) %>
       </div>
 
       <div class="sitemap_right_tools">

--- a/app/views/alchemy/admin/elements/_header.html.erb
+++ b/app/views/alchemy/admin/elements/_header.html.erb
@@ -16,7 +16,7 @@
     <%= render_hint_for(element, size: "1x", fixed_width: false) %>
     <%= render "alchemy/admin/elements/preview_text_quote", element: element %>
   </span>
-  <%= render Alchemy::Admin::ElementStatusIndicators.new(element:) %>
+  <%= render Alchemy.config.admin_components.element_status_indicators.new(element:) %>
   <sl-tooltip content="<%= Alchemy.t(element.folded? ? :show_element_content : :hide_element_content) %>">
     <%= button_tag(class: "element-toggle") do %>
       <% if element.compact? %>

--- a/app/views/alchemy/admin/elements/_header.html.erb
+++ b/app/views/alchemy/admin/elements/_header.html.erb
@@ -16,22 +16,7 @@
     <%= render_hint_for(element, size: "1x", fixed_width: false) %>
     <%= render "alchemy/admin/elements/preview_text_quote", element: element %>
   </span>
-  <span class="element-status-icons">
-    <% unless element.public? || element.scheduled? %>
-      <%= render_icon("cloud-off", size: "1x") %>
-      <span class="element-hidden-label">
-        <%= Alchemy.t(:element_hidden) %>
-      </span>
-    <% end %>
-    <sl-tooltip
-      class="element-scheduled-icon"
-      content="<%= Alchemy.t(element.public_on&.future? ? :public_on : :public_until, scope: :element_scheduled, public_on: element.public_on && l(element.public_on, format: :"alchemy.default"), public_until: element.public_until && l(element.public_until, format: :"alchemy.default")) %>"
-      <%= "hidden" if !element.scheduled? %>
-    >
-      <%= render_icon("calendar-schedule", size: "1x") %>
-      <%= element.public_on&.future? ? element.public_on && l(element.public_on, format: :"alchemy.short_datetime") : element.public_until && l(element.public_until, format: :"alchemy.short_datetime") %>
-    </sl-tooltip>
-  </span>
+  <%= render Alchemy::Admin::ElementStatusIndicators.new(element:) %>
   <sl-tooltip content="<%= Alchemy.t(element.folded? ? :show_element_content : :hide_element_content) %>">
     <%= button_tag(class: "element-toggle") do %>
       <% if element.compact? %>

--- a/app/views/alchemy/admin/elements/_toolbar.html.erb
+++ b/app/views/alchemy/admin/elements/_toolbar.html.erb
@@ -43,5 +43,5 @@
       </button>
     </alchemy-delete-element-button>
   </sl-tooltip>
-  <%= render Alchemy::Admin::PublishElementButton.new(element:) %>
+  <%= render Alchemy.config.admin_components.element_publish_button.new(element:) %>
 </div>

--- a/app/views/alchemy/admin/pages/_publication_fields.html.erb
+++ b/app/views/alchemy/admin/pages/_publication_fields.html.erb
@@ -1,2 +1,2 @@
 <%# Overwrite this partial if you want to add more fields to the page schedule form %>
-<%= render Alchemy::Admin::PagePublicationFields.new(page:) %>
+<%= render Alchemy.config.admin_components.page_publication_fields.new(page:) %>

--- a/app/views/alchemy/admin/pages/_table.html.erb
+++ b/app/views/alchemy/admin/pages/_table.html.erb
@@ -33,7 +33,7 @@
   <% end %>
   <% table.column :updated_at, sortable: true %>
   <% table.column :status, class_name: :right do |page| %>
-    <%= render Alchemy::Admin::PageStatusIndicators.new(page:) %>
+    <%= render Alchemy.config.admin_components.page_status_indicators.new(page:) %>
   <% end %>
 
   <% table.with_action :info, Alchemy.t(:page_infos) do |page| %>

--- a/lib/alchemy/configurations/admin_components.rb
+++ b/lib/alchemy/configurations/admin_components.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Alchemy
+  module Configurations
+    # === Admin Component Registry
+    #
+    # Overridable admin ViewComponents, keyed by role. Extensions can swap a
+    # component for their own by assigning a different class name in an
+    # initializer:
+    #
+    #     Alchemy.config.admin_components.element_publish_button =
+    #       "MyEngine::Admin::CustomPublishButton"
+    #
+    # Core renders these through the registry instead of referencing the class
+    # directly, so the swap takes effect everywhere the component is used.
+    class AdminComponents < Alchemy::Configuration
+      # The per-element publish control rendered in the element toolbar.
+      option :element_publish_button, :class, default: "Alchemy::Admin::PublishElementButton"
+
+      # The page publication/visibility fields rendered in the page settings form.
+      option :page_publication_fields, :class, default: "Alchemy::Admin::PagePublicationFields"
+
+      # The visibility state badges rendered in the element header.
+      option :element_status_indicators, :class, default: "Alchemy::Admin::ElementStatusIndicators"
+
+      # The status badges rendered for a page in the page listing and sitemap.
+      option :page_status_indicators, :class, default: "Alchemy::Admin::PageStatusIndicators"
+    end
+  end
+end

--- a/lib/alchemy/configurations/main.rb
+++ b/lib/alchemy/configurations/main.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "alchemy/configuration"
+require "alchemy/configurations/admin_components"
 require "alchemy/configurations/dashboard"
 require "alchemy/configurations/default_language"
 require "alchemy/configurations/default_site"
@@ -486,6 +487,13 @@ module Alchemy
       # === Dashboard configuration
       #
       configuration :dashboard, Dashboard
+
+      # === Admin component registry
+      #
+      # Overridable admin ViewComponents keyed by role, so extensions can swap
+      # a component for their own.
+      #
+      configuration :admin_components, AdminComponents
 
       # === Publishable resolver
       #

--- a/spec/components/alchemy/admin/element_editor_spec.rb
+++ b/spec/components/alchemy/admin/element_editor_spec.rb
@@ -315,6 +315,24 @@ RSpec.describe Alchemy::Admin::ElementEditor, type: :component do
       expect(page).to have_selector("alchemy-publish-element-button")
     end
 
+    it "renders the publish component configured in the admin component registry" do
+      stub_const("StubPublishButton", Class.new(ViewComponent::Base) do
+        def initialize(element:)
+          @element = element
+        end
+
+        def call
+          '<div class="stub-publish-button"></div>'.html_safe
+        end
+      end)
+      allow(Alchemy.config.admin_components).to receive(:element_publish_button).and_return(StubPublishButton)
+
+      render_inline(described_class.new(element: element))
+
+      expect(page).to have_selector(".stub-publish-button")
+      expect(page).not_to have_selector("alchemy-publish-element-button")
+    end
+
     context "with message given in element definition" do
       let(:element) { create(:alchemy_element, name: "with_message") }
 

--- a/spec/components/alchemy/admin/element_status_indicators_spec.rb
+++ b/spec/components/alchemy/admin/element_status_indicators_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::Admin::ElementStatusIndicators, type: :component do
+  before { render_inline(described_class.new(element: element)) }
+
+  context "when the element is hidden" do
+    let(:element) { build_stubbed(:alchemy_element, public_on: nil, public_until: nil) }
+
+    it "renders the hidden indicator" do
+      expect(page).to have_selector("alchemy-icon[name='cloud-off']")
+      expect(page).to have_selector(".element-hidden-label")
+    end
+
+    it "keeps the scheduled indicator hidden" do
+      expect(page).to have_selector(".element-scheduled-icon[hidden]")
+    end
+  end
+
+  context "when the element is scheduled" do
+    let(:element) { build_stubbed(:alchemy_element, public_on: 1.day.from_now, public_until: nil) }
+
+    it "shows the scheduled indicator" do
+      expect(page).to have_selector("alchemy-icon[name='calendar-schedule']")
+      expect(page).to have_no_selector(".element-scheduled-icon[hidden]")
+    end
+
+    it "does not render the hidden indicator" do
+      expect(page).to have_no_selector("alchemy-icon[name='cloud-off']")
+    end
+  end
+
+  context "when the element is currently public" do
+    let(:element) { build_stubbed(:alchemy_element, public_on: 1.day.ago, public_until: nil) }
+
+    it "renders neither the hidden badge nor a visible scheduled badge" do
+      expect(page).to have_no_selector("alchemy-icon[name='cloud-off']")
+      expect(page).to have_selector(".element-scheduled-icon[hidden]")
+    end
+  end
+end

--- a/spec/libraries/alchemy/configurations/admin_components_spec.rb
+++ b/spec/libraries/alchemy/configurations/admin_components_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::Configurations::AdminComponents do
+  subject(:admin_components) { described_class.new }
+
+  describe "#element_publish_button" do
+    it "defaults to the core publish element button component" do
+      expect(admin_components.element_publish_button).to eq(Alchemy::Admin::PublishElementButton)
+    end
+
+    it "can be overridden with a custom component class" do
+      stub_const("Custom::VisibilityButton", Class.new)
+      admin_components.element_publish_button = "Custom::VisibilityButton"
+      expect(admin_components.element_publish_button).to eq(Custom::VisibilityButton)
+    end
+  end
+
+  describe "#page_publication_fields" do
+    it "defaults to the core page publication fields component" do
+      expect(admin_components.page_publication_fields).to eq(Alchemy::Admin::PagePublicationFields)
+    end
+
+    it "can be overridden with a custom component class" do
+      stub_const("Custom::PageVisibilityFields", Class.new)
+      admin_components.page_publication_fields = "Custom::PageVisibilityFields"
+      expect(admin_components.page_publication_fields).to eq(Custom::PageVisibilityFields)
+    end
+  end
+
+  describe "#element_status_indicators" do
+    it "defaults to the core element status indicators component" do
+      expect(admin_components.element_status_indicators).to eq(Alchemy::Admin::ElementStatusIndicators)
+    end
+
+    it "can be overridden with a custom component class" do
+      stub_const("Custom::ElementStatus", Class.new)
+      admin_components.element_status_indicators = "Custom::ElementStatus"
+      expect(admin_components.element_status_indicators).to eq(Custom::ElementStatus)
+    end
+  end
+
+  describe "#page_status_indicators" do
+    it "defaults to the core page status indicators component" do
+      expect(admin_components.page_status_indicators).to eq(Alchemy::Admin::PageStatusIndicators)
+    end
+
+    it "can be overridden with a custom component class" do
+      stub_const("Custom::PageStatus", Class.new)
+      admin_components.page_status_indicators = "Custom::PageStatus"
+      expect(admin_components.page_status_indicators).to eq(Custom::PageStatus)
+    end
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

Several admin visibility controls are rendered by referencing their ViewComponent classes directly — the element publish button, the page publication fields, and the element/page status indicators. That makes them hard for extensions to replace: a plain partial override depends on engine view-path ordering, and ViewComponent sidecar templates cannot be overridden through the view paths at all.

This introduces `Alchemy.config.admin_components`, a small config-backed registry of overridable admin ViewComponents keyed by role. Core renders these components through the registry instead of a hard class reference, so an extension can swap any of them for its own by assigning a different class in an initializer:

```ruby
Alchemy.config.admin_components.element_publish_button = "MyEngine::Admin::VisibilityButton"
```

Registered roles: `element_publish_button`, `page_publication_fields`, `element_status_indicators`, `page_status_indicators`. The element status indicators (the hidden/scheduled badges in the element header) are newly extracted from inline header markup into an `Alchemy::Admin::ElementStatusIndicators` component, mirroring the existing `PageStatusIndicators`.

Together with the configurable publishable resolver, this gives extensions clean seams to customize both the publication logic and its admin UI without patching core or copying partials.

### Notable changes (remove if none)

No behavior change for existing installs — the defaults render exactly the same components as before.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change