### PR TITLE
fix(admin): render element preview text as plain text

### DIFF
--- a/app/views/alchemy/admin/elements/_preview_text_quote.html.erb
+++ b/app/views/alchemy/admin/elements/_preview_text_quote.html.erb
@@ -1,3 +1,3 @@
 <span id="element_<%= element.id %>_preview_text_quote" class="preview_text_quote">
-  <%= sanitize(element.preview_text.presence || '&nbsp;') %>
+  <%= strip_tags(element.preview_text.presence || '&nbsp;') %>
 </span>

--- a/spec/components/alchemy/admin/element_editor_spec.rb
+++ b/spec/components/alchemy/admin/element_editor_spec.rb
@@ -386,6 +386,20 @@ RSpec.describe Alchemy::Admin::ElementEditor, type: :component do
       end
     end
 
+    context "with preview text containing HTML" do
+      before do
+        allow(element).to receive(:preview_text) { "<h1>Hello</h1><img src=x>" }
+      end
+
+      it "renders it as plain text" do
+        render_inline(described_class.new(element: element))
+
+        expect(page).to have_css(".preview_text_quote", text: "Hello")
+        expect(page).to have_no_css(".preview_text_quote h1")
+        expect(page).to have_no_css(".preview_text_quote img")
+      end
+    end
+
     context "with element beeing taggable" do
       let(:element) { create(:alchemy_element, name: "taggable") }
 


### PR DESCRIPTION
## What is this pull request for?

The element header in the admin elements list has run the element preview text through `sanitize` since 2011, back when Richtext previews still carried their markup along. `sanitize` is an allow-list sanitizer, so it happily passes `<h1>`, `<div>`, `<a href>` and `<img src>` through. That means an Author or Editor can put markup into any text-ish ingredient used as the element title and have it render as live HTML in the admin interface of every other user who opens that page — including the outbound request an `<img src>` triggers.

This is not XSS: `script`, `style`, event handlers and `javascript:` URLs are all stripped, and the front end views escape their values correctly. An author can also already publish arbitrary HTML through the Html and Richtext ingredients by design, so the practical impact is limited to spoofing the admin UI. It is still the wrong helper for the job. Preview text is plain text by definition, and keeping an allow-list sanitizer on that path means any future gap in the allow list turns straight into an admin side injection.

`strip_tags` is what we actually want here. Richtext already strips its body and Html already escapes its value, so nothing depended on tags surviving the preview, and `strip_tags` keeps the `&nbsp;` fallback intact while escaping stray angle brackets.

This was reported through a security advisory by @bugmithlegend, @xploitscout-rce and @hacker-gam. Thanks for taking the time to look at Alchemy and to write the report up carefully.

### Notable changes (remove if none)

None. Element preview text was never intended to render markup.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change