### PR TITLE
fix(uploader): restrict attachment uploads to an allowlist by default

### DIFF
--- a/app/models/alchemy/attachment.rb
+++ b/app/models/alchemy/attachment.rb
@@ -206,7 +206,7 @@ module Alchemy
     private
 
     def file_type_allowed
-      unless extension&.in?(self.class.allowed_filetypes)
+      unless extension&.downcase&.in?(self.class.allowed_filetypes.map(&:downcase))
         errors.add(:file, Alchemy.t("not a valid file"))
       end
     end

--- a/lib/alchemy/configurations/uploader.rb
+++ b/lib/alchemy/configurations/uploader.rb
@@ -4,7 +4,21 @@ module Alchemy
   module Configurations
     class Uploader < Alchemy::Configuration
       class AllowedFileTypes < Alchemy::Configuration
-        option :alchemy_attachments, :collection, item_type: :string, default: ["*"]
+        # Document, media and archive formats Alchemy knows how to display.
+        # Executables and other active content are deliberately absent.
+        DEFAULT_ATTACHMENT_FILE_TYPES = %w[
+          pdf
+          doc docx odt rtf txt
+          xls xlsx ods csv
+          ppt pptx odp
+          vcf
+          zip
+          avif gif jpeg jpg png psd svg tif tiff webp
+          aac flac m4a mp3 oga ogg wav weba
+          avi flv m4v mov mp4 mpeg mpg ogv webm wmv
+        ].freeze
+
+        option :alchemy_attachments, :collection, item_type: :string, default: DEFAULT_ATTACHMENT_FILE_TYPES
         option :alchemy_pictures, :collection, item_type: :string, default: %w[jpg jpeg gif png svg webp]
 
         def set(configuration_hash)

--- a/lib/alchemy/upgrader/eight_four.rb
+++ b/lib/alchemy/upgrader/eight_four.rb
@@ -12,6 +12,41 @@ module Alchemy
         run %(bundle add dragonfly --version "~> 1.4")
       end
 
