### PR TITLE
feat(csp): send a Content Security Policy with admin responses

### DIFF
--- a/app/controllers/alchemy/admin/base_controller.rb
+++ b/app/controllers/alchemy/admin/base_controller.rb
@@ -12,6 +12,7 @@ module Alchemy
       include Locale
       include Timezone
 
+      before_action :set_content_security_policy
       before_action :load_locked_pages
 
       check_authorization
@@ -34,6 +35,25 @@ module Alchemy
       end
 
       private
+
+      # Applies Alchemy's own Content Security Policy, but only if the host
+      # application has opted in, and has not configured a policy of its own,
+      # and the request is for one of Alchemy's own controllers.
+      #
+      # That last condition matters because controllers of the host
+      # application can inherit from this class. Their views would not be ours
+      # to make assumptions about.
+      def set_content_security_policy
+        policy_class = Alchemy.config.admin_content_security_policy
+        return unless policy_class
+        return unless controller_path.start_with?("alchemy/")
+        return if request.content_security_policy
+
+        policy = policy_class.new(request)
+        request.content_security_policy_nonce_generator ||= policy.nonce_generator
+        request.content_security_policy = policy.call
+        request.content_security_policy_report_only = policy.report_only?
+      end
 
       def safe_redirect_path(path = params[:redirect_to], fallback: admin_path)
         if is_safe_redirect_path?(path)

--- a/app/views/layouts/alchemy/admin.html.erb
+++ b/app/views/layouts/alchemy/admin.html.erb
@@ -8,6 +8,7 @@
     <link rel="shortcut icon" href="<%= asset_path('alchemy/favicon.ico') %>">
     <link rel="preload" href="<%= asset_path("alchemy/icons-sprite.svg") %>" as="image" type="<%= Mime::Type.lookup_by_extension(:svg) %>" crossorigin>
     <%= csrf_meta_tag %>
+    <%= csp_meta_tag %>
     <meta name="robots" content="noindex">
     <meta name="turbo-prefetch" content="false">
     <meta name="turbo-cache-control" content="no-cache">

