### PR TITLE
fix(security): reject executable url schemes in nodes and ingredients

### DIFF
--- a/app/helpers/alchemy/admin/base_helper.rb
+++ b/app/helpers/alchemy/admin/base_helper.rb
@@ -272,8 +272,11 @@ module Alchemy
       end
 
       # Returns the regular expression used for external url validation in link dialog.
+      #
+      # Anchored with ^ instead of \A because the link dialog receives this as a
+      # JavaScript literal, where Ruby's anchors are a syntax error.
       def link_url_regexp
-        Alchemy.config.format_matchers.link_url || /^(mailto:|\/|[a-z]+:\/\/)/
+        Alchemy.config.format_matchers.link_url || Alchemy::Configurations::FormatMatchers::LINK_URL
       end
 
       # Renders a hint with tooltip

--- a/app/models/alchemy/ingredients/link.rb
+++ b/app/models/alchemy/ingredients/link.rb
@@ -12,6 +12,8 @@ module Alchemy
 
       allow_settings %i[text]
 
+      validates_with Alchemy::SafeUrlValidator, attributes: [:value]
+
       alias_method :link, :value
     end
   end

--- a/app/models/alchemy/ingredients/picture.rb
+++ b/app/models/alchemy/ingredients/picture.rb
@@ -38,6 +38,8 @@ module Alchemy
         upsample
       ]
 
+      validates_with Alchemy::SafeUrlValidator, attributes: [:link]
+
       delegate :description_for, :name, to: :picture, allow_nil: true
 
       def alt_text(language: Alchemy::Current.language)

--- a/app/models/alchemy/ingredients/text.rb
+++ b/app/models/alchemy/ingredients/text.rb
@@ -23,6 +23,8 @@ module Alchemy
         input_type
         linkable
       ]
+
+      validates_with Alchemy::SafeUrlValidator, attributes: [:link]
     end
   end
 end

--- a/app/models/alchemy/node.rb
+++ b/app/models/alchemy/node.rb
@@ -97,6 +97,7 @@ module Alchemy
     validates :menu_type, presence: true
     validates :name, presence: true, if: -> { page.nil? }
     validates :url, format: {with: VALID_URL_REGEX}, unless: -> { url.nil? }
+    validates_with Alchemy::SafeUrlValidator, attributes: [:url]
 
     # Returns the name
     #

--- a/app/models/alchemy/safe_url_validator.rb
+++ b/app/models/alchemy/safe_url_validator.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Alchemy
+  # Validates that a url does not carry an executable scheme.
+  #
+  # Only schemes listed in +Alchemy.config.allowed_url_schemes+ pass. Urls
+  # without a scheme (absolute and relative paths, anchors, queries and
+  # protocol relative urls) pass as well, they cannot carry executable code.
+  #
+  #   validates_with Alchemy::SafeUrlValidator, attributes: [:url]
+  #
+  class SafeUrlValidator < ActiveModel::EachValidator
+    SCHEME_REGEX = /\A(?<scheme>[a-z][a-z0-9+.-]*):/i
+
+    # Browsers drop these before they parse a url, which makes "java\tscript:"
+    # a working "javascript:" url. They have to go before the scheme is read.
+    STRIPPED_CHARS = /[\u0000-\u0020]/
+
+    def validate_each(record, attribute, value)
+      return if value.blank?
+
+      scheme = SCHEME_REGEX.match(value.to_s.gsub(STRIPPED_CHARS, ""))&.[](:scheme)&.downcase
+      return if scheme.nil? || allowed_schemes.include?(scheme)
+
+      record.errors.add(attribute, :invalid_url_scheme, scheme: scheme)
+    end
+
+    private
+
+    def allowed_schemes
+      Alchemy.config.allowed_url_schemes.map(&:downcase)
+    end
+  end
+end

--- a/config/locales/alchemy.en.yml
+++ b/config/locales/alchemy.en.yml
@@ -795,6 +795,8 @@ en:
 
   # Translations for error messages.
   errors:
+    messages:
+      invalid_url_scheme: "uses the not allowed scheme %{scheme}:"
     attributes:
       public_until:
         must_be_after_public_on: "must be after visible from date"

