### PR TITLE
fix(csp): allow images from any https host

### DIFF
--- a/lib/alchemy/admin/content_security_policy.rb
+++ b/lib/alchemy/admin/content_security_policy.rb
@@ -14,6 +14,11 @@ module Alchemy
     # back to an admin path, unless a preview host is configured, in which case
     # that host is added to +frame-src+.
     #
+    # +img-src+ is the exception: it allows any https host, because the host
+    # serving the pictures is not knowable here. Narrow it in a subclass, or
+    # keep pictures same origin with
+    # +config.active_storage.resolve_model_to_route = :rails_storage_proxy+.
+    #
     # Assets your application adds through +admin_stylesheets+ or through
     # +Alchemy.importmap+ are picked up automatically, so a module pinned to a
     # CDN does not need any extra configuration. Subclass to allow anything
@@ -59,7 +64,10 @@ module Alchemy
           # Inline style attributes cannot carry a nonce. Turbo sets them for
           # its progress bar, and so do several of our bundled dependencies.
           policy.style_src_attr :unsafe_inline
-          policy.img_src :self, :data, :blob, *asset_hosts
+          # Pictures come from wherever the storage backend puts them, which
+          # cannot be read from here. ActiveStorage redirects to a signed
+          # service URL, and a redirect still has to match the host.
+          policy.img_src :self, :data, :blob, :https
           policy.font_src :self, :data, *asset_hosts
           policy.media_src :self, :blob, *asset_hosts
           policy.connect_src :self, *asset_hosts

--- a/spec/requests/alchemy/admin/admin_content_security_policy_spec.rb
+++ b/spec/requests/alchemy/admin/admin_content_security_policy_spec.rb
@@ -34,6 +34,11 @@ RSpec.describe "Admin Content Security Policy" do
     expect(policy).to include("style-src-attr 'unsafe-inline'")
   end
 
+  it "allows images from any https host, because the storage host is not knowable" do
+    get alchemy.admin_dashboard_path
+    expect(policy[/img-src [^;]*/]).to eq("img-src 'self' data: blob: https:")
+  end
+
   it "nonces every inline script it renders" do
     get alchemy.admin_dashboard_path
     nonce = policy[/'nonce-([^']+)'/, 1]
@@ -101,6 +106,12 @@ RSpec.describe "Admin Content Security Policy" do
       ActionController::Base.asset_host = ->(_source, request) { "https://#{request.host}" }
       get alchemy.admin_dashboard_path
       expect(policy).to match(%r{script-src [^;]*https://www\.example\.com})
+    end
+
+    it "does not repeat itself in img-src, which allows every https host already" do
+      ActionController::Base.asset_host = "https://assets.example.com"
+      get alchemy.admin_dashboard_path
+      expect(policy[/img-src [^;]*/]).to eq("img-src 'self' data: blob: https:")
     end
 
     it "raises a helpful error instead of dropping an unusable host" do


### PR DESCRIPTION
## What is this pull request for?

The admin Content Security Policy blocks pictures whenever the storage backend serves them from somewhere other than the app's own origin.

`img-src` was built from the asset host, which is the one host Alchemy can actually read. The storage host is not: ActiveStorage hands out a same origin path (`rails_blob_path(..., only_path: true)`) that redirects to a signed service URL, and CSP keeps matching the host across a redirect — per CSP3 only the *path* check is skipped once the redirect count is non-zero. So a bucket on S3, GCS or Azure gets blocked, and Dragonfly behaves the same way as soon as a `url_host` or CDN is configured.

Enumerating those hosts instead is not really available to us. `ActiveStorage::Service` exposes no host accessor, so we would have to sign a throwaway URL for a fake key just to parse an origin out of it, per service class, and that falls apart on `Mirror`, `Disk` and custom services. That is per-backend knowledge in an engine, and when it guesses wrong the symptom is a blank picture library.

So `img-src` now allows any https host. This is the same thing Rails' own generated initializer recommends, and it is deliberately scoped to this one directive: everywhere else the host *is* knowable, and opening `script-src` or `connect-src` the same way would give up what the policy is actually for. The asset host drops out of `img-src` because every https asset host is already covered by the scheme.

The trade-off worth naming: `img-src https:` gives up the exfiltration guard on images — a dangling-markup or CSS-injection leak can send bytes out through an image URL, and editor-pasted remote images will load. It gives up nothing on code execution. Apps that want it narrow can subclass the policy, or keep pictures same origin with `config.active_storage.resolve_model_to_route = :rails_storage_proxy`, which is now mentioned in the class docs.

### Notable changes (remove if none)

Nothing breaking — this widens a directive that was previously blocking legitimate requests.

Already merged into `8.4-stable` via #4253, so this carries no `backport-to-8.4-stable` label — the bot would only try to cherry-pick a commit that is already there.

## Checklist
- [x] I have followed [Pull Request guidelines](https://github.com/AlchemyCMS/alchemy_cms/blob/main/CONTRIBUTING.md)
- [x] I have added a detailed description into each commit message
- [x] I have added tests to cover this change