--- a/lib/alchemy/admin/content_security_policy.rb
+++ b/lib/alchemy/admin/content_security_policy.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+module Alchemy
+  module Admin
+    # The Content Security Policy Alchemy applies to its own admin responses.
+    #
+    # Configured by default. Set it to nil to send no policy at all:
+    #
+    #     Alchemy.config.admin_content_security_policy = nil
+    #
+    # 'self' follows the origin the admin is served from, so mounting it under
+    # its own subdomain through +Alchemy.admin_constraints+ needs no extra
+    # configuration. The page preview is same origin as well, because it falls
+    # back to an admin path, unless a preview host is configured, in which case
+    # that host is added to +frame-src+.
+    #
+    # Assets your application adds through +admin_stylesheets+ or through
+    # +Alchemy.importmap+ are picked up automatically, so a module pinned to a
+    # CDN does not need any extra configuration. Subclass to allow anything
+    # else, and configure the subclass instead:
+    #
+    #     class AdminContentSecurityPolicy < Alchemy::Admin::ContentSecurityPolicy
+    #       def call
+    #         super.tap do |policy|
+    #           policy.connect_src(*policy.directives["connect-src"], "https://api.example.com")
+    #         end
+    #       end
+    #     end
+    #
+    class ContentSecurityPolicy
+      class InvalidSourceError < StandardError; end
+
+      # Rails calls an asset host proc with the asset source, so we need one to
+      # evaluate it with. Any source resolves to the same origin unless the
+      # host shards, which the %d form covers separately.
+      ASSET_SOURCE = "/"
+
+      def initialize(request = nil)
+        @request = request
+      end
+
+      attr_reader :request
+      # Send the policy as Content-Security-Policy-Report-Only, which reports
+      # violations to the browser console and to +report_uri+ without blocking
+      # anything. Worth running first, to find what a policy would break.
+      def report_only? = false
+
+      # Authorizes the inline scripts Alchemy renders. It has to be
+      # unguessable, otherwise injected markup could carry a valid nonce.
+      def nonce_generator = ->(_request) { SecureRandom.base64(16) }
+
+      def call
+        ActionDispatch::ContentSecurityPolicy.new do |policy|
+          policy.default_src :self
+          # script-src and style-src have to be named explicitly, because Rails
+          # only appends the nonce to directives the policy actually declares.
+          policy.script_src :self, *asset_hosts, *importmap_origins
+          policy.style_src :self, *asset_hosts, *admin_stylesheet_origins
+          # Inline style attributes cannot carry a nonce. Turbo sets them for
+          # its progress bar, and so do several of our bundled dependencies.
+          policy.style_src_attr :unsafe_inline
+          policy.img_src :self, :data, :blob, *asset_hosts
+          policy.font_src :self, :data, *asset_hosts
+          policy.media_src :self, :blob, *asset_hosts
+          policy.connect_src :self, *asset_hosts
+          policy.frame_src :self, *preview_hosts
+          policy.object_src :none
+          policy.base_uri :self
+          policy.form_action :self
+          # An endpoint of your own that the browser POSTs a JSON report to
+          # whenever it blocks something:
+          #
+          #   policy.report_uri "/csp-violation-reports"
+        end
+      end
+
+      private
+
+      def asset_hosts
+        host = ActionController::Base.asset_host
+        return [] if host.blank?
+
+        hosts = if host.respond_to?(:call)
+          [call_asset_host(host)]
+        elsif host.include?("%d")
+          # Rails shards these over four hosts.
+          4.times.map { host % _1 }
+        else
+          [host]
+        end
+        hosts.filter_map { origin(_1) }.uniq
+      end
+
+      def call_asset_host(host)
+        arity = host.respond_to?(:arity) ? host.arity : host.method(:call).arity
+        args = [ASSET_SOURCE]
+        args << request if request && (arity > 1 || arity < 0)
+        host.call(*args)
+      end
+
+      # Modules can be pinned to a CDN, in which case the pin holds an absolute
+      # URL instead of an asset name.
+      def importmap_origins
+        Alchemy.importmap.packages.values.filter_map { origin(_1.path) }.uniq
+      end
+
+      # Admin stylesheets are usually asset names, but an absolute URL is
+      # allowed here too.
+      def admin_stylesheet_origins
+        Alchemy.config.admin_stylesheets.filter_map { origin(_1) }.uniq
+      end
+
+      # A CSP source is an origin, so anything with a host contributes one and
+      # everything else (asset names, module specifiers) is same origin already.
+      def origin(url)
+        uri = URI.parse(url.to_s)
+        return nil unless uri.host
+
+        port = ":#{uri.port}" if uri.port && uri.port != uri.default_port
+        "#{uri.scheme ? "#{uri.scheme}://" : "//"}#{uri.host}#{port}"
+      rescue URI::InvalidURIError => error
+        raise InvalidSourceError, "Cannot build a Content Security Policy source from " \
+          "#{url.inspect} (#{error.message}). It came from your asset host, your " \
+          "admin stylesheets, an importmap pin or a preview host."
+      end
+
+      # The page editor renders the frontend of the application in an iframe,
+      # which is a different host whenever a preview host is configured.
+      def preview_hosts
+        preview = Alchemy.config.preview
+        ([preview.host] + preview.per_site_configs.map(&:host)).filter_map { origin(_1) }.uniq
+      end
+    end
+  end
+end

--- a/lib/alchemy/configurations/main.rb
+++ b/lib/alchemy/configurations/main.rb
@@ -511,6 +511,18 @@ module Alchemy
       #
       configuration :admin_components, AdminComponents
 
+      # === Admin Content Security Policy
+      #
+      # The class building the Content Security Policy Alchemy sends with its
+      # own admin responses. Set to +nil+ to send no policy at all.
+      #
+      # It never replaces a policy the host application has configured, and it
+      # only applies to Alchemy's own controllers.
+      #
+      #    Alchemy.config.admin_content_security_policy = "MyApp::AdminContentSecurityPolicy"
+      #
+      option :admin_content_security_policy, :class, default: "Alchemy::Admin::ContentSecurityPolicy"
+
       # === Publishable resolver
       #
       # The class used to resolve publication state for Publishable records

--- a/lib/alchemy/upgrader/eight_four.rb
+++ b/lib/alchemy/upgrader/eight_four.rb
@@ -47,6 +47,14 @@ module Alchemy
         TODO
       end
 
