### PR TITLE
feat(csp): add nonces to inline script tags

### DIFF
--- a/app/components/alchemy/menubar.html.erb
+++ b/app/components/alchemy/menubar.html.erb
@@ -117,7 +117,7 @@
     </div>
   </template>
 
-  <script type="module" data-turbo-eval="false">
+  <%= tag.script(type: "module", data: {turbo_eval: false}, nonce: helpers.content_security_policy_nonce) do %>
     class Menubar extends HTMLElement {
       connectedCallback() {
         const template = this.querySelector("template")
@@ -153,5 +153,5 @@
     }
 
     customElements.define("alchemy-menubar", Menubar)
-  </script>
+  <% end %>
 </alchemy-menubar>

--- a/app/views/alchemy/_preview_mode_code.html.erb
+++ b/app/views/alchemy/_preview_mode_code.html.erb
@@ -1,6 +1,6 @@
 <% if Alchemy::Current.preview_page? %>
-  <script type="text/javascript">
+  <%= tag.script(type: "text/javascript", nonce: content_security_policy_nonce) do %>
     Alchemy = { locale: "<%= session[:alchemy_locale] %>" };
-  </script>
+  <% end %>
   <%= javascript_include_tag("alchemy/preview.min") %>
 <% end %>

--- a/app/views/alchemy/admin/nodes/index.html.erb
+++ b/app/views/alchemy/admin/nodes/index.html.erb
@@ -41,8 +41,8 @@
   <% end %>
 <% end %>
 
-<script type="module">
+<%= tag.script(type: "module", nonce: content_security_policy_nonce) do %>
   import { NodeTree } from "alchemy_admin/node_tree"
 
   NodeTree()
-</script>
+<% end %>

--- a/app/views/alchemy/admin/pages/edit.html.erb
+++ b/app/views/alchemy/admin/pages/edit.html.erb
@@ -142,7 +142,7 @@
 <% end %>
 
 <% content_for :javascripts do %>
-<script type="module">
+<%= tag.script(type: "module", nonce: content_security_policy_nonce) do %>
   document.addEventListener("turbo:load", function() {
     document.querySelectorAll('#unlock_page_form, #publish_page_form').forEach(function(form) {
       form.addEventListener('submit', function(event) {
@@ -155,5 +155,5 @@
     });
     Alchemy.PageLeaveObserver();
   }, { once: true });
-</script>
+<% end %>
 <% end %>

--- a/app/views/alchemy/admin/partials/_routes.html.erb
+++ b/app/views/alchemy/admin/partials/_routes.html.erb
@@ -1,4 +1,4 @@
-<script>
+<%= tag.script(nonce: content_security_policy_nonce) do %>
   Alchemy.routes = {
 
     admin_picture_path: function(id) {
@@ -45,4 +45,4 @@
     api_elements_path: '<%= alchemy.api_elements_path %>',
     api_ingredients_path: '<%= alchemy.api_ingredients_path %>'
   };
-</script>
+<% end %>

--- a/app/views/alchemy/admin/pictures/index.html.erb
+++ b/app/views/alchemy/admin/pictures/index.html.erb
@@ -99,7 +99,7 @@
 <%= render "library_sidebar" %>
 
 <% content_for :javascripts do %>
-  <script type="module">
+  <%= tag.script(type: "module", nonce: content_security_policy_nonce) do %>
     import { ImageOverlay } from "alchemy_admin/image_overlay";
     import { pictureSelector } from "alchemy_admin/picture_selector";
     import { on } from "alchemy_admin/utils/events";
@@ -115,5 +115,5 @@
       overlay.open();
       event.preventDefault();
     });
-  </script>
+  <% end %>
 <% end %>

--- a/app/views/alchemy/admin/tinymce/_setup.html.erb
+++ b/app/views/alchemy/admin/tinymce/_setup.html.erb
@@ -8,7 +8,7 @@
   <link rel="preload" href="<%= asset_path("#{tinymce_base_path}/plugins/#{plugin}/plugin.min.js") %>" as="script">
 <% end %>
 
-<script>
+<%= tag.script(nonce: content_security_policy_nonce) do %>
   var tinyMCEPreInit = <%== {
     base: ActionController::Base.config.asset_host ?
       asset_url(tinymce_base_path, host: ActionController::Base.config.asset_host) :
@@ -18,4 +18,4 @@
   Alchemy.TinymceDefaults = <%== Alchemy::Tinymce.init.merge(
     plugins: Alchemy::Tinymce.plugins.join(",")
   ).to_json %>;
-</script>
+<% end %>

--- a/app/views/alchemy/admin/uploader/_setup.html.erb
+++ b/app/views/alchemy/admin/uploader/_setup.html.erb
@@ -1,3 +1,3 @@
-<script>
+<%= tag.script(nonce: content_security_policy_nonce) do %>
   Alchemy.uploader_defaults = <%== Alchemy.config.uploader.to_json %>
-</script>
+<% end %>

--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -18,21 +18,21 @@
       <%= stylesheet_link_tag(stylesheet, 'data-turbo-track' => true) %>
     <% end %>
     <%= yield :stylesheets %>
-    <script>
+    <%= tag.script(nonce: content_security_policy_nonce) do %>
       // Global Alchemy JavaScript object.
       var Alchemy = {};
       // Store regular expression for external link url matching.
       Alchemy.link_url_regexp = <%= link_url_regexp.inspect %>;
       // JS translations
       <%= alchemy_admin_js_translations %>
-    </script>
+    <% end %>
     <%= render 'alchemy/admin/tinymce/setup' %>
     <%= render 'alchemy/admin/partials/routes' %>
     <%= javascript_importmap_tags("alchemy_admin", importmap: Alchemy.importmap) %>
     <% Alchemy.config.admin_js_imports.each do |path| %>
-      <script type="module">
+      <%= tag.script(type: "module", nonce: content_security_policy_nonce) do %>
         import "<%= path %>"
-      </script>
+      <% end %>
     <% end %>
     <%= yield :javascript_includes %>
   </head>

--- a/spec/requests/alchemy/admin/content_security_policy_spec.rb
+++ b/spec/requests/alchemy/admin/content_security_policy_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Content Security Policy" do
+  before do
+    authorize_user(:as_admin)
+    allow_any_instance_of(ActionDispatch::Request)
+      .to receive(:content_security_policy_nonce) { "test-nonce" }
+  end
+
+  # Script tags that carry no src attribute, and therefore need a nonce to run
+  # under a policy that does not allow 'unsafe-inline'.
+  def inline_scripts_without_nonce
+    response.body.scan(/<script(?![^>]*\ssrc=)[^>]*>/)
+      .reject { _1.include?('nonce="test-nonce"') }
+  end
+
+  it "nonces the inline scripts of the admin layout" do
+    get alchemy.admin_dashboard_path
+    expect(inline_scripts_without_nonce).to be_empty
+  end
+
+  it "nonces the inline scripts of the page edit view" do
+    page = create(:alchemy_page)
+    get alchemy.edit_admin_page_path(page)
+    expect(inline_scripts_without_nonce).to be_empty
+  end
+
+  it "nonces the inline scripts of the pictures index view" do
+    create(:alchemy_language)
+    get alchemy.admin_pictures_path
+    expect(inline_scripts_without_nonce).to be_empty
+  end
+
+  it "nonces the inline scripts of the nodes index view" do
+    create(:alchemy_language)
+    get alchemy.admin_nodes_path
+    expect(inline_scripts_without_nonce).to be_empty
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

Alchemy renders ten inline `<script>` tags with no nonce on them. That means any host app that turns on a nonce-based Content Security Policy immediately breaks its own Alchemy admin — I confirmed this by booting the dummy app with `default-src 'self'; script-src 'self' 'nonce-…'` and requesting the dashboard, which is one of the simplest admin pages and still emitted four blocked inline scripts.

That leaves integrators with two bad options: add `'unsafe-inline'` to `script-src`, which makes the policy close to meaningless, or exclude the admin path from the policy, which leaves the highest value surface in the application as the one unprotected part. The second is the one most people will reach for.

Rendering these tags through `tag.script` lets Rails attach the request nonce when a policy is configured and omit the attribute entirely when it is not, so the rendered output is byte-for-byte unchanged for apps that have no CSP. No new configuration and no behaviour change — this only makes a policy possible for the apps that want one.

The menubar and the preview mode code are included even though they are not admin views, because both are injected into the host application's frontend, where a policy is considerably more likely to already exist.

Worth noting what is *not* needed: I scanned all 16 shipped JS bundles, `vendor/javascript/tinymce.min.js` included, and there is no `eval(` or `new Function(` anywhere, so `'unsafe-eval'` is not required. Handlebars templates are precompiled at build time, and importmap-rails already nonces its own tags.

### Notable changes (remove if none)

None for apps without a CSP configured — `content_security_policy_nonce` returns nil there and `tag.script` omits the attribute.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change