+      # The attachment uploader used to accept every file type.
+      def notify_attachment_filetypes_default
+        default = Alchemy::Configurations::Uploader::AllowedFileTypes::DEFAULT_ATTACHMENT_FILE_TYPES
+        current = Alchemy.config.uploader.allowed_filetypes.alchemy_attachments.to_a
+        return unless current == default || current.include?("*")
+
+        closing = if current.include?("*")
+          <<~TEXT.strip
+            Your app configures `["*"]`, so it still accepts every file type.
+            Please consider adopting the new default.
+          TEXT
+        else
+          <<~TEXT.strip
+            Setting it back to `["*"]` restores the old behaviour and disables
+            file type validation entirely.
+          TEXT
+        end
+
+        todo(<<~TODO.strip, "Attachment uploads are now restricted to an allowlist")
+          The `uploader.allowed_filetypes.alchemy_attachments` setting used to
+          default to `["*"]`, which accepts every file type, including
+          executables. It now defaults to a list of document, media and archive
+          formats:
+
+          #{default.each_slice(8).map { |slice| "  #{slice.join(" ")}" }.join("\n")}
+
+          Please check whether your editors upload file types that are not on
+          this list. If they do, add them in `config/initializers/alchemy.rb`:
+
+            config.uploader.allowed_filetypes.alchemy_attachments = %w[#{default.first(3).join(" ")} ...]
+
+          #{closing}
+        TODO
+      end
+
       # Element partials that render nested elements through the
       # +nested_elements+ association issue one database query per parent
       # element. Rendering through the block helper's +nested_elements+

--- a/lib/generators/alchemy/install/templates/alchemy.rb.tt
+++ b/lib/generators/alchemy/install/templates/alchemy.rb.tt
@@ -166,13 +166,18 @@ Alchemy.configure do |config|
   #   upload_limit       [Integer]    # Set an amount of files upload limit of files which can be uploaded at once. Set 0 for unlimited.
   #   file_size_limit*   [Integer]    # Set a file size limit in mega bytes for a per file limit.
   #
-  # *) Allow filetypes to upload. Pass * to allow all kind of files.
+  # *) Allow filetypes to upload. Passing * disables file type validation and
+  #    allows every kind of file, including executables.
   #
   # config.uploader.tap do |uploader|
   #   uploader.upload_limit = <%= @default_config.uploader.upload_limit.inspect %>
   #   uploader.file_size_limit = <%= @default_config.uploader.file_size_limit.inspect %>
   #   uploader.allowed_filetypes.tap do |file_types|
-  #     file_types.alchemy_attachments = <%= @default_config.uploader.allowed_filetypes.alchemy_attachments.map(&:to_s) %>
+  #     file_types.alchemy_attachments = %w[
+<% @default_config.uploader.allowed_filetypes.alchemy_attachments.each_slice(8) do |extensions| -%>
+  #       <%= extensions.join(" ") %>
+<% end -%>
+  #     ]
   #     file_types.alchemy_pictures = <%= @default_config.uploader.allowed_filetypes.alchemy_pictures.map(&:to_s) %>
   #   end
   # end

--- a/lib/tasks/alchemy/upgrade.rake
+++ b/lib/tasks/alchemy/upgrade.rake
@@ -60,7 +60,8 @@ namespace :alchemy do
     namespace "8.4" do
       task "run" => [
         "alchemy:upgrade:8.4:add_dragonfly_gem",
-        "alchemy:upgrade:8.4:upgrade_nested_elements_rendering"
+        "alchemy:upgrade:8.4:upgrade_nested_elements_rendering",
+        "alchemy:upgrade:8.4:notify_attachment_filetypes_default"
       ]
 
       desc "Add dragonfly gem to the Gemfile if the app uses the dragonfly storage adapter"
@@ -71,6 +72,11 @@ namespace :alchemy do
       desc "Rewrite element partials to render nested elements through the block helper"
       task upgrade_nested_elements_rendering: [:environment] do
         Alchemy::Upgrader["8.4"].upgrade_nested_elements_rendering
+      end
+
+      desc "Notify about the new attachment upload allowlist default"
+      task notify_attachment_filetypes_default: [:environment] do
+        Alchemy::Upgrader["8.4"].notify_attachment_filetypes_default
       end
     end
   end

--- a/spec/dummy/config/initializers/alchemy.rb
+++ b/spec/dummy/config/initializers/alchemy.rb
@@ -210,13 +210,21 @@ Alchemy.configure do |config|
   #   upload_limit       [Integer]    # Set an amount of files upload limit of files which can be uploaded at once. Set 0 for unlimited.
   #   file_size_limit*   [Integer]    # Set a file size limit in mega bytes for a per file limit.
   #
-  # *) Allow filetypes to upload. Pass * to allow all kind of files.
+  # *) Allow filetypes to upload. Passing * disables file type validation and
+  #    allows every kind of file, including executables.
   #
   # config.uploader.tap do |uploader|
   #   uploader.upload_limit = 50
   #   uploader.file_size_limit = 100
   #   uploader.allowed_filetypes.tap do |file_types|
-  #     file_types.alchemy_attachments = ["*"]
+  #     file_types.alchemy_attachments = %w[
+  #       pdf doc docx odt rtf txt xls xlsx
+  #       ods csv ppt pptx odp vcf zip avif
+  #       gif jpeg jpg png psd svg tif tiff
+  #       webp aac flac m4a mp3 oga ogg wav
+  #       weba avi flv m4v mov mp4 mpeg mpg
+  #       ogv webm wmv
+  #     ]
   #     file_types.alchemy_pictures = ["jpg", "jpeg", "gif", "png", "svg", "webp"]
   #   end
   # end

--- a/spec/lib/alchemy/upgrader/eight_four_spec.rb
+++ b/spec/lib/alchemy/upgrader/eight_four_spec.rb
@@ -42,6 +42,43 @@ RSpec.describe Alchemy::Upgrader::EightFour do
     end
   end
 
+  describe "#notify_attachment_filetypes_default" do
+    subject { upgrader.notify_attachment_filetypes_default }
+
+    context "when the app uses the new default allowlist" do
+      it "adds a todo about the change" do
+        expect(upgrader).to receive(:todo).with(kind_of(String), kind_of(String))
+        subject
+      end
+    end
+
+    context "when the app configured its own allowlist" do
+      before do
+        allow(Alchemy.config.uploader.allowed_filetypes).to receive(:alchemy_attachments) do
+          %w[pdf docx png]
+        end
+      end
+
+      it "does not add a todo" do
+        expect(upgrader).not_to receive(:todo)
+        subject
+      end
+    end
+
+    context "when the app still allows every file type" do
+      before do
+        allow(Alchemy.config.uploader.allowed_filetypes).to receive(:alchemy_attachments) do
+          ["*"]
+        end
+      end
+
+      it "adds a todo about the change" do
+        expect(upgrader).to receive(:todo).with(/still accepts every file type/, kind_of(String))
+        subject
+      end
+    end
+  end
+
   describe "#upgrade_nested_elements_rendering" do
     subject { upgrader.upgrade_nested_elements_rendering }
 

--- a/spec/models/alchemy/attachment_spec.rb
+++ b/spec/models/alchemy/attachment_spec.rb
@@ -352,6 +352,20 @@ module Alchemy
         end
       end
 
+      context "having an uppercased extension" do
+        let(:file) { fixture_file_upload("image2.PNG") }
+
+        before do
+          allow(Alchemy.config.uploader.allowed_filetypes).to receive(:alchemy_attachments) do
+            ["png"]
+          end
+        end
+
+        it "should be valid" do
+          expect(attachment).to be_valid
+        end
+      end
+
       context "having a png and everything allowed" do
         before do
           allow(Alchemy.config.uploader.allowed_filetypes).to receive(:alchemy_attachments) do


### PR DESCRIPTION
## What is this pull request for?

`uploader.allowed_filetypes.alchemy_attachments` defaulted to `["*"]`, and that
wildcard makes `Alchemy::Attachment` skip its file type validation entirely. Any user
with Library access could therefore upload an executable and have it served
byte-for-byte with accurate MIME labelling from `/attachment/:id/download`, on the
CMS's own domain. Reported as GHSA-v29p-hfcc-48q3.

The new default is the document, media and archive formats Alchemy already knows how
to display — the mime types in `Alchemy::Filetypes`, which back the attachment
previews and icons, plus PDF and the OpenDocument formats, which are missing there.
Keeping audio and video on the list matters: `Ingredients::AudioView` and
`VideoView` are built on attachments, so a documents-only default would break a
first-class feature.

Because this rejects uploads that used to be accepted, `rake alchemy:upgrade` now
explains the change, prints the new list and shows how to extend it. It stays quiet
for apps that configured their own list, and it also speaks up for apps that
explicitly set `["*"]` — those keep accepting every file type and are exactly the
population the advisory is about.

Depends on #4205. On the dragonfly adapter the extension an attachment reports is
derived from its mime type rather than its file name, so without that fix `mp3`, `m4a`
and `mov` are rejected despite being on this list. Please merge that one first.

### Notable changes (remove if none)

This is a breaking change for any app relying on the wildcard default. Setting
`config.uploader.allowed_filetypes.alchemy_attachments = ["*"]` restores the previous
behaviour, at the cost of disabling file type validation.

The validation now compares case insensitively. The Active Storage adapter reports an
attachment's extension exactly as the file was named, so `REPORT.PDF` would otherwise
be rejected by a list containing `pdf` — invisible until now, because the wildcard
skipped the comparison.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change