+      def notify_admin_content_security_policy
+        todo(<<~TODO.strip, "The admin now sends a Content Security Policy")
+          If you have inline scripts or anything else in your admin that a CSP
+          would block, subclass `Alchemy::Admin::ContentSecurityPolicy`, or set
+          `config.admin_content_security_policy = nil` to turn it off.
+        TODO
+      end
+
       # Element partials that render nested elements through the
       # +nested_elements+ association issue one database query per parent
       # element. Rendering through the block helper's +nested_elements+

--- a/lib/alchemy_cms.rb
+++ b/lib/alchemy_cms.rb
@@ -21,6 +21,7 @@ require "view_component"
 
 # Require globally used Alchemy mixins
 require_relative "alchemy/ability_helper"
+require_relative "alchemy/admin/content_security_policy"
 require_relative "alchemy/admin/locale"
 require_relative "alchemy/admin/timezone"
 require_relative "alchemy/admin/preview_time"

--- a/lib/generators/alchemy/install/templates/alchemy.rb.tt
+++ b/lib/generators/alchemy/install/templates/alchemy.rb.tt
@@ -256,6 +256,17 @@ Alchemy.configure do |config|
   # Additional stylesheets to be included in the Alchemy admin UI
   # config.admin_stylesheets.add("my_app/admin_extension")
 
+  # === Admin Content Security Policy
+  #
+  # The class building the Content Security Policy Alchemy sends with its own
+  # admin responses. Set it to nil to send no policy at all.
+  #
+  # Alchemy never replaces a policy your application has configured itself.
+  # Your asset host, your admin stylesheets and modules pinned to a CDN are
+  # allowed automatically. Subclass it to allow anything else.
+  #
+  # config.admin_content_security_policy = <%= @default_config.raw_admin_content_security_policy.inspect %>
+
   # Define page publish targets
   #
   # A publish target is a ActiveJob that gets performed

--- a/lib/tasks/alchemy/upgrade.rake
+++ b/lib/tasks/alchemy/upgrade.rake
@@ -61,7 +61,8 @@ namespace :alchemy do
       task "run" => [
         "alchemy:upgrade:8.4:add_dragonfly_gem",
         "alchemy:upgrade:8.4:upgrade_nested_elements_rendering",
-        "alchemy:upgrade:8.4:notify_attachment_filetypes_default"
+        "alchemy:upgrade:8.4:notify_attachment_filetypes_default",
+        "alchemy:upgrade:8.4:notify_admin_content_security_policy"
       ]
 
       desc "Add dragonfly gem to the Gemfile if the app uses the dragonfly storage adapter"
@@ -77,6 +78,11 @@ namespace :alchemy do
       desc "Notify about the new attachment upload allowlist default"
       task notify_attachment_filetypes_default: [:environment] do
         Alchemy::Upgrader["8.4"].notify_attachment_filetypes_default
+      end
+
+      desc "Notify about the new admin Content Security Policy"
+      task notify_admin_content_security_policy: [:environment] do
+        Alchemy::Upgrader["8.4"].notify_admin_content_security_policy
       end
     end
   end

--- a/spec/dummy/config/initializers/alchemy.rb
+++ b/spec/dummy/config/initializers/alchemy.rb
@@ -244,4 +244,15 @@ Alchemy.configure do |config|
 
   # The sizes for the preview size select in the page editor.
   # config.page_preview_sizes = [360, 640, 768, 1024, 1280, 1440]
+
+  # === Admin Content Security Policy
+  #
+  # The class building the Content Security Policy Alchemy sends with its own
+  # admin responses. Set it to nil to send no policy at all.
+  #
+  # Alchemy never replaces a policy your application has configured itself.
+  # Your asset host, your admin stylesheets and modules pinned to a CDN are
+  # allowed automatically. Subclass it to allow anything else.
+  #
+  # config.admin_content_security_policy = "Alchemy::Admin::ContentSecurityPolicy"
 end

--- a/spec/lib/alchemy/upgrader/eight_four_spec.rb
+++ b/spec/lib/alchemy/upgrader/eight_four_spec.rb
@@ -79,6 +79,15 @@ RSpec.describe Alchemy::Upgrader::EightFour do
     end
   end
 
