### PR TITLE
fix(admin): make the language switch a POST request

### DIFF
--- a/app/views/alchemy/admin/partials/_language_tree_select.html.erb
+++ b/app/views/alchemy/admin/partials/_language_tree_select.html.erb
@@ -2,7 +2,7 @@
 <% if can?(:switch_language, Alchemy::Page) && languages.many? %>
 <div class="toolbar_button">
   <sl-tooltip content="<%= Alchemy.t("Language tree") %>">
-    <%= form_tag switch_admin_languages_path, method: 'get' do %>
+    <%= form_tag switch_admin_languages_path do %>
       <alchemy-auto-submit>
         <%= select_tag(
           :language_id,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,7 +85,7 @@ Alchemy::Engine.routes.draw do
     resources :legacy_page_urls
     resources :languages do
       collection do
-        get :switch
+        post :switch
       end
     end
 

--- a/spec/controllers/alchemy/admin/languages_controller_spec.rb
+++ b/spec/controllers/alchemy/admin/languages_controller_spec.rb
@@ -144,7 +144,7 @@ describe Alchemy::Admin::LanguagesController do
 
   describe "#switch" do
     subject(:switch) do
-      get :switch, params: {language_id: language.id}
+      post :switch, params: {language_id: language.id}
     end
 
     let(:language) { create(:alchemy_language, :klingon) }

--- a/spec/routing/routing_spec.rb
+++ b/spec/routing/routing_spec.rb
@@ -242,6 +242,24 @@ describe "The Routing" do
           id: "3"
         )
       end
+
+      it "should route to language switch" do
+        expect({
+          post: "/admin/languages/switch"
+        }).to route_to(
+          controller: "alchemy/admin/languages",
+          action: "switch"
+        )
+      end
+
+      it "should not switch the language on GET requests" do
+        expect({
+          get: "/admin/languages/switch"
+        }).not_to route_to(
+          controller: "alchemy/admin/languages",
+          action: "switch"
+        )
+      end
     end
 
     context "customized" do


### PR DESCRIPTION
## What is this pull request for?

`GET /admin/languages/switch` wrote `session[:alchemy_language_id]`, which
violates HTTP semantics for a safe method. Beyond being incorrect on its own
terms, it makes the endpoint hostile to anything that speculatively follows
links — a browser prefetcher or a caching proxy could silently change an
editor's working language without them ever choosing to switch. Moving the
action behind POST fixes that and, as a side effect, brings it under Rails'
authenticity token check.

This was reported to us privately as a CSRF vulnerability. It is not one:
languages are not an authorization boundary in Alchemy. There is no
per-language or per-site role, and `Alchemy::Permissions` grants
`edit_content` over `Alchemy::Page.all` gated only on the page layout's
`editable_by` roles, so the language a request switches to is always one the
user was already fully permitted to edit. No privilege boundary is crossed
and no content is modified. We closed the advisory as informative, but the
underlying HTTP hygiene point was fair and worth acting on in the open.

Thanks to @bugmithlegend, @xploitscout-rce and @hacker-gam for the careful
write-up and reproduction steps.

### Notable changes

This is a breaking route change. `switch_admin_languages_path` no longer
responds to GET, so any application or custom toolbar linking to it must
submit a POST instead. The bundled language selector partial has been updated
accordingly; because it already submits through `<alchemy-auto-submit>` and
`do_redirect_to` already replies `303 See Other`, the Turbo round trip needs
no other change.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change