### PR TITLE
chore(admin): remove dead create_language route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,6 @@ Alchemy::Engine.routes.draw do
       collection do
         post :flush
         post :copy_language_tree
-        get :create_language
         get :link
         get :tree
       end

--- a/spec/routing/routing_spec.rb
+++ b/spec/routing/routing_spec.rb
@@ -260,6 +260,15 @@ describe "The Routing" do
           action: "switch"
         )
       end
+
+      it "should not route to a create_language action" do
+        expect({
+          get: "/admin/pages/create_language"
+        }).not_to route_to(
+          controller: "alchemy/admin/pages",
+          action: "create_language"
+        )
+      end
     end
 
     context "customized" do


### PR DESCRIPTION
## What is this pull request for?

`get :create_language` in the admin pages routes points at an
`Alchemy::Admin::PagesController#create_language` action that does not exist
and, going by `git log -S`, has not existed since the Rails 3 port. Requesting
the path has only ever raised `AbstractController::ActionNotFound`. Creating a
language root page is handled by the ordinary `pages#create` action via the
form in `_create_language_form.html.erb`, and nothing in the codebase
references the generated URL helper.

This was spotted in passing during a security report about a different admin
route. Thanks to @bugmithlegend, @xploitscout-rce and @hacker-gam for noticing
it.

### Notable changes

`create_language_admin_pages_path` no longer exists. Any application calling it
was already generating a URL that could only 404, so this should not affect
working code.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change