+  describe "#notify_admin_content_security_policy" do
+    subject { upgrader.notify_admin_content_security_policy }
+
+    it "adds a todo about the new policy" do
+      expect(upgrader).to receive(:todo).with(kind_of(String), kind_of(String))
+      subject
+    end
+  end
+
   describe "#upgrade_nested_elements_rendering" do
     subject { upgrader.upgrade_nested_elements_rendering }
 

--- a/spec/requests/alchemy/admin/admin_content_security_policy_spec.rb
+++ b/spec/requests/alchemy/admin/admin_content_security_policy_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin Content Security Policy" do
+  before { authorize_user(:as_admin) }
+
+  around do |example|
+    configured = Alchemy.config.raw_admin_content_security_policy
+    example.run
+    Alchemy.config.admin_content_security_policy = configured
+  end
+
+  def policy = response.headers["Content-Security-Policy"]
+
+  it "is applied by default" do
+    get alchemy.admin_dashboard_path
+    expect(policy).to be_present
+  end
+
+  it "is not applied when set to nil" do
+    Alchemy.config.admin_content_security_policy = nil
+    get alchemy.admin_dashboard_path
+    expect(policy).to be_nil
+  end
+
+  it "declares script-src explicitly so the nonce is added to it" do
+    get alchemy.admin_dashboard_path
+    expect(policy).to match(/script-src [^;]*'nonce-/)
+  end
+
+  it "allows inline style attributes, which cannot carry a nonce" do
+    get alchemy.admin_dashboard_path
+    expect(policy).to include("style-src-attr 'unsafe-inline'")
+  end
+
+  it "nonces every inline script it renders" do
+    get alchemy.admin_dashboard_path
+    nonce = policy[/'nonce-([^']+)'/, 1]
+    inline_scripts = response.body.scan(/<script(?![^>]*\ssrc=)[^>]*>/)
+    expect(inline_scripts).to all(include(%(nonce="#{nonce}")))
+  end
+
+  it "exposes the nonce to Turbo through the meta tag" do
+    get alchemy.admin_dashboard_path
+    nonce = policy[/'nonce-([^']+)'/, 1]
+    expect(response.body).to include(%(<meta name="csp-nonce" content="#{nonce}"))
+  end
+
+  it "allows modules that are pinned to a CDN" do
+    Alchemy.importmap.pin "flatpickr/de", to: "https://ga.jspm.io/npm:flatpickr/de.js"
+    get alchemy.admin_dashboard_path
+    expect(policy).to match(%r{script-src [^;]*https://ga\.jspm\.io})
+  ensure
+    Alchemy.importmap.packages.delete("flatpickr/de")
+  end
+
+  it "allows admin stylesheets served from another host" do
+    Alchemy.config.admin_stylesheets.add("https://cdn.example.com/admin.css")
+    get alchemy.admin_dashboard_path
+    expect(policy).to match(%r{style-src [^;]*https://cdn\.example\.com})
+  ensure
+    Alchemy.config.admin_stylesheets.delete("https://cdn.example.com/admin.css")
+  end
+
+  it "takes the nonce generator from the policy class" do
+    stub_const("FixedNoncePolicy", Class.new(Alchemy::Admin::ContentSecurityPolicy) do
+      def nonce_generator = ->(_request) { "fixed-nonce" }
+    end)
+    Alchemy.config.admin_content_security_policy = "FixedNoncePolicy"
+    get alchemy.admin_dashboard_path
+    expect(policy).to include("'nonce-fixed-nonce'")
+  end
+
+  describe "asset host" do
+    around do |example|
+      host = ActionController::Base.asset_host
+      example.run
+      ActionController::Base.asset_host = host
+    end
+
+    it "allows a plain asset host" do
+      ActionController::Base.asset_host = "https://assets.example.com"
+      get alchemy.admin_dashboard_path
+      expect(policy).to match(%r{script-src [^;]*https://assets\.example\.com})
+    end
+
+    it "expands a sharded asset host" do
+      ActionController::Base.asset_host = "https://assets%d.example.com"
+      get alchemy.admin_dashboard_path
+      expect(policy).to include("https://assets0.example.com", "https://assets3.example.com")
+    end
+
+    it "evaluates an asset host proc" do
+      ActionController::Base.asset_host = ->(_source) { "https://from-proc.example.com" }
+      get alchemy.admin_dashboard_path
+      expect(policy).to match(%r{script-src [^;]*https://from-proc\.example\.com})
+    end
+
+    it "passes the request to a proc that asks for it" do
+      ActionController::Base.asset_host = ->(_source, request) { "https://#{request.host}" }
+      get alchemy.admin_dashboard_path
+      expect(policy).to match(%r{script-src [^;]*https://www\.example\.com})
+    end
+
+    it "raises a helpful error instead of dropping an unusable host" do
+      ActionController::Base.asset_host = "https://exa mple.com"
+      expect { get alchemy.admin_dashboard_path }
+        .to raise_error(Alchemy::Admin::ContentSecurityPolicy::InvalidSourceError, /asset host/)
+    end
+  end
+
+  it "sends it report only when the policy class says so" do
+    stub_const("ReportOnlyPolicy", Class.new(Alchemy::Admin::ContentSecurityPolicy) do
+      def report_only? = true
+    end)
+    Alchemy.config.admin_content_security_policy = "ReportOnlyPolicy"
+    get alchemy.admin_dashboard_path
+    expect(policy).to be_nil
+    expect(response.headers["Content-Security-Policy-Report-Only"]).to be_present
+  end
+
+  it "uses the configured class, so it can be replaced" do
+    stub_const("CustomPolicy", Class.new(Alchemy::Admin::ContentSecurityPolicy) do
+      def call = super.tap { _1.frame_src :self, "https://preview.example.com" }
+    end)
+    Alchemy.config.admin_content_security_policy = "CustomPolicy"
+    get alchemy.admin_dashboard_path
+    expect(policy).to include("frame-src 'self' https://preview.example.com")
+  end
+
+  it "never replaces a policy the host application configured" do
+    host_policy = ActionDispatch::ContentSecurityPolicy.new { |p| p.default_src :https }
+    allow_any_instance_of(ActionDispatch::Request)
+      .to receive(:content_security_policy).and_return(host_policy)
+    get alchemy.admin_dashboard_path
+    expect(policy).to eq("default-src https:")
+  end
+end


### PR DESCRIPTION
## What is this pull request for?

The admin renders content that editors control, and it runs with the session of whoever is looking at it. Today a single missed escape or a gap in a sanitizer allow list is enough to turn that into script execution — there is no second layer. A Content Security Policy is that layer: it keeps a mistake of that kind a display bug instead of a session compromise.

It is on by default, for new installations and upgrades alike, because the entire admin surface Alchemy ships works under it. I ran the browser suite with the policy enforcing and instrumented the admin with a `securitypolicyviolation` listener across the dashboard, page editor, pictures library, nodes index, TinyMCE and the image cropper. The only violation anywhere was Turbo injecting the stylesheet for its progress bar, which is why `csp_meta_tag` is now in the admin layout — Turbo reads its nonce from there. After that, zero violations.

The policy is built by a configurable class, so an application with its own needs subclasses it rather than writing a policy from scratch. Alchemy fills in the host dependent sources from what it already knows, which for most applications means nothing to configure at all: the asset host (including the sharded `%d` form and proc form), the preview hosts the page editor loads in an iframe, admin stylesheets served from another host, and modules pinned to a CDN.

Two boundaries are deliberate. It is applied only to Alchemy's own controllers, never to controllers of the host application that inherit from `Alchemy::Admin::BaseController` — those views are not ours to make assumptions about. And it is skipped entirely when the application has configured a policy of its own, so it can never quietly narrow a policy somebody wrote on purpose.

`'self'` follows the origin the admin is served from, so mounting it under its own subdomain through `Alchemy.admin_constraints` needs no configuration. The page preview stays same origin too, because it falls back to an admin path unless a preview host is set.

The one concession is `style-src-attr 'unsafe-inline'`. Inline style attributes cannot carry a nonce, and removing ours would not help: Turbo and several bundled dependencies set them as well. It is a much weaker allowance than `script-src 'unsafe-inline'`, since a style attribute cannot execute anything.

### Notable changes (remove if none)

The admin sends a `Content-Security-Policy` header where it previously sent none. Applications with inline scripts in admin views of their own will see them blocked; the upgrader raises a todo pointing at the two ways out. `config.admin_content_security_policy = nil` restores the previous behaviour.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change