--- a/lib/alchemy/configurations/format_matchers.rb
+++ b/lib/alchemy/configurations/format_matchers.rb
@@ -3,9 +3,15 @@
 module Alchemy
   module Configurations
     class FormatMatchers < Alchemy::Configuration
+      # Naming the hierarchical schemes explicitly matters: a shape match like
+      # `[a-z]+://` also admits `javascript://%0aalert(1)`, which browsers
+      # execute. This is the link dialog's client side check only, the server
+      # side boundary is Alchemy.config.allowed_url_schemes.
+      LINK_URL = /^((mailto|tel):|(https?|ftp):\/\/|\/)/
+
       option :email, :regexp, default: /\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/
       option :url, :regexp, default: /\A[a-z0-9]+([-.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?\z/ix
-      option :link_url, :regexp, default: /^(tel:|mailto:|\/|[a-z]+:\/\/)/
+      option :link_url, :regexp, default: LINK_URL
     end
   end
 end

--- a/lib/alchemy/configurations/main.rb
+++ b/lib/alchemy/configurations/main.rb
@@ -207,6 +207,22 @@ module Alchemy
       #
       option :link_target_options, :collection, item_type: :string, default: %w[blank]
 
+      # === Allowed url schemes
+      #
+      # Url schemes editors are allowed to store in menu nodes and linkable
+      # ingredients. Any other scheme is rejected, because a scheme like
+      # `javascript:` turns an editable url into script execution in your
+      # site's own origin.
+      #
+      # Urls without a scheme (absolute and relative paths, anchors, queries
+      # and protocol relative urls) are always allowed.
+      #
+      # == Example:
+      #
+      #   config.allowed_url_schemes = %w[http https mailto]
+      #
+      option :allowed_url_schemes, :collection, item_type: :string, default: %w[http https mailto tel ftp]
+
       # === Format matchers
       #
       # Named aliases for regular expressions that can be used in various places.

--- a/lib/alchemy/test_support/shared_ingredient_examples.rb
+++ b/lib/alchemy/test_support/shared_ingredient_examples.rb
@@ -80,3 +80,55 @@ RSpec.shared_examples_for "an alchemy ingredient" do
     it { is_expected.to be_a("#{described_class}View".constantize) }
   end
 end
+
+# Shared by the ingredients that store an editor supplied url.
+#
+#   it_behaves_like "a linkable alchemy ingredient", :link
+#
+RSpec.shared_examples_for "a linkable alchemy ingredient" do |url_attribute|
+  describe "url scheme validation" do
+    let(:element) { build(:alchemy_element, name: "article") }
+
+    subject(:ingredient) do
+      described_class.new(element: element, role: "headline")
+    end
+
+    # captured in a let, a block parameter is not in scope inside a def
+    let(:attribute) { url_attribute }
+
+    def errors_for(url)
+      ingredient.public_send(:"#{attribute}=", url)
+      ingredient.valid?
+      ingredient.errors[attribute]
+    end
+
+    it "allows a blank url" do
+      expect(errors_for(nil)).to be_empty
+    end
+
+    it "allows an allowed scheme" do
+      expect(errors_for("https://example.com")).to be_empty
+      expect(errors_for("mailto:jane@example.com")).to be_empty
+    end
+
+    it "allows a relative url" do
+      expect(errors_for("/a/path")).to be_empty
+      expect(errors_for("#an-anchor")).to be_empty
+    end
+
+    it "rejects an executable scheme" do
+      expect(errors_for("javascript:alert(document.domain)")).to be_present
+      expect(errors_for("data:text/html;base64,PHN2Zz4=")).to be_present
+      expect(errors_for("vbscript:msgbox(1)")).to be_present
+    end
+
+    it "rejects an executable scheme obfuscated by whitespace" do
+      expect(errors_for(" javascript:alert(1)")).to be_present
+      expect(errors_for("java\tscript:alert(1)")).to be_present
+    end
+
+    it "rejects a javascript url disguised as an authority" do
+      expect(errors_for("javascript://%0aalert(1)")).to be_present
+    end
+  end
+end

--- a/spec/helpers/alchemy/admin/base_helper_spec.rb
+++ b/spec/helpers/alchemy/admin/base_helper_spec.rb
@@ -198,11 +198,45 @@ module Alchemy
         expect(subject).to be_a(Regexp)
       end
 
+      it "does not match an executable scheme out of the box" do
+        expect(subject).to_not match("javascript:alert(1)")
+        expect(subject).to_not match("javascript://%0aalert(1)")
+      end
+
       context "if the expression from config is nil" do
         before { stub_alchemy_config(format_matchers: {link_url: nil}) }
 
         it "returns the default expression" do
           expect(subject).to_not be_nil
+        end
+
+        it "matches urls with an allowed scheme" do
+          expect(subject).to match("https://example.com")
+          expect(subject).to match("mailto:jane@example.com")
+          expect(subject).to match("tel:+4912345")
+          expect(subject).to match("/an/absolute/path")
+        end
+
+        it "does not match an executable scheme" do
+          expect(subject).to_not match("javascript:alert(1)")
+          expect(subject).to_not match("data:text/html;base64,PHN2Zz4=")
+        end
+
+        # "[a-z]+://" style shape matching accepts this: the "//" reads as an
+        # authority, while JavaScript reads it as a line comment.
+        it "does not match a javascript url disguised as an authority" do
+          expect(subject).to_not match("javascript://%0aalert(1)")
+        end
+
+        it "does not match a url without scheme or leading slash" do
+          expect(subject).to_not match("something")
+        end
+
+        # The expression is handed to the link dialog as a JavaScript literal,
+        # where Ruby's \A and \z anchors are a syntax error.
+        it "only uses anchors JavaScript understands" do
+          expect(subject.source).to_not include('\A')
+          expect(subject.source).to_not include('\z')
         end
       end
     end

--- a/spec/libraries/alchemy/configurations/format_matchers_spec.rb
+++ b/spec/libraries/alchemy/configurations/format_matchers_spec.rb
@@ -51,5 +51,17 @@ RSpec.describe Alchemy::Configurations::FormatMatchers do
     it "does not match relative paths" do
       expect("relative/path").not_to match(format_matchers.link_url)
     end
+
+    it "does not match executable schemes" do
+      expect("javascript:alert(1)").not_to match(format_matchers.link_url)
+      expect("data:text/html;base64,PHN2Zz4=").not_to match(format_matchers.link_url)
+      expect("vbscript:msgbox(1)").not_to match(format_matchers.link_url)
+    end
+
+    # A shape match like "[a-z]+://" accepts this, because the "//" reads as an
+    # authority while JavaScript reads it as a line comment.
+    it "does not match a javascript url disguised as an authority" do
+      expect("javascript://%0aalert(1)").not_to match(format_matchers.link_url)
+    end
   end
 end

--- a/spec/models/alchemy/ingredients/link_spec.rb
+++ b/spec/models/alchemy/ingredients/link_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe Alchemy::Ingredients::Link do
   it_behaves_like "an alchemy ingredient"
+  it_behaves_like "a linkable alchemy ingredient", :value
 
   let(:element) { build(:alchemy_element) }
 

--- a/spec/models/alchemy/ingredients/picture_spec.rb
+++ b/spec/models/alchemy/ingredients/picture_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe Alchemy::Ingredients::Picture do
   it_behaves_like "an alchemy ingredient"
+  it_behaves_like "a linkable alchemy ingredient", :link
 
   it { is_expected.to delegate_method(:description_for).to(:picture).allow_nil }
   it { is_expected.to delegate_method(:name).to(:picture).allow_nil }

--- a/spec/models/alchemy/ingredients/text_spec.rb
+++ b/spec/models/alchemy/ingredients/text_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe Alchemy::Ingredients::Text do
   it_behaves_like "an alchemy ingredient"
+  it_behaves_like "a linkable alchemy ingredient", :link
   it_behaves_like "having dom ids"
 
   let(:element) { build(:alchemy_element, name: "article") }

--- a/spec/models/alchemy/node_spec.rb
+++ b/spec/models/alchemy/node_spec.rb
@@ -164,8 +164,53 @@ module Alchemy
         expect(build(:alchemy_node, url: "something")).to be_invalid
       end
 
-      it "is valid with leading protocol scheme" do
-        expect(build(:alchemy_node, url: "i2+ts-z.app:widget.io")).to be_valid
+      it "is valid with an allowed protocol scheme" do
+        expect(build(:alchemy_node, url: "mailto:jane@example.com")).to be_valid
+        expect(build(:alchemy_node, url: "tel:+4912345")).to be_valid
+      end
+
+      it "is invalid with a scheme that is not allowed" do
+        expect(build(:alchemy_node, url: "i2+ts-z.app:widget.io")).to be_invalid
+      end
+
+      it "is invalid with an executable scheme" do
+        expect(build(:alchemy_node, url: "javascript:alert(document.domain)")).to be_invalid
+        expect(build(:alchemy_node, url: "data:text/html;base64,PHN2Zz4=")).to be_invalid
+        expect(build(:alchemy_node, url: "vbscript:msgbox(1)")).to be_invalid
+      end
+
+      it "is invalid with an executable scheme obfuscated by whitespace" do
+        expect(build(:alchemy_node, url: " javascript:alert(1)")).to be_invalid
+        expect(build(:alchemy_node, url: "java\tscript:alert(1)")).to be_invalid
+      end
+
+      it "is invalid with a javascript url disguised as an authority" do
+        expect(build(:alchemy_node, url: "javascript://%0aalert(1)")).to be_invalid
+      end
+
+      context "with a page attached" do
+        # #url returns the page path while a page is attached, so a raw url
+        # stored alongside it only becomes live once the page is detached.
+        it "rejects a stored unsafe url when the page gets detached" do
+          node = create(:alchemy_node, :with_page, name: "Detachable")
+          node.update_columns(url: "javascript:alert(1)")
+          node.reload
+          node.page = nil
+          expect(node).to be_invalid
+        end
+      end
+
+      context "with allowed_url_schemes configured" do
+        around do |example|
+          previous = Alchemy.config.allowed_url_schemes.to_a
+          Alchemy.config.allowed_url_schemes = previous + ["i2+ts-z.app"]
+          example.run
+          Alchemy.config.allowed_url_schemes = previous
+        end
+
+        it "is valid with the configured scheme" do
+          expect(build(:alchemy_node, url: "i2+ts-z.app:widget.io")).to be_valid
+        end
       end
 
       context "with page attached" do

--- a/spec/models/alchemy/safe_url_validator_spec.rb
+++ b/spec/models/alchemy/safe_url_validator_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Alchemy::SafeUrlValidator do
+  let(:model_class) do
+    Class.new do
+      include ActiveModel::Validations
+
+      def self.name
+        "SafeUrlValidatorDummy"
+      end
+
+      attr_accessor :url
+
+      validates_with Alchemy::SafeUrlValidator, attributes: [:url]
+    end
+  end
+
+  subject(:record) { model_class.new }
+
+  def validate(url)
+    record.url = url
+    record.valid?
+  end
+
+  context "with a blank url" do
+    it "is valid" do
+      expect(validate(nil)).to be(true)
+      expect(validate("")).to be(true)
+    end
+  end
+
+  context "with an allowed scheme" do
+    %w[
+      http://example.com
+      https://example.com
+      mailto:jane@example.com
+      tel:+4912345
+      ftp://example.com/file.zip
+    ].each do |url|
+      it "allows #{url}" do
+        expect(validate(url)).to be(true)
+      end
+    end
+
+    it "allows an uppercased scheme" do
+      expect(validate("HTTPS://example.com")).to be(true)
+    end
+  end
+
+  context "with a url that carries no scheme" do
+    %w[
+      /an/absolute/path
+      #an-anchor
+      ?query=1
+      a/relative/path
+      //protocol-relative.example
+    ].each do |url|
+      it "allows #{url}" do
+        expect(validate(url)).to be(true)
+      end
+    end
+  end
+
+  context "with an executable scheme" do
+    [
+      "javascript:alert(document.domain)",
+      "data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==",
+      "vbscript:msgbox(1)"
+    ].each do |url|
+      it "rejects #{url}" do
+        expect(validate(url)).to be(false)
+      end
+    end
+
+    it "adds an error on the attribute" do
+      validate("javascript:alert(1)")
+      expect(record.errors[:url]).to be_present
+    end
+
+    it "rejects a mixed case scheme" do
+      expect(validate("JaVaScRiPt:alert(1)")).to be(false)
+    end
+
+    it "rejects a scheme hidden behind leading whitespace" do
+      expect(validate(" javascript:alert(1)")).to be(false)
+    end
+
+    # Browsers strip tabs and newlines from URLs before parsing the scheme, so
+    # "java\tscript:" executes. Verified in Firefox.
+    it "rejects a scheme split by embedded whitespace" do
+      expect(validate("java\tscript:alert(1)")).to be(false)
+      expect(validate("java\nscript:alert(1)")).to be(false)
+      expect(validate("java\rscript:alert(1)")).to be(false)
+    end
+
+    it "rejects a scheme split by an embedded null byte" do
+      expect(validate("java" + 0.chr + "script:alert(1)")).to be(false)
+    end
+
+    # /^(mailto:|\/|[a-z]+:\/\/)/ style shape matching accepts this, because the
+    # "//" reads as an authority while JavaScript reads it as a line comment.
+    it "rejects a javascript url disguised as an authority" do
+      expect(validate("javascript://%0aalert(1)")).to be(false)
+      expect(validate("javascript://\nalert(1)")).to be(false)
+    end
+  end
+
+  context "when the allowed schemes are configured" do
+    around do |example|
+      previous = Alchemy.config.allowed_url_schemes.to_a
+      Alchemy.config.allowed_url_schemes = %w[https]
+      example.run
+      Alchemy.config.allowed_url_schemes = previous
+    end
+
+    it "allows a configured scheme" do
+      expect(validate("https://example.com")).to be(true)
+    end
+
+    it "rejects a scheme that is no longer allowed" do
+      expect(validate("http://example.com")).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

Menu nodes and the linkable ingredients accepted any url scheme, so an author level
account could store a `javascript:` url. The shipped menu template and the `Link`,
`Text` and `Picture` view components render that value straight into an `href`, so an
administrator activating the link executed it in the site's own origin. That is a
privilege escalation path from the lowest content role to full admin, reported as
GHSA-x84w-hjc5-6pqw.

The boundary has to sit on the models. The link dialog already carried a url matcher,
but it runs in the browser and is bypassed by posting to the node and ingredient
endpoints directly. Its default also matched schemes by shape (`[a-z]+://`), which
accepts `javascript://%0a…` because the slashes read as an authority to a url parser
and as a line comment to JavaScript.

Schemes are now checked server side against `Alchemy.config.allowed_url_schemes`
(`http`, `https`, `mailto`, `tel`, `ftp` by default), so integrators can widen the list
without patching the gem. Urls that carry no scheme keep working untouched. Control
characters are stripped before the scheme is read, because browsers drop them too,
which makes `java<TAB>script:` a live url.

`Alchemy::Ingredients::File` is unaffected, its href comes from the attachment rather
than editor input.

### Notable changes (maybe breaking?)

Nodes and ingredients that store a url with an unlisted scheme now fail validation on
save. Previously any scheme was accepted, so a node url such as `i2+ts-z.app:widget.io`
was valid and is not any more unless the scheme is added to the config. Existing rows
are not migrated and keep rendering until they are saved again.

`Alchemy.config.format_matchers.link_url` changed its default to close the
`javascript://` hole. It is still honoured when set, and is now defined once as
`Alchemy::Configurations::FormatMatchers::LINK_URL` so the dialog and the config cannot
drift apart.

Richtext is deliberately out of scope. `RichtextView` renders unsanitized html unless a
`sanitizer` setting is configured, which is a specified default with its own spec and a
separate discussion from url schemes.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change