### PR TITLE
fix(admin): show validation errors on the new element form

### DIFF
--- a/app/views/alchemy/admin/elements/_form.html.erb
+++ b/app/views/alchemy/admin/elements/_form.html.erb
@@ -6,16 +6,13 @@
   <%= turbo_frame_tag @element do %>
     <%= alchemy_form_for [:admin, @element] do |form| %>
       <%= form.hidden_field :page_version_id %>
-      <div class="input">
-        <%= form.label(:name, class: "control-label required") do %>
-          <%= Alchemy.t(:element_of_type) %><abbr>*</abbr>
-        <% end %>
+      <%= form.input :name, label: Alchemy.t(:element_of_type) do %>
         <%= render Alchemy::Admin::ElementSelect.new(
           @elements,
           field_name: form.field_name(:name),
           autofocus: true
         ) %>
-      </div>
+      <% end %>
       <%= form.hidden_field :parent_element_id, value: @parent_element.try(:id) %>
       <%= form.submit Alchemy.t(:add) %>
     <%- end -%>

--- a/spec/features/admin/edit_elements_feature_spec.rb
+++ b/spec/features/admin/edit_elements_feature_spec.rb
@@ -147,6 +147,7 @@ RSpec.describe "The edit elements feature", type: :system do
       # Submitting without choosing an element fails the name validation
       within ".alchemy-dialog" do
         click_button("Add")
+        expect(page).to have_css("small.error", text: "can't be blank")
         # The re-rendered form still lets us add a nested element and does not
         # widen the list to every element allowed on the page.
         tom_select("Text", from: "Element")


### PR DESCRIPTION
## What is this pull request for?

Creating an element from the "New element" dialog silently swallowed the reason when validation failed. Submitting without picking an element re-rendered the form inside its turbo frame with no feedback at all, so the dialog just blinked and left the user guessing.

The error markup was never missing from the wrapper or the stylesheet — `app/stylesheets/alchemy/admin/forms.scss` even has a dedicated `.field_with_errors .ts-control` branch for it. The field simply stopped going through simple_form when the element select moved into a view component: a hand rolled label and `div.input` bypass the `:alchemy` wrapper, and with it its error component. Rendering the component as a simple_form block input puts the field back under the wrapper, so the message and the error class come back while the component itself stays as it is.

It also gives the feature spec something to wait for. Both renders of the form are markup identical, so the scenario had nothing to synchronize on and raced the turbo frame swap, driving the select that was about to be replaced. That is what made it fail intermittently on CI.

### Screenshots

<img width="1280" height="714" alt="4fb04430-35d8-4d30-ba50-2ab3eef247a4" src="https://github.com/user-attachments/assets/33be6d72-d398-4bdc-9b70-e181fac5591d" />


## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
