### PR TITLE
fix(dragonfly): derive the attachment extension from the file name

### DIFF
--- a/app/models/alchemy/storage_adapter/dragonfly.rb
+++ b/app/models/alchemy/storage_adapter/dragonfly.rb
@@ -148,6 +148,12 @@ module Alchemy
       # @param [Alchemy::Attachment]
       # @return [String]
       def file_extension(attachment)
+        extension = File.extname(file_name(attachment).to_s).delete_prefix(".").downcase
+        return extension if extension.present?
+
+        # Marcel returns the canonical extension for a mime type, which is not
+        # always the one the file was named after: `audio/mpeg` yields `mpga`,
+        # not `mp3`. Only reach for it when the name has no extension at all.
         content_type = file_mime_type(attachment)
         Marcel::Magic.new(content_type).extensions.first if content_type
       end

--- a/spec/models/alchemy/storage_adapter/dragonfly_spec.rb
+++ b/spec/models/alchemy/storage_adapter/dragonfly_spec.rb
@@ -255,6 +255,47 @@ RSpec.describe Alchemy::StorageAdapter::Dragonfly, if: Alchemy.storage_adapter.d
     end
   end
 
+  describe ".file_extension" do
+    subject { described_class.file_extension(attachment) }
+
+    let(:attachment) do
+      Alchemy::Attachment.new.tap do |attachment|
+        attachment.write_attribute(:file_name, file_name)
+        attachment.write_attribute(:file_mime_type, file_mime_type)
+      end
+    end
+
+    context "when the mime type maps to a different canonical extension" do
+      let(:file_name) { "song.mp3" }
+      let(:file_mime_type) { "audio/mpeg" }
+
+      it { is_expected.to eq("mp3") }
+    end
+
+    context "with an uppercased extension" do
+      let(:file_name) { "REPORT.PDF" }
+      let(:file_mime_type) { "application/pdf" }
+
+      it { is_expected.to eq("pdf") }
+    end
+
+    context "when the file name has no extension" do
+      let(:file_name) { "report" }
+      let(:file_mime_type) { "application/pdf" }
+
+      it "falls back to the mime type" do
+        is_expected.to eq("pdf")
+      end
+    end
+
+    context "without a file name or mime type" do
+      let(:file_name) { nil }
+      let(:file_mime_type) { nil }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe ".has_convertible_format?" do
     subject { Alchemy.storage_adapter.has_convertible_format?(picture) }
 


### PR DESCRIPTION
## What is this pull request for?

The dragonfly storage adapter derived an attachment's extension by asking Marcel for
the canonical extension of the stored mime type. That is frequently not the extension
the file was actually named after:

| Uploaded | Stored mime type | Marcel's canonical extension |
| --- | --- | --- |
| `song.mp3` | `audio/mpeg` | `mpga` |
| `voice.m4a` | `audio/mp4` | `mp4a` |
| `clip.mov` | `video/quicktime` | `qt` |

Apps that restrict `uploader.allowed_filetypes.alchemy_attachments` therefore reject
mp3, m4a and mov uploads even with exactly those extensions on the allowlist, because
`Alchemy::Attachment#file_type_allowed` compares the allowlist against this value.

The same wrong value feeds `Attachment#suffix`, so it also leaks into the format
segment of attachment URLs and into `Attachment#slug`, which strips
`/\.#{extension}$/` and then converts leftover dots to spaces — `song.mp3` becomes the
slug `song+mp3` rather than `song`.

Reading the extension off the stored file name is what the Active Storage adapter
already does, and it is what both the uploader's client side validation and the
`accept` attribute of the upload field assume. Marcel is still consulted when the file
name carries no extension at all.

The default allowlist is `["*"]`, which skips validation entirely, so this only
surfaces on installs that restrict the list — which is why it has gone unnoticed. No
fixture in the suite is an audio or video file, so the dragonfly matrix leg could not
have caught it either.

### Notable changes (remove if none)

`Attachment#suffix` now returns the file name's extension rather than a canonical one,
so generated attachment URLs change for affected files (`.qt` becomes `.mov`). Existing
links keep resolving: `/attachment/:id/show(/:name)` matches on `:id` and the name
segment is free-form.

The value is downcased, matching `image_file_extension` in the same adapter, so the
allowlist comparison keeps working the way it does today for uppercased file names.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change