### PR TITLE
fix(admin): scope nested element form to parent on validation error

### DIFF
--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -49,8 +49,9 @@ module Alchemy
         if @element.save
           render :create, status: 201
         else
+          @parent_element = @element.parent_element
           @element.page_version = @page_version
-          @elements = @page.available_element_definitions
+          @elements = @page.available_elements_within_current_scope(@parent_element)
           render :new, status: 422
         end
       end

--- a/spec/controllers/alchemy/admin/elements_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/elements_controller_spec.rb
@@ -293,6 +293,26 @@ module Alchemy
           end
         end
 
+        context "if an invalid nested element could not be saved" do
+          let!(:parent) do
+            create(:alchemy_element, :with_nestable_elements, page_version: page_version)
+          end
+
+          subject do
+            post :create, params: {element: {name: "", page_version_id: page_version.id, parent_element_id: parent.id}}
+          end
+
+          it "assigns the parent element" do
+            subject
+            expect(assigns(:parent_element)).to eq(parent)
+          end
+
+          it "assigns only the elements nestable within the parent" do
+            subject
+            expect(assigns(:elements).map(&:name)).to match_array(parent.definition.nestable_elements)
+          end
+        end
+
         context "with ingredient validations" do
           subject do
             post :create, params: {element: {page_version_id: page_version.id, name: "all_you_can_eat"}}, xhr: true

--- a/spec/features/admin/edit_elements_feature_spec.rb
+++ b/spec/features/admin/edit_elements_feature_spec.rb
@@ -138,6 +138,26 @@ RSpec.describe "The edit elements feature", type: :system do
       end
       expect(page).to have_selector(".element-editor[data-element-name='text']")
     end
+
+    scenario "a validation error keeps the form scoped to the parent element", :js do
+      visit alchemy.admin_elements_path(page_version_id: element.page_version_id)
+      page.find(".add-nestable-element-button").click
+      expect(page).to have_css(".alchemy-dialog")
+
+      # Submitting without choosing an element fails the name validation
+      within ".alchemy-dialog" do
+        click_button("Add")
+        # The re-rendered form still lets us add a nested element and does not
+        # widen the list to every element allowed on the page.
+        tom_select("Text", from: "Element")
+        click_button("Add")
+      end
+
+      expect(page).to have_css(".alchemy-dialog", count: 0)
+      expect(page).to have_selector(
+        "#element_#{element.id}_nested_elements .element-editor[data-element-name='text']"
+      )
+    end
   end
 
   describe "Copy element", :js do


### PR DESCRIPTION
## What is this pull request for?

When adding a nested element fails validation, the create action re-renders the new-element form incorrectly: it uses the page-wide element list and never re-assigns the parent element. As a result the dialog stops being the "add nested element" form and turns into the generic page-level "New element" form — it offers every element allowed on the page instead of only those nestable within the current parent, and because the `parent_element_id` is dropped, a resubmitted element is created at the top level instead of inside its parent.

The fix mirrors what the `new` action already does: assign `@parent_element` from the element being created and build the list with `available_elements_within_current_scope`, so the re-rendered form stays scoped to the parent and keeps the nesting on resubmit.

### Screenshots

Remove if no visual changes have been made.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change