### PR TITLE
fix: Remove default role from user

### DIFF
--- a/app/models/concerns/alchemy/user_methods.rb
+++ b/app/models/concerns/alchemy/user_methods.rb
@@ -3,8 +3,6 @@ module Alchemy
     extend ActiveSupport::Concern
 
     included do
-      attribute :alchemy_roles, default: "member"
-
       # Unlock all locked pages before destroy.
       before_destroy :unlock_pages!
 
@@ -26,7 +24,6 @@ module Alchemy
       }
 
       validates :alchemy_roles,
-        presence: true,
         inclusion: {
           in: Alchemy.config.user_roles,
           message: "is not included in #{Alchemy.config.user_roles.join(", ")}"

--- a/lib/alchemy/test_support/factories/dummy_user_factory.rb
+++ b/lib/alchemy/test_support/factories/dummy_user_factory.rb
@@ -4,7 +4,10 @@ FactoryBot.define do
   factory :alchemy_dummy_user, class: "DummyUser" do
     sequence(:email) { |n| "john.#{n}@doe.com" }
     password { "s3cr3t" }
-    alchemy_roles { ["member"] }
+
+    trait :as_member do
+      alchemy_roles { ["member"] }
+    end
 
     trait :as_admin do
       alchemy_roles { ["admin"] }

--- a/spec/controllers/alchemy/api/pages_controller_spec.rb
+++ b/spec/controllers/alchemy/api/pages_controller_spec.rb
@@ -104,7 +104,7 @@ module Alchemy
 
           context "as member user" do
             before do
-              authorize_user(build(:alchemy_dummy_user))
+              authorize_user(build(:alchemy_dummy_user, :as_member))
             end
 
             it "returns published pages readable by the member role, but not those restricted to another role" do

--- a/spec/controllers/alchemy/attachments_controller_spec.rb
+++ b/spec/controllers/alchemy/attachments_controller_spec.rb
@@ -85,7 +85,7 @@ module Alchemy
       end
 
       context "as member user" do
-        before { authorize_user(build(:alchemy_dummy_user)) }
+        before { authorize_user(build(:alchemy_dummy_user, :as_member)) }
 
         it "should be possible to download attachments from restricted pages" do
           get :download, params: {id: attachment.id}

--- a/spec/features/page_feature_spec.rb
+++ b/spec/features/page_feature_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe "Show page feature:", type: :system do
 
     context "as a member user" do
       before do
-        authorize_user(create(:alchemy_dummy_user))
+        authorize_user(create(:alchemy_dummy_user, :as_member))
       end
 
       it "I am able to visit the page" do

--- a/spec/libraries/permissions_spec.rb
+++ b/spec/libraries/permissions_spec.rb
@@ -65,7 +65,7 @@ describe Alchemy::Permissions do
   end
 
   context "A member" do
-    let(:user) { build(:alchemy_dummy_user) }
+    let(:user) { build(:alchemy_dummy_user, :as_member) }
 
     it "can download all attachments" do
       is_expected.to be_able_to(:download, attachment)

--- a/spec/models/alchemy/user_methods_spec.rb
+++ b/spec/models/alchemy/user_methods_spec.rb
@@ -3,20 +3,13 @@
 require "rails_helper"
 
 RSpec.describe Alchemy::UserMethods do
-  let(:user) { build_stubbed(:alchemy_dummy_user) }
+  let(:user) { build(:alchemy_dummy_user) }
 
-  it "should have at least member role" do
-    expect(user.alchemy_roles).not_to be_blank
-    expect(user.alchemy_roles).to include("member")
+  it "should not have a default role" do
+    expect(user.alchemy_roles).to be_blank
   end
 
   describe "validations" do
-    it "should validate alchemy_roles" do
-      user.alchemy_roles = nil
-      expect(user).not_to be_valid
-      expect(user.errors[:alchemy_roles]).to include("can't be blank")
-    end
-
     it "should validate alchemy_roles inclusion" do
       user.alchemy_roles = ["invalid_role"]
       expect(user).not_to be_valid
@@ -28,7 +21,7 @@ RSpec.describe Alchemy::UserMethods do
     let!(:user) { create(:alchemy_dummy_user, :as_admin) }
 
     describe ".alchemy_admins" do
-      let!(:member) { create(:alchemy_dummy_user, alchemy_roles: "member") }
+      let!(:member) { create(:alchemy_dummy_user, :as_member) }
 
       it "should only return users with admin role" do
         expect(Alchemy.config.user_class.alchemy_admins).to include(user)
@@ -86,6 +79,8 @@ RSpec.describe Alchemy::UserMethods do
   end
 
   describe "#has_alchemy_role?" do
+    let(:user) { build(:alchemy_dummy_user, :as_member) }
+
     context "with given role" do
       it "should return true." do
         expect(user.has_alchemy_role?("member")).to be_truthy
@@ -106,6 +101,8 @@ RSpec.describe Alchemy::UserMethods do
   end
 
   describe "#alchemy_roles" do
+    let(:user) { build(:alchemy_dummy_user, :as_member) }
+
     it "should return an array of user roles" do
       expect(user.alchemy_roles).to eq(["member"])
     end

--- a/spec/requests/alchemy/api/nodes_controller_spec.rb
+++ b/spec/requests/alchemy/api/nodes_controller_spec.rb
@@ -117,7 +117,7 @@ module Alchemy
         end
 
         context "as member user" do
-          before { authorize_user(build(:alchemy_dummy_user)) }
+          before { authorize_user(build(:alchemy_dummy_user, :as_member)) }
 
           it "returns nodes to restricted pages readable with their role, but not those restricted to another role" do
             get alchemy.api_nodes_path(params: {format: :json})


### PR DESCRIPTION
## What is this pull request for?

With the recent introduction of `Alchemy::UserMethods` we started to ship an implicit default `member` role.

But Alchemy never expected a default role to exist.

`alchemy-devise` shipped a default member role, but custom user implementations might have no default role at all. 

Since member users are allowed to visit restricted pages by default, we should not ship a default member rule in order to not break existing sites.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change
