### PR TITLE
fix(ci): run tests on backport PRs

### DIFF
--- a/.github/workflows/check-bot-commit.yml
+++ b/.github/workflows/check-bot-commit.yml
@@ -20,6 +20,10 @@ jobs:
         run: |
           SHA="${{ github.event.pull_request.head.sha || github.sha }}"
           AUTHOR_EMAIL=$(gh api "repos/${{ github.repository }}/commits/${SHA}" --jq '.commit.author.email')
-          if [ "$AUTHOR_EMAIL" = "alchemy@blish.cloud" ]; then
+          # Backport PRs cherry-pick the bot's "Update build artifacts" commit,
+          # preserving its bot author (and committer), so the author check alone
+          # would wrongly skip their tests. Exclude the backport branches, whose
+          # tests must still run.
+          if [ "$AUTHOR_EMAIL" = "alchemy@blish.cloud" ] && [[ "${{ github.head_ref }}" != backport/* ]]; then
             echo "is_bot=true" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
## What is this pull request for?

The bot-commit check that skips CI after the CI bot pushes rebuilt build artifacts was also skipping tests on backport PRs, leaving them untested.

Backport PRs are created by cherry-picking the merged PR's commits onto a stable branch. When a PR includes asset changes, its history ends with the bot's `Update build artifacts` commit, and `git cherry-pick` preserves that commit's author (and, because the backport tool sets the committer from the original author, its committer too). Since `check-bot-commit` only inspected the head commit's author email, it flagged the backport PR's head as a bot commit and skipped RSpec and Vitest.

The fix keeps the loop-breaking skip for the bot's own artifact pushes — which target the original PR branch — but excludes `backport/*` branches, so backport PRs run the full suite. On `push` events `github.head_ref` is empty, so behavior there is unchanged.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change