### PR TITLE
fix(csv export): escape formulas in admin resource exports [8.3-stable]

### DIFF
--- a/app/helpers/alchemy/resources_helper.rb
+++ b/app/helpers/alchemy/resources_helper.rb
@@ -99,6 +99,31 @@ module Alchemy
       end
     end
 
+    # Returns the value prepared for a cell of a CSV export.
+    #
+    # Spreadsheet applications evaluate a cell starting with one of these characters
+    # as a formula, turning exported content into code that runs on the machine
+    # opening the file. The tab keeps the cell text and, unlike the more common
+    # single quote, survives Excel saving and re-opening the file, which strips
+    # quotes and would reactivate the formula. It only works inside a quoted field,
+    # so the export generates with `force_quotes`.
+    #
+    # A bare negative number is exempt, because spreadsheets read it as a number
+    # instead of a formula, so escaping it would only break arithmetic on the
+    # exported column. An expression like `-2+3` is a formula and stays escaped.
+    #
+    # @see https://owasp.org/www-community/attacks/CSV_Injection
+    #
+    # @param [Object] value
+    # @return [String]
+    #
+    def csv_value(value)
+      value = value.to_s
+      return value if value.match?(/\A-\d+(\.\d+)?\z/)
+
+      value.match?(/\A[-=+@\t\r\n\uFF0D\uFF1D\uFF0B\uFF20]/) ? "\t#{value}" : value
+    end
+
     # Returns a options hash for simple_form input fields.
     def resource_attribute_field_options(attribute)
       options = {hint: resource_handler.help_text_for(attribute)}

--- a/app/views/alchemy/admin/resources/index.csv.erb
+++ b/app/views/alchemy/admin/resources/index.csv.erb
@@ -1,13 +1,13 @@
-<% csv = CSV.generate(col_sep: ";", row_sep: "\r\n") do |row| %>
+<% csv = CSV.generate(col_sep: ";", row_sep: "\r\n", force_quotes: true) do |row| %>
   <% row << ["Id"] + resource_handler.attributes.collect do |a|
-              resource_handler.model.human_attribute_name(a[:name])
+              csv_value(resource_handler.model.human_attribute_name(a[:name]))
             end %>
   <% resources_instance_variable.each do |resource| %>
     <% row << [resource.id] + resource_handler.attributes.map do |a|
                 if a[:type] == :boolean
                   resource.send(a[:name]) ? 'x' : ''
                 else
-                  render_attribute(resource, a, {truncate: false}).to_s.strip
+                  csv_value(render_attribute(resource, a, {truncate: false}).to_s.strip)
                 end
               end %>
   <% end %>

--- a/spec/helpers/alchemy/resources_helper_spec.rb
+++ b/spec/helpers/alchemy/resources_helper_spec.rb
@@ -388,4 +388,36 @@ describe Alchemy::ResourcesHelper do
       expect(test_controller.resource_name).to eq("my_resource")
     end
   end
+
+  describe "#csv_value" do
+    it "returns a harmless value unchanged" do
+      expect(test_controller.csv_value("Hello")).to eq("Hello")
+    end
+
+    it "casts the value into a string" do
+      expect(test_controller.csv_value(1)).to eq("1")
+    end
+
+    ["=", "+", "-", "@", "\uFF1D", "\uFF0B", "\uFF0D", "\uFF20", "\t", "\r", "\n"].each do |character|
+      it "prefixes a value starting with #{character.inspect} with a tab" do
+        expect(test_controller.csv_value("#{character}1+1")).to eq("\t#{character}1+1")
+      end
+    end
+
+    it "does not prefix a value containing a formula character in the middle" do
+      expect(test_controller.csv_value("1+1=2")).to eq("1+1=2")
+    end
+
+    it "does not prefix a negative integer" do
+      expect(test_controller.csv_value("-5")).to eq("-5")
+    end
+
+    it "does not prefix a negative decimal" do
+      expect(test_controller.csv_value("-5.0")).to eq("-5.0")
+    end
+
+    it "prefixes a negative number that continues into an expression" do
+      expect(test_controller.csv_value("-2+3")).to eq("\t-2+3")
+    end
+  end
 end

--- a/spec/requests/alchemy/admin/resources_requests_spec.rb
+++ b/spec/requests/alchemy/admin/resources_requests_spec.rb
@@ -24,5 +24,35 @@ RSpec.describe "Resource requests" do
       csv = CSV.parse(response.body, col_sep: ";")
       expect(csv[1][7]).to_not include("...")
     end
+
+    it "neutralizes spreadsheet formulas in exported values" do
+      create(:event, name: "=CMD|'/C calc.exe'!A0")
+      get "/admin/events.csv"
+      csv = CSV.parse(response.body, col_sep: ";")
+      name_column = csv[0].index(Event.human_attribute_name(:name))
+      expect(csv[1][name_column]).to eq("\t=CMD|'/C calc.exe'!A0")
+    end
+
+    it "quotes every field so that the neutralizing tab survives a spreadsheet round trip" do
+      create(:event, name: "=1+1")
+      get "/admin/events.csv"
+      expect(response.body).to include(%("\t=1+1"))
+    end
+
+    it "keeps negative numbers usable as numbers" do
+      create(:event, entrance_fee: -5.0)
+      get "/admin/events.csv"
+      csv = CSV.parse(response.body, col_sep: ";")
+      fee_column = csv[0].index(Event.human_attribute_name(:entrance_fee))
+      expect(csv[1][fee_column]).to eq("-5.0")
+    end
+
+    it "does not allow a column separator in a value to start a new cell" do
+      create(:event, name: "Party;=1+1")
+      get "/admin/events.csv"
+      csv = CSV.parse(response.body, col_sep: ";")
+      name_column = csv[0].index(Event.human_attribute_name(:name))
+      expect(csv[1][name_column]).to eq("Party;=1+1")
+    end
   end
 end


### PR DESCRIPTION
## What is this pull request for?

Backport of 66affd7af (GHSA-v6px-36qm-x844) to the 8.3 series. The advisory covers every
release from 2.6.0 onwards, so the maintained 8.3 line needs the fix too — without it the
advisory offers no available patch to anyone tracking 8.3.

The cherry-pick applied without conflict, and the helper and request specs pass on this
branch.

### Notable changes

Same export format change as on main. Every CSV field is now quoted, which stays valid
RFC 4180 but means anything consuming these exports by splitting on `;` needs a real
parser. Values beginning with `=`, `+`, `-`, `@`, tab, carriage return, line feed or
their full-width variants gain a leading tab, so automated importers should strip
whitespace from string columns. Bare negative numbers are exempt, keeping numeric
columns usable for arithmetic.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
