### PR TITLE
docs(models): regenerate schema annotations after dropping text defaults

### DIFF
--- a/app/models/alchemy/attachment.rb
+++ b/app/models/alchemy/attachment.rb
@@ -5,7 +5,7 @@
 # Table name: alchemy_attachments
 #
 #  id              :integer          not null, primary key
-#  cached_tag_list :text             default("[]"), not null
+#  cached_tag_list :text             not null
 #  file_mime_type  :string
 #  file_name       :string
 #  file_size       :integer

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -5,7 +5,7 @@
 # Table name: alchemy_elements
 #
 #  id                :integer          not null, primary key
-#  cached_tag_list   :text             default("[]"), not null
+#  cached_tag_list   :text             not null
 #  fixed             :boolean          default(FALSE), not null
 #  folded            :boolean          default(FALSE), not null
 #  name              :string

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -5,7 +5,7 @@
 # Table name: alchemy_pages
 #
 #  id              :integer          not null, primary key
-#  cached_tag_list :text             default("[]"), not null
+#  cached_tag_list :text             not null
 #  depth           :integer
 #  language_code   :string
 #  language_root   :boolean          default(FALSE), not null
@@ -15,7 +15,7 @@
 #  locked_by       :integer
 #  name            :string
 #  page_layout     :string
-#  permitted_roles :text             default("[\"member\"]"), not null
+#  permitted_roles :text             not null
 #  published_at    :datetime
 #  restricted      :boolean          default(FALSE), not null
 #  rgt             :integer

--- a/app/models/alchemy/picture.rb
+++ b/app/models/alchemy/picture.rb
@@ -5,7 +5,7 @@
 # Table name: alchemy_pictures
 #
 #  id                :integer          not null, primary key
-#  cached_tag_list   :text             default("[]"), not null
+#  cached_tag_list   :text             not null
 #  image_file_format :string
 #  image_file_height :integer
 #  image_file_name   :string


### PR DESCRIPTION
## What is this pull request for?

Commit 6fa93ea1f removed the database-level defaults from the `cached_tag_list` and `permitted_roles` text columns, moving them into the model attributes API so every database adapter behaves identically. The model annotation blocks were never regenerated afterwards, so they still advertised `default("[]")` and `default("[\"member\"]")` defaults that no longer exist in `schema.rb`.

This regenerates the annotations with `annotaterb models` so the schema comments in the affected models match the actual schema again. Comment-only change; no runtime behavior is affected.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [ ] I have added tests